### PR TITLE
Fix Bison 2.5 compilation with DSM5 toolchain

### DIFF
--- a/cross/bison/patches/gets.patch
+++ b/cross/bison/patches/gets.patch
@@ -1,0 +1,13 @@
+--- lib/stdio.in.h_org	2014-04-26 01:24:51.806205276 +0200
++++ lib/stdio.in.h	2014-04-26 01:24:37.058176287 +0200
+@@ -180,8 +180,10 @@
+ /* It is very rare that the developer ever has full control of stdin,
+    so any use of gets warrants an unconditional warning.  Assume it is
+    always declared, since it is required by C89.  */
++#if defined gets
+ #undef gets
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
++#endif
+ 
+ #if @GNULIB_FOPEN@
+ # if @REPLACE_FOPEN@


### PR DESCRIPTION
Patch to get Bison to cross compile with the DSM5 toolchains. The compile error only affects x86 arches, but non-x86 doesn't complain when the patch is applied.
Needed with #865.
