### PR TITLE
spksrc: Add mercurial/hg download method

### DIFF
--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -96,6 +96,30 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	        ln -s $${localFile} $${localHead} ; \
 	      fi ; \
 	      ;; \
+	    hg) \
+	      if [ "$(PKG_HG_REV)" = "tip" ]; then \
+	        rev=`hg identify -r "tip" $${url}` ; \
+	      else \
+	        rev=$(PKG_HG_REV) ; \
+	      fi ; \
+	      localFolder=$(NAME)-r$${rev} ; \
+	      localFile=$${localFolder}.tar.gz ; \
+	      localTip=$(NAME)-rtip.tar.gz ; \
+	      if [ ! -f $${localFile} ]; then \
+	        rm -fr $${localFolder}.part ; \
+	        echo "hg clone -r $${rev} $${url}" ; \
+	        hg clone -r $${rev} $${url} $${localFolder}.part ; \
+	        mv $${localFolder}.part $${localFolder} ; \
+	        tar --exclude-vcs -czf $${localFile} $${localFolder} ; \
+	        rm -fr $${localFolder} ; \
+	      else \
+	        $(MSG) "  File $${localFile} already downloaded" ; \
+	      fi ; \
+	      if [ "$(PKG_HG_REV)" = "tip" ]; then \
+	        rm -f $${localTip} ; \
+	        ln -s $${localFile} $${localTip} ; \
+	      fi ; \
+	      ;; \
 	    *) \
 	      localFile=$(PKG_DIST_FILE) ; \
 	      if [ -z "$${localFile}" ]; then \


### PR DESCRIPTION
Adds mercurial/hg download method to spksrc.

Example syntax:
PKG_NAME = syncserver
PKG_VERS = 1.0
PKG_EXT = tar.gz
PKG_DOWNLOAD_METHOD = hg
PKG_HG_REV = tip || ba4bf783018f || rpm-1.0-9   #supported: tip, revision id, tags
PKG_DIST_NAME = server-full
PKG_DIST_SITE = http://hg.mozilla.org/services
PKG_DIST_FILE = $(PKG_NAME)-r$(PKG_HG_REV).$(PKG_EXT)
PKG_DIR = $(PKG_NAME)-r*
