### PR TITLE
Fix compile failure due to incorrect detection of sslv2 in openssl

### DIFF
--- a/cross/curl/Makefile
+++ b/cross/curl/Makefile
@@ -15,14 +15,18 @@ GNU_CONFIGURE = 1
 
 CONFIGURE_TARGET = myConfigure
 POST_INSTALL_TARGET = myPostInstall
-
+POST_CONFIGURE_TARGET = myPostConfigure
 
 include ../../mk/spksrc.cross-cc.mk
 
 .PHONY: myConfigure
 myConfigure:
-	$(RUN) ./configure $(REAL_CONFIGURE_ARGS) --disable-HAVE_SSLV2_CLIENT_METHOD CFLAGS= 
+	$(RUN) ./configure $(REAL_CONFIGURE_ARGS) CFLAGS=
 
 .PHONY: myPostInstall
 myPostInstall:
 	sed -i.orig 's#prefix=/#prefix=$(INSTALL_DIR)/#' $(STAGING_INSTALL_PREFIX)/bin/curl-config
+
+.PHONY: myPostConfigure
+myPostConfigure:
+	sed -i.orig 's/D\["HAVE_SSLV2_CLIENT_METHOD"\]/#D\["HAVE_SSLV2_CLIENT_METHOD"\]/' $(WORK_DIR)/$(PKG_DIR)/config.status


### PR DESCRIPTION
Arch: ALL
Build System: 3.2.0-4-686-pae #1 SMP Debian 3.2.46-1 i686 GNU/Linux (Debian Wheezy v7.0)

Trying to build curl fails with:

...
../lib/.libs/libcurl.so -lz -lrt
../lib/.libs/libcurl.so: undefined reference to `SSLv2_client_method'
collect2: error: ld returned 1 exit status
make[3]: *** [curl] Error 1
make[3]: Leaving directory`/opt/spksrc/cross/curl/work/curl-7.30.0/src'
make[2]: **\* [all] Error 2
make[2]: Leaving directory `/opt/spksrc/cross/curl/work/curl-7.30.0/src'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory`/opt/spksrc/cross/curl/work/curl-7.30.0'
make: **\* [compile_target] Error 2

Curl's configure is improperly identifying openssl (default spksrc package/settings) with sslv2 enabled. 
Added  --disable-HAVE_SSLV2_CLIENT_METHOD to override
