### PR TITLE
Update Makefile for libtorrent

### DIFF
--- a/cross/libtorrent/Makefile
+++ b/cross/libtorrent/Makefile
@@ -15,6 +15,7 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --enable-python-binding --with-boost-system=boost_system --with-boost-python=boost_python
 CONFIGURE_ARGS += PYTHON=$(WORK_DIR)/../../../native/python/work-native/install/usr/local/bin/python PYTHON_CPPFLAGS=-I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR)
 ADDITIONAL_CFLAGS = -I$(STAGING_INSTALL_PREFIX)/include/python2.7
+ADDITIONAL_LDFLAGS = "-Wl,-Bsymbolic"
 
 BOOST_LIBRARIES += system python
 ENV += BOOST_LIBRARIES="$(BOOST_LIBRARIES)"


### PR DESCRIPTION
Fix for the -fPIC error:

cc1: warning: command line option "-ftemplate-depth-100" is valid for C++/ObjC++ but not for C
x86_64-linux-gnu-gcc: -lpthread: linker input file unused because linking not done
  CXX      asio_ssl.lo
  CXXLD    libtorrent-rasterbar.la
/root/spksrc/toolchains/syno-cedarview/work/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/4.2.0/../../../../x86_64-linux-gnu/bin/ld: .libs/chained_buffer.o: relocation R_X86_64_PC32 against `boost::function1<void, char*>::clear()' can not be used when making a shared object; recompile with -fPIC
/root/spksrc/toolchains/syno-cedarview/work/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/4.2.0/../../../../x86_64-linux-gnu/bin/ld: final link failed: Bad value
collect2: ld returned 1 exit status

as reported on http://sourceforge.net/mailarchive/message.php?msg_id=30296008
