### PR TITLE
Fix Sonarr launch menu icon

### DIFF
--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbdrone
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 3
+SPK_REV = 4
 SPK_ICON = src/sonarr.png
 DSM_UI_DIR = app
 
@@ -20,7 +20,7 @@ DESCRIPTION_SPN = Sonarr es un PVR para los usuarios de grupos de noticias. Se p
 ADMIN_PORT = 8989
 RELOAD_UI = yes
 DISPLAY_NAME = Sonarr
-CHANGELOG = "NzbDrone to Sonarr"
+CHANGELOG = "Fixed icon in launch menu"
 
 HOMEPAGE = https://sonarr.tv
 LICENSE  =

--- a/spk/sonarr/src/app/config
+++ b/spk/sonarr/src/app/config
@@ -3,7 +3,7 @@
         "com.synocommunity.packages.sonarr": {
             "title": "Sonarr",
             "desc": "Sonarr Web UI",
-            "icon": "images/sonarr-{0}.png",
+            "icon": "images/nzbdrone-{0}.png",
             "type": "url",
             "protocol": "http",
             "port": "8989",


### PR DESCRIPTION
icon file name in ```spk/sonarr/src/app/config``` needed to match the ```spk_name``` to show up properly in launch menu