### PR TITLE
Update config and -template for NZBGet 14

### DIFF
--- a/cross/nzbget/Makefile
+++ b/cross/nzbget/Makefile
@@ -5,7 +5,7 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://sourceforge.net/projects/nzbget/files
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-DEPENDS = cross/libxml2 cross/ncurses cross/libsigc++ cross/libpar2 cross/openssl
+DEPENDS = cross/libxml2 cross/ncurses cross/openssl
 
 HOMEPAGE = http://nzbget.sourceforge.net/
 COMMENT  = NZBGet is a command-line based binary newsgrabber for nzb files, written in C++. It supports client/server mode, automatic par-check/-repair and web-interface. NZBGet requires low system resources.

--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbget
 SPK_VERS = 14.0
-SPK_REV = 12
+SPK_REV = 13
 SPK_ICON = src/nzbget.png
 DSM_UI_DIR = app
 
@@ -13,7 +13,7 @@ DESCRIPTION_SPN = NZBGet es una aplicación de linea de comandos escrita en C++ 
 RELOAD_UI = yes
 ADMIN_PORT = 6789
 DISPLAY_NAME = NZBGet
-CHANGELOG = "Update NZBGet to 14.0"
+CHANGELOG = "1. Update NZBGet to 14.0<br>2. Fix configuration"
 
 HOMEPAGE = http://nzbget.sourceforge.net/
 LICENSE  =

--- a/spk/nzbget/src/nzbget.conf
+++ b/spk/nzbget/src/nzbget.conf
@@ -91,7 +91,7 @@ LockFile=/usr/local/nzbget/var/nzbget.pid
 
 # Where to store log file, if it needs to be created.
 #
-# NOTE: See also option <CreateLog>.
+# NOTE: See also option <WriteLog>.
 LogFile=/usr/local/nzbget/var/nzbget.log
 
 # Configuration file template.
@@ -594,12 +594,13 @@ ReloadQueue=yes
 
 # Continue download of partially downloaded files (yes, no).
 #
-# If active the current state is saved after every article download and
-# reloaded after restart. This is about files included in download jobs (usually
-# rar-files), not about download-jobs (nzb-files) itself. Download-jobs are always
+# If active the current state (the info about what articles were already
+# downloaded) is saved every second and is reloaded after restart. This is
+# about files included in download jobs (usually rar-files), not about
+# download-jobs (nzb-files) itself. Download-jobs are always
 # continued regardless of that option.
 #
-# Disabling this option might slighlty reduce disk access and is
+# Disabling this option may slighlty reduce disk access and is
 # therefore recommended on fast connections.
 ContinuePartial=yes
 
@@ -614,36 +615,88 @@ PropagationDelay=0
 # Decode articles (yes, no).
 #
 # yes - decode articles using internal decoder (supports yEnc and UU formats);
-# no - the articles will not be decoded and joined. Useful for debugging to
-#      look at article's source text.
+# no - articles will not be decoded/joined. Useful to look at article's source text.
+#
+# NOTE: This option is primary for debugging purposes. You should not
+# disable it.
 Decode=yes
+
+# Memory limit for article cache (megabytes).
+#
+# Article cache helps to improve performance. First the amount of disk
+# operations can be significantly reduced. Second the created files are
+# less fragmented, which again speeds up the post-processing (unpacking).
+#
+# The article cache works best with option <DirectWrite> which can
+# effectively use even small cache (like 50 MB).
+#
+# If option <DirectWrite> is disabled the cache should be big enough to
+# hold all articles of one file (typically up to 200 MB, sometimes even
+# 500 MB). Otherwise the articles are written into temporary directory
+# when the cache is full, which degrades performance.
+#
+# Value "0" disables article cache.
+#
+# In 32 bit mode the maximum allowed value is 1900.
+#
+# NOTE: Also see option <WriteBuffer>.
+ArticleCache=0
 
 # Write decoded articles directly into destination output file (yes, no).
 #
-# Files are posted to Usenet in multiple pieces (articles). Each file typically
-# requires hundreds of articles.
+# Files are posted to Usenet in multiple pieces (articles). Each file
+# typically consists of hundreds of articles.
 #
-# When option <DirectWrite> is disabled, the program downloads all articles
-# into temporary directory and then combines them into destination file.
+# When option <DirectWrite> is disabled and the article cache (option
+# <ArticleCache>) is not active or is full the program saves downloaded
+# articles into temporary directory and later reads them all to write
+# again into the destination file.
 #
-# With this option enabled the program at first creates the output
-# destination file with required size (total size of all articles),
-# then writes on the fly decoded articles directly to the file
-# without creating of any temporary files.
+# When option <DirectWrite> is enabled the program at first creates the
+# output destination file with required size (total size of all articles),
+# then writes the articles directly to this file without creating of any
+# temporary files. If article cache (option <ArticleCache>) is active
+# the downloaded articles are saved into cache first and are written
+# into the destination file when the cache flushes. This happen when
+# all articles of the file are downloaded or when the cache becomes
+# full to 90%.
 #
-# This may improve performance but depends on OS and file system ability to
-# instantly create large files without initializing them with nulls. Such
-# files are called sparse files and are supported by modern file systems
-# like EXT3 on Linux or NTFS on Windows.
+# The direct write relies on the ability of file system to create 
+# empty files without allocating the space on the drive (sparse files),
+# which most modern file systems support including EXT3, EXT4
+# and NTFS. The notable exception is HFS+ (default file system on OSX).
 #
-# Using of this option reduces disk operations but may produce more fragmented
-# files (depends on disk driver), which may slow down the unpack.
-#
-# NOTE: It's recommended to test how the option behave on your platform to find the
-# best setting. For test try to download few big nzb-files (each 4GB or more)
-# and measure the time used for download and unpack (use timestamps
-# in the log-file to determine when the unpack was ended).
+# The direct write usually improves performance by reducing the amount
+# of disk operations but may produce more fragmented files when used
+# without article cache.
 DirectWrite=yes
+
+# Memory limit for per article write buffer (kilobytes).
+#
+# When downloaded articles are written into disk the OS collects
+# data in the internal buffer before flushing it into disk. This option
+# controls the size of this buffer per connection/download thread.
+#
+# Larger buffers decrease the amount of disk operations and help
+# producing less fragmented files speeding up the post-processing
+# (unpack).
+#
+# To calculate the maximum memory required for all download threads multiply
+# WriteBuffer by number of connections configured in section
+# "NEWS-SERVERS". The option sets the limit, the actual buffer can be
+# smaller if the article size (typically about 500 KB) is below the limit.
+#
+# Write-buffer is managed by OS (system libraries) and therefore
+# the effect of the option is highly OS-dependent.
+#
+# Recommended value for computers with enough memory: 1024.
+#
+# Value "0" disables the setting of buffer size. In this case a buffer
+# of default size (OS and compiler specific) is used, which is usually
+# too small (1-4 KB) and therefore not optimal.
+#
+# NOTE: Also see option <ArticleCache>.
+WriteBuffer=0
 
 # Check CRC of downloaded and decoded articles (yes, no).
 #
@@ -671,8 +724,13 @@ Retries=3
 # Set the interval between retries (seconds).
 RetryInterval=10
 
-# Set connection timeout (seconds).
-ConnectionTimeout=60
+# Set connection timeout for article downloading (seconds).
+ArticleTimeout=60
+
+# Set connection timeout for URL fetching (seconds).
+#
+# This includes fetching of nzb-files via URLs and fetching of RSS feeds.
+UrlTimeout=60
 
 # Timeout until a download-thread should be killed (seconds).
 #
@@ -704,29 +762,6 @@ DownloadRate=0
 # run tests to determine how the option affects the CPU usage and the
 # download speed on a particular system.
 AccurateRate=no
-
-# Set the size of memory buffer used by writing the articles (bytes).
-#
-# Bigger values decrease disk-io, but increase memory usage.
-# Value "0" causes an OS-dependent default value to be used.
-# With value "-1" (which means "max/auto") the program sets the size of
-# buffer according to the size of current article (typically less than 500K).
-#
-# NOTE: The value must be written in bytes, do not use postfixes "K" or "M".
-#
-# NOTE: To calculate the memory usage multiply WriteBufferSize by max number
-# of connections, configured in section "NEWS-SERVERS".
-#
-# NOTE: Typical article's size not exceed 500000 bytes, so using bigger values
-# (like several megabytes) will just waste memory.
-#
-# NOTE: For desktop computers with large amount of memory value "-1" (max/auto)
-# is recommended, but for computers with very low memory (routers, NAS)
-# value "0" (default OS-dependent size) could be better alternative.
-#
-# NOTE: Write-buffer is managed by OS (system libraries) and therefore
-# the effect of the option is highly OS-dependent.
-WriteBufferSize=0
 
 # Pause if disk space gets below this value (megabytes).
 #
@@ -808,11 +843,21 @@ UrlForce=yes
 ##############################################################################
 ### LOGGING                                                                ###
 
-# Create log file (yes, no).
-CreateLog=yes
+# How to use log file (none, append, reset, rotate).
+#
+#  none   - do not write into log file;
+#  append - append to the existing log file or create it;
+#  reset  - delete existing log file on program start and create a new one;
+#  rotate - create new log file for each day, delete old files,
+#           see option <RotateLog>.
+WriteLog=append
 
-# Delete log file upon server start (only in server-mode) (yes, no).
-ResetLog=no
+# Log file rotation period (days).
+#
+# Defines how long to keep old log-files, when log rotation is active
+# (option <WriteLog> is set to "rotate").
+RotateLog=3
+
 
 # How error messages must be printed (screen, log, both, none).
 ErrorTarget=both
@@ -929,21 +974,24 @@ UpdateInterval=200
 # Examples: "1-7", "1-5", "5,6", "1-5, 7".
 #Task1.WeekDays=1-7
 
-# Command to be executed ( PauseDownload, UnpauseDownload, PauseScan, UnpauseScan,
-# DownloadRate, Script, Process, ActivateServer, DeactivateServer, FetchFeed).
+# Command to be executed (PauseDownload, UnpauseDownload, PausePostProcess,
+# UnpausePostProcess, PauseScan, UnpauseScan, DownloadRate, Script, Process,
+# ActivateServer, DeactivateServer, FetchFeed).
 #
 # Possible commands:
-#   PauseDownload    - pause download;
-#   UnpauseDownload  - resume download;
-#   PauseScan        - pause scan of incoming nzb-directory;
-#   UnpauseScan      - resume scan of incoming nzb-directory;
-#   DownloadRate     - set download rate limit;
-#   Script           - execute one or multiple scheduler scripts. The scripts
-#                      must be written specially for NZBGet;
-#   Process          - execute an external (any) program;
-#   ActivateServer   - activate news-server;
-#   DeactivateServer - deactivate news-server;
-#   FetchFeed        - fetch RSS feed.
+#   PauseDownload      - pause download;
+#   UnpauseDownload    - resume download;
+#   PausePostProcess   - pause post-processing;
+#   UnpausePostProcess - resume post-processing;
+#   PauseScan          - pause scan of incoming nzb-directory;
+#   UnpauseScan        - resume scan of incoming nzb-directory;
+#   DownloadRate       - set download rate limit;
+#   Script             - execute one or multiple scheduler scripts. The scripts
+#                        must be written specially for NZBGet;
+#   Process            - execute an external (any) program;
+#   ActivateServer     - activate news-server;
+#   DeactivateServer   - deactivate news-server;
+#   FetchFeed          - fetch RSS feed.
 #
 # On start the program checks all tasks and determines current state
 # for download-pause, scan-pause, download-rate and active servers.
@@ -1032,6 +1080,17 @@ UpdateInterval=200
 #           eventually on another faster computer.
 ParCheck=auto
 
+# Check for renamed and missing files (yes, no).
+#
+# Par-rename restores original file names using information stored
+# in par2-files. It also detects missing files (files listed in
+# par2-files but not present on disk). When enabled the par-rename is
+# performed as the first step of post-processing for every nzb-file.
+#
+# Par-rename is very fast and is highly recommended, especially if
+# unpack is disabled.
+ParRename=yes
+
 # Automatic par-repair after par-verification (yes, no).
 #
 # If option <ParCheck> is set to "Auto" or "Force" this option defines
@@ -1049,34 +1108,53 @@ ParRepair=yes
 #  Auto    - a limited scan is performed first. If the par-checker 
 #            detects missing files, it scans other files in the 
 #            directory until all required files are found.
-#
-# NOTE: For par-check/repair NZBGet uses library libpar2. The widely
-# used version 0.2 of the library has few bugs, sometimes causing
-# a crash of the program. This is especially true when using "full" or
-# "auto" par-scan. NZBGet is supplied with patches addressing these
-# issues. Please apply the patches to libpar2 and recompile it.
 ParScan=auto
 
-# Check for renamed and missing files (yes, no).
+# Quick file verification during par-check (yes, no).
 #
-# Par-rename restores original file names using information stored
-# in par2-files. It also detects missing files (files listed in
-# par2-files but not present on disk). When enabled the par-rename is
-# performed as the first step of post-processing for every nzb-file.
+# If the option is active the files are quickly verified using
+# checksums calculated during download; quick verification is very fast 
+# because it doesn't require the reading of files from disk, NZBGet 
+# knows checksums of downloaded files and quickly compares them with 
+# checksums stored in the par-file.
 #
-# Par-rename is very fast and is highly recommended, especially if
-# unpack is disabled.
-ParRename=yes
+# If the option is disabled the files are verified as usual. That's
+# slow. Use this if the quick verification doesn't work properly.
+ParQuick=yes
 
-# Files to ignore when looking for missing files.
+# Memory limit for par-repair buffer (megabytes).
 #
-# List of file extensions or file names to ignore by par-rename. The
-# entries must be separated with commas. The entries can be file
-# extensions or any text the file name may end with.
+# Set the amount of RAM that the par-checker may use during repair. Having
+# the buffer as big as the total size of all damaged blocks allows for
+# the optimal repair speed. The option sets the maximum buffer size, the
+# allocated buffer can be smaller.
 #
-# If par-rename detects missing files it will ignore files matching
-# this option and will not initiate par-check/repair. This avoids
-# time costing par-check/repair for unimportant files.
+# If you have a lot of RAM set the option to few hundreds (MB) for the
+# best repair performance.
+ParBuffer=16
+
+# Number of threads to use during par-repair (0-99).
+#
+# On multi-core CPUs for the best speed set the option to the number of
+# logical cores (physical cores + hyper-threading units). If you want
+# to utilize the CPU to 100% you may need to add one or two additional threads
+# to compensate for wait intervals used for thread synchronization.
+#
+# On single-core CPUs use only one thread.
+#
+# Set to '0' to automatically use all available CPU cores (may not
+# work on old or exotic platforms).
+ParThreads=0
+
+# Files to ignore during par-check.
+#
+# List of file extensions or file names to ignore by par-rename and
+# par-check. The entries must be separated with commas. The entries
+# can be file extensions or any text the file name may end with.
+#
+# If par-rename or par-check detect missing or damaged files they
+# will ignore files matching this option and will not initiate
+# repair. This avoids time costing repair for unimportant files.
 #
 # NOTE: Files matching the option <ExtCleanupDisk> are ignored as well.
 #
@@ -1115,10 +1193,6 @@ HealthCheck=delete
 # affect the first stage of parcheck - verification of files. However the
 # verification speed is constant, it doesn't depend on files integrity and
 # therefore it is not necessary to limit the time needed for the first stage.
-#
-# NOTE: This option requires an extended version of libpar2 (the original
-# version doesn't support the cancelling of repairing). Please refer to
-# NZBGet's README for info on how to apply the patch to libpar2.
 ParTimeLimit=0
 
 # Pause download queue during check/repair (yes, no).
@@ -1143,6 +1217,11 @@ ParCleanupQueue=yes
 # List of file extensions or file names to delete after successful
 # download. The entries must be separated with commas. The entries 
 # can be file extensions or any text the file name may end with.
+#
+# Files or extensions listed here are also ignored by par-rename
+# and par-check.
+#
+# NOTE: See also option <ParIgnoreExt>.
 #
 # Example: .par2, .sfv
 ExtCleanupDisk=.par2, .sfv, _brokenlog.txt
@@ -1321,6 +1400,9 @@ SevenZipCmd=7z
 # parameter with name "myvar" and value "my value" will be associated
 # with nzb-file.
 #
+# To inform NZBGet about bad download:
+#   echo "[NZB] MARK=BAD";
+#
 # Return value: NZBGet processes the exit code returned by the script:
 #  93 - post-process successful (status = SUCCESS);
 #  94 - post-process failed (status = FAILURE);
@@ -1366,7 +1448,10 @@ PostScript=
 #  NZBNP_TOP  	   - flag indicating that the file will be added to the top
 #                    of queue: 0 or 1;
 #  NZBNP_PAUSED	   - flag indicating that the file will be added as
-#                    paused: 0 or 1.
+#                    paused: 0 or 1;
+#  NZBNP_DUPEKEY   - duplicate key of nzb-file;
+#  NZBNP_DUPESCORE - duplicate score of nzb-file;
+#  NZBNP_DUPEMODE  - duplicate mode of nzb-file: SCORE, ALL, FORCE.
 #
 # In addition to these arguments NZBGet passes all nzbget.conf-options 
 # as environment variables. These variables have prefix "NZBOP_" and
@@ -1421,6 +1506,15 @@ PostScript=
 # To change paused-flag (nzb-file will be added in paused state):
 #   echo "[NZB] PAUSED=1";
 #
+# To change duplicate key:
+#   echo "[NZB] DUPEKEY=tv show s01e02";
+#
+# To change duplicate score:
+#   echo "[NZB] DUPESCORE=integer_value";
+#
+# To change duplicate mode:
+#   echo "[NZB] DUPEMODE=(SCORE|ALL|FORCE)";
+#
 # The script can delete processed file, rename it or move somewhere.
 # After the calling of the script the file will be either added to queue
 # (if it was an nzb-file) or renamed by adding the extension ".processed".
@@ -1465,12 +1559,16 @@ ScanScript=
 #                   from nzb-directory this is the fullname with path.
 #                   If the file was added via web-interface it contains
 #                   only filename without path;
-#  NZBNA_EVENT    - describes why the script was called. Currently the
-#                   queue scripts are called only after adding nzb-files
-#                   to queue (NZBNA_EVENT=NZB_ADDED). In the future the
-#                   list of supported events may be extended. The script
-#                   MUST check that parameter to avoid conflicts with
-#                   future NZBGet versions;
+#  NZBNA_EVENT    - describes why the script was called:
+#                   NZB_ADDED - after adding of nzb-file to queue;
+#                   FILE_DOWNLOADED - after a file included in nzb is
+#                   downloaded;
+#                   NZB_DOWNLOADED - after all files in nzb are downloaded
+#                   (before post-processing).
+#                   In the future the list of supported events may be
+#                   extended. To avoid conflicts with future NZBGet
+#                   versions the script must exit if the parameter
+#                   has a value unknown to the script.
 #  NZBNA_CATEGORY - category of nzb-file (if assigned);
 #  NZBNA_NZBID    - id of the nzb-file. This ID can be used with 
 #                   calls to nzbget edit-command;
@@ -1484,7 +1582,20 @@ ScanScript=
 # options with predefined possible values (yes/no, etc.) the values are
 # passed always in lower case.
 #
-# Examples:
+# The script can printing special messages into standard output (which
+# is processed by NZBGet).
+#
+# To assign post-processing parameters:
+#   echo "[NZB] NZBPR_myvar=my value";
+#
+# The prefix "NZBPR_" will be removed. In this example a post-processing
+# parameter with name "myvar" and value "my value" will be associated
+# with nzb-file.
+#
+# To inform NZBGet about bad download:
+#   echo "[NZB] MARK=BAD";
+#
+# Examples of what the script can do:
 # 1) pausing nzb-file using file-id:
 # "$NZBOP_APPBIN" -c "$NZBOP_CONFIGFILE" -E G P $NZBNA_NZBID;
 # 2) setting category using nzb-name:
@@ -1516,3 +1627,27 @@ ScriptOrder=DeleteSamples.py, nzbToMedia*.py, Email.py, Logger.py
 #
 # NOTE: See also options <ParPauseQueue> and <UnpackPauseQueue>.
 ScriptPauseQueue=no
+
+# Minimum interval between calls of queue-scripts (seconds).
+#
+# Queue-scripts are executed during download, after every file included in
+# nzb-file is downloaded. If the files are small they may be downloaded
+# very fast causing queue-scripts to be working all the time. Sometimes
+# this may lead to a performance decrease on systems with slow CPUs.
+#
+# This option allows to reduce the number of calls of queue-scripts by
+# skipping "file-downloaded"-events if the previous call of queue-scripts
+# for the same download (nzb-file) were performed a short time ago
+# (as defined by the option).
+#
+# Value "-1" disables executing of queue-scripts on
+# "file-downloaded"-events. Scripts are still executed on events
+# "nzb-added" and "nzb-downloaded".
+#
+# NOTE: This options affects only queue-scripts and only
+# "file-downloaded"-events. Queue-scripts can be activated using
+# option <QueueScript> (for pure queue-scripts) or option <PostScript>
+# (for dual-mode scripts which act as queue- and post-processing-scripts
+# at the same time).
+EventInterval=0
+

--- a/spk/nzbget/src/nzbget.conf.template
+++ b/spk/nzbget/src/nzbget.conf.template
@@ -91,7 +91,7 @@ LockFile=${MainDir}/nzbget.lock
 
 # Where to store log file, if it needs to be created.
 #
-# NOTE: See also option <CreateLog>.
+# NOTE: See also option <WriteLog>.
 LogFile=${DestDir}/nzbget.log
 
 # Configuration file template.
@@ -594,12 +594,13 @@ ReloadQueue=yes
 
 # Continue download of partially downloaded files (yes, no).
 #
-# If active the current state is saved after every article download and
-# reloaded after restart. This is about files included in download jobs (usually
-# rar-files), not about download-jobs (nzb-files) itself. Download-jobs are always
+# If active the current state (the info about what articles were already
+# downloaded) is saved every second and is reloaded after restart. This is
+# about files included in download jobs (usually rar-files), not about
+# download-jobs (nzb-files) itself. Download-jobs are always
 # continued regardless of that option.
 #
-# Disabling this option might slighlty reduce disk access and is
+# Disabling this option may slighlty reduce disk access and is
 # therefore recommended on fast connections.
 ContinuePartial=yes
 
@@ -614,36 +615,88 @@ PropagationDelay=0
 # Decode articles (yes, no).
 #
 # yes - decode articles using internal decoder (supports yEnc and UU formats);
-# no - the articles will not be decoded and joined. Useful for debugging to
-#      look at article's source text.
+# no - articles will not be decoded/joined. Useful to look at article's source text.
+#
+# NOTE: This option is primary for debugging purposes. You should not
+# disable it.
 Decode=yes
+
+# Memory limit for article cache (megabytes).
+#
+# Article cache helps to improve performance. First the amount of disk
+# operations can be significantly reduced. Second the created files are
+# less fragmented, which again speeds up the post-processing (unpacking).
+#
+# The article cache works best with option <DirectWrite> which can
+# effectively use even small cache (like 50 MB).
+#
+# If option <DirectWrite> is disabled the cache should be big enough to
+# hold all articles of one file (typically up to 200 MB, sometimes even
+# 500 MB). Otherwise the articles are written into temporary directory
+# when the cache is full, which degrades performance.
+#
+# Value "0" disables article cache.
+#
+# In 32 bit mode the maximum allowed value is 1900.
+#
+# NOTE: Also see option <WriteBuffer>.
+ArticleCache=0
 
 # Write decoded articles directly into destination output file (yes, no).
 #
-# Files are posted to Usenet in multiple pieces (articles). Each file typically
-# requires hundreds of articles.
+# Files are posted to Usenet in multiple pieces (articles). Each file
+# typically consists of hundreds of articles.
 #
-# When option <DirectWrite> is disabled, the program downloads all articles
-# into temporary directory and then combines them into destination file.
+# When option <DirectWrite> is disabled and the article cache (option
+# <ArticleCache>) is not active or is full the program saves downloaded
+# articles into temporary directory and later reads them all to write
+# again into the destination file.
 #
-# With this option enabled the program at first creates the output
-# destination file with required size (total size of all articles),
-# then writes on the fly decoded articles directly to the file
-# without creating of any temporary files.
+# When option <DirectWrite> is enabled the program at first creates the
+# output destination file with required size (total size of all articles),
+# then writes the articles directly to this file without creating of any
+# temporary files. If article cache (option <ArticleCache>) is active
+# the downloaded articles are saved into cache first and are written
+# into the destination file when the cache flushes. This happen when
+# all articles of the file are downloaded or when the cache becomes
+# full to 90%.
 #
-# This may improve performance but depends on OS and file system ability to
-# instantly create large files without initializing them with nulls. Such
-# files are called sparse files and are supported by modern file systems
-# like EXT3 on Linux or NTFS on Windows.
+# The direct write relies on the ability of file system to create 
+# empty files without allocating the space on the drive (sparse files),
+# which most modern file systems support including EXT3, EXT4
+# and NTFS. The notable exception is HFS+ (default file system on OSX).
 #
-# Using of this option reduces disk operations but may produce more fragmented
-# files (depends on disk driver), which may slow down the unpack.
-#
-# NOTE: It's recommended to test how the option behave on your platform to find the
-# best setting. For test try to download few big nzb-files (each 4GB or more)
-# and measure the time used for download and unpack (use timestamps
-# in the log-file to determine when the unpack was ended).
+# The direct write usually improves performance by reducing the amount
+# of disk operations but may produce more fragmented files when used
+# without article cache.
 DirectWrite=yes
+
+# Memory limit for per article write buffer (kilobytes).
+#
+# When downloaded articles are written into disk the OS collects
+# data in the internal buffer before flushing it into disk. This option
+# controls the size of this buffer per connection/download thread.
+#
+# Larger buffers decrease the amount of disk operations and help
+# producing less fragmented files speeding up the post-processing
+# (unpack).
+#
+# To calculate the maximum memory required for all download threads multiply
+# WriteBuffer by number of connections configured in section
+# "NEWS-SERVERS". The option sets the limit, the actual buffer can be
+# smaller if the article size (typically about 500 KB) is below the limit.
+#
+# Write-buffer is managed by OS (system libraries) and therefore
+# the effect of the option is highly OS-dependent.
+#
+# Recommended value for computers with enough memory: 1024.
+#
+# Value "0" disables the setting of buffer size. In this case a buffer
+# of default size (OS and compiler specific) is used, which is usually
+# too small (1-4 KB) and therefore not optimal.
+#
+# NOTE: Also see option <ArticleCache>.
+WriteBuffer=0
 
 # Check CRC of downloaded and decoded articles (yes, no).
 #
@@ -671,8 +724,13 @@ Retries=3
 # Set the interval between retries (seconds).
 RetryInterval=10
 
-# Set connection timeout (seconds).
-ConnectionTimeout=60
+# Set connection timeout for article downloading (seconds).
+ArticleTimeout=60
+
+# Set connection timeout for URL fetching (seconds).
+#
+# This includes fetching of nzb-files via URLs and fetching of RSS feeds.
+UrlTimeout=60
 
 # Timeout until a download-thread should be killed (seconds).
 #
@@ -704,29 +762,6 @@ DownloadRate=0
 # run tests to determine how the option affects the CPU usage and the
 # download speed on a particular system.
 AccurateRate=no
-
-# Set the size of memory buffer used by writing the articles (bytes).
-#
-# Bigger values decrease disk-io, but increase memory usage.
-# Value "0" causes an OS-dependent default value to be used.
-# With value "-1" (which means "max/auto") the program sets the size of
-# buffer according to the size of current article (typically less than 500K).
-#
-# NOTE: The value must be written in bytes, do not use postfixes "K" or "M".
-#
-# NOTE: To calculate the memory usage multiply WriteBufferSize by max number
-# of connections, configured in section "NEWS-SERVERS".
-#
-# NOTE: Typical article's size not exceed 500000 bytes, so using bigger values
-# (like several megabytes) will just waste memory.
-#
-# NOTE: For desktop computers with large amount of memory value "-1" (max/auto)
-# is recommended, but for computers with very low memory (routers, NAS)
-# value "0" (default OS-dependent size) could be better alternative.
-#
-# NOTE: Write-buffer is managed by OS (system libraries) and therefore
-# the effect of the option is highly OS-dependent.
-WriteBufferSize=0
 
 # Pause if disk space gets below this value (megabytes).
 #
@@ -808,11 +843,21 @@ UrlForce=yes
 ##############################################################################
 ### LOGGING                                                                ###
 
-# Create log file (yes, no).
-CreateLog=yes
+# How to use log file (none, append, reset, rotate).
+#
+#  none   - do not write into log file;
+#  append - append to the existing log file or create it;
+#  reset  - delete existing log file on program start and create a new one;
+#  rotate - create new log file for each day, delete old files,
+#           see option <RotateLog>.
+WriteLog=append
 
-# Delete log file upon server start (only in server-mode) (yes, no).
-ResetLog=no
+# Log file rotation period (days).
+#
+# Defines how long to keep old log-files, when log rotation is active
+# (option <WriteLog> is set to "rotate").
+RotateLog=3
+
 
 # How error messages must be printed (screen, log, both, none).
 ErrorTarget=both
@@ -929,21 +974,24 @@ UpdateInterval=200
 # Examples: "1-7", "1-5", "5,6", "1-5, 7".
 #Task1.WeekDays=1-7
 
-# Command to be executed ( PauseDownload, UnpauseDownload, PauseScan, UnpauseScan,
-# DownloadRate, Script, Process, ActivateServer, DeactivateServer, FetchFeed).
+# Command to be executed (PauseDownload, UnpauseDownload, PausePostProcess,
+# UnpausePostProcess, PauseScan, UnpauseScan, DownloadRate, Script, Process,
+# ActivateServer, DeactivateServer, FetchFeed).
 #
 # Possible commands:
-#   PauseDownload    - pause download;
-#   UnpauseDownload  - resume download;
-#   PauseScan        - pause scan of incoming nzb-directory;
-#   UnpauseScan      - resume scan of incoming nzb-directory;
-#   DownloadRate     - set download rate limit;
-#   Script           - execute one or multiple scheduler scripts. The scripts
-#                      must be written specially for NZBGet;
-#   Process          - execute an external (any) program;
-#   ActivateServer   - activate news-server;
-#   DeactivateServer - deactivate news-server;
-#   FetchFeed        - fetch RSS feed.
+#   PauseDownload      - pause download;
+#   UnpauseDownload    - resume download;
+#   PausePostProcess   - pause post-processing;
+#   UnpausePostProcess - resume post-processing;
+#   PauseScan          - pause scan of incoming nzb-directory;
+#   UnpauseScan        - resume scan of incoming nzb-directory;
+#   DownloadRate       - set download rate limit;
+#   Script             - execute one or multiple scheduler scripts. The scripts
+#                        must be written specially for NZBGet;
+#   Process            - execute an external (any) program;
+#   ActivateServer     - activate news-server;
+#   DeactivateServer   - deactivate news-server;
+#   FetchFeed          - fetch RSS feed.
 #
 # On start the program checks all tasks and determines current state
 # for download-pause, scan-pause, download-rate and active servers.
@@ -1032,6 +1080,17 @@ UpdateInterval=200
 #           eventually on another faster computer.
 ParCheck=auto
 
+# Check for renamed and missing files (yes, no).
+#
+# Par-rename restores original file names using information stored
+# in par2-files. It also detects missing files (files listed in
+# par2-files but not present on disk). When enabled the par-rename is
+# performed as the first step of post-processing for every nzb-file.
+#
+# Par-rename is very fast and is highly recommended, especially if
+# unpack is disabled.
+ParRename=yes
+
 # Automatic par-repair after par-verification (yes, no).
 #
 # If option <ParCheck> is set to "Auto" or "Force" this option defines
@@ -1049,34 +1108,53 @@ ParRepair=yes
 #  Auto    - a limited scan is performed first. If the par-checker 
 #            detects missing files, it scans other files in the 
 #            directory until all required files are found.
-#
-# NOTE: For par-check/repair NZBGet uses library libpar2. The widely
-# used version 0.2 of the library has few bugs, sometimes causing
-# a crash of the program. This is especially true when using "full" or
-# "auto" par-scan. NZBGet is supplied with patches addressing these
-# issues. Please apply the patches to libpar2 and recompile it.
 ParScan=auto
 
-# Check for renamed and missing files (yes, no).
+# Quick file verification during par-check (yes, no).
 #
-# Par-rename restores original file names using information stored
-# in par2-files. It also detects missing files (files listed in
-# par2-files but not present on disk). When enabled the par-rename is
-# performed as the first step of post-processing for every nzb-file.
+# If the option is active the files are quickly verified using
+# checksums calculated during download; quick verification is very fast 
+# because it doesn't require the reading of files from disk, NZBGet 
+# knows checksums of downloaded files and quickly compares them with 
+# checksums stored in the par-file.
 #
-# Par-rename is very fast and is highly recommended, especially if
-# unpack is disabled.
-ParRename=yes
+# If the option is disabled the files are verified as usual. That's
+# slow. Use this if the quick verification doesn't work properly.
+ParQuick=yes
 
-# Files to ignore when looking for missing files.
+# Memory limit for par-repair buffer (megabytes).
 #
-# List of file extensions or file names to ignore by par-rename. The
-# entries must be separated with commas. The entries can be file
-# extensions or any text the file name may end with.
+# Set the amount of RAM that the par-checker may use during repair. Having
+# the buffer as big as the total size of all damaged blocks allows for
+# the optimal repair speed. The option sets the maximum buffer size, the
+# allocated buffer can be smaller.
 #
-# If par-rename detects missing files it will ignore files matching
-# this option and will not initiate par-check/repair. This avoids
-# time costing par-check/repair for unimportant files.
+# If you have a lot of RAM set the option to few hundreds (MB) for the
+# best repair performance.
+ParBuffer=16
+
+# Number of threads to use during par-repair (0-99).
+#
+# On multi-core CPUs for the best speed set the option to the number of
+# logical cores (physical cores + hyper-threading units). If you want
+# to utilize the CPU to 100% you may need to add one or two additional threads
+# to compensate for wait intervals used for thread synchronization.
+#
+# On single-core CPUs use only one thread.
+#
+# Set to '0' to automatically use all available CPU cores (may not
+# work on old or exotic platforms).
+ParThreads=0
+
+# Files to ignore during par-check.
+#
+# List of file extensions or file names to ignore by par-rename and
+# par-check. The entries must be separated with commas. The entries
+# can be file extensions or any text the file name may end with.
+#
+# If par-rename or par-check detect missing or damaged files they
+# will ignore files matching this option and will not initiate
+# repair. This avoids time costing repair for unimportant files.
 #
 # NOTE: Files matching the option <ExtCleanupDisk> are ignored as well.
 #
@@ -1115,10 +1193,6 @@ HealthCheck=delete
 # affect the first stage of parcheck - verification of files. However the
 # verification speed is constant, it doesn't depend on files integrity and
 # therefore it is not necessary to limit the time needed for the first stage.
-#
-# NOTE: This option requires an extended version of libpar2 (the original
-# version doesn't support the cancelling of repairing). Please refer to
-# NZBGet's README for info on how to apply the patch to libpar2.
 ParTimeLimit=0
 
 # Pause download queue during check/repair (yes, no).
@@ -1143,6 +1217,11 @@ ParCleanupQueue=yes
 # List of file extensions or file names to delete after successful
 # download. The entries must be separated with commas. The entries 
 # can be file extensions or any text the file name may end with.
+#
+# Files or extensions listed here are also ignored by par-rename
+# and par-check.
+#
+# NOTE: See also option <ParIgnoreExt>.
 #
 # Example: .par2, .sfv
 ExtCleanupDisk=.par2, .sfv, _brokenlog.txt
@@ -1321,6 +1400,9 @@ SevenZipCmd=7z
 # parameter with name "myvar" and value "my value" will be associated
 # with nzb-file.
 #
+# To inform NZBGet about bad download:
+#   echo "[NZB] MARK=BAD";
+#
 # Return value: NZBGet processes the exit code returned by the script:
 #  93 - post-process successful (status = SUCCESS);
 #  94 - post-process failed (status = FAILURE);
@@ -1366,7 +1448,10 @@ PostScript=
 #  NZBNP_TOP  	   - flag indicating that the file will be added to the top
 #                    of queue: 0 or 1;
 #  NZBNP_PAUSED	   - flag indicating that the file will be added as
-#                    paused: 0 or 1.
+#                    paused: 0 or 1;
+#  NZBNP_DUPEKEY   - duplicate key of nzb-file;
+#  NZBNP_DUPESCORE - duplicate score of nzb-file;
+#  NZBNP_DUPEMODE  - duplicate mode of nzb-file: SCORE, ALL, FORCE.
 #
 # In addition to these arguments NZBGet passes all nzbget.conf-options 
 # as environment variables. These variables have prefix "NZBOP_" and
@@ -1421,6 +1506,15 @@ PostScript=
 # To change paused-flag (nzb-file will be added in paused state):
 #   echo "[NZB] PAUSED=1";
 #
+# To change duplicate key:
+#   echo "[NZB] DUPEKEY=tv show s01e02";
+#
+# To change duplicate score:
+#   echo "[NZB] DUPESCORE=integer_value";
+#
+# To change duplicate mode:
+#   echo "[NZB] DUPEMODE=(SCORE|ALL|FORCE)";
+#
 # The script can delete processed file, rename it or move somewhere.
 # After the calling of the script the file will be either added to queue
 # (if it was an nzb-file) or renamed by adding the extension ".processed".
@@ -1465,12 +1559,16 @@ ScanScript=
 #                   from nzb-directory this is the fullname with path.
 #                   If the file was added via web-interface it contains
 #                   only filename without path;
-#  NZBNA_EVENT    - describes why the script was called. Currently the
-#                   queue scripts are called only after adding nzb-files
-#                   to queue (NZBNA_EVENT=NZB_ADDED). In the future the
-#                   list of supported events may be extended. The script
-#                   MUST check that parameter to avoid conflicts with
-#                   future NZBGet versions;
+#  NZBNA_EVENT    - describes why the script was called:
+#                   NZB_ADDED - after adding of nzb-file to queue;
+#                   FILE_DOWNLOADED - after a file included in nzb is
+#                   downloaded;
+#                   NZB_DOWNLOADED - after all files in nzb are downloaded
+#                   (before post-processing).
+#                   In the future the list of supported events may be
+#                   extended. To avoid conflicts with future NZBGet
+#                   versions the script must exit if the parameter
+#                   has a value unknown to the script.
 #  NZBNA_CATEGORY - category of nzb-file (if assigned);
 #  NZBNA_NZBID    - id of the nzb-file. This ID can be used with 
 #                   calls to nzbget edit-command;
@@ -1484,7 +1582,20 @@ ScanScript=
 # options with predefined possible values (yes/no, etc.) the values are
 # passed always in lower case.
 #
-# Examples:
+# The script can printing special messages into standard output (which
+# is processed by NZBGet).
+#
+# To assign post-processing parameters:
+#   echo "[NZB] NZBPR_myvar=my value";
+#
+# The prefix "NZBPR_" will be removed. In this example a post-processing
+# parameter with name "myvar" and value "my value" will be associated
+# with nzb-file.
+#
+# To inform NZBGet about bad download:
+#   echo "[NZB] MARK=BAD";
+#
+# Examples of what the script can do:
 # 1) pausing nzb-file using file-id:
 # "$NZBOP_APPBIN" -c "$NZBOP_CONFIGFILE" -E G P $NZBNA_NZBID;
 # 2) setting category using nzb-name:
@@ -1516,3 +1627,27 @@ ScriptOrder=
 #
 # NOTE: See also options <ParPauseQueue> and <UnpackPauseQueue>.
 ScriptPauseQueue=no
+
+# Minimum interval between calls of queue-scripts (seconds).
+#
+# Queue-scripts are executed during download, after every file included in
+# nzb-file is downloaded. If the files are small they may be downloaded
+# very fast causing queue-scripts to be working all the time. Sometimes
+# this may lead to a performance decrease on systems with slow CPUs.
+#
+# This option allows to reduce the number of calls of queue-scripts by
+# skipping "file-downloaded"-events if the previous call of queue-scripts
+# for the same download (nzb-file) were performed a short time ago
+# (as defined by the option).
+#
+# Value "-1" disables executing of queue-scripts on
+# "file-downloaded"-events. Scripts are still executed on events
+# "nzb-added" and "nzb-downloaded".
+#
+# NOTE: This options affects only queue-scripts and only
+# "file-downloaded"-events. Queue-scripts can be activated using
+# option <QueueScript> (for pure queue-scripts) or option <PostScript>
+# (for dual-mode scripts which act as queue- and post-processing-scripts
+# at the same time).
+EventInterval=0
+


### PR DESCRIPTION
Replaced the conf and -template files with up-to-date ones for v14.
Also removed `cross/libsigc++` and `cross/libpar`: no longer needed.

Did a quick test with upgrade and a new install: both seem to work as expected.
