### PR TITLE
Enable IPV6 support for curl - Transmission can connect to ipv6 trackers

### DIFF
--- a/cross/curl/Makefile
+++ b/cross/curl/Makefile
@@ -16,6 +16,7 @@ GNU_CONFIGURE = 1
 CONFIGURE_TARGET = myConfigure
 POST_INSTALL_TARGET = myPostInstall
 
+CONFIGURE_ARGS = --enable-ipv6
 
 include ../../mk/spksrc.cross-cc.mk
 


### PR DESCRIPTION
Enables ipv6 support for curl; this allows the transmission package (for which curl is a dependency) to connect to ipv6 only trackers.
