### PR TITLE
Mono: Fix- Redundant lines should have been removed from cross not spk

### DIFF
--- a/cross/mono/Makefile
+++ b/cross/mono/Makefile
@@ -25,13 +25,3 @@ MONO_NATIVE_INSTALL = $(WORK_DIR)/../../../native/$(PKG_NAME)/work-native/instal
 .PHONY: myPreConfigure
 myPreConfigure:
 	$(RUN) autoreconf
-
-.PHONY: myPostInstall
-myPostInstall:
-	install -m 755 -d $(STAGING_DIR)/lib
-	tar -cpf - -C $(MONO_NATIVE_INSTALL)/usr/local/lib . | tar -xpkf - -C $(STAGING_DIR)/lib
-	install -m 755 -d $(STAGING_DIR)/etc/mono
-	tar -cpf - -C $(MONO_NATIVE_INSTALL)/usr/local/etc/mono . | tar -xpkf - -C $(STAGING_DIR)/etc/mono
-	install -m 755 -d $(STAGING_DIR)/bin
-	tar -cpf - -C $(MONO_NATIVE_INSTALL)/usr/local/bin . | tar -xpkf - -C $(STAGING_DIR)/bin
-

--- a/spk/mono/Makefile
+++ b/spk/mono/Makefile
@@ -41,6 +41,12 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: mono_extra_install
 mono_extra_install:
+	install -m 755 -d $(STAGING_DIR)/lib
+	cp -nR $(MONO_NATIVE_INSTALL)/usr/local/lib $(STAGING_DIR)/
+	install -m 755 -d $(STAGING_DIR)/etc/mono
+	cp -nR $(MONO_NATIVE_INSTALL)/usr/local/etc/mono $(STAGING_DIR)/etc/
+	install -m 755 -d $(STAGING_DIR)/bin
+	cp -nR $(MONO_NATIVE_INSTALL)/usr/local/bin $(STAGING_DIR)/
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 755 -d $(STAGING_DIR)/app/images


### PR DESCRIPTION
The essential mono lib files do not make it into the package if these lines are removed from ```spk/mono/Makefile``` (as done in most recent commit.) To fix this I removed them from cross instead. This solves the issue