### PR TITLE
Add support for building erlang on cedarview

### DIFF
--- a/cross/erlang/Makefile
+++ b/cross/erlang/Makefile
@@ -5,7 +5,7 @@ PKG_DIST_NAME = otp_src_$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.erlang.org/download/
 PKG_DIR = otp_src_$(PKG_VERS)
 
-DEPENDS = native/$(PKG_NAME) cross/ncurses cross/openssl
+DEPENDS = native/$(PKG_NAME) cross/ncurses cross/openssl cross/libatomic_ops
 
 HOMEPAGE = http://www.erlang.org
 COMMENT  = Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability.
@@ -15,6 +15,10 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS += --with-ssl=$(STAGING_INSTALL_PREFIX) erl_xcomp_sysroot=$(INSTALL_DIR)
 ifeq ($(findstring $(ARCH),88f5281 88f6281),$(ARCH))
 CONFIGURE_ARGS += --disable-smp-require-native-atomics
+endif
+
+ifeq ($(findstring $(ARCH),cedarview),$(ARCH))
+CONFIGURE_ARGS += --with-libatomic_ops
 endif
 
 INSTALL_TARGET = myInstall

--- a/cross/libatomic_ops/Makefile
+++ b/cross/libatomic_ops/Makefile
@@ -1,0 +1,14 @@
+PKG_NAME = libatomic_ops
+PKG_VERS = 7.4.0
+PKG_EXT = tar.gz
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = http://www.ivmaisoft.com/atomic_ops/download/
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+HOMEPAGE = https://github.com/ivmai/libatomic_ops/
+COMMENT  = Atomic memory update operations portable implementation
+LICENSE  = https://github.com/ivmai/libatomic_ops/blob/master/doc/LICENSING.txt
+
+GNU_CONFIGURE = 1
+
+include ../../mk/spksrc.cross-cc.mk

--- a/cross/libatomic_ops/PLIST
+++ b/cross/libatomic_ops/PLIST
@@ -1,0 +1,2 @@
+lib:lib/libatomic_ops.a
+lib:lib/libatomic_ops_gpl.a

--- a/cross/libatomic_ops/digests
+++ b/cross/libatomic_ops/digests
@@ -1,0 +1,3 @@
+libatomic_ops-7.4.0.tar.gz SHA1 3397c2b2a02be3c27af6ed603332e81464447653
+libatomic_ops-7.4.0.tar.gz SHA256 2875ccc29254d3375dab9c5930c42df342f148f8cd7c646621dbf03f8c1d5b5a
+libatomic_ops-7.4.0.tar.gz MD5 59f9a7cc845dcc775e7b7901eb582766


### PR DESCRIPTION
Erlang R16 needs some atomic operations that do not appear to be available in the cedarview toolchain.  The suggested solution to the missing operations is to use libatomic_ops (http://www.erlang.org/doc/installation_guide/INSTALL.html)
