### PR TITLE
Correct PKG_DIST_SITE link for berkeleydb

### DIFF
--- a/cross/berkeleydb/Makefile
+++ b/cross/berkeleydb/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = db
 PKG_VERS = 5.3.28
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/downloads/SynoCommunity/spksrc
+PKG_DIST_SITE = http://www.oracle.com/technetwork/products/berkeleydb/overview/index.htm
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 SRC_DIR = build_unix
 


### PR DESCRIPTION
As we show the URL in the error message, we might as well correct the link.
