### PR TITLE
Add minimum firmware flag to Python SPK

### DIFF
--- a/spk/python/Makefile
+++ b/spk/python/Makefile
@@ -9,7 +9,7 @@ DEPENDS += cross/setuptools cross/distutils2 cross/pip cross/virtualenv cross/py
 DEPENDS += cross/pycrypto cross/pycurl cross/pil cross/cheetah cross/yenc
 DEPENDS += cross/sqlalchemy cross/pyaudio cross/pyalsa cross/lxml cross/twisted
 DEPENDS += cross/zope.interface cross/markupsafe cross/sphinxbase cross/pocketsphinx
-DEPENDS += cross/wheel cross/duplicity cross/mercurial cross/scrypt
+DEPENDS += cross/wheel cross/mercurial cross/scrypt
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Python Programming Language.
@@ -19,6 +19,8 @@ RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python
 CHANGELOG = "1. Update modules\n2. Add bsddb and duplicity modules\n3. Add mercurial and scrypt modules"
+BETA = 1
+FIRMWARE = 5.0-4418
 
 HOMEPAGE   = http://www.python.org/
 LICENSE    =


### PR DESCRIPTION
Using the DSM5 toolchains, the Python SPK does not work with older DSM versions. Added a minimum firmware version (DSM5 beta), to indicate this during installation of the SPK.

Other packages might be affected, although it'll need to be tested (haven't started that). 

For people who want to stay on DSM4.x for whatever reason, we could offer an unmaintained DSM4 version in the package repo or on the site as direct download.
