### PR TITLE
FIX: Debian chroot fails to start up slow scripts

### DIFF
--- a/spk/debian-chroot/src/app/application/direct.py
+++ b/spk/debian-chroot/src/app/application/direct.py
@@ -2,6 +2,7 @@ from pyextdirect.configuration import create_configuration, expose, LOAD, STORE_
 from pyextdirect.router import Router
 import os
 import subprocess
+import time
 from config import *
 from db import *
 


### PR DESCRIPTION
This script starts all Debian chroot services defined via the DSM Debian chroot web interface. If an init.d script didn't return immediately, it would wait on the script, except it doesn't seem this was ever tested as the time package is never imported. When this script would wait on a slow init.d script, it would throw an exception and error out. I discovered this while trying to run ElasticSearch on startup.