### PR TITLE
debian-chroot: automatically start services on package activation

### DIFF
--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -55,6 +55,7 @@ debian-chroot_extra_install: $(STAGING_DIR)/share/requirements.pybundle
 	install -m 644 src/app/style.css $(STAGING_DIR)/app/style.css
 	install -m 644 src/app/debian-chroot.js $(STAGING_DIR)/app/debian-chroot.js
 	install -m 755 src/app/setup.py $(STAGING_DIR)/app/setup.py
+	install -m 755 src/app/start.py $(STAGING_DIR)/app/start.py
 	install -m 755 src/app/stop.py $(STAGING_DIR)/app/stop.py
 	install -m 755 src/app/debian-chroot.cgi.py $(STAGING_DIR)/app/debian-chroot.cgi
 	install -m 755 -d $(STAGING_DIR)/app/application

--- a/spk/debian-chroot/src/app/application/direct.py
+++ b/spk/debian-chroot/src/app/application/direct.py
@@ -76,6 +76,12 @@ class Services(Base):
                 while service.status:
                     time.sleep(0.8)
 
+    def start_all(self):
+        for service in self.session.query(Service).all():
+            if not service.status:
+                service.start()
+                while not service.status:
+                    time.sleep(0.8)
 
 class Overview(Base):
     def __init__(self):

--- a/spk/debian-chroot/src/app/start.py
+++ b/spk/debian-chroot/src/app/start.py
@@ -1,0 +1,7 @@
+#!/usr/local/debian-chroot/env/bin/python
+from application.direct import Services
+
+
+if __name__ == '__main__':
+    services = Services()
+    services.start_all()

--- a/spk/debian-chroot/src/dsm-control.sh
+++ b/spk/debian-chroot/src/dsm-control.sh
@@ -19,6 +19,9 @@ start_daemon ()
         grep -q "${CHROOTTARGET}/sys " /proc/mounts || mount -t sysfs sys ${CHROOTTARGET}/sys
         grep -q "${CHROOTTARGET}/dev " /proc/mounts || mount -o bind /dev ${CHROOTTARGET}/dev
         grep -q "${CHROOTTARGET}/dev/pts " /proc/mounts || mount -o bind /dev/pts ${CHROOTTARGET}/dev/pts
+        
+        # Start all services
+        ${INSTALL_DIR}/app/start.py
     fi
 }
 


### PR DESCRIPTION
With this patch the DSM automatically starts every defined service after a manual package activation or a reboot.
