### PR TITLE
Update ffmpeg, fix compile issues

### DIFF
--- a/cross/ffmpeg/Makefile
+++ b/cross/ffmpeg/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = ffmpeg
-PKG_VERS = 2.1.1
+PKG_VERS = 2.6
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.ffmpeg.org/releases/

--- a/cross/ffmpeg/digests
+++ b/cross/ffmpeg/digests
@@ -1,0 +1,3 @@
+ffmpeg-2.6.tar.gz SHA1 9fb8f3c294efb11c6852fd9f114e3c731b67a1a0
+ffmpeg-2.6.tar.gz SHA256 69a2326c744ef58d24b74706ed0c98db1c38fc4c990e2152c0ad4f05b9bd8afa
+ffmpeg-2.6.tar.gz MD5 d175d293e53dec181f1a36d4bfdaebf1

--- a/cross/ffmpeg/patches/Makefile.patch
+++ b/cross/ffmpeg/patches/Makefile.patch
@@ -1,0 +1,11 @@
+--- Makefile.orig	2015-03-15 09:26:17.015099900 +0100
++++ Makefile	2015-03-15 09:26:27.707050432 +0100
+@@ -92,7 +92,7 @@
+ $(foreach V,$(SUBDIR_VARS),$(eval $(call RESET,$(V))))
+ SUBDIR := $(1)/
+ include $(SRC_PATH)/$(1)/Makefile
+--include $(SRC_PATH)/$(1)/$(ARCH)/Makefile
++-include $(SRC_PATH)/$(1)/$(FFMPEG_ARCH)/Makefile
+ -include $(SRC_PATH)/$(1)/$(INTRINSICS)/Makefile
+ include $(SRC_PATH)/library.mak
+ endef

--- a/cross/ffmpeg/patches/common.mak.patch
+++ b/cross/ffmpeg/patches/common.mak.patch
@@ -1,0 +1,13 @@
+--- common.mak.orig	2015-03-15 09:29:05.910777051 +0100
++++ common.mak	2015-03-15 09:29:27.522698423 +0100
+@@ -122,8 +122,8 @@
+ DEP_LIBS := $(foreach lib,$(FFLIBS),$(call PATH_LIBNAME,$(lib)))
+ 
+ SRC_DIR    := $(SRC_PATH)/lib$(NAME)
+-ALLHEADERS := $(subst $(SRC_DIR)/,$(SUBDIR),$(wildcard $(SRC_DIR)/*.h $(SRC_DIR)/$(ARCH)/*.h))
+-SKIPHEADERS += $(ARCH_HEADERS:%=$(ARCH)/%) $(SKIPHEADERS-)
++ALLHEADERS := $(subst $(SRC_DIR)/,$(SUBDIR),$(wildcard $(SRC_DIR)/*.h $(SRC_DIR)/$(FFMPEG_ARCH)/*.h))
++SKIPHEADERS += $(ARCH_HEADERS:%=$(FFMPEG_ARCH)/%) $(SKIPHEADERS-)
+ SKIPHEADERS := $(SKIPHEADERS:%=$(SUBDIR)%)
+ HOBJS        = $(filter-out $(SKIPHEADERS:.h=.h.o),$(ALLHEADERS:.h=.h.o))
+ checkheaders: $(HOBJS)

--- a/cross/ffmpeg/patches/configure.patch
+++ b/cross/ffmpeg/patches/configure.patch
@@ -1,0 +1,11 @@
+--- configure.orig	2015-03-15 09:25:36.895298320 +0100
++++ configure	2015-03-15 09:25:53.523239324 +0100
+@@ -5612,7 +5612,7 @@
+ SRC_PATH:=\$(SRC_PATH:.%=..%)
+ endif
+ CC_IDENT=$cc_ident
+-ARCH=$arch
++FFMPEG_ARCH=$arch
+ INTRINSICS=$intrinsics
+ CC=$cc
+ CXX=$cxx

--- a/cross/x264/Makefile
+++ b/cross/x264/Makefile
@@ -1,10 +1,9 @@
 PKG_NAME = x264
-PKG_VERS = 20130819-2245
+PKG_VERS = 20141218-2245
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-snapshot-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = ftp://ftp.videolan.org/pub/x264/snapshots/
 PKG_DIR = $(PKG_NAME)-snapshot-$(PKG_VERS)
-
 
 DEPENDS =
 GNU_CONFIGURE = 1


### PR DESCRIPTION
ffmpeg
- Update to 2.6
- Fix compile issue with armada* arches

x264
- Update to latest

ref #1446