### PR TITLE
leptonica: New upstream version (1.70)

### DIFF
--- a/cross/leptonica/Makefile
+++ b/cross/leptonica/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = leptonica
-PKG_VERS = 1.68
+PKG_VERS = 1.70
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://leptonica.org/source

--- a/cross/leptonica/PLIST
+++ b/cross/leptonica/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/liblept.so
-lnk:lib/liblept.so.2
-lib:lib/liblept.so.2.0.0
+lnk:lib/liblept.so.4
+lib:lib/liblept.so.4.0.1

--- a/cross/leptonica/digests
+++ b/cross/leptonica/digests
@@ -1,0 +1,3 @@
+leptonica-1.70.tar.gz SHA1 476edd5cc3f627f5ad988fcca6b62721188fce13
+leptonica-1.70.tar.gz SHA256 d3d209a1f6d1f7a80119486b5011bc8c6627e582c927ab44ba33c37edb2cfba2
+leptonica-1.70.tar.gz MD5 5ac2a31cf5b4f0e8f5a853a5266c42ef


### PR DESCRIPTION
"cross/leptonica" is not used (yet) in spksrc so new upstream shouldn't make any conflict.

"zlib-include.patch" is removed because it is already part of upstream.
