### PR TITLE
Add database export during uninstallation to packages using MySQL db

### DIFF
--- a/spk/fengoffice/src/installer.sh
+++ b/spk/fengoffice/src/installer.sh
@@ -11,6 +11,7 @@ SSS="/var/packages/${PACKAGE}/scripts/start-stop-status"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="fengoffice"
 MYSQL_DATABASE="fengoffice"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -65,9 +66,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     # Stop the package
@@ -81,8 +90,12 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/fengoffice/src/wizard/uninstall_uifile
+++ b/spk/fengoffice/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove fengoffice database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the fengoffice database, all users and projects will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove fengoffice database"
-		}]
+		"desc": "Attention: The fengoffice database will be removed during package uninstallation. All users and projects will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the fengoffice database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
 		}]
-	}]	
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/fengoffice/src/wizard/uninstall_uifile_enu
+++ b/spk/fengoffice/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove fengoffice database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the fengoffice database, all users and projects will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove fengoffice database"
-		}]
+		"desc": "Attention: The fengoffice database will be removed during package uninstallation. All users and projects will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the fengoffice database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
 		}]
-	}]	
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/horde/src/wizard/uninstall_uifile
+++ b/spk/horde/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove Horde database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the horde database, all personal data will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove horde database"
-		}]
+		"desc": "Attention: The Horde database will be removed during package uninstallation. All feeds will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the horde database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/horde/src/wizard/uninstall_uifile_enu
+++ b/spk/horde/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove Horde database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the horde database, all personal data will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove horde database"
-		}]
+		"desc": "Attention: The Horde database will be removed during package uninstallation. All feeds will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the horde database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/mantisbt/src/installer.sh
+++ b/spk/mantisbt/src/installer.sh
@@ -10,6 +10,7 @@ INSTALL_DIR="/usr/local/${PACKAGE}"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="mantisbt"
 MYSQL_DATABASE="mantisbt"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -70,9 +71,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     exit 0
@@ -83,8 +92,12 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/mantisbt/src/wizard/uninstall_uifile
+++ b/spk/mantisbt/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove mantisbt database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the mantisbt database, all bug reports will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove mantisbt database"
-		}]
+		"desc": "Attention: The mantisbt database will be removed during package uninstallation. All bug reports will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the mantisbt database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/mantisbt/src/wizard/uninstall_uifile_enu
+++ b/spk/mantisbt/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove mantisbt database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the mantisbt database, all bug reports will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove mantisbt database"
-		}]
+		"desc": "Attention: The mantisbt database will be removed during package uninstallation. All bug reports will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the mantisbt database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/newznab/src/installer.sh
+++ b/spk/newznab/src/installer.sh
@@ -10,6 +10,7 @@ SSS="/var/packages/${PACKAGE}/scripts/start-stop-status"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="newznab"
 MYSQL_DATABASE="newznab"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -66,9 +67,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     # Stop the package
@@ -82,8 +91,12 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/newznab/src/wizard/uninstall_uifile
+++ b/spk/newznab/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove newznab database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the newznab database, all indexed releases will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove newznab database"
-		}]
+		"desc": "Attention: The newznab database will be removed during package uninstallation. All indexed releases will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the newznab database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/newznab/src/wizard/uninstall_uifile_enu
+++ b/spk/newznab/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove newznab database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the newznab database, all indexed releases will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove newznab database"
-		}]
+		"desc": "Attention: The newznab database will be removed during package uninstallation. All indexed releases will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the newznab database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/newznab/src/wizard/uninstall_uifile_fre
+++ b/spk/newznab/src/wizard/uninstall_uifile_fre
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Suppression de la base de donnée newznab",
 	"items": [{
-		"type": "multiselect",
-		"desc": "Si vous supprimez la base de donnée newznab, toutes les releses indexées seront supprimées.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Supprimer la base de donnée newznab"
-		}]
+		"desc": "Si vous supprimez la base de donnée newznab, toutes les releses indexées seront supprimées."
 	}, {
 		"type": "password",
-		"desc": "Saisissez votre mot de passe MySQL pour supprimer la base de donnée newznab.",
+		"desc": "Saisissez votre mot de passe MySQL",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Mot de passe Root"
+			"desc": "Mot de passe Root",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Facultatif: Fournir répertoire pour l'exportation de base de données. Laissez vide pour sauter à l'exportation. Le répertoire sera créé s'il n'existe pas",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "L'emplacement de base de données à l'exportation",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Chemin doit commencer avec /volume?/ avec ? le numéro du volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/owncloud/src/installer.sh
+++ b/spk/owncloud/src/installer.sh
@@ -10,6 +10,7 @@ INSTALL_DIR="/usr/local/${PACKAGE}"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="owncloud"
 MYSQL_DATABASE="owncloud"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -83,9 +84,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     # Stop the package
@@ -104,8 +113,12 @@ postuninst ()
     rm -f /etc/php/conf.d/${PACKAGE_NAME}.ini
     rm -f /etc/httpd/sites-enabled-user/${PACKAGE_NAME}.conf
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/owncloud/src/wizard/uninstall_uifile
+++ b/spk/owncloud/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove owncloud database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the owncloud database, all users will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove owncloud database"
-		}]
+		"desc": "Attention: The owncloud database will be removed during package uninstallation. All users will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the owncloud database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
 		}]
-	}]	
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/owncloud/src/wizard/uninstall_uifile_enu
+++ b/spk/owncloud/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove owncloud database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the owncloud database, all users will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove owncloud database"
-		}]
+		"desc": "Attention: The owncloud database will be removed during package uninstallation. All users will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the owncloud database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
 		}]
-	}]	
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/owncloud/src/wizard/uninstall_uifile_fre
+++ b/spk/owncloud/src/wizard/uninstall_uifile_fre
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Supprimer la base de donnée owncloud",
 	"items": [{
-		"type": "multiselect",
-		"desc": "Si vous supprimez la base de donnée owncloud, tous les utilisateurs seront supprimés.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Supprimer la base de donnée owncloud"
-		}]
+		"desc": "Si vous supprimez la base de donnée owncloud, tous les utilisateurs seront supprimés."
 	}, {
 		"type": "password",
-		"desc": "Saisissez votre mot de passe MySQL pour supprimer la base de donnée owncloud.",
+		"desc": "Saisissez votre mot de passe MySQL",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Mot de passe Root"
+			"desc": "Mot de passe Root",
+			"allowBlank": false
 		}]
-	}]	
+	}, {
+		"type": "textfield",
+		"desc": "Facultatif: Fournir répertoire pour l'exportation de base de données. Laissez vide pour sauter à l'exportation. Le répertoire sera créé s'il n'existe pas",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "L'emplacement de base de données à l'exportation",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Chemin doit commencer avec /volume?/ avec ? le numéro du volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/roundcube/src/installer.sh
+++ b/spk/roundcube/src/installer.sh
@@ -9,6 +9,7 @@ INSTALL_DIR="/usr/local/${PACKAGE}"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="roundcube"
 MYSQL_DATABASE="roundcube"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -66,9 +67,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     exit 0
@@ -79,8 +88,12 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/roundcube/src/wizard/uninstall_uifile
+++ b/spk/roundcube/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove Roundcube database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the roundcube database, mailboxes settings and contacts will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove roundcube database"
-		}]
+		"desc": "Attention: The roundcube database will be removed during package uninstallation. All mailbox settings and contacts will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the roundcube database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/roundcube/src/wizard/uninstall_uifile_enu
+++ b/spk/roundcube/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove Roundcube database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the roundcube database, mailboxes settings and contacts will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove roundcube database"
-		}]
+		"desc": "Attention: The roundcube database will be removed during package uninstallation. All mailbox settings and contacts will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the roundcube database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/selfoss/src/installer.sh
+++ b/spk/selfoss/src/installer.sh
@@ -10,6 +10,7 @@ SSS="/var/packages/${PACKAGE}/scripts/start-stop-status"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="selfoss"
 MYSQL_DATABASE="selfoss"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -70,9 +71,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     # Stop the package
@@ -86,8 +95,12 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/selfoss/src/wizard/uninstall_uifile
+++ b/spk/selfoss/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove selfoss database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the selfoss database, all feeds will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove selfoss database"
-		}]
+		"desc": "Attention: The selfoss database will be removed during package uninstallation. All feeds will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the selfoss database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/selfoss/src/wizard/uninstall_uifile_enu
+++ b/spk/selfoss/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove selfoss database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the selfoss database, all feeds will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove selfoss database"
-		}]
+		"desc": "Attention: The selfoss database will be removed during package uninstallation. All feeds will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the selfoss database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/selfoss/src/wizard/uninstall_uifile_fre
+++ b/spk/selfoss/src/wizard/uninstall_uifile_fre
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Suppression de la base de donnée selfoss",
 	"items": [{
-		"type": "multiselect",
-		"desc": "Si vous supprimez la base de donnée selfoss, tous les flux seront supprimées.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Supprimer la base de donnéee selfoss"
-		}]
+		"desc": "Si vous supprimez la base de donnée selfoss, tous les flux seront supprimées."
 	}, {
 		"type": "password",
-		"desc": "Saisissez votre mot de passe MySQL pour supprimer la base de donnée selfoss.",
+		"desc": "Saisissez votre mot de passe MySQL",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Mot de passe Root"
+			"desc": "Mot de passe Root",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Facultatif: Fournir répertoire pour l'exportation de base de données. Laissez vide pour sauter à l'exportation. Le répertoire sera créé s'il n'existe pas",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "L'emplacement de base de données à l'exportation",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Chemin doit commencer avec /volume?/ avec ? le numéro du volume"
+				}
+			}
 		}]
 	}]
 }]

--- a/spk/syncserver/src/wizard/uninstall_uifile
+++ b/spk/syncserver/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
-    "step_title": "Remove Firefox Sync Server database",
-    "items": [{
-        "type": "multiselect",
-        "desc": "If you remove the Firefox Sync Server database, all users and sync data will be deleted.",
-        "subitems": [{
-            "key": "wizard_remove_database",
-            "desc": "Remove Firefox Sync Server database"
-        }]
-    }, {
-        "type": "password",
-        "desc": "Enter your MySQL password to remove the Firefox Sync Server database.",
-        "subitems": [{
-            "key": "wizard_mysql_password_root",
-            "desc": "Root password"
-        }]
-    }]    
+	"step_title": "Remove Firefox Sync Server database",
+	"items": [{
+		"desc": "Attention: The Firefox Sync Server database will be removed during package uninstallation. All users and sync data will be deleted."
+	}, {
+		"type": "password",
+		"desc": "Enter your MySQL password",
+		"subitems": [{
+			"key": "wizard_mysql_password_root",
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/syncserver/src/wizard/uninstall_uifile_enu
+++ b/spk/syncserver/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
-    "step_title": "Remove Firefox Sync Server database",
-    "items": [{
-        "type": "multiselect",
-        "desc": "If you remove the Firefox Sync Server database, all users and sync data will be deleted.",
-        "subitems": [{
-            "key": "wizard_remove_database",
-            "desc": "Remove Firefox Sync Server database"
-        }]
-    }, {
-        "type": "password",
-        "desc": "Enter your MySQL password to remove the Firefox Sync Server database.",
-        "subitems": [{
-            "key": "wizard_mysql_password_root",
-            "desc": "Root password"
-        }]
-    }]    
+	"step_title": "Remove Firefox Sync Server database",
+	"items": [{
+		"desc": "Attention: The Firefox Sync Server database will be removed during package uninstallation. All users and sync data will be deleted."
+	}, {
+		"type": "password",
+		"desc": "Enter your MySQL password",
+		"subitems": [{
+			"key": "wizard_mysql_password_root",
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}
+		}]
+	}]
 }]

--- a/spk/tt-rss/src/installer.sh
+++ b/spk/tt-rss/src/installer.sh
@@ -10,6 +10,7 @@ SSS="/var/packages/${PACKAGE}/scripts/start-stop-status"
 WEB_DIR="/var/services/web"
 USER="$([ $(grep buildnumber /etc.defaults/VERSION | cut -d"\"" -f2) -ge 4418 ] && echo -n http || echo -n nobody)"
 MYSQL="/usr/syno/mysql/bin/mysql"
+MYSQLDUMP="/usr/syno/mysql/bin/mysqldump"
 MYSQL_USER="ttrss"
 MYSQL_DATABASE="ttrss"
 TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
@@ -72,9 +73,17 @@ postinst ()
 preuninst ()
 {
     # Check database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
         echo "Incorrect MySQL root password"
         exit 1
+    fi
+
+    # Check database export location
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a -n "${wizard_dbexport_path}" ]; then
+        if [ -f "${wizard_dbexport_path}" -o -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+            echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+            exit 1
+        fi
     fi
 
     # Stop the package
@@ -88,8 +97,12 @@ postuninst ()
     # Remove link
     rm -f ${INSTALL_DIR}
 
-    # Remove database
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" -a "${wizard_remove_database}" == "true" ]; then
+    # Export and remove database
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        if [ -n "${wizard_dbexport_path}" ]; then
+            mkdir -p ${wizard_dbexport_path}
+            ${MYSQLDUMP} -u root -p"${wizard_mysql_password_root}" ${MYSQL_DATABASE} > ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql
+        fi
         ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "DROP DATABASE ${MYSQL_DATABASE}; DROP USER '${MYSQL_USER}'@'localhost';"
     fi
 

--- a/spk/tt-rss/src/wizard/uninstall_uifile
+++ b/spk/tt-rss/src/wizard/uninstall_uifile
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove ttrss database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the ttrss database, all feeds will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove ttrss database"
-		}]
+		"desc": "Attention: The ttrss database will be removed during package uninstallation. All feeds will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the ttrss database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}		
 		}]
 	}]
 }]

--- a/spk/tt-rss/src/wizard/uninstall_uifile_enu
+++ b/spk/tt-rss/src/wizard/uninstall_uifile_enu
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Remove ttrss database",
 	"items": [{
-		"type": "multiselect",
-		"desc": "If you remove the ttrss database, all feeds will be deleted.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Remove ttrss database"
-		}]
+		"desc": "Attention: The ttrss database will be removed during package uninstallation. All feeds will be deleted."
 	}, {
 		"type": "password",
-		"desc": "Enter your MySQL password to remove the ttrss database.",
+		"desc": "Enter your MySQL password",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Root password"
+			"desc": "Root password",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Optional: Provide directory for database export. Leave blank to skip export. The directory will be created if it does not exist",
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "Database export location",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Path should begin with /volume?/ with ? the number of the volume"
+				}
+			}		
 		}]
 	}]
 }]

--- a/spk/tt-rss/src/wizard/uninstall_uifile_fre
+++ b/spk/tt-rss/src/wizard/uninstall_uifile_fre
@@ -1,18 +1,28 @@
 [{
 	"step_title": "Suppression de la base de donnée ttrss",
 	"items": [{
-		"type": "multiselect",
-		"desc": "Si vous supprimez la base de donnée ttrss, tous les flux seront supprimées.",
-		"subitems": [{
-			"key": "wizard_remove_database",
-			"desc": "Supprimer la base de donnée ttrss"
-		}]
+		"desc": "Si vous supprimez la base de donnée ttrss, tous les flux seront supprimées."
 	}, {
 		"type": "password",
-		"desc": "Saisissez votre mot de passe MySQL pour supprimer la base de donnée ttrss.",
+		"desc": "Saisissez votre mot de passe MySQL",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "Mot de passe Root"
+			"desc": "Mot de passe Root",
+			"allowBlank": false
+		}]
+	}, {
+		"type": "textfield",
+		"desc": "Facultatif: Fournir répertoire pour l'exportation de base de données. Laissez vide pour sauter à l'exportation. Le répertoire sera créé s'il n'existe pas",	
+		"subitems": [{
+			"key": "wizard_dbexport_path",
+			"desc": "L'emplacement de base de données à l'exportation",
+			"validator": {
+				"allowBlank": true,
+				"regex": {
+					"expr": "/^\\\/volume[0-9]+\\\//",
+					"errorText": "Chemin doit commencer avec /volume?/ avec ? le numéro du volume"
+				}
+			}		
 		}]
 	}]
 }]


### PR DESCRIPTION
As per #556, this PR changes two things: it adds a database export option, and will _always_ remove the database from MySQL during package uninstall.

This way, reinstalling the same package won't cause issues(e.g. #1246, https://github.com/SynoCommunity/spksrc/issues/556#issuecomment-56098717), and it still allows the data to be available in one form or the other.

Note this PR (for now) only updates ttrss spk. Any thoughts, before I change the rest of the packages?
