### PR TITLE
btsync: Sync group added, for easy folder permissions

### DIFF
--- a/spk/btsync/Makefile
+++ b/spk/btsync/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = btsync
 SPK_VERS = 1.4.103
-SPK_REV = 9
+SPK_REV = 10
 SPK_ICON = src/btsync.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie s√
 ADMIN_PORT = 8888
 RELOAD_UI = yes
 DISPLAY_NAME = BitTorrent Sync
-CHANGELOG = "Update to 1.4.103"
+CHANGELOG = "Sync group added, for easy folder permissions"
 
 HOMEPAGE   = http://www.bittorrent.com/sync
 LICENSE    =

--- a/spk/btsync/src/installer.sh
+++ b/spk/btsync/src/installer.sh
@@ -16,6 +16,23 @@ TMP_DIR="${SYNOPKG_PKGDEST}/../../@tmp"
 SERVICETOOL="/usr/syno/bin/servicetool"
 FWPORTS="/var/packages/${PACKAGE}/scripts/${PACKAGE}.sc"
 
+GROUP_SYNC="sc-btsync"
+GROUP_SYNC_DESC="SynoCommunity's BitTorrent Sync group"
+
+sync_group_create ()
+{
+    # Create sync group and add user (Does nothing when sync group already exists)
+    synogroup --add ${GROUP_SYNC} ${USER} > /dev/null
+    # Set description of the sync group
+    synogroup --descset ${GROUP_SYNC} "${GROUP_SYNC_DESC}"
+}
+
+sync_group_remove ()
+{
+    # Remove sync group
+    synogroup --del ${GROUP_SYNC} > /dev/null
+}
+
 preinst ()
 {
     exit 0
@@ -31,6 +48,8 @@ postinst ()
 
     # Create user
     adduser -h ${INSTALL_DIR}/var -g "${DNAME} User" -G ${GROUP} -s /bin/sh -S -D ${USER}
+
+    sync_group_create
 
     # Edit the configuration according to the wizard
     sed -i "s|@device_name@|${wizard_device_name:=NAS}|g" ${CFG_FILE}
@@ -51,6 +70,8 @@ preuninst ()
 
     # Remove the user (if not upgrading)
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
+        sync_group_remove
+
         delgroup ${USER} ${GROUP}
         deluser ${USER}
     fi
@@ -75,6 +96,14 @@ preupgrade ()
 {
     # Stop the package
     ${SSS} stop > /dev/null
+
+    # Revision 3 introduces backward incompatible changes
+    if [ `echo ${SYNOPKG_OLD_PKGVER} | sed -r "s/^.*-([0-9]+)$/\1/"` -lt 3 ]; then
+        echo "Please uninstall previous version, no update possible!"
+        exit 1
+    fi
+
+    sync_group_create
 
     # Save some stuff
     rm -fr ${TMP_DIR}/${PACKAGE}

--- a/spk/btsync/src/wizard/install_uifile
+++ b/spk/btsync/src/wizard/install_uifile
@@ -1,4 +1,9 @@
 [{
+    "step_title": "Information",
+    "items": [{
+        "desc": "The group sc-btsync will be created during installation, if not already created. You must provide the synocomm-sync group with read/write permissions on the folders you want to sync. You can set these permissions via Control Panel -> Group."
+    }]
+}, {
     "step_title": "Basic configuration",
     "items": [{
         "type": "textfield",

--- a/spk/btsync/src/wizard/install_uifile_enu
+++ b/spk/btsync/src/wizard/install_uifile_enu
@@ -1,4 +1,9 @@
 [{
+    "step_title": "Information",
+    "items": [{
+        "desc": "The group sc-btsync will be created during installation, if not already created. You must provide the synocomm-sync group with read/write permissions on the folders you want to sync. You can set these permissions via Control Panel -> Group."
+    }]
+}, {
     "step_title": "Basic configuration",
     "items": [{
         "type": "textfield",

--- a/spk/btsync/src/wizard/install_uifile_fre
+++ b/spk/btsync/src/wizard/install_uifile_fre
@@ -1,4 +1,9 @@
 [{
+    "step_title": "Information",
+    "items": [{
+        "desc": "The group sc-btsync will be created during installation, if not already created. You must provide the synocomm-sync group with read/write permissions on the folders you want to sync. You can set these permissions via Control Panel -> Group."
+    }]
+}, {
     "step_title": "Configuration de base",
     "items": [{
         "type": "textfield",

--- a/spk/btsync/src/wizard/install_uifile_ger
+++ b/spk/btsync/src/wizard/install_uifile_ger
@@ -1,0 +1,20 @@
+[{
+    "step_title": "Information",
+    "items": [{
+        "desc": "Die Gruppe sc-btsync wird während der Installation erstellt, wenn sie noch nicht erstellt wurde. Sie müssen der synocomm-sync Gruppe für die Ordner die Sie synchronisieren wollen Lesen/Schreiben Rechte geben. Die Rechte können Sie über die Systemsteuerung -> Gruppen gewähren."
+    }]
+}, {
+    "step_title": "Grundeinstellung",
+    "items": [{
+        "type": "textfield",
+        "desc": "Name von ihrem Gerät",
+        "subitems": [{
+            "key": "wizard_device_name",
+            "desc": "Gerätename",
+            "defaultValue": "NAS",
+            "validator": {
+                "allowBlank": false
+            }
+        }]
+    }]
+}]

--- a/spk/btsync/src/wizard/upgrade_uifile
+++ b/spk/btsync/src/wizard/upgrade_uifile
@@ -1,0 +1,6 @@
+[{
+    "step_title": "Information",
+    "items": [{
+        "desc": "The group sc-btsync will be created during update, if not already created. You must provide the synocomm-sync group with read/write permissions on the folders you want to sync. You can set these permissions via Control Panel -> Group."
+    }]
+}]

--- a/spk/btsync/src/wizard/upgrade_uifile_enu
+++ b/spk/btsync/src/wizard/upgrade_uifile_enu
@@ -1,0 +1,6 @@
+[{
+    "step_title": "Information",
+    "items": [{
+        "desc": "The group sc-btsync will be created during update, if not already created. You must provide the synocomm-sync group with read/write permissions on the folders you want to sync. You can set these permissions via Control Panel -> Group."
+    }]
+}]

--- a/spk/btsync/src/wizard/upgrade_uifile_fre
+++ b/spk/btsync/src/wizard/upgrade_uifile_fre
@@ -1,0 +1,6 @@
+[{
+    "step_title": "Information",
+    "items": [{
+        "desc": "The group sc-btsync will be created during update, if not already created. You must provide the synocomm-sync group with read/write permissions on the folders you want to sync. You can set these permissions via Control Panel -> Group."
+    }]
+}]

--- a/spk/btsync/src/wizard/upgrade_uifile_ger
+++ b/spk/btsync/src/wizard/upgrade_uifile_ger
@@ -1,0 +1,6 @@
+[{
+    "step_title": "Information",
+    "items": [{
+        "desc": "Die Gruppe sc-btsync wird während der Installation erstellt, wenn sie noch nicht erstellt wurde. Sie müssen der synocomm-sync Gruppe für die Ordner die Sie synchronisieren wollen Lesen/Schreiben Rechte geben. Die Rechte können Sie über die Systemsteuerung -> Gruppen gewähren."
+    }]
+}]


### PR DESCRIPTION
Good this way? Any suggestions?

Binaries for testing: http://www.andreasgiemza.de/btsync-for-synocommunity/1.4.103-with-sync-group-test/
Check here which package you need: https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model (88f6282 uses the 88f6281 architecture)

Changes:
- Removed adding user when creating group and using addgroup.
- Removed the check for empty group because now every package get it own group.