### PR TITLE
Added "force update" flag to init script, useful for systems that do not stay on 24/7 (sickbeard updates show info at 3AM)

### DIFF
--- a/spk/sickbeard/src/dsm-control.sh
+++ b/spk/sickbeard/src/dsm-control.sh
@@ -18,7 +18,7 @@ LOG_FILE="${INSTALL_DIR}/var/Logs/sickbeard.log"
 
 start_daemon ()
 {
-    su - ${USER} -c "PATH=${PATH} ${PYTHON} ${SICKBEARD} --daemon --pidfile ${PID_FILE} --config ${CFG_FILE} --datadir ${INSTALL_DIR}/var/"
+    su - ${USER} -c "PATH=${PATH} ${PYTHON} ${SICKBEARD} --daemon --pidfile ${PID_FILE} --config ${CFG_FILE} --datadir ${INSTALL_DIR}/var/ --forceupdate"
 }
 
 stop_daemon ()


### PR DESCRIPTION
Systems that do not stay online overnight (3AM specifically) will experience a problem where sickbeard will not automatically download new episodes after a while because it is unaware of the existence of new episodes. Adding the --forceupdate flag to the initialization script fixes this issue by making sickbeard update its tv shows on start instead of the scheduled 3AM. Sickbeard does not allow the user to change the time when this happens in the settings (3AM is hardcoded) so this seems like an easy fix for anybody experiencing these issues.