### PR TITLE
Create user btsync in DSM, for easy folder permissions

### DIFF
--- a/spk/btsync/Makefile
+++ b/spk/btsync/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = btsync
 SPK_VERS = 1.4.83
-SPK_REV = 8
+SPK_REV = 9
 SPK_ICON = src/btsync.png
 DSM_UI_DIR = app
 


### PR DESCRIPTION
User is created with synouser, so people can give the btsync user comfortably folder permissions over DSM. The user is created with an random password and deactivated.

**Important:** New installation is needed, upgrading doesn't add the user in DSM.

Tested and working.

~~**Important 2:** Shit, you must deinstall the old version because, `synouser --del ${USER}` doesn't remove the user which was created with adduser. Should I add `deluser ${USER}` to preuninst?~~

~~Or should I create an new package? btsync-dsm?~~

~~**Testing:**~~
~~When people want to test it, here are the builds: http://www.andreasgiemza.de/btsync-for-synocommunity/1.4.83-create-user-in-dsm-test/~~

~~Old version must be removed first. ~~

~~When you have activated ssh. Please tell me the btsync line of /etc/passwd.~~

**Not working like it should ... when i change the folder permission of the btsync user the home directory and shell is reseted .. but only on my 413j. This is not happening on my 210j. That's a problem ...**
