### PR TITLE
stops zsh compinit from complaining about insecure directories

### DIFF
--- a/cross/zsh/Makefile
+++ b/cross/zsh/Makefile
@@ -19,4 +19,4 @@ include ../../mk/spksrc.cross-cc.mk
 
 .PHONY: myInstall
 myInstall:
-	$(RUN) $(MAKE) install DESTDIR=$(INSTALL_DIR)
+	umask 022; $(RUN) $(MAKE) install DESTDIR=$(INSTALL_DIR)


### PR DESCRIPTION
removes the group write permissions during the make install phase

This commit is necessary, in addition to the changes brought by #1226, in order to avoid the following error while running zsh:

```
$ zsh
zsh compinit: insecure directories, run compaudit for list.
Ignore insecure directories and continue [y] or abort compinit [n]?

$ compaudit
There are insecure directories:
/usr/local/zsh/share/zsh
/usr/local/zsh/share/zsh/5.0.5
```
