### PR TITLE
updating sabnzbd to 0.7.16

### DIFF
--- a/cross/sabnzbd/Makefile
+++ b/cross/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = SABnzbd
-PKG_VERS = 0.7.14
+PKG_VERS = 0.7.16
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-src.$(PKG_EXT)
 PKG_DIST_SITE = http://downloads.sourceforge.net/project/sabnzbdplus/sabnzbdplus/$(PKG_VERS)

--- a/cross/sabnzbd/digests
+++ b/cross/sabnzbd/digests
@@ -1,3 +1,3 @@
-SABnzbd-0.7.14-src.tar.gz SHA1 606fb862a2be7b326921eac9a192468b7ce22fc1
-SABnzbd-0.7.14-src.tar.gz SHA256 b5aefb2911349697db3be86eca815622a2bddb4ab370ed5522b4b0322d45c843
-SABnzbd-0.7.14-src.tar.gz MD5 69421a6d05fde2f69bf69f8b7c1c97e4
+SABnzbd-0.7.16-src.tar.gz SHA1 6b15e7b86e6d1e9aa910b2af9d7a00f08749cb96
+SABnzbd-0.7.16-src.tar.gz SHA256 2c50496c8be81ac4498944a5209b2c6b3bdfecc48cf4e0df54552c5d985e5772
+SABnzbd-0.7.16-src.tar.gz MD5 13f7ff753e22e81fa6f7efab8c3c7213

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sabnzbd
-SPK_VERS = 0.7.14
-SPK_REV = 7
+SPK_VERS = 0.7.16
+SPK_REV = 1
 SPK_ICON = src/sabnzbd.png
 DSM_UI_DIR = app
 


### PR DESCRIPTION
simple version number bump -- 0.7.16 has some queue fixes for "ENCRYPTED" errors
