### PR TITLE
Updated broken libpng download path and bumped to 1.5.17

### DIFF
--- a/cross/libpng/Makefile
+++ b/cross/libpng/Makefile
@@ -1,11 +1,11 @@
 PKG_NAME = libpng
-PKG_VERS = 1.5.10
+PKG_VERS = 1.5.17
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.simplesystems.org/pub/libpng/png/src
+PKG_DIST_SITE = ftp://ftp.simplesystems.org/pub/png/src/libpng15
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-DEPENDS =
+DEPENDS = cross/zlib
 
 HOMEPAGE = http://www.libpng.org/pub/png/libpng.html
 COMMENT  = Portable Network Graphics Library
@@ -14,4 +14,3 @@ LICENSE  = http://www.libpng.org/pub/png/src/libpng-LICENSE.txt
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk
-


### PR DESCRIPTION
Looking at the previous ftp path I'm guessing they changed the dir structure. It also looks like they are only putting latest libpng versions in their respective dirs (libpng15,libpng16,etc). As soon as it gets bumped to 1.5.18 this download path will be invalid too. 

Technically it requires zlib, though configure finds it anyway. I noticed some other packages' Makefile that have cross/zlib in DEPENDS that compile fine without it being explicitly set also. So I figure add it to DEPENDS anyway since it technically does and to keep things consistent with other packages.
