### PR TITLE
Sonarr runs mono with debug flag

### DIFF
--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbdrone
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/sonarr.png
 DSM_UI_DIR = app
 
@@ -20,7 +20,7 @@ DESCRIPTION_SPN = Sonarr es un PVR para los usuarios de grupos de noticias. Se p
 ADMIN_PORT = 8989
 RELOAD_UI = yes
 DISPLAY_NAME = Sonarr
-CHANGELOG = "Fixed icon in launch menu"
+CHANGELOG = "Now runs mono in debug mode"
 
 HOMEPAGE = https://sonarr.tv
 LICENSE  =

--- a/spk/sonarr/src/dsm-control.sh
+++ b/spk/sonarr/src/dsm-control.sh
@@ -14,11 +14,11 @@ INSTALL_LOG="${INSTALL_DIR}/var/install.log"
 MONO_PATH="/usr/local/mono/bin"
 MONO="${MONO_PATH}/mono"
 SONARR="${INSTALL_DIR}/share/NzbDrone/NzbDrone.exe"
-COMMAND="env PATH=${MONO_PATH}:${PATH} LD_LIBRARY_PATH=${INSTALL_DIR}/lib ${MONO} ${SONARR}"
+COMMAND="env PATH=${MONO_PATH}:${PATH} LD_LIBRARY_PATH=${INSTALL_DIR}/lib ${MONO} -- --debug ${SONARR}"
 
 start_daemon ()
 {
-    start-stop-daemon -S -q -b -N 10 -x ${COMMAND} -c ${USER} > /dev/null
+    start-stop-daemon -c ${USER} -S -q -b -N 10 -x ${COMMAND} > /dev/null
     sleep 2
 }
 


### PR DESCRIPTION
Changed so that mono runs in debug mode to assist Sonarr devs when troubleshooting issues (adds line numbers to logging.)