### PR TITLE
Vim: Fix FRE description + add CSY description

### DIFF
--- a/spk/vim/Makefile
+++ b/spk/vim/Makefile
@@ -7,7 +7,7 @@ DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Vim is an advanced text editor that seeks to provide the power of the de-facto Unix editor Vi, with a more complete feature set.
-DESCRIPTION_CSY= Vim je pokročilý textový editor, který usiluje o to poskytnout sílu de-facto Unixového editoru Vi, s komplexnější sadou vlastností.
+DESCRIPTION_CSY = Vim je pokročilý textový editor, který usiluje o to poskytnout sílu de-facto Unixového editoru Vi, s komplexnější sadou vlastností.
 DESCRIPTION_FRE = Vim est un éditeur de texte avancé basé sur Vi \\\(unix\\\) avec des fonctions plus complètes.
 RELOAD_UI = no
 DISPLAY_NAME = Vim


### PR DESCRIPTION
In Makefile:
    - Backslash parentheses in FRE description to avoid their evaluation:
        <code>/bin/sh: 1: Syntax error: "(" unexpected</code>
    - Add CSY description
