### PR TITLE
remove python from boost

### DIFF
--- a/cross/boost/Makefile
+++ b/cross/boost/Makefile
@@ -5,7 +5,7 @@ PKG_DIR = $(PKG_NAME)_$(subst .,_,$(PKG_VERS))
 PKG_DIST_NAME = $(PKG_DIR).$(PKG_EXT)
 PKG_DIST_SITE = http://sourceforge.net/projects/$(PKG_NAME)/files/$(PKG_NAME)/$(PKG_VERS)
 
-DEPENDS = cross/bzip2 cross/zlib cross/python
+DEPENDS = cross/bzip2 cross/zlib
 
 HOMEPAGE = http://www.boost.org/
 COMMENT  = Boost provides free peer-reviewed portable C++ source libraries.


### PR DESCRIPTION
Remove Python dependency. If boost_python is required, it needs to be added as dependency to the calling package. having the dependency in the boost package just results in building python for packages that don't need it.