### PR TITLE
Security Update openssl to version 1.0.1m and 0.9.8zf

### DIFF
--- a/cross/openssl-0.x/Makefile
+++ b/cross/openssl-0.x/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 0.9.8za
+PKG_VERS = 0.9.8zf
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.openssl.org/source

--- a/cross/openssl-0.x/digests
+++ b/cross/openssl-0.x/digests
@@ -1,3 +1,3 @@
-openssl-0.9.8za.tar.gz SHA1 aadca1eb1a103a5536b24e1ed7e45051e2939731
-openssl-0.9.8za.tar.gz SHA256 cdcb98d0fbc026ca798b17919334310271d3a593554ffd6a59659b9222fd4e48
-openssl-0.9.8za.tar.gz MD5 2f989915f8fea49aa1bc37aa58500cce
+openssl-0.9.8zf.tar.gz SHA1 3f2f4ca864b13a237ae063cd34d01bbdbc8f108f
+openssl-0.9.8zf.tar.gz SHA256 d5245a29128984192acc5b1fc01e37429b7a01c53cadcb2645e546718b300edb
+openssl-0.9.8zf.tar.gz MD5 c69a4a679233f7df189e1ad6659511ec

--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.1l
+PKG_VERS = 1.0.1m
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.1l.tar.gz SHA1 4547a0b4269acf76b1f9e7d188896867d6fc8c18
-openssl-1.0.1l.tar.gz SHA256 b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4
-openssl-1.0.1l.tar.gz MD5 cdb22925fc9bc97ccbf1e007661f2aa6
+openssl-1.0.1m.tar.gz SHA1 4ccaf6e505529652f9fdafa01d1d8300bd9f3179
+openssl-1.0.1m.tar.gz SHA256 095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74
+openssl-1.0.1m.tar.gz MD5 d143d1555d842a069cb7cc34ba745a06


### PR DESCRIPTION
Fix these vulnerabilities  for openssl 1.0.1 and 0.9.8 :

Segmentation fault in ASN1_TYPE_cmp (CVE-2015-0286)
ASN.1 structure reuse memory corruption (CVE-2015-0287)
PKCS7 NULL pointer dereferences (CVE-2015-0289)
DoS via reachable assert in SSLv2 servers (CVE-2015-0293)
Use After Free following d2i_ECPrivatekey error (CVE-2015-0209)
X509_to_X509_REQ NULL pointer deref (CVE-2015-0288)

Fix these vulnerabilities  for openssl 0.9.8 :

Reclassified: RSA silently downgrades to EXPORT_RSA Client (CVE-2015-0204)
