### PR TITLE
spksrc: Add Firewall/port-forwarding support

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -135,6 +135,7 @@ ifneq ($(strip $(SSS_SCRIPT)),)
 DSM_SCRIPTS_ += start-stop-status
 endif
 DSM_SCRIPTS_ += installer
+DSM_SCRIPTS_ += $(notdir $(FWPORTS))
 DSM_SCRIPTS_ += $(notdir $(basename $(ADDITIONAL_SCRIPTS)))
 
 DSM_SCRIPTS = $(addprefix $(DSM_SCRIPTS_DIR)/,$(DSM_SCRIPTS_))
@@ -172,7 +173,9 @@ $(DSM_SCRIPTS_DIR)/start-stop-status: $(SSS_SCRIPT)
 	@$(dsm_script_copy)
 $(DSM_SCRIPTS_DIR)/installer: $(INSTALLER_SCRIPT)
 	@$(dsm_script_copy)
-$(DSM_SCRIPTS_DIR)/%: $(filter %.sh,$(ADDITIONAL_SCRIPTS)) 
+$(DSM_SCRIPTS_DIR)/%: $(filter %.sc,$(FWPORTS))
+	@$(dsm_script_copy)	
+$(DSM_SCRIPTS_DIR)/%: $(filter %.sh,$(ADDITIONAL_SCRIPTS))
 	@$(dsm_script_copy)
 
 


### PR DESCRIPTION
Proposal for adding firewall support into spksrc.
See "Install Package Related Ports Information into DSM" of Synology Developers Guide for background and more info on .sc-file contents.

Usage:
Makefile
Add `FWPORTS = src/${SPK_NAME}.sc`

Installer.sh
Add var `FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"`
Add var `SERVICETOOL="/usr/syno/bin/servicetool"`
In postinst (), add:
`# Add port-forwarding config
${SERVICETOOL} --install-configure-file --package ${FWPORTS}`
In preuninst (), add:
`# Remove port-forwarding config
if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
    ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc
fi'`
