### PR TITLE
squidguard 1.5 package bugs correction and add logs rotation

### DIFF
--- a/cross/squidguard/patches/sgDb.c.patch
+++ b/cross/squidguard/patches/sgDb.c.patch
@@ -1,0 +1,11 @@
+--- ./src/sgDb.c.old	2014-06-07 16:01:30.426370538 +0200
++++ ./src/sgDb.c	2014-06-07 16:02:10.289478740 +0200
+@@ -112,7 +112,7 @@
+     }
+   }
+ #endif
+-#if DB_VERSION_MAJOR == 4
++#if DB_VERSION_MAJOR >= 4
+   if(globalUpdate || createdb || (dbfile != NULL && stat(dbfile,&st))){
+     flag = DB_CREATE;
+     if(createdb)

--- a/cross/squidguardmanager/patches/squid_wrapper.c.patch
+++ b/cross/squidguardmanager/patches/squid_wrapper.c.patch
@@ -5,7 +5,7 @@
  #include <stdlib.h>
  
 -#define SQUID_BINARY "/usr/sbin/squid3"
-+#define SQUID_BINARY "/usr/local/squid/sbin/squid"
++#define SQUID_BINARY "/usr/local/squidguard/sbin/squid"
  
  int main(int argc, char **argv, char **envp) {
    char *squidprog[] = { SQUID_BINARY, "-k", "reconfigure", NULL };

--- a/cross/squidguardmanager/patches/squidguardmgr.cgi.patch
+++ b/cross/squidguardmanager/patches/squidguardmgr.cgi.patch
@@ -1,6 +1,6 @@
---- cgi-bin/squidguardmgr.cgi.old	2013-01-16 14:52:34.878040714 +0100
-+++ cgi-bin/squidguardmgr.cgi	2013-01-16 16:18:42.973068959 +0100
-@@ -14,6 +14,57 @@
+--- cgi-bin/squidguardmgr.cgi.old	2014-06-07 20:11:07.370279654 +0200
++++ cgi-bin/squidguardmgr.cgi	2014-07-03 18:27:36.137067489 +0200
+@@ -14,6 +14,58 @@
  
  use strict qw{vars subs};
  
@@ -54,16 +54,118 @@
 +		"fr_FR"
 +		);
 +$LANG = getpreferedlang(@supported);
++my $RUNASUSER = 'squid';
 +
  $VERSION     = '1.11',
  $AUTHOR      = 'Gilles DAROLD <gilles AT darold DOT net>';
  $COPYRIGHT   = 'Copyright &copy; 2010-2012 Gilles DAROLD, all rights reserved';
-@@ -37,7 +88,6 @@
+@@ -24,8 +76,8 @@
+ my $SC_PROGRAM  = 'SquidClamav Manager';
+ 
+ # Default SquidGuard installation path
+-my $DBHOME = "/var/lib/squidguard/db";
+-my $LOGDIR = "/var/log/squid";
++my $DBHOME = "/usr/local/squidguard/var/db";
++my $LOGDIR = "/usr/local/squidguard/var/logs";
+ 
+ # Variables that can be overidden into the squidguardmgr.conf file
+ our $DIFF       = '/usr/bin/diff';
+@@ -33,11 +85,10 @@
+ our $FIND       = '/usr/bin/find';
+ our $RM         = '/bin/rm';
+ our $TAIL       = '/usr/bin/tail';
+-our $SQUIDGUARD = '/usr/local/bin/squidGuard';
++our $SQUIDGUARD = '/usr/local/squidguard/bin/squidGuard';
  our $BLDESC     = 'description.dat';
- our $CONF_FILE  = '/usr/local/squidGuard/squidguard.conf';
+-our $CONF_FILE  = '/usr/local/squidGuard/squidguard.conf';
++our $CONF_FILE  = '/usr/local/squidguard/etc/squidguard.conf';
  our $LANGDIR    = 'lang';
 -our $LANG       = 'en_US';
  our $IMG_DIR    = 'images';
  our $CSS_FILE   = 'squidguardmgr.css';
  our $JS_FILE    = 'squidguardmgr.js';
-
+@@ -45,8 +96,8 @@
+ our $LOG_LINES  = 1000;
+ our $SQUIDCLAMAV   = '/usr/bin/squidclamav';
+ our $SC_CONF_FILE  = '/etc/squidclamav.conf';
+-our $SQUID_WRAPPER = '/var/www/squidguardmgr/squid_wrapper';
+-our $C_ICAP_SOCKET = '/var/run/c-icap/c-icap.ctl';
++our $SQUID_WRAPPER = '/usr/local/squidguard/share/www/squidguardmgr/squid_wrapper';
++our $C_ICAP_SOCKET = '/usr/local/squidguard/var/run/c-icap/c-icap.ctl';
+ our $KEEP_DIFF  = 1;
+ 
+ # Configuration file
+@@ -155,7 +206,7 @@
+ 	if ($VIEW eq 'squid') {
+ 		if ($SQUID_WRAPPER) {
+ 			print "Running: $SQUID_WRAPPER ... \n";
+-			$ERROR = `$SQUID_WRAPPER 2>&1`;
++			$ERROR = `su - squid -c $SQUID_WRAPPER 2>&1`;
+ 			&error($ERROR) if ($ERROR);
+ 			print "Ok." if (!$ERROR);
+ 		}
+@@ -264,7 +315,7 @@
+ 
+ if ($ACTION eq 'squid') {
+ 	if ($SQUID_WRAPPER) {
+-		$ERROR = `$SQUID_WRAPPER`;
++		$ERROR = `su - squid -c $SQUID_WRAPPER 2>&1`;
+ 	}
+ 	$ACTION = '';
+ }
+@@ -861,6 +912,7 @@
+ 	if (open(OUT, ">>$file")) {
+ 		print OUT join("\n", @add), "\n";
+ 		close OUT;
++		`chown $RUNASUSER $file`;
+ 		if ($KEEP_DIFF) {
+ 			# Store these items into a squidGuard diff history file
+ 			&add_hist_item("$file.diff.hist", '+', @add);
+@@ -882,6 +934,7 @@
+ 	} else {
+ 		$file =~ s#$CONFIG{dbhome}/##;
+ 		$ERROR = `$SQUIDGUARD -C $file`;
++		`chown $RUNASUSER $file`;
+ 	}
+ }
+ 
+@@ -919,6 +972,7 @@
+ 			if (open(OUT, ">$file")) {
+ 				print OUT "$txt";
+ 				close OUT;
++				`chown $RUNASUSER $file`;
+ 				# Store these items into a squidGuard diff history file
+ 				if ($KEEP_DIFF) {
+ 					&add_hist_item("$file.diff.hist", '-', @removed);
+@@ -939,6 +993,7 @@
+ 				map { s/^/\-/; } @removed;
+ 				print OUT join("\n", @removed), "\n";
+ 				close OUT;
++				`chown $RUNASUSER $file`;				
+ 				print `$SQUIDGUARD -u $file.tmpdiff`;
+ 				unlink("$file.tmpdiff");
+ 			} else {
+@@ -988,6 +1043,7 @@
+ 		map { s/^/$prefix/ } @add;
+ 		print OUT join("\n", @add), "\n";
+ 		close OUT;
++		`chown $RUNASUSER $file`;	
+ 	} else {
+ 		&error("Can't open $file for writing: $!");
+ 	}
+@@ -1573,6 +1629,7 @@
+ 		$BL =~ s/[^a-z0-9\_\-]+//ig;
+ 		$BL = lc($BL);
+ 		mkdir("$CONFIG{dbhome}/$BL");
++		`chown $RUNASUSER $CONFIG{dbhome}/$BL`;	
+ 		$ACTION = 'bledit';
+ 		$BL =~ s/\/.*//;
+ 	}
+@@ -2505,6 +2562,7 @@
+ 		$DIFF = '';
+ 	}
+ 	rename("$CONFIG{dbhome}/$bl.tmp", "$CONFIG{dbhome}/$bl");
++	`chown $RUNASUSER $CONFIG{dbhome}/$bl`;
+ 	if (!$DIFF) {
+ 		$ERROR = `$SQUIDGUARD -C $bl`;
+ 	}

--- a/spk/squidguard/Makefile
+++ b/spk/squidguard/Makefile
@@ -43,6 +43,7 @@ xz-compress:
 	install -m 755 -d $(STAGING_DIR)/var/cache
 	install -m 755 -d $(STAGING_DIR)/var/db
 	install -m 755 src/update_db.sh $(STAGING_DIR)/bin/
+        install -m 750 src/logrotate.sh $(STAGING_DIR)/bin/
 	install -m 755 src/etc/* $(STAGING_DIR)/etc/
 	install -m 644 src/app/config $(STAGING_DIR)/share/www/squidguardmgr/
 	install -m 755 src/app/squidGuard.cgi $(STAGING_DIR)/share/www/squidguardmgr/

--- a/spk/squidguard/Makefile
+++ b/spk/squidguard/Makefile
@@ -43,7 +43,7 @@ xz-compress:
 	install -m 755 -d $(STAGING_DIR)/var/cache
 	install -m 755 -d $(STAGING_DIR)/var/db
 	install -m 755 src/update_db.sh $(STAGING_DIR)/bin/
-        install -m 750 src/logrotate.sh $(STAGING_DIR)/bin/
+	install -m 750 src/logrotate.sh $(STAGING_DIR)/bin/
 	install -m 755 src/etc/* $(STAGING_DIR)/etc/
 	install -m 644 src/app/config $(STAGING_DIR)/share/www/squidguardmgr/
 	install -m 755 src/app/squidGuard.cgi $(STAGING_DIR)/share/www/squidguardmgr/

--- a/spk/squidguard/src/etc/squid.conf
+++ b/spk/squidguard/src/etc/squid.conf
@@ -47,8 +47,6 @@ acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl localnet src fc00::/7       # RFC 4193 local private network range
 acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
 acl manager proto cache_object
-acl localhost src 127.0.0.1/255.255.255.255
-acl to_localhost dst 127.0.0.0/8
 acl SSL_ports port 443 563        # https, snews
 acl SSL_ports port 873                # rsync
 acl Safe_ports port 80                # http

--- a/spk/squidguard/src/etc/squidclamav.conf.tpl
+++ b/spk/squidguard/src/etc/squidclamav.conf.tpl
@@ -1,0 +1,79 @@
+#-----------------------------------------------------------------------------
+# SquidClamav default configuration file
+#
+# To know to customize your configuration file, see squidclamav manpage
+# or go to http://squidclamav.darold.net/
+#
+#-----------------------------------------------------------------------------
+#
+# Global configuration
+#
+
+# Maximum size of a file that may be scanned. Any file bigger that this value
+# will not be scanned.
+maxsize 5000000
+
+# When a virus is found then redirect the user to this URL
+redirect http://==HOSTNAME==:5000/webman/3rdparty/squidguard/clwarn.cgi
+
+# Path to the squiGuard binary if you want URL filtering, note that you'd better
+# use the squid configuration directive 'url_rewrite_program' instead.
+#squidguard /usr/local/squidGuard/bin/squidGuard
+
+# Path to the clamd socket, use clamd_local if you use Unix socket or if clamd
+# is listening on an Inet socket, comment clamd_local and set the clamd_ip and
+# clamd_port to the corresponding value.
+clamd_local /usr/local/squidguard/var/run/clamd/clamd.ctl
+#clamd_ip 192.168.1.5,127.0.0.1
+# clamd_port 3310
+
+# Set the timeout for clamd connection. Default is 1 second, this is a good
+# value but if you have slow service you can increase up to 3.
+timeout 1
+
+# Force SquidClamav to log all virus detection or squiguard block redirection
+# to the c-icap log file.
+logredir 0
+
+# Enable / disable DNS lookup of client ip address. Default is enabled '1' to
+# preserve backward compatibility but you must desactivate this feature if you
+# don't use trustclient with hostname in the regexp or if you don't have a DNS
+# on your network. Disabling it will also speed up squidclamav.
+dnslookup 1
+
+# Enable / Disable Clamav Safe Browsing feature. You mus have enabled the
+# corresponding behavior in clamd by enabling SafeBrowsing into freshclam.conf
+# Enabling it will first make a safe browsing request to clamd and then the
+# virus scan request. 
+safebrowsing 0
+
+#
+# Here is some defaut regex pattern to have a high speed proxy on system
+# with low resources.
+#
+
+# Do not scan images
+#abort ^.*\.(ico|gif|png|jpg)$
+#abortcontent ^image\/.*$
+
+# Do not scan text files
+#abort ^.*\.(css|xml|xsl|js|html|jsp)$
+#abortcontent ^text\/.*$
+#abortcontent ^application\/x-javascript$
+
+# Do not scan streamed videos
+#abortcontent ^video\/x-flv$
+#abortcontent ^video\/mp4$
+
+# Do not scan flash files
+#abort ^.*\.swf$
+#abortcontent ^application\/x-shockwave-flash$
+
+# Do not scan sequence of framed Microsoft Media Server (MMS) data packets
+#abortcontent ^.*application\/x-mms-framed.*$
+
+# White list some sites
+#whitelist .*\.clamav.net
+
+# See also 'trustuser' and 'trustclient' configuration directives
+

--- a/spk/squidguard/src/installer.sh
+++ b/spk/squidguard/src/installer.sh
@@ -37,31 +37,42 @@ postinst ()
     # Patch template files
     hostname=`hostname`
     sed "s/==HOSTNAME==/$hostname/g" ${ETC_DIR}/squidguard.conf.tpl > ${ETC_DIR}/squidguard.conf
+    sed "s/==HOSTNAME==/$hostname/g" ${ETC_DIR}/squidclamav.conf.tpl > ${ETC_DIR}/squidclamav.conf
     
     # Correct the files ownership
     chown -R ${RUNAS}:users ${SYNOPKG_PKGDEST}
-    chown 0:0 ${SQUID_WRAPPER}
-	chmod +s ${SQUID_WRAPPER}
-	
+    # use "su - squid -c $SQUID_WRAPPER" in cgi file squidguardmgr.cgi instead
+    ##chown 0:0 ${SQUID_WRAPPER}
+    ##chmod +s ${SQUID_WRAPPER}
+    # need when new DB files are created via web interface (avoid permission error because squidGuard is launch with squid user)
+    chmod u+s ${INSTALL_DIR}/bin/squidGuard
+    
     # Init squid cache directory
     su - ${RUNAS} -c "${SQUID} -z -f ${CFG_FILE}"
 
     # Install webman
     ln -s ${WWW_DIR} ${WEBMAN_DIR}/${PACKAGE}
     ln -sf ${INSTALL_DIR}/etc/squidguardmgr.conf ${WEBMAN_DIR}/${PACKAGE}/
+    # For squidclamav redirect
+    ln -sf ${INSTALL_DIR}/libexec/squidclamav/clwarn.cgi ${WEBMAN_DIR}/${PACKAGE}/clwarn.cgi
       
-    # Init crontab : update squidguard DB each day at 1 a.m
+    # Init crontab : 
+    #    update squidguard DB each day at 1 a.m
+    #    logs rotate every sunday at 0:15 a.a
     grep ${PACKAGE} /etc/crontab
     if [ $? -eq 1 ]; then
-        echo "0 1       *       *       *       root    ${INSTALL_DIR}/bin/update_db.sh > ${INSTALL_DIR}/var/logs/update_db.log" >> /etc/crontab
-        /usr/syno/etc/rc.d/S04crond.sh stop
+        echo "0	1	*	*	*	root	${INSTALL_DIR}/bin/update_db.sh > ${INSTALL_DIR}/var/logs/update_db.log 2>&1" >> /etc/crontab
+        echo "15	0	*	*	0	root	${INSTALL_DIR}/bin/logrotate.sh > ${INSTALL_DIR}/bin/logrotate.log 2>&1" >> /etc/crontab
+        /usr/syno/etc/rc.d/S04crond.sh stop >> /dev/null
         sleep 1
-        /usr/syno/etc/rc.d/S04crond.sh start
+        /usr/syno/etc/rc.d/S04crond.sh start >> /dev/null
     fi
+
+    # launch first the update
+    ${INSTALL_DIR}/bin/update_db.sh > ${INSTALL_DIR}/var/logs/update_db.log 2>&1
 
     # Add firewall config
     ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null
-
     exit 0
 }
 
@@ -81,7 +92,13 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
     rm -Rf ${WEBMAN_DIR}/${PACKAGE}
-    sed "/${PACKAGE}/d" /etc/crontab
+    cp /etc/crontab /etc/crontab.old
+    cat /etc/crontab | sed "/${PACKAGE}/d" >/etc/crontab.new
+    cat /etc/crontab.new >/etc/crontab
+    rm /etc/crontab.new
+    /usr/syno/etc/rc.d/S04crond.sh stop >> /dev/null
+    sleep 1
+    /usr/syno/etc/rc.d/S04crond.sh start >> /dev/null
     deluser ${RUNAS}
     
     exit 0

--- a/spk/squidguard/src/logrotate.sh
+++ b/spk/squidguard/src/logrotate.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Script for log rotate with compression and purge after 5 rotations
+
+# Log directory
+LOGDIR="/usr/local/squidguard/var/logs"
+# Maximum number of archive logs to keep
+MAXNUM=5
+
+if [ ! -w $LOGDIR -o ! -x $LOGDIR ]; then
+	echo "$0: you don't have the appropriate permission in $LOGDIR" >&2
+	exit 1
+fi
+
+for LOGFILE in `ls -1 ${LOGDIR}/*.log `;do
+	## Check if the last log archive exists and delete it.
+	if [ -f "$LOGFILE.$MAXNUM.gz" ]; then
+		echo "Purge old log $LOGFILE.$MAXNUM.gz"
+		/bin/rm "$LOGFILE.$MAXNUM.gz"
+	fi
+
+	NUM=`expr $MAXNUM - 1`
+	## Check the previous log file.
+	while [ $NUM -ge 0 ]
+	do
+		NUM1=`expr $NUM + 1`
+		if [ -f "$LOGFILE.$NUM.gz" ]; then
+			echo "Move old log $LOGFILE.$NUM.gz to $LOGFILE.$NUM1.gz"
+			/bin/mv "$LOGFILE.$NUM.gz" "$LOGFILE.$NUM1.gz"
+		fi
+		NUM=`expr $NUM - 1`
+	done
+
+	# Compress and clear the log file
+	if [ -f "$LOGFILE" ]; then
+		echo "Rotate log $LOGFILE to $LOGFILE.0.gz"
+		/bin/cp "$LOGFILE" "$LOGFILE.0"
+		/bin/cat /dev/null > "$LOGFILE"
+		/bin/gzip -f -9 "$LOGFILE.0"
+	fi
+done

--- a/spk/squidguard/src/update_db.sh
+++ b/spk/squidguard/src/update_db.sh
@@ -11,7 +11,7 @@ DB_DIR="${INSTALL_DIR}/var/db"
 RSYNC_DIR="rsync://ftp.ut-capitole.fr/blacklist/dest/"
 
 cd ${DB_DIR}
-rync -arpogvt ${RSYNC_DIR} .
+rsync -arpogvt ${RSYNC_DIR} .
 if [ $? -eq 0 ]
 then
   chown -R ${RUNAS}:root ${DB_DIR}


### PR DESCRIPTION
Bugs correction :
Hello,

Here are the different modification I had done for the squidguard 1.5 package of synocommunity :
- patch sgDb.c filefor error when squidguard try to create new berkleyDB "FATAL: sgDbLoadTextFile: put: Invalid argument"
- patch squid_wrapper.c file to use the good path to squid binary
- patch squidguardmgr.cgi file to 
   o use the good paths binary/config files
   o change owner of new directories/files created by cgi (because cgi run as root and squidguard as squid user)
   o use "su - squid -c $SQUID_WRAPPER" command instead of "$SQUID_WRAPPER" in cgi (because cgi run as root and squidguard as squid user)
- Modify squid.conf to suppress the duplicate entries definitions
- Add squidclamav.conf.tpl template file for virus dectection redirection to good clwarn.cgi path
- Add log rotation script logrotate.sh to rotate/compress/purge all log files in /usr/local/squidguard/var/logs directory and avoid to use too many place