### PR TITLE
Vim: src/*.sh scripts fix + enhancements

### DIFF
--- a/spk/vim/src/dsm-control.sh
+++ b/spk/vim/src/dsm-control.sh
@@ -13,10 +13,14 @@ case $1 in
         exit 0
         ;;
     status)
-        exit 1
+	if [ -e /usr/local/bin/vim ]; then
+		exit 0
+	else
+		exit 150
+	fi
         ;;
     log)
-        exit 1
+        exit 0
         ;;
     *)
         exit 1

--- a/spk/vim/src/installer.sh
+++ b/spk/vim/src/installer.sh
@@ -18,9 +18,17 @@ postinst ()
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
     
-    # Put mc in the PATH
+    # Put vim in the PATH
     mkdir -p /usr/local/bin
     ln -s ${INSTALL_DIR}/bin/vim-utf8 /usr/local/bin/vim
+    ln -s ${INSTALL_DIR}/bin/vimdiff /usr/local/bin/vimdiff
+    #
+    if [ -L /bin/vi ]; then
+        if [ "$(ls -l /bin/vi | grep busybox)" ]; then
+            rm -f /bin/vi
+            ln -s ${INSTALL_DIR}/bin/vim-utf8 /bin/vi
+        fi
+    fi
 
     exit 0
 }
@@ -35,6 +43,14 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
     rm -f /usr/local/bin/vim
+    rm -f /usr/local/bin/vimdiff
+    #
+    if [ -L /bin/vi ]; then
+        if [ "$(ls -l /bin/vi | grep vim-utf8)" ]; then
+            rm -f /bin/vi
+            ln -s busybox /bin/vi
+        fi
+    fi
 
     exit 0
 }


### PR DESCRIPTION
src/dsm-control.sh:
    - Add simple check for "status" + appropriate return codes
    - Fix "log" return code to non-error state

src/installer.sh:
    - Add "vimdiff" symlink into /usr/local/bin
    - Alter /bin/vi symlink from "busybox" to "vim-utf8" when Vim package is installed
