### PR TITLE
Rule updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-SUPPORTED_TCS = $(notdir $(wildcard toolchains/syno-*))
-SUPPORTED_ARCHS = $(notdir $(subst syno-,/,$(SUPPORTED_TCS)))
+AVAILABLE_TCS = $(notdir $(wildcard toolchains/syno-*))
+AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))
 SUPPORTED_SPKS = $(patsubst spk/%/Makefile,%,$(wildcard spk/*/Makefile))
 
 
@@ -61,8 +61,8 @@ natives:
 	done
 
 .PHONY: toolchains kernel-modules
-toolchains: $(addprefix toolchain-,$(SUPPORTED_ARCHS))
-kernel-modules: $(addprefix kernel-,$(SUPPORTED_ARCHS))
+toolchains: $(addprefix toolchain-,$(AVAILABLE_ARCHS))
+kernel-modules: $(addprefix kernel-,$(AVAILABLE_ARCHS))
 
 toolchain-%:
 	-@cd toolchains/syno-$*/ && MAKEFLAGS= $(MAKE)

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -20,6 +20,18 @@ PIP_WHEEL = $(PIP) wheel --no-use-wheel --no-deps --wheel-dir $(STAGING_DIR)/whe
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk
 
+# Toolchains
+AVAILABLE_TCS = $(notdir $(wildcard ../../toolchains/syno-*))
+AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))
+
+#Toolchain filters
+SUPPORTED_ARCHS = $(sort $(filter-out 88f5281% powerpc% ppc824% ppc854x%, $(AVAILABLE_ARCHS)))
+LEGACY_ARCHS = $(sort $(filter-out $(SUPPORTED_ARCHS), $(AVAILABLE_ARCHS)))
+
+# Use x64 when kernels are not needed
+ARCHS_NO_KRNLSUPP = $(filter-out x64%, $(SUPPORTED_ARCHS))
+ARCHS_DUPES = $(filter-out x86% bromolow% cedarview% avoton%, $(SUPPORTED_ARCHS))
+
 # Available Arches
 ARM5_ARCHES = 88f5281 88f6281
 ARM7_ARCHES = armada370 armadaxp armada375 alpine comcerto2k

--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -91,10 +91,6 @@ clean:
 
 all: install
 
-
-SUPPORTED_TCS = $(notdir $(wildcard ../../toolchains/syno-*))
-SUPPORTED_ARCHS = $(notdir $(subst syno-,/,$(SUPPORTED_TCS)))
-
 .PHONY: $(DIGESTS_FILE)
 $(DIGESTS_FILE):
 	@$(MSG) "Generating digests for $(PKG_NAME)"
@@ -120,9 +116,22 @@ dependency-tree:
 	done
 
 .PHONY: all-archs
-all-archs: $(addprefix arch-,$(SUPPORTED_ARCHS))
+all-archs: $(addprefix arch-,$(AVAILABLE_ARCHS))
 
 arch-%:
 	@$(MSG) Building package for arch $*
 	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$(basename $(subst .,,$*)))) TCVERSION=$(if $(findstring $*,$(basename $(subst -,.,$(basename $(subst .,,$*))))),$(DEFAULT_TC),$(notdir $(subst -,/,$*)))
+
+.PHONY: kernel-required
+kernel-required:
+	@if [ -n "$(REQ_KERNEL)" ]; then \
+	  exit 1 ; \
+	fi
+	@for depend in $(DEPENDS) ; do \
+	  if $(MAKE) --no-print-directory -C ../../$$depend kernel-required >/dev/null 2>&1 ; then \
+	    exit 0 ; \
+	  else \
+	    exit 1 ; \
+	  fi ; \
+	done
 


### PR DESCRIPTION
- Move toolchain definitions from spk.mk and cross-cc.mk to common.mk
- Rename `SUPPORTED_TCS/ARCHS` to `AVAILABLE_TCS/ARCHS`
- Add main rules: `all-supported` and `all-legacy`
- Add REQ_KERNEL support to `all-supported` and `all-archs-latest` rules.

Ref #1366