### PR TITLE
Update oscam/dsm-control.sh

### DIFF
--- a/spk/oscam/src/dsm-control.sh
+++ b/spk/oscam/src/dsm-control.sh
@@ -16,7 +16,7 @@ start_daemon ()
 {
     su - ${RUNAS} -c "${OSCAM} -b -c ${INSTALL_DIR}/var"
     sleep 1
-    pidof -s oscam > ${PID_FILE}
+    pidof oscam | awk '{print $1}' > ${PID_FILE}
 }
 
 stop_daemon ()


### PR DESCRIPTION
pidof -s is no longer supported in DSM5.