### PR TITLE
Convert remaining pybundles to wheel

### DIFF
--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -5,6 +5,7 @@ SPK_ICON = src/debian.png
 DSM_UI_DIR = app
 
 DEPENDS  =
+WHEELS = pyextdirect==0.3.1 flask Werkzeug Jinja2 itsdangerous
 SPK_DEPENDS = "python>2.7.3-3"
 
 MAINTAINER = SynoCommunity
@@ -47,7 +48,9 @@ endif
 include ../../mk/spksrc.spk.mk
 
 .PHONY: debian-chroot_extra_install
-debian-chroot_extra_install: $(STAGING_DIR)/share/requirements.pybundle
+debian-chroot_extra_install:
+	install -m 755 -d ${STAGING_DIR}/share/wheelhouse
+	install -m 644 ${WORK_DIR}/wheelhouse/* ${STAGING_DIR}/share/wheelhouse/
 	install -m 755 -d $(STAGING_DIR)/var
 	debootstrap --foreign --arch $(DEBIAN_ARCH) wheezy $(STAGING_DIR)/var/chroottarget "http://ftp.debian.org/debian"
 	install -m 644 src/sources.list $(STAGING_DIR)/var/chroottarget/etc/apt/sources.list.default
@@ -74,8 +77,3 @@ debian-chroot_extra_install: $(STAGING_DIR)/share/requirements.pybundle
 		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
 		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
 	done
-
-$(STAGING_DIR)/share/requirements.pybundle:
-	@$(MSG) "Bundling requirements"
-	install -m 755 -d $(STAGING_DIR)/share
-	@cd $(WORK_DIR) && $(PIP) bundle $@ pyextdirect==0.3.1 flask

--- a/spk/debian-chroot/src/installer.sh
+++ b/spk/debian-chroot/src/installer.sh
@@ -26,8 +26,8 @@ postinst ()
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${INSTALL_DIR}/env > /dev/null
 
-    # Install the bundle
-    ${INSTALL_DIR}/env/bin/pip install --no-index -U ${INSTALL_DIR}/share/requirements.pybundle > /dev/null
+    # Install the wheels/requirements
+    ${INSTALL_DIR}/env/bin/pip install --use-wheel --no-deps --no-index -U --force-reinstall -f ${INSTALL_DIR}/share/wheelhouse -r ${INSTALL_DIR}/share/wheelhouse/requirements.txt > /dev/null 2>&1
 
     # Setup the database
     ${INSTALL_DIR}/env/bin/python ${INSTALL_DIR}/app/setup.py

--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 BETA = 1
 
 DEPENDS  = cross/$(SPK_NAME)
-
+WHEELS = Mako chardet pyxdg
 SPK_DEPENDS = "python>2.7.3-3"
 
 MAINTAINER = SynoCommunity
@@ -32,9 +32,11 @@ override ARCH=
 include ../../mk/spksrc.spk.mk
 
 .PHONY: deluge_extra_install
-deluge_extra_install: $(STAGING_DIR)/share/requirements.pybundle
+deluge_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 644 src/config.yml $(STAGING_DIR)/var/config.yml
+	install -m 755 -d ${STAGING_DIR}/share/wheelhouse
+	install -m 644 ${WORK_DIR}/wheelhouse/* ${STAGING_DIR}/share/wheelhouse/
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 755 src/app/deluge.cgi.py $(STAGING_DIR)/app/deluge.cgi
@@ -43,8 +45,3 @@ deluge_extra_install: $(STAGING_DIR)/share/requirements.pybundle
 		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
 		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
 	done
-
-$(STAGING_DIR)/share/requirements.pybundle:
-	@$(MSG) "Bundling requirements"
-	install -m 755 -d $(STAGING_DIR)/share
-	@cd $(WORK_DIR) && $(PIP) bundle --no-dependencies $@ Mako chardet pyxdg

--- a/spk/deluge/src/installer.sh
+++ b/spk/deluge/src/installer.sh
@@ -38,8 +38,8 @@ postinst ()
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${INSTALL_DIR}/env > /dev/null
 
-    # Install the bundle
-    ${INSTALL_DIR}/env/bin/pip install --no-index -U ${INSTALL_DIR}/share/requirements.pybundle > /dev/null
+    # Install the wheels/requirements
+    ${INSTALL_DIR}/env/bin/pip install --use-wheel --no-deps --no-index -U --force-reinstall -f ${INSTALL_DIR}/share/wheelhouse -r ${INSTALL_DIR}/share/wheelhouse/requirements.txt > /dev/null 2>&1
 
     # Install Deluge
     cd ${INSTALL_DIR}/share/deluge && ${INSTALL_DIR}/env/bin/python setup.py install > /dev/null

--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -5,6 +5,7 @@ SPK_ICON = src/gateone.png
 DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/dtach
+WHEELS = certifi backports.ssl-match-hostname tornado
 SPK_DEPENDS = "python>2.7.3-3"
 
 MAINTAINER = SynoCommunity
@@ -33,7 +34,9 @@ ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
 include ../../mk/spksrc.spk.mk
 
 .PHONY: gateone_extra_install
-gateone_extra_install: $(STAGING_DIR)/share/requirements.pybundle $(STAGING_DIR)/share/GateOne
+gateone_extra_install: $(STAGING_DIR)/share/GateOne
+	install -m 755 -d ${STAGING_DIR}/share/wheelhouse
+	install -m 644 ${WORK_DIR}/wheelhouse/* ${STAGING_DIR}/share/wheelhouse/
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 755 -d $(STAGING_DIR)/ssl
 	install -m 755 -d $(STAGING_DIR)/var
@@ -44,11 +47,6 @@ gateone_extra_install: $(STAGING_DIR)/share/requirements.pybundle $(STAGING_DIR)
 		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
 		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
 	done
-
-$(STAGING_DIR)/share/requirements.pybundle:
-	@$(MSG) "Bundling requirements"
-	install -m 755 -d $(STAGING_DIR)/share
-	@cd $(WORK_DIR) && $(PIP) bundle --no-use-wheel $@ "tornado<3" configobj
 
 $(STAGING_DIR)/share/GateOne:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/gateone/src/installer.sh
+++ b/spk/gateone/src/installer.sh
@@ -37,8 +37,8 @@ postinst ()
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${INSTALL_DIR}/env > /dev/null
 
-    # Install the bundle
-    ${INSTALL_DIR}/env/bin/pip install --no-index -U ${INSTALL_DIR}/share/requirements.pybundle > /dev/null
+    # Install the wheels/requirements
+    ${INSTALL_DIR}/env/bin/pip install --use-wheel --no-deps --no-index -U --force-reinstall -f ${INSTALL_DIR}/share/wheelhouse -r ${INSTALL_DIR}/share/wheelhouse/requirements.txt > /dev/null 2>&1
 
     # Install GateOne
     ${PYTHON} ${INSTALL_DIR}/share/GateOne/setup.py install --prefix=${INSTALL_DIR} > /dev/null

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -5,6 +5,7 @@ SPK_ICON = src/haproxy.png
 DSM_UI_DIR = app
 
 DEPENDS = cross/$(SPK_NAME)
+WHEELS = pyextdirect==0.3.1 flask Werkzeug Jinja2 itsdangerous
 SPK_DEPENDS = "python>2.7.3-3"
 
 MAINTAINER = SynoCommunity
@@ -32,7 +33,9 @@ POST_STRIP_TARGET = haproxy_extra_install
 include ../../mk/spksrc.spk.mk
 
 .PHONY: haproxy_extra_install
-haproxy_extra_install: $(STAGING_DIR)/share/requirements.pybundle
+haproxy_extra_install:
+	install -m 755 -d ${STAGING_DIR}/share/wheelhouse
+	install -m 644 ${WORK_DIR}/wheelhouse/* ${STAGING_DIR}/share/wheelhouse/
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/var/crt
 	install -m 755 -d $(STAGING_DIR)/app
@@ -55,8 +58,3 @@ haproxy_extra_install: $(STAGING_DIR)/share/requirements.pybundle
 		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
 		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
 	done
-
-$(STAGING_DIR)/share/requirements.pybundle:
-	@$(MSG) "Bundling requirements"
-	install -m 755 -d $(STAGING_DIR)/share
-	@cd $(WORK_DIR) && $(PIP) bundle $@ pyextdirect==0.3.1 flask

--- a/spk/haproxy/src/installer.sh
+++ b/spk/haproxy/src/installer.sh
@@ -38,8 +38,8 @@ postinst ()
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${INSTALL_DIR}/env > /dev/null
 
-    # Install the bundle
-    ${INSTALL_DIR}/env/bin/pip install --no-index -U ${INSTALL_DIR}/share/requirements.pybundle > /dev/null
+    # Install the wheels/requirements
+    ${INSTALL_DIR}/env/bin/pip install --use-wheel --no-deps --no-index -U --force-reinstall -f ${INSTALL_DIR}/share/wheelhouse -r ${INSTALL_DIR}/share/wheelhouse/requirements.txt > /dev/null 2>&1
 
     # Setup the database
     ${INSTALL_DIR}/env/bin/python ${INSTALL_DIR}/app/setup.py

--- a/spk/subliminal/Makefile
+++ b/spk/subliminal/Makefile
@@ -1,10 +1,13 @@
 SPK_NAME = subliminal
-SPK_VERS = 0.6.4
-SPK_REV = 10
+SPK_VERS = 0.7.5
+SPK_REV = 11
 SPK_ICON = src/subliminal.png
 DSM_UI_DIR = app
 
 DEPENDS =
+WHEELS = "subliminal==$(SPK_VERS)" pyextdirect configobj flask Werkzeug Jinja2
+WHEELS += beautifulsoup4 guessit enzyme html5lib dogpile.cache dogpile.core babelfish 
+WHEELS += chardet pysrt pyxdg
 SPK_DEPENDS = "python>2.7.3-3"
 
 MAINTAINER = SynoCommunity
@@ -12,7 +15,7 @@ DESCRIPTION = Subliminal allows you automatically download best-matching subtitl
 DESCRIPTION_FRE = Subliminal vous permet de télécharger automatiquement les meilleurs sous-titres pour vos films et séries sur votre DiskStation. Ce paquet est nommé d\\\'après Subliminal, la librairie Python utilisée pour rechercher et télécharger les sous-titres.
 RELOAD_UI = yes
 DISPLAY_NAME = Subliminal
-CHANGELOG = "1. DSM 5.0 compatibility"
+CHANGELOG = "Update to 0.7.5"
 
 HOMEPAGE   = https://github.com/Diaoul/subliminal
 LICENSE    = LGPL
@@ -32,7 +35,9 @@ override ARCH=
 include ../../mk/spksrc.spk.mk
 
 .PHONY: subliminal_extra_install
-subliminal_extra_install: $(STAGING_DIR)/share/requirements.pybundle
+subliminal_extra_install:
+	install -m 755 -d ${STAGING_DIR}/share/wheelhouse
+	install -m 644 ${WORK_DIR}/wheelhouse/* ${STAGING_DIR}/share/wheelhouse/
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 755 -d $(STAGING_DIR)/cache
@@ -58,8 +63,3 @@ subliminal_extra_install: $(STAGING_DIR)/share/requirements.pybundle
 		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
 		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
 	done
-
-$(STAGING_DIR)/share/requirements.pybundle:
-	@$(MSG) "Bundling requirements"
-	install -m 755 -d $(STAGING_DIR)/share
-	@cd $(WORK_DIR) && $(PIP) bundle --no-use-wheel $@ subliminal==$(SPK_VERS) pyextdirect==0.3.1 configobj flask

--- a/spk/subliminal/src/installer.sh
+++ b/spk/subliminal/src/installer.sh
@@ -31,8 +31,8 @@ postinst ()
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${INSTALL_DIR}/env > /dev/null
 
-    # Install the bundle
-    ${INSTALL_DIR}/env/bin/pip install --no-index -U ${INSTALL_DIR}/share/requirements.pybundle > /dev/null
+    # Install the wheels/requirements
+    ${INSTALL_DIR}/env/bin/pip install --use-wheel --no-deps --no-index -U --force-reinstall -f ${INSTALL_DIR}/share/wheelhouse -r ${INSTALL_DIR}/share/wheelhouse/requirements.txt > /dev/null 2>&1
 
     # Setup the database
     ${INSTALL_DIR}/env/bin/python ${INSTALL_DIR}/app/setup.py


### PR DESCRIPTION
Converted the remaining pybundles to wheel:
- Debian Chroot
- Deluge
- GateOne
- HAProxy

- Subliminal (+update Subliminal to 0.7.5 and prepare for new release)