### PR TITLE
Update zlib to version 1.2.8

### DIFF
--- a/cross/zlib/Makefile
+++ b/cross/zlib/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = zlib
-PKG_VERS = 1.2.7
+PKG_VERS = 1.2.8
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://zlib.net

--- a/cross/zlib/PLIST
+++ b/cross/zlib/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libz.so
 lnk:lib/libz.so.1
-lib:lib/libz.so.1.2.7
+lib:lib/libz.so.1.2.8


### PR DESCRIPTION
Version 1.2.7 does not seem to be reachable.
Update to the 1.2.8 version.
