### PR TITLE
Support URL in Package Center

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -71,6 +71,9 @@ endif
 ifneq ($(strip $(HELPURL)),)
 	@echo helpurl=\"$(HELPURL)\" >> $@
 endif
+ifneq ($(strip $(SUPPORTURL)),)
+	@echo support_url=\"$(SUPPORTURL)\" >> $@
+endif
 ifneq ($(strip $(INSTALL_DEP_SERVICES)),)
 	@echo install_dep_services=\"$(INSTALL_DEP_SERVICES)\" >> $@
 endif


### PR DESCRIPTION
I've added an additional step to `spksrc.spk.mk` which inserts a support URL into the package `INFO` file, if one has been specified in the `Makefile` of the package.
