### PR TITLE
Update haproxy, support gzip, fix <1024 ports

### DIFF
--- a/cross/haproxy/Makefile
+++ b/cross/haproxy/Makefile
@@ -1,14 +1,14 @@
 PKG_NAME = haproxy
-PKG_VERS = 1.5.12
+PKG_VERS = 1.5.14
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://haproxy.1wt.eu/download/1.5/src
+PKG_DIST_SITE = http://www.haproxy.org/download/1.5/src
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/openssl cross/zlib
 
 MAINTAINER = SynoCommunity
-HOMEPAGE   = http://haproxy.1wt.eu/
+HOMEPAGE   = http://www.haproxy.org
 COMMENT    = HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 LICENSE    = GNU GPL 2
 

--- a/cross/haproxy/digests
+++ b/cross/haproxy/digests
@@ -1,3 +1,3 @@
-haproxy-1.5.12.tar.gz SHA1 c488f7f108ddefb558bd86e7cbc1b71636ada856
-haproxy-1.5.12.tar.gz SHA256 6648dd7d6b958d83dd7101eab5792178212a66c884bec0ebcd8abc39df83bb78
-haproxy-1.5.12.tar.gz MD5 4b94b257f16d88c315716b062b22e48a
+haproxy-1.5.14.tar.gz SHA1 159f5beb8fdc6b8059ae51b53dc935d91c0fb51f
+haproxy-1.5.14.tar.gz SHA256 9565dd38649064d0350a2883fa81ccfe92eb17dcda457ebdc01535e1ab0c8f99
+haproxy-1.5.14.tar.gz MD5 ad9d7262b96ba85a0f8c6acc6cb9edde

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = haproxy
-SPK_VERS = 1.5.12
+SPK_VERS = 1.5.14
 SPK_REV = 18
 SPK_ICON = src/haproxy.png
 DSM_UI_DIR = app
@@ -14,7 +14,7 @@ DESCRIPTION_FRE = HAProxy est un produit libre, performant et fiable qui permet 
 ADMIN_PORT = 8280
 RELOAD_UI = yes
 DISPLAY_NAME = HAProxy
-CHANGELOG = "1. Update to 1.5.12<br>2. Added gzip compression support<br>3. Fix listening on <1024 ports"
+CHANGELOG = "1. Update to 1.5.14<br>2. Added gzip compression support<br>3. Fix listening on <1024 ports"
 
 HOMEPAGE   = http://haproxy.1wt.eu/
 LICENSE    = GNU GPL 2

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = haproxy
 SPK_VERS = 1.5.14
-SPK_REV = 18
+SPK_REV = 19
 SPK_ICON = src/haproxy.png
 DSM_UI_DIR = app
 


### PR DESCRIPTION
Fixes #1704
Fixes #1730 
Fixes #1782
Updates haproxy to latest stable version (from 1.5.11 to 1.5.14)