### PR TITLE
libjpeg: force HAVE_BOOLEAN

### DIFF
--- a/cross/libjpeg/patches/have-boolean.patch
+++ b/cross/libjpeg/patches/have-boolean.patch
@@ -1,0 +1,11 @@
+--- jconfig.cfg	2010-04-29 14:42:58.000000000 +0200
++++ jconfig.cfg	2014-05-15 00:32:13.000000000 +0200
+@@ -51,3 +51,8 @@
+ #undef PROGRESS_REPORT
+ 
+ #endif /* JPEG_CJPEG_DJPEG */
++
++/* At least libpng and libtiff have TRUE,FALSE defined as constant */
++typedef int boolean;
++#define HAVE_BOOLEAN
++


### PR DESCRIPTION
to avoid conflicts like:
.../spksrc/cross/leptonica/work-evansport/install//usr/local/include/jmorecfg.h:263:16: error: expected identifier before numeric constant
make[5]: **\* [tif_jpeg.lo] Error 1

Because in other libraries (libtiff and giflib in my case) is TRUE,FALSE defined as constants.
Using HAVE_BOOLEAN forces libjpeg to use it as constants too.

P.S.: I'm not really sure if it is a clean solution, but I don't know how to do better. So this is something between "pull request" and "issue".
