### PR TITLE
Wheels on py3 with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM 32bit/debian:jessie
 MAINTAINER SynoCommunity <https://synocommunity.com>
 
+ENV LANG C.UTF-8
+
 # Install required packages
 RUN apt-get update && \
     apt-get install -y automake \
@@ -25,6 +27,7 @@ RUN apt-get update && \
         mercurial \
         ncurses-dev \
         pkg-config \
+        python3-pip \
         subversion \
         swig \
         xmlto \

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -14,7 +14,7 @@ MSG = echo "===> "
 RUN = cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV)
 
 # Pip command
-PIP = pip
+PIP ?= pip
 PIP_WHEEL = $(PIP) wheel --no-use-wheel --no-deps --wheel-dir $(STAGING_DIR)/wheelhouse
 
 # Available languages


### PR DESCRIPTION
Fixes #1658, allowing pure-python wheels to be downloaded/built for Python3 use.