### PR TITLE
FIX: Debian chroot fails to start up slow scripts

### DIFF
--- a/spk/debian-chroot/src/app/application/direct.py
+++ b/spk/debian-chroot/src/app/application/direct.py
@@ -2,6 +2,7 @@ from pyextdirect.configuration import create_configuration, expose, LOAD, STORE_
 from pyextdirect.router import Router
 import os
 import subprocess
+import time
 from config import *
 from db import *
 


### PR DESCRIPTION
The original PR (#1381) was auto closed by GH. All credits to @HakShak. 