### PR TITLE
Transmission updates

### DIFF
--- a/spk/transmission/src/dsm-control.sh
+++ b/spk/transmission/src/dsm-control.sh
@@ -6,7 +6,7 @@ DNAME="Transmission"
 
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
-PATH="${INSTALL_DIR}/bin:/usr/local/bin:/bin:/usr/bin:/usr/syno/bin"
+PATH="${INSTALL_DIR}/bin:${PATH}"
 USER="transmission"
 TRANSMISSION="${INSTALL_DIR}/bin/transmission-daemon"
 PID_FILE="${INSTALL_DIR}/var/transmission.pid"

--- a/spk/transmission/src/installer.sh
+++ b/spk/transmission/src/installer.sh
@@ -7,7 +7,7 @@ DNAME="Transmission"
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
 SSS="/var/packages/${PACKAGE}/scripts/start-stop-status"
-PATH="${INSTALL_DIR}/bin:/usr/local/bin:/bin:/usr/bin:/usr/syno/bin"
+PATH="${INSTALL_DIR}/bin:${PATH}"
 USER="transmission"
 GROUP="users"
 CFG_FILE="${INSTALL_DIR}/var/settings.json"
@@ -16,6 +16,12 @@ TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
 preinst ()
 {
+    if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
+        if [ ! -d "${wizard_download_dir}" ]; then
+            echo "Download folder ${wizard_download_dir} does not exist."
+            exit 1
+        fi
+    fi
     exit 0
 }
 
@@ -40,6 +46,13 @@ postinst ()
     else
         sed -i -e "s|@watch_dir_enabled@|false|g" ${CFG_FILE}
         sed -i -e "/@watch_dir@/d" ${CFG_FILE}
+    fi
+    if [ -d "${wizard_incomplete_dir}" ]; then
+        sed -i -e "s|@incomplete_dir_enabled@|true|g" ${CFG_FILE}
+        sed -i -e "s|@incomplete_dir@|${wizard_incomplete_dir}|g" ${CFG_FILE}
+    else
+        sed -i -e "s|@incomplete_dir_enabled@|false|g" ${CFG_FILE}
+        sed -i -e "/@incomplete_dir@/d" ${CFG_FILE}
     fi
 
     # Correct the files ownership

--- a/spk/transmission/src/settings.json
+++ b/spk/transmission/src/settings.json
@@ -1,5 +1,7 @@
 {
     "download-dir": "@download_dir@",
+    "incomplete-dir": "@incomplete_dir@", 
+    "incomplete-dir-enabled": @incomplete_dir_enabled@,
     "rpc-authentication-required": true,
     "rpc-username": "@username@",
     "rpc-password": "@password@",

--- a/spk/transmission/src/wizard/install_uifile
+++ b/spk/transmission/src/wizard/install_uifile
@@ -5,7 +5,8 @@
         "desc": "Download directory. Defaults to /volume1/downloads",
         "subitems": [{
             "key": "wizard_download_dir",
-            "desc": "Download directory"
+            "desc": "Download directory",
+            "defaultValue": "/volume1/downloads"
         }]
     }, {
         "type": "textfield",
@@ -13,6 +14,13 @@
         "subitems": [{
             "key": "wizard_watch_dir",
             "desc": "Watch directory"
+        }]
+    }, {
+        "type": "textfield",
+        "desc": "Directory to keep files in until torrent is complete. Leave empty to disable",
+        "subitems": [{
+            "key": "wizard_incomplete_dir",
+            "desc": "Incomplete directory"
         }]
     }]
 }, {

--- a/spk/transmission/src/wizard/install_uifile_enu
+++ b/spk/transmission/src/wizard/install_uifile_enu
@@ -5,7 +5,8 @@
         "desc": "Download directory. Defaults to /volume1/downloads",
         "subitems": [{
             "key": "wizard_download_dir",
-            "desc": "Download directory"
+            "desc": "Download directory",
+            "defaultValue": "/volume1/downloads"
         }]
     }, {
         "type": "textfield",
@@ -13,6 +14,13 @@
         "subitems": [{
             "key": "wizard_watch_dir",
             "desc": "Watch directory"
+        }]
+    }, {
+        "type": "textfield",
+        "desc": "Directory to keep files in until torrent is complete. Leave empty to disable",
+        "subitems": [{
+            "key": "wizard_incomplete_dir",
+            "desc": "Incomplete directory"
         }]
     }]
 }, {

--- a/spk/transmission/src/wizard/install_uifile_fre
+++ b/spk/transmission/src/wizard/install_uifile_fre
@@ -5,7 +5,8 @@
         "desc": "Répertoire de téléchargement. /volume1/downloads par défaut",
         "subitems": [{
             "key": "wizard_download_dir",
-            "desc": "Répertoire de téléchargement"
+            "desc": "Répertoire de téléchargement",
+            "defaultValue": "/volume1/downloads"
         }]
     }, {
         "type": "textfield",
@@ -13,6 +14,13 @@
         "subitems": [{
             "key": "wizard_watch_dir",
             "desc": "Répertoire surveillé"
+        }]
+    }, {
+        "type": "textfield",
+        "desc": "Directory to keep files in until torrent is complete. Leave empty to disable",
+        "subitems": [{
+            "key": "wizard_incomplete_dir",
+            "desc": "Incomplete directory"
         }]
     }]
 }, {


### PR DESCRIPTION
- Add Incomplete dir option to wizard
- Check if download folder exists on install

Note: if the incomplete dir does not exist on install, it will be disabled (same as with watchfolder)

Btw, this needs a french translation for the wizard before merging.
