### PR TITLE
Patch URL download for giflib from sourceforge

### DIFF
--- a/cross/giflib/Makefile
+++ b/cross/giflib/Makefile
@@ -3,7 +3,7 @@ PKG_VERS = 4.1.6
 PKG_EXT = tar.bz2
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 PKG_DIST_NAME = $(PKG_DIR).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.sourceforge.net/project/giflib/giflib%204.x/$(PKG_DIR)
+PKG_DIST_SITE = http://sourceforge.net/projects/giflib/files/giflib-4.x/$(PKG_DIR)
 
 DEPENDS =
 


### PR DESCRIPTION
URL doesn't work on my side.
Got error 404
