### PR TITLE
Add Symlinks in the path for several packages + Permissions fix

### DIFF
--- a/cross/ruby/PLIST
+++ b/cross/ruby/PLIST
@@ -10,3 +10,4 @@ lib:lib/libruby-static.a
 rsc:lib/pkgconfig/ruby-2.0.pc
 rsc:lib/ruby/2.0.0
 rsc:lib/ruby/gems
+rsc:include/ruby-2.0.0

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = debian-chroot
 SPK_VERS = 7.4
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/debian.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ DESCRIPTION = Debian is a free operating system \(OS\) that comes with over 2900
 DESCRIPTION_FRE = Debian est un système d\\\'exploitation \\\(SE\\\) qui rend disponible plus de 29000 paquets, logiciels précompilés et empaquetés dans un joli format pour rendre son installation facile sur votre DiskStation. Debian Chroot vous permet de bénéficier du SE Debian au sein de votre DiskStation, aux cotés de DSM. Ce paquet est destiné aux utilisateurs avancés uniquement.
 RELOAD_UI = yes
 DISPLAY_NAME = Debian Chroot
-CHANGELOG = "1. DSM 5.0 compatibility"
+CHANGELOG = "1. Fixed permissions\n2. DSM 5.0 compatibility"
 
 HOMEPAGE   = http://www.debian.org/
 LICENSE    =

--- a/spk/debian-chroot/src/installer.sh
+++ b/spk/debian-chroot/src/installer.sh
@@ -23,6 +23,10 @@ postinst ()
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
 
+    # Set the permissions
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
+
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${INSTALL_DIR}/env > /dev/null
 

--- a/spk/git/Makefile
+++ b/spk/git/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = git
 SPK_VERS = 1.8.4
-SPK_REV = 3
+SPK_REV = 4
 SPK_ICON = src/git.png
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)

--- a/spk/git/src/installer.sh
+++ b/spk/git/src/installer.sh
@@ -21,6 +21,10 @@ postinst ()
     # Install busybox stuff
     ${INSTALL_DIR}/bin/busybox --install ${INSTALL_DIR}/bin
 
+    # Set the permissions
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
+
     # Put symlinks in the PATH
     mkdir -p /usr/local/bin
     ln -s ${INSTALL_DIR}/bin/git /usr/local/bin/git

--- a/spk/git/src/installer.sh
+++ b/spk/git/src/installer.sh
@@ -21,6 +21,14 @@ postinst ()
     # Install busybox stuff
     ${INSTALL_DIR}/bin/busybox --install ${INSTALL_DIR}/bin
 
+    # Put symlinks in the PATH
+    mkdir -p /usr/local/bin
+    ln -s ${INSTALL_DIR}/bin/git /usr/local/bin/git
+    ln -s ${INSTALL_DIR}/bin/git-receive-pack /usr/local/bin/git-receive-pack
+    ln -s ${INSTALL_DIR}/bin/git-shell /usr/local/bin/git-shell
+    ln -s ${INSTALL_DIR}/bin/git-upload-archive /usr/local/bin/git-upload-archive
+    ln -s ${INSTALL_DIR}/bin/git-upload-pack /usr/local/bin/git-upload-pack
+
     exit 0
 }
 
@@ -33,6 +41,11 @@ postuninst ()
 {
     # Remove link
     rm -f ${INSTALL_DIR}
+    rm -f /usr/local/bin/git
+    rm -f /usr/local/bin/git-receive-pack
+    rm -f /usr/local/bin/git-shell
+    rm -f /usr/local/bin/git-upload-archive
+    rm -f /usr/local/bin/git-upload-pack
 
     exit 0
 }

--- a/spk/node/Makefile
+++ b/spk/node/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = node
 SPK_VERS = 0.10.6
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/nodejs.png
 
 DEPENDS  = cross/$(SPK_NAME)
@@ -10,6 +10,7 @@ DESCRIPTION = Node.js is a platform built on Chrome\'s JavaScript runtime for ea
 STARTABLE = no
 DISPLAY_NAME = Node.js
 BETA = 1
+CHANGELOG = "Added symlinks"
 
 HOMEPAGE   = http://nodejs.org/
 LICENSE    = MIT

--- a/spk/node/src/installer.sh
+++ b/spk/node/src/installer.sh
@@ -20,7 +20,8 @@ postinst ()
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
 
     # Correct the files ownership
-    chown -R ${USER}:root ${SYNOPKG_PKGDEST}
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
 
     # Put symlinks in the PATH
     mkdir -p /usr/local/bin

--- a/spk/node/src/installer.sh
+++ b/spk/node/src/installer.sh
@@ -22,6 +22,11 @@ postinst ()
     # Correct the files ownership
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
+    # Put symlinks in the PATH
+    mkdir -p /usr/local/bin
+    ln -s ${INSTALL_DIR}/bin/node /usr/local/bin/node
+    ln -s ${INSTALL_DIR}/bin/npm /usr/local/bin/npm
+
     exit 0
 }
 
@@ -34,6 +39,8 @@ postuninst ()
 {
     # Remove link
     rm -f ${INSTALL_DIR}
+    rm -f /usr/local/bin/node
+    rm -f /usr/local/bin/npm
 
     exit 0
 }

--- a/spk/python/Makefile
+++ b/spk/python/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python
 SPK_SHORT_VERS = 2.7
 SPK_VERS =$(SPK_SHORT_VERS).6
-SPK_REV = 8
+SPK_REV = 9
 SPK_ICON = src/python.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
@@ -18,7 +18,7 @@ DESCRIPTION_SPN = Lenguaje de programación Python.
 RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python
-CHANGELOG = "1. Add wheel, mercurial and scrypt modules"
+CHANGELOG = "1. Add symlinks\n2. Add wheel, mercurial and scrypt modules"
 
 HOMEPAGE   = http://www.python.org/
 LICENSE    =

--- a/spk/python/src/installer.sh
+++ b/spk/python/src/installer.sh
@@ -18,6 +18,11 @@ postinst ()
 {
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
+    ln -s ${INSTALL_DIR}/bin/python /usr/local/bin/python
+    ln -s ${INSTALL_DIR}/bin/python2 /usr/local/bin/python2
+    ln -s ${INSTALL_DIR}/bin/python2.7 /usr/local/bin/python2.7
+    ln -s ${INSTALL_DIR}/bin/pydoc /usr/local/bin/pydoc
+    ln -s ${INSTALL_DIR}/bin/pip /usr/local/bin/pip
 
     # Install busybox stuff
     ${INSTALL_DIR}/bin/busybox --install ${INSTALL_DIR}/bin
@@ -44,6 +49,11 @@ postuninst ()
 {
     # Remove link
     rm -f ${INSTALL_DIR}
+    rm -f /usr/local/bin/python
+    rm -f /usr/local/bin/python2
+    rm -f /usr/local/bin/python2.7
+    rm -f /usr/local/bin/pydoc
+    rm -f /usr/local/bin/pip
 
     exit 0
 }

--- a/spk/python/src/installer.sh
+++ b/spk/python/src/installer.sh
@@ -33,6 +33,10 @@ postinst ()
     echo "System installed modules:" >> ${INSTALL_DIR}/install.log
     ${INSTALL_DIR}/bin/pip freeze >> ${INSTALL_DIR}/install.log
 
+    # Set the permissions
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
+
     # Byte-compile in background
     ${INSTALL_DIR}/bin/python -m compileall -q -f ${INSTALL_DIR}/lib/python2.7 > /dev/null &
     ${INSTALL_DIR}/bin/python -OO -m compileall -q -f ${INSTALL_DIR}/lib/python2.7 > /dev/null &

--- a/spk/ruby/Makefile
+++ b/spk/ruby/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ruby
 SPK_VERS = 2.0.0-p353
-SPK_REV = 6
+SPK_REV = 7
 SPK_ICON = src/ruby.png
 
 DEPENDS  = cross/$(SPK_NAME)
@@ -13,6 +13,7 @@ RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Ruby
 BETA = 1
+CHANGELOG = "Added symlinks and includes"
 
 HOMEPAGE   = http://www.ruby-lang.org/
 LICENSE    =

--- a/spk/ruby/src/installer.sh
+++ b/spk/ruby/src/installer.sh
@@ -19,6 +19,15 @@ postinst ()
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
 
+    mkdir -p /usr/local/bin
+    ln -s ${INSTALL_DIR}/bin/erb /usr/local/bin/erb
+    ln -s ${INSTALL_DIR}/bin/gem /usr/local/bin/gem
+    ln -s ${INSTALL_DIR}/bin/irb /usr/local/bin/irb
+    ln -s ${INSTALL_DIR}/bin/rake /usr/local/bin/rake
+    ln -s ${INSTALL_DIR}/bin/rdoc /usr/local/bin/rdoc
+    ln -s ${INSTALL_DIR}/bin/ri /usr/local/bin/ri
+    ln -s ${INSTALL_DIR}/bin/ruby /usr/local/bin/ruby
+
     exit 0
 }
 
@@ -31,6 +40,14 @@ postuninst ()
 {
     # Remove link
     rm -f ${INSTALL_DIR}
+
+    rm -f /usr/local/bin/erb
+    rm -f /usr/local/bin/gem
+    rm -f /usr/local/bin/irb
+    rm -f /usr/local/bin/rake
+    rm -f /usr/local/bin/rdoc
+    rm -f /usr/local/bin/ri
+    rm -f /usr/local/bin/ruby
 
     exit 0
 }

--- a/spk/ruby/src/installer.sh
+++ b/spk/ruby/src/installer.sh
@@ -28,6 +28,10 @@ postinst ()
     ln -s ${INSTALL_DIR}/bin/ri /usr/local/bin/ri
     ln -s ${INSTALL_DIR}/bin/ruby /usr/local/bin/ruby
 
+    # Set the permissions
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
+
     exit 0
 }
 

--- a/spk/sickbeard/src/installer.sh
+++ b/spk/sickbeard/src/installer.sh
@@ -35,7 +35,7 @@ postinst ()
     adduser -h ${INSTALL_DIR}/var -g "${DNAME} User" -G ${GROUP} -s /bin/sh -S -D ${USER}
 
     # Correct the files ownership
-    chown -R ${USER}:root ${SYNOPKG_PKGDEST}
+    chown -hR ${USER}:root ${SYNOPKG_PKGDEST}
 
     # Add firewall config
     ${SERVICETOOL} --install-configure-file --package ${FWPORTS} >> /dev/null

--- a/spk/vim/Makefile
+++ b/spk/vim/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = vim
 SPK_VERS = 7.4
-SPK_REV = 2
+SPK_REV = 3
 SPK_ICON = src/vim.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -13,7 +13,7 @@ RELOAD_UI = no
 DISPLAY_NAME = Vim
 STARTABLE = no
 BETA = 1
-CHANGELOG = "1. Support UTF8 by default"
+CHANGELOG = "1. Fixed permissions\n2. Support UTF8 by default"
 
 HOMEPAGE   = http://www.vim.org/
 LICENSE    = Charityware

--- a/spk/vim/src/installer.sh
+++ b/spk/vim/src/installer.sh
@@ -17,6 +17,10 @@ postinst ()
 {
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
+   
+    # Set the permissions
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
     
     # Put mc in the PATH
     mkdir -p /usr/local/bin

--- a/spk/zsh/Makefile
+++ b/spk/zsh/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = zsh
 SPK_VERS = 5.0.5
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/zsh.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -12,6 +12,7 @@ RELOAD_UI = no
 DISPLAY_NAME = Z shell
 STARTABLE = no
 BETA = 1
+CHANGELOG = "Fixed file ownership"
 
 HOMEPAGE   = http://www.zsh.org/
 LICENSE    = Custom

--- a/spk/zsh/src/installer.sh
+++ b/spk/zsh/src/installer.sh
@@ -18,6 +18,10 @@ postinst ()
     # Link
     ln -s ${SYNOPKG_PKGDEST} ${INSTALL_DIR}
 
+    # Set the permissions
+    chown -hR root:root ${SYNOPKG_PKGDEST}
+    chmod -R go-w ${SYNOPKG_PKGDEST}
+
     # Put zsh in the PATH
     mkdir -p /usr/local/bin
     ln -s ${INSTALL_DIR}/bin/zsh /usr/local/bin/zsh


### PR DESCRIPTION
This pull request adds symlinks into /usr/local/bin as a post installation step for the following packages:
- git
- node
- ruby
- python

Additionally, it also fixes the permissions and the ownership for the installed files. 
Before the fix the files were assigned to the same uid of the user building the package on the build system which could be a problem since a user on the synology might have had the same uid and thus might have been able to tamper with the installed files. Now all the files are owned by root.

Other packages might be affected by the same problem.