### PR TITLE
Update openssl to 1.0.2b

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2a
+PKG_VERS = 1.0.2b
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://www.openssl.org/source
+PKG_DIST_SITE = ftp://ftp.openssl.org/source
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2a.tar.gz SHA1 46ecd325b8e587fa491f6bb02ad4a9fb9f382f5f
-openssl-1.0.2a.tar.gz SHA256 15b6393c20030aab02c8e2fe0243cb1d1d18062f6c095d67bca91871dc7f324a
-openssl-1.0.2a.tar.gz MD5 a06c547dac9044161a477211049f60ef
+openssl-1.0.2b.tar.gz SHA1 9006e53ca56a14d041e3875320eedfa63d82aba7
+openssl-1.0.2b.tar.gz SHA256 d5d488cc9f0a07974195a7427094ea3cab9800a4e90178b989aa621fbc238e3f
+openssl-1.0.2b.tar.gz MD5 7729b259e2dea7d60b32fc3934d6984b


### PR DESCRIPTION
Just running a full build on vagrant - will confirm an all green shortly - can confirm this worked...

===>  Downloading files for openssl
wget ftp://ftp.openssl.org/source/openssl-1.0.2b.tar.gz
2015-06-12 15:13:38 URL: ftp://ftp.openssl.org/source/openssl-1.0.2b.tar.gz [5281009] -> "openssl-1.0.2b.tar.gz.part" [1]
===>  Verifying files for openssl
===>    Checking sha1sum of file openssl-1.0.2b.tar.gz
===>    Checking sha256sum of file openssl-1.0.2b.tar.gz
===>    Checking md5sum of file openssl-1.0.2b.tar.gz
/home/vagrant/spksrc/cross/openssl/../../distrib/openssl-1.0.2b.tar.gz