### PR TITLE
BTSync fix for missing add folder dialog

### DIFF
--- a/cross/btsync/Makefile
+++ b/cross/btsync/Makefile
@@ -2,12 +2,12 @@ PKG_NAME = btsync
 PKG_VERS = 1.4.75
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)_$(BTSYNC_ARCH)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = www.andreasgiemza.de/btsync-for-synocommunity/$(PKG_VERS)
+PKG_DIST_SITE = http://syncapp.bittorrent.com/$(PKG_VERS)
 PKG_DIR = $(PKG_NAME)
 
 DEPENDS =
 
-HOMEPAGE = http://labs.bittorrent.com/experiments/sync.html
+HOMEPAGE = http://www.bittorrent.com/sync
 COMMENT  = Automatically sync files via secure, distributed technology
 LICENSE  =
 

--- a/spk/btsync/Makefile
+++ b/spk/btsync/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = btsync
 SPK_VERS = 1.4.75
-SPK_REV = 5
+SPK_REV = 6
 SPK_ICON = src/btsync.png
 DSM_UI_DIR = app
 
@@ -14,7 +14,7 @@ RELOAD_UI = yes
 DISPLAY_NAME = BitTorrent Sync
 CHANGELOG = "Update to 1.4.75"
 
-HOMEPAGE   = http://labs.bittorrent.com/experiments/sync.html
+HOMEPAGE   = http://www.bittorrent.com/sync
 LICENSE    =
 
 WIZARDS_DIR = src/wizard/

--- a/spk/btsync/src/installer.sh
+++ b/spk/btsync/src/installer.sh
@@ -34,8 +34,6 @@ postinst ()
 
     # Edit the configuration according to the wizard
     sed -i -e "s|@device_name@|${wizard_device_name:=NAS}|g" \
-           -e "s|@login@|${wizard_login:=login}|g" \
-           -e "s|@password@|${wizard_password:=password}|g" \
            ${CFG_FILE}
 
     # Correct the files ownership

--- a/spk/btsync/src/sync.conf
+++ b/spk/btsync/src/sync.conf
@@ -4,8 +4,6 @@
   "pid_file" : "/usr/local/btsync/var/syncapp.pid",
   "webui" :
   {
-    "listen" : "0.0.0.0:8888",
-    "login" : "@login@",
-    "password" : "@password@"
+    "listen" : "0.0.0.0:8888"
   }
 }

--- a/spk/btsync/src/wizard/install_uifile
+++ b/spk/btsync/src/wizard/install_uifile
@@ -11,27 +11,5 @@
                 "allowBlank": false
             }
         }]
-    }, {
-        "type": "textfield",
-        "desc": "Login of the web interface",
-        "subitems": [{
-            "key": "wizard_login",
-            "desc": "Login",
-            "defaultValue": "login",
-            "validator": {
-                "allowBlank": false
-            }
-        }]
-    }, {
-        "type": "password",
-        "desc": "Password of the web interface. Defaults to password",
-        "subitems": [{
-            "key": "wizard_password",
-            "desc": "Password",
-            "defaultValue": "password",
-            "validator": {
-                "allowBlank": false
-            }
-        }]
     }]
 }]

--- a/spk/btsync/src/wizard/install_uifile_enu
+++ b/spk/btsync/src/wizard/install_uifile_enu
@@ -11,27 +11,5 @@
                 "allowBlank": false
             }
         }]
-    }, {
-        "type": "textfield",
-        "desc": "Login of the web interface",
-        "subitems": [{
-            "key": "wizard_login",
-            "desc": "Login",
-            "defaultValue": "login",
-            "validator": {
-                "allowBlank": false
-            }
-        }]
-    }, {
-        "type": "password",
-        "desc": "Password of the web interface. Defaults to password",
-        "subitems": [{
-            "key": "wizard_password",
-            "desc": "Password",
-            "defaultValue": "password",
-            "validator": {
-                "allowBlank": false
-            }
-        }]
     }]
 }]

--- a/spk/btsync/src/wizard/install_uifile_fre
+++ b/spk/btsync/src/wizard/install_uifile_fre
@@ -11,27 +11,5 @@
                 "allowBlank": false
             }
         }]
-    }, {
-        "type": "textfield",
-        "desc": "Nom d'utilisateur de l'interface web",
-        "subitems": [{
-            "key": "wizard_login",
-            "desc": "Nom d'utilisateur",
-            "defaultValue": "login",
-            "validator": {
-                "allowBlank": false
-            }
-        }]
-    }, {
-        "type": "password",
-        "desc": "Mot de passe de l'interface web. password par défaut",
-        "subitems": [{
-            "key": "wizard_password",
-            "desc": "Mot de passe",
-            "defaultValue": "password",
-            "validator": {
-                "allowBlank": false
-            }
-        }]
     }]
 }]


### PR DESCRIPTION
I hope this works ... tested it on my DS413j, but I don't know if this model had the problem ...

Would be nice if people could test it. Here can you find the download: http://www.andreasgiemza.de/btsync-for-synocommunity/1.4.75-packages-fix-for-missing-add-folder-dialog-test/

Please made feedback in this thread. Thanks.

Sources:
- https://github.com/SynoCommunity/spksrc/issues/1229#issuecomment-55250139
- http://forum.bittorrent.com/topic/31586-synologynastentative-solution-to-resolve-cannot-accept-eula-cannot-see-folders-in-add-folder-view/

**By the way:** I also increased the SPK_REV value. Not sure if it really necessary, because only new installs had the problem ...

Tested and working on:
- DS1813+
- DS210j
- DS413j
- DS212J
- DS212+ 
