### PR TITLE
Rules 'n' things

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -20,9 +20,24 @@ endif
 
 ifneq ($(REQ_KERNEL),)
   ifeq ($(ARCH),x64)
-    $(error x64 arch cannot be used when REQ_KERNEL is set )
+    @$(error x64 arch cannot be used when REQ_KERNEL is set )
   endif
 endif
+
+# Check if package supports ARCH
+ifneq ($(UNSUPPORTED_ARCH),)
+  ifeq ($(UNSUPPORTED_ARCH),$(ARCH))
+    @$(error Stop: ARCH $(ARCH) is not a supported architecture )
+  endif
+endif
+
+# Check minimum DSM requirements of package
+ifneq ($(REQUIRED_DSM),)
+  ifneq ($(REQUIRED_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_DSM))))
+    @$(error Stop: Toolchain $(TCVERSION) is lower than required version in Makefile $(REQUIRED_DSM) )
+  endif
+endif
+
 
 #####
 
@@ -71,16 +86,7 @@ smart-clean:
 clean:
 	rm -fr work work-*
 
-# Compare optional Makefile REQUIRED_DSM to provided TCVERSION. If REQ_DSM is lower than TCVERSION, exit
-checkversion:
-ifneq ($(REQUIRED_DSM),)
-  ifneq ($(REQUIRED_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_DSM))))
-	@$(MSG) "Stop: Toolchain $(TCVERSION) is lower than required version in Makefile $(REQUIRED_DSM) "
-	@exit 1
-  endif
-endif
-
-all: checkversion install
+all: install
 
 
 SUPPORTED_TCS = $(notdir $(wildcard ../../toolchains/syno-*))
@@ -108,6 +114,19 @@ dependency-tree:
 	@for depend in $(DEPENDS) ; \
 	do \
 	  $(MAKE) --no-print-directory -C ../../$$depend dependency-tree ; \
+	done
+
+.PHONY: kernel-required
+kernel-required:
+	@if [ -n "$(REQ_KERNEL)" ]; then \
+	  exit 1 ; \
+	fi
+	@for depend in $(DEPENDS) ; do \
+	  if $(MAKE) --no-print-directory -C ../../$$depend kernel-required >/dev/null 2>&1 ; then \
+	    exit 0 ; \
+	  else \
+	    exit 1 ; \
+	  fi ; \
 	done
 
 .PHONY: all-archs


### PR DESCRIPTION
Follow-up of #1276. Some fixes, some new functionality.

The `kernel_required` rule passes on information from a sub-make to the top level. A check file is created on each level if REQ_KERNEL is set, and is passed on from level to level, until it ends up at the top level.
The downside is the rules don't look great, but I'm not sure there's a way around that.

x64-related: the evansport arch is not included in Synology's x64 arch, probably because it's 32-bit (?).
