### PR TITLE
Add firewall config to packages

### DIFF
--- a/spk/bitlbee/Makefile
+++ b/spk/bitlbee/Makefile
@@ -18,7 +18,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/bitlbee/src/bitlbee.sc
+++ b/spk/bitlbee/src/bitlbee.sc
@@ -1,0 +1,6 @@
+[bitlbee]
+title="BitlBee"
+desc="BitlBee"
+port_forward="yes"
+dst.ports="6667/tcp"
+

--- a/spk/bitlbee/src/installer.sh
+++ b/spk/bitlbee/src/installer.sh
@@ -14,6 +14,8 @@ BITLBEE="${INSTALL_DIR}/sbin/bitlbee"
 CFG_FILE="${INSTALL_DIR}/var/bitlbee.conf"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -38,6 +40,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -50,6 +55,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/btsync/Makefile
+++ b/spk/btsync/Makefile
@@ -20,6 +20,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/btsync/src/btsync.sc
+++ b/spk/btsync/src/btsync.sc
@@ -1,0 +1,6 @@
+[btsync]
+title="BitTorrent Sync"
+desc="BitTorrent Sync"
+port_forward="yes"
+dst.ports="8888/tcp,3838/udp"
+

--- a/spk/btsync/src/installer.sh
+++ b/spk/btsync/src/installer.sh
@@ -13,6 +13,8 @@ GROUP="users"
 CFG_FILE="${INSTALL_DIR}/var/sync.conf"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -39,6 +41,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -51,6 +56,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/couchpotatoserver-custom/Makefile
+++ b/spk/couchpotatoserver-custom/Makefile
@@ -22,6 +22,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/couchpotatoserver-custom/src/couchpotatoserver-custom.sc
+++ b/spk/couchpotatoserver-custom/src/couchpotatoserver-custom.sc
@@ -1,0 +1,6 @@
+[couchpotato-custom]
+title="CouchPotato Custom"
+desc="CouchPotato Custom"
+port_forward="yes"
+dst.ports="5050/tcp"
+

--- a/spk/couchpotatoserver-custom/src/installer.sh
+++ b/spk/couchpotatoserver-custom/src/installer.sh
@@ -16,6 +16,8 @@ GIT="${GIT_DIR}/bin/git"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -45,6 +47,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -57,6 +62,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/couchpotatoserver/Makefile
+++ b/spk/couchpotatoserver/Makefile
@@ -24,6 +24,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/couchpotatoserver/src/couchpotatoserver.sc
+++ b/spk/couchpotatoserver/src/couchpotatoserver.sc
@@ -1,0 +1,6 @@
+[couchpotato]
+title="CouchPotato"
+desc="CouchPotato"
+port_forward="yes"
+dst.ports="5050/tcp"
+

--- a/spk/couchpotatoserver/src/installer.sh
+++ b/spk/couchpotatoserver/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="users"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -34,6 +36,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -46,6 +51,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -20,6 +20,7 @@ LICENSE    = GPL
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/deluge/src/deluge.sc
+++ b/spk/deluge/src/deluge.sc
@@ -1,0 +1,6 @@
+[deluge]
+title="Deluge"
+desc="Deluge"
+port_forward="yes"
+dst.ports="8112/tcp"
+

--- a/spk/deluge/src/installer.sh
+++ b/spk/deluge/src/installer.sh
@@ -15,6 +15,8 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 CFG_FILE="${INSTALL_DIR}/var/config.ini"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -48,6 +50,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -60,6 +65,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/ejabberd/Makefile
+++ b/spk/ejabberd/Makefile
@@ -21,6 +21,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/ejabberd/src/ejabberd.sc
+++ b/spk/ejabberd/src/ejabberd.sc
@@ -1,0 +1,6 @@
+[ejabberd]
+title="ejabberd"
+desc="ejabberd"
+port_forward="yes"
+dst.ports="5280/tcp"
+

--- a/spk/ejabberd/src/installer.sh
+++ b/spk/ejabberd/src/installer.sh
@@ -11,6 +11,8 @@ PATH="${INSTALL_DIR}/bin:${INSTALL_DIR}/usr/bin:${PATH}"
 USER="ejabberd"
 GROUP="users"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -41,6 +43,9 @@ postinst ()
         ${SSS} stop > /dev/null
     fi
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -53,6 +58,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/flexget/Makefile
+++ b/spk/flexget/Makefile
@@ -19,6 +19,7 @@ LICENSE    = GPL
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/flexget/src/flexget.sc
+++ b/spk/flexget/src/flexget.sc
@@ -1,0 +1,6 @@
+[flexget]
+title="FlexGet"
+desc="FlexGet"
+port_forward="yes"
+dst.ports="8290/tcp"
+

--- a/spk/flexget/src/installer.sh
+++ b/spk/flexget/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="users"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -38,6 +40,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -50,6 +55,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -21,6 +21,7 @@ LICENSE    = AGPLv3
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/gateone/src/gateone.sc
+++ b/spk/gateone/src/gateone.sc
@@ -1,0 +1,6 @@
+[gateone]
+title="GateOne"
+desc="GateOne"
+port_forward="yes"
+dst.ports="8271/tcp"
+

--- a/spk/gateone/src/installer.sh
+++ b/spk/gateone/src/installer.sh
@@ -15,6 +15,8 @@ PYTHON="${INSTALL_DIR}/env/bin/python"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -44,6 +46,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -56,6 +61,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -22,6 +22,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/haproxy/src/haproxy.sc
+++ b/spk/haproxy/src/haproxy.sc
@@ -1,0 +1,6 @@
+[haproxy]
+title="HAProxy"
+desc="HAProxy"
+port_forward="yes"
+dst.ports="8280/tcp"
+

--- a/spk/haproxy/src/installer.sh
+++ b/spk/haproxy/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="nobody"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -44,6 +46,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -56,6 +61,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/headphones-custom/Makefile
+++ b/spk/headphones-custom/Makefile
@@ -23,6 +23,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/headphones-custom/src/headphones-custom.sc
+++ b/spk/headphones-custom/src/headphones-custom.sc
@@ -1,0 +1,6 @@
+[headphones-custom]
+title="Headphones Custom"
+desc="Headphones Custom"
+port_forward="yes"
+dst.ports="8182/tcp"
+

--- a/spk/headphones-custom/src/installer.sh
+++ b/spk/headphones-custom/src/installer.sh
@@ -16,6 +16,8 @@ GIT="${GIT_DIR}/bin/git"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -45,6 +47,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -57,6 +62,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/headphones/Makefile
+++ b/spk/headphones/Makefile
@@ -21,6 +21,7 @@ LICENSE    =
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/headphones/src/headphones.sc
+++ b/spk/headphones/src/headphones.sc
@@ -1,0 +1,6 @@
+[headphones]
+title="Headphones"
+desc="Headphones"
+port_forward="yes"
+dst.ports="8181/tcp"
+

--- a/spk/headphones/src/installer.sh
+++ b/spk/headphones/src/installer.sh
@@ -15,6 +15,8 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 CFG_FILE="${INSTALL_DIR}/var/config.ini"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -35,6 +37,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -47,6 +52,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/htpcmanager/Makefile
+++ b/spk/htpcmanager/Makefile
@@ -18,6 +18,7 @@ HOMEPAGE   = http://htpc.io
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 COPY_TARGET = nop

--- a/spk/htpcmanager/src/htpcmanager.sc
+++ b/spk/htpcmanager/src/htpcmanager.sc
@@ -1,0 +1,6 @@
+[htpcmanager]
+title="HTPC-Manager"
+desc="HTPC-Manager"
+port_forward="yes"
+dst.ports="8087/tcp"
+

--- a/spk/htpcmanager/src/installer.sh
+++ b/spk/htpcmanager/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="users"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -34,6 +36,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -46,6 +51,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/lazylibrarian/Makefile
+++ b/spk/lazylibrarian/Makefile
@@ -20,6 +20,7 @@ LICENSE    =
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/lazylibrarian/src/installer.sh
+++ b/spk/lazylibrarian/src/installer.sh
@@ -15,6 +15,8 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 CFG_FILE="${INSTALL_DIR}/var/config.ini"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -35,6 +37,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -47,6 +52,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/lazylibrarian/src/lazylibrarian.sc
+++ b/spk/lazylibrarian/src/lazylibrarian.sc
@@ -1,0 +1,6 @@
+[lazylibrarian]
+title="LazyLibrarian"
+desc="LazyLibrarian"
+port_forward="yes"
+dst.ports="8082/tcp"
+

--- a/spk/maraschino/Makefile
+++ b/spk/maraschino/Makefile
@@ -19,6 +19,7 @@ LICENSE    = GPL
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/maraschino/src/installer.sh
+++ b/spk/maraschino/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="nobody"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -34,6 +36,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -46,6 +51,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/maraschino/src/maraschino.sc
+++ b/spk/maraschino/src/maraschino.sc
@@ -1,0 +1,6 @@
+[maraschino]
+title="Maraschino"
+desc="Maraschino"
+port_forward="yes"
+dst.ports="8260/tcp"
+

--- a/spk/museek-plus/Makefile
+++ b/spk/museek-plus/Makefile
@@ -19,7 +19,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/museek-plus/src/installer.sh
+++ b/spk/museek-plus/src/installer.sh
@@ -12,6 +12,8 @@ USER="root"
 CFG_FILE="${INSTALL_DIR}/var/config.xml"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -34,6 +36,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -41,6 +46,11 @@ preuninst ()
 {
     # Stop the package
     ${SSS} stop > /dev/null
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
+    fi
 
     exit 0
 }

--- a/spk/museek-plus/src/museek-plus.sc
+++ b/spk/museek-plus/src/museek-plus.sc
@@ -1,0 +1,6 @@
+[museek-plus]
+title="Museek+"
+desc="Museek+"
+port_forward="yes"
+dst.ports="2240,2242/tcp"
+

--- a/spk/mylar/Makefile
+++ b/spk/mylar/Makefile
@@ -19,6 +19,7 @@ LICENSE    =
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/mylar/src/installer.sh
+++ b/spk/mylar/src/installer.sh
@@ -15,6 +15,8 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 CFG_FILE="${INSTALL_DIR}/var/config.ini"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -35,6 +37,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -47,6 +52,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/mylar/src/mylar.sc
+++ b/spk/mylar/src/mylar.sc
@@ -1,0 +1,6 @@
+[mylar]
+title="Mylar"
+desc="Mylar"
+port_forward="yes"
+dst.ports="8090/tcp"
+

--- a/spk/nzbget-testing/Makefile
+++ b/spk/nzbget-testing/Makefile
@@ -23,6 +23,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/nzbget-testing/src/installer.sh
+++ b/spk/nzbget-testing/src/installer.sh
@@ -13,6 +13,8 @@ GROUP="users"
 CFG_FILE="${INSTALL_DIR}/var/nzbget.conf"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -46,6 +48,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -58,6 +63,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/nzbget-testing/src/nzbget-testing.sc
+++ b/spk/nzbget-testing/src/nzbget-testing.sc
@@ -1,0 +1,6 @@
+[nzbget-testing]
+title="NZBGet Testing"
+desc="NZBGet Testing"
+port_forward="yes"
+dst.ports="9876/tcp"
+

--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -22,6 +22,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/nzbget/src/installer.sh
+++ b/spk/nzbget/src/installer.sh
@@ -13,6 +13,8 @@ GROUP="users"
 CFG_FILE="${INSTALL_DIR}/var/nzbget.conf"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -46,6 +48,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -58,6 +63,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/nzbget/src/nzbget.sc
+++ b/spk/nzbget/src/nzbget.sc
@@ -1,0 +1,6 @@
+[nzbget]
+title="NZBGet"
+desc="NZBGet"
+port_forward="yes"
+dst.ports="6789/tcp"
+

--- a/spk/nzbmegasearch/Makefile
+++ b/spk/nzbmegasearch/Makefile
@@ -19,6 +19,7 @@ LICENSE    = GPLv2
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/nzbmegasearch/src/installer.sh
+++ b/spk/nzbmegasearch/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="users"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -34,6 +36,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -46,6 +51,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/nzbmegasearch/src/nzbmegasearch.sc
+++ b/spk/nzbmegasearch/src/nzbmegasearch.sc
@@ -1,0 +1,6 @@
+[nzbmegasearch]
+title="NZBmegasearcH"
+desc="NZBmegasearcH"
+port_forward="yes"
+dst.ports="8086/tcp"
+

--- a/spk/oscam/Makefile
+++ b/spk/oscam/Makefile
@@ -18,7 +18,7 @@ LICENSE  =
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/oscam/src/installer.sh
+++ b/spk/oscam/src/installer.sh
@@ -10,6 +10,8 @@ PATH="${INSTALL_DIR}/bin:/usr/local/bin:/bin:/usr/bin:/usr/syno/bin"
 RUNAS="root"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -27,11 +29,20 @@ postinst ()
     # Correct the files ownership
     chown -R ${RUNAS}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
 preuninst ()
 {
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
+    fi
+
     exit 0
 }
 

--- a/spk/oscam/src/oscam.sc
+++ b/spk/oscam/src/oscam.sc
@@ -1,0 +1,6 @@
+[oscam]
+title="OSCam"
+desc="OSCam"
+port_forward="yes"
+dst.ports="83/tcp"
+

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -22,6 +22,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_DEP_SERVICES = apache-web
 START_DEP_SERVICES = apache-web

--- a/spk/rutorrent/src/installer.sh
+++ b/spk/rutorrent/src/installer.sh
@@ -15,6 +15,8 @@ GROUP="users"
 APACHE_USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -76,6 +78,9 @@ postinst ()
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
     chown -R ${APACHE_USER} ${WEB_DIR}/${PACKAGE}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -88,6 +93,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/rutorrent/src/rutorrent.sc
+++ b/spk/rutorrent/src/rutorrent.sc
@@ -1,0 +1,6 @@
+[rutorrent]
+title="ruTorrent"
+desc="ruTorrent"
+port_forward="yes"
+dst.ports="8050/tcp"
+

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -24,6 +24,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/sabnzbd/src/installer.sh
+++ b/spk/sabnzbd/src/installer.sh
@@ -15,6 +15,8 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 CFG_FILE="${INSTALL_DIR}/var/config.ini"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -59,6 +61,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -71,6 +76,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/sabnzbd/src/sabnzbd.sc
+++ b/spk/sabnzbd/src/sabnzbd.sc
@@ -1,0 +1,6 @@
+[sabnzbd]
+title="SABnzbd"
+desc="SABnzbd"
+port_forward="yes"
+dst.ports="8080/tcp"
+

--- a/spk/sickbeard-custom/Makefile
+++ b/spk/sickbeard-custom/Makefile
@@ -22,6 +22,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/sickbeard-custom/src/installer.sh
+++ b/spk/sickbeard-custom/src/installer.sh
@@ -16,6 +16,8 @@ GIT="${GIT_DIR}/bin/git"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -48,6 +50,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -60,6 +65,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/sickbeard-custom/src/sickbeard-custom.sc
+++ b/spk/sickbeard-custom/src/sickbeard-custom.sc
@@ -1,0 +1,6 @@
+[sickbeard-custom]
+title="SickBeard Custom"
+desc="SickBeard Custom"
+port_forward="yes"
+dst.ports="8083/tcp"
+

--- a/spk/sickbeard/Makefile
+++ b/spk/sickbeard/Makefile
@@ -20,6 +20,7 @@ LICENSE    = GPL
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/sickbeard/src/installer.sh
+++ b/spk/sickbeard/src/installer.sh
@@ -15,6 +15,8 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 CFG_FILE="${INSTALL_DIR}/var/config.ini"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -35,6 +37,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -47,6 +52,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/sickbeard/src/sickbeard.sc
+++ b/spk/sickbeard/src/sickbeard.sc
@@ -1,0 +1,6 @@
+[sickbeard]
+title="SickBeard"
+desc="SickBeard"
+port_forward="yes"
+dst.ports="8081/tcp"
+

--- a/spk/squidguard/Makefile
+++ b/spk/squidguard/Makefile
@@ -19,7 +19,7 @@ LICENSE    = GNU PL - Copyright © 1990,2007 Oracle.  All rights reserved for be
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS = 
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 POST_STRIP_TARGET = xz-compress

--- a/spk/squidguard/src/installer.sh
+++ b/spk/squidguard/src/installer.sh
@@ -15,6 +15,9 @@ WWW_DIR="/var/packages/${PACKAGE}/target/share/www/squidguardmgr"
 WEBMAN_DIR="/usr/syno/synoman/webman/3rdparty"
 SQUID_WRAPPER="${WWW_DIR}/squid_wrapper"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
+
 preinst ()
 {
     exit 0
@@ -55,12 +58,21 @@ postinst ()
         sleep 1
         /usr/syno/etc/rc.d/S04crond.sh start
     fi
-    
+
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
 preuninst ()
 {
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
+    fi
+
     exit 0
 }
 

--- a/spk/squidguard/src/squidguard.sc
+++ b/spk/squidguard/src/squidguard.sc
@@ -1,0 +1,6 @@
+[squidguard]
+title="SquidGuard"
+desc="SquidGuard"
+port_forward="yes"
+dst.ports="563,3128/tcp"
+

--- a/spk/syncserver/src/syncserver.sc
+++ b/spk/syncserver/src/syncserver.sc
@@ -3,3 +3,5 @@ title="Firefox Sync Server (8130)"
 desc="Firefox Sync Server"
 port_forward="yes"
 dst.ports="8130/tcp"
+
+

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -22,7 +22,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/transmission/src/installer.sh
+++ b/spk/transmission/src/installer.sh
@@ -13,6 +13,8 @@ GROUP="users"
 CFG_FILE="${INSTALL_DIR}/var/settings.json"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -69,6 +71,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -81,6 +86,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/transmission/src/transmission.sc
+++ b/spk/transmission/src/transmission.sc
@@ -1,0 +1,6 @@
+[transmission]
+title="Transmission"
+desc="Transmission"
+port_forward="yes"
+dst.ports="9091/tcp,udp"
+

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -21,7 +21,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/tvheadend/src/installer.sh
+++ b/spk/tvheadend/src/installer.sh
@@ -12,6 +12,8 @@ USER="tvheadend"
 GROUP="users"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -36,6 +38,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -48,6 +53,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/tvheadend/src/tvheadend.sc
+++ b/spk/tvheadend/src/tvheadend.sc
@@ -1,0 +1,6 @@
+[tvheadend]
+title="Tvheadend"
+desc="Tvheadend"
+port_forward="yes"
+dst.ports="9981,9982/tcp"
+

--- a/spk/umurmur/Makefile
+++ b/spk/umurmur/Makefile
@@ -18,7 +18,7 @@ LICENSE    =
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/umurmur/src/installer.sh
+++ b/spk/umurmur/src/installer.sh
@@ -13,9 +13,17 @@ GEN_CERT="${INSTALL_DIR}/sbin/gencert.sh"
 LOG_FILE="${INSTALL_DIR}/var/umurmurd.log"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
+    fi
+
     exit 0
 }
 
@@ -36,6 +44,9 @@ postinst ()
 
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
+
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
 
     exit 0
 }

--- a/spk/umurmur/src/umurmur.sc
+++ b/spk/umurmur/src/umurmur.sc
@@ -1,0 +1,6 @@
+[umurmur]
+title="uMurmur"
+desc="uMurmur"
+port_forward="yes"
+dst.ports="64737/tcp,udp"
+

--- a/spk/xdm/Makefile
+++ b/spk/xdm/Makefile
@@ -19,6 +19,7 @@ LICENSE    = GPL
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/xdm/src/installer.sh
+++ b/spk/xdm/src/installer.sh
@@ -14,6 +14,8 @@ GROUP="users"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -34,6 +36,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -46,6 +51,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/xdm/src/xdm.sc
+++ b/spk/xdm/src/xdm.sc
@@ -1,0 +1,6 @@
+[xdm]
+title="XDM"
+desc="XDM"
+port_forward="yes"
+dst.ports="8085/tcp"
+

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -21,7 +21,7 @@ WIZARDS_DIR = src/wizard/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
-ADDITIONAL_SCRIPTS =
+FWPORTS          = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 

--- a/spk/znc/src/installer.sh
+++ b/spk/znc/src/installer.sh
@@ -13,6 +13,8 @@ GROUP="nobody"
 ZNC="${INSTALL_DIR}/bin/znc"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 
+SERVICETOOL="/usr/syno/bin/servicetool"
+FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
 preinst ()
 {
@@ -40,6 +42,9 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Add firewall config
+    ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
+
     exit 0
 }
 
@@ -52,6 +57,11 @@ preuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         delgroup ${USER} ${GROUP}
         deluser ${USER}
+    fi
+
+    # Remove firewall config
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        ${SERVICETOOL} --remove-configure-file --package ${PACKAGE}.sc >> /dev/null
     fi
 
     exit 0

--- a/spk/znc/src/znc.sc
+++ b/spk/znc/src/znc.sc
@@ -1,0 +1,6 @@
+[znc]
+title="ZNC"
+desc="ZNC"
+port_forward="yes"
+dst.ports="8250/tcp"
+


### PR DESCRIPTION
This adds the firewall configuration for most, if not all packages that need it. Closes #145.

Took the used ports from the wiki page. Any packages not in the wiki are not added here, so I might be missing some of the last added packages.

Note: For now, I have not added optional (SSL) ports that are configurable from within packages, although technically, it's possible with a second section in the .sc file.

Anyone in for a sanity check before it's merged? I think I lost mine ;)

edit: Hooray, we've gotten to #1000. Do we get any prizes with that?
