### PR TITLE
sets the owner and the group for the package.tgz contents to root

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -36,7 +36,7 @@ include ../../mk/spksrc.strip.mk
 $(WORK_DIR)/package.tgz: strip
 	$(create_target_dir)
 	@[ -f $@ ] && rm $@ || true
-	(cd $(STAGING_DIR) && tar cpzf $@ *)
+	(cd $(STAGING_DIR) && tar cpzf $@ --owner=root --group=root *)
 
 $(WORK_DIR)/INFO: Makefile $(SPK_ICON)
 	$(create_target_dir)


### PR DESCRIPTION
instead of the user building the package

This pull request is a follow up to the comments of #1170.

I've tested the behaviour with vim and zsh and it seems to be correct, now the package contents correctly belong to root instead of the user with uid 1000 (that was used to build the packages on the synocommunity server)
