### PR TITLE
Allows running git-daemon from the Syno UI using a dedicated git user

### DIFF
--- a/cross/git/Makefile
+++ b/cross/git/Makefile
@@ -17,7 +17,7 @@ CONFIGURE_ARGS  = --without-tcltk --without-python ac_cv_fread_reads_directories
 INSTALL_TARGET = myInstall
 POST_INSTALL_TARGET = myPostInstall
 
-BUSYBOX_CONFIG = tr
+BUSYBOX_CONFIG = usrmng
 ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
 
 include ../../mk/spksrc.cross-cc.mk

--- a/spk/git/Makefile
+++ b/spk/git/Makefile
@@ -8,9 +8,7 @@ DEPENDS = cross/$(SPK_NAME)
 MAINTAINER = SynoCommunity
 DESCRIPTION = Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
 DESCRIPTION_FRE = Git est un logiciel de gestion de version décentralisée gratuit et open source destiné à gérer aussi bien les petits que les très gros projets avec vitesse et efficacité.
-STARTABLE = no
 DISPLAY_NAME = Git
-CHANGELOG = "1. Add missing tr"
 
 HOMEPAGE = http://git-scm.com/
 LICENSE  =
@@ -21,4 +19,13 @@ ADDITIONAL_SCRIPTS =
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
+POST_STRIP_TARGET =  git_extra_install
+
 include ../../mk/spksrc.spk.mk
+
+.PHONY: git_extra_install
+git_extra_install:
+	install -m 755 -d $(STAGING_DIR)/var
+	install -m 755 -d $(STAGING_DIR)/var/run
+	install -m 755 -d $(STAGING_DIR)/var/log
+	install -m 755 -d $(STAGING_DIR)/var/repositories

--- a/spk/git/src/dsm-control.sh
+++ b/spk/git/src/dsm-control.sh
@@ -6,20 +6,73 @@ DNAME="Git"
 
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
+PID_FILE="${INSTALL_DIR}/var/run/git-daemon.pid"
+LOG_FILE="${INSTALL_DIR}/var/log/git-daemon.log"
+USER="git"
+BASE_PATH="${INSTALL_DIR}/var/repositories"
+
+start_daemon ()
+{
+    su - ${USER} -c "${INSTALL_DIR}/bin/git daemon --export-all --base-path=${BASE_PATH} --pid-file=${PID_FILE} --reuseaddr --verbose --detach ${BASE_PATH}"
+}
+
+stop_daemon ()
+{
+    kill `cat ${PID_FILE}`
+    wait_for_status 1 20 || kill -9 `cat ${PID_FILE}`
+    rm -f ${PID_FILE}
+}
+
+daemon_status ()
+{
+    if [ -f ${PID_FILE} ] && kill -0 `cat ${PID_FILE}` > /dev/null 2>&1; then
+        return
+    fi
+    rm -f ${PID_FILE}
+    return 1
+}
+
+wait_for_status ()
+{
+    counter=$2
+    while [ ${counter} -gt 0 ]; do
+        daemon_status
+        [ $? -eq $1 ] && return
+        let counter=counter-1
+        sleep 1
+    done
+    return 1
+}
 
 
 case $1 in
     start)
-        exit 0
+        if daemon_status; then
+            echo ${DNAME} is already running
+        else
+            echo Starting ${DNAME} ...
+            start_daemon
+        fi
         ;;
     stop)
-        exit 0
+        if daemon_status; then
+            echo Stopping ${DNAME} ...
+            stop_daemon
+        else
+            echo ${DNAME} is not running
+        fi
         ;;
     status)
-        exit 0
+        if daemon_status; then
+            echo ${DNAME} is running
+            exit 0
+        else
+            echo ${DNAME} is not running
+            exit 1
+        fi
         ;;
     log)
-        exit 1
+        echo ${LOG_FILE}
         ;;
     *)
         exit 1

--- a/spk/git/src/installer.sh
+++ b/spk/git/src/installer.sh
@@ -6,7 +6,12 @@ DNAME="Git"
 
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
-
+PID_FILE="${INSTALL_DIR}/var/run/git-daemon.pid"
+LOG_FILE="${INSTALL_DIR}/var/log/git-daemon.log"
+BASE_PATH="${INSTALL_DIR}/var/repositories"
+SSS="/var/packages/${PACKAGE}/scripts/start-stop-status"
+USER="git"
+GROUP="users"
 
 preinst ()
 {
@@ -17,15 +22,38 @@ postinst ()
 {
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
+    ln -s ${SYNOPKG_PKGDEST}/bin/git /usr/bin/
+    ln -s ${SYNOPKG_PKGDEST}/bin/git /usr/bin/git-receive-pack
+    ln -s ${SYNOPKG_PKGDEST}/bin/git-upload-pack /usr/bin/
 
     # Install busybox stuff
     ${INSTALL_DIR}/bin/busybox --install ${INSTALL_DIR}/bin
+
+    # Create user
+    ${INSTALL_DIR}/bin/adduser -h ${BASE_PATH} -g "${DNAME} User" -G ${GROUP} -s /bin/sh -S -D ${USER}
+
+    # Symlink to serve via http
+    mkdir -p ${BASE_PATH}
+    ln -s ${BASE_PATH} /var/services/web/git
+
+    # Correct the files ownership
+    chown -R ${USER}:root ${SYNOPKG_PKGDEST}
+    chmod -R 775 ${SYNOPKG_PKGDEST}
 
     exit 0
 }
 
 preuninst ()
 {
+    # Stop the package
+    ${SSS} stop > /dev/null
+
+    # Remove the user (if not upgrading)
+    if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
+        ${INSTALL_DIR}/bin/delgroup ${USER} ${GROUP}
+        ${INSTALL_DIR}/bin/deluser ${USER}
+    fi
+
     exit 0
 }
 
@@ -33,6 +61,10 @@ postuninst ()
 {
     # Remove link
     rm -f ${INSTALL_DIR}
+    rm -f /usr/bin/git
+    rm -f /usr/bin/git-upload-pack
+    rm -f /usr/bin/git-receive-pack
+    rm -f /var/services/web/git
 
     exit 0
 }


### PR DESCRIPTION
Hello SynoCommunity, 

I needed to have a git server running on port 9418 so I decided to fork spksrc as the original package doesn't wrap git-daemon. I had cloned the repository before the last few commits you have made so I hope I'm not doing it too wrong. It's my first time using the spksrc framework (hats off for putting this together, impressive piece of work !), makefiles, git and github altogether.

The other thing I could see missing are logs. Maybe I got it wrong but git-daemon doen't seem to have a dedicated --log-file option or something similar. It could maybe be done redirecting the output of the command but I ran in some permissions issues trying to do so. The process run as as the git user but the logs are created by root. The --user parameter doesn't seem to work out really well as well permissions wise, when running the server it gets a permission denied trying to get some config from /root/.git/somewhere.

This has been built on a dedicated to cross compiling ebian box I made and it has been tested successfully on cedarview. My DS412+ is happily running as a git server now.

Thanks and regards,
Julien
