### PR TITLE
Update Debian-Chroot to Jessie

### DIFF
--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = debian-chroot
 SPK_VERS = 8.1
-SPK_REV = 1
+SPK_REV = 5
 SPK_ICON = src/debian.png
 DSM_UI_DIR = app
 

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = debian-chroot
-SPK_VERS = 7.4
-SPK_REV = 5
+SPK_VERS = 8.1
+SPK_REV = 1
 SPK_ICON = src/debian.png
 DSM_UI_DIR = app
 
@@ -52,7 +52,7 @@ debian-chroot_extra_install:
 	install -m 755 -d ${STAGING_DIR}/share/wheelhouse
 	install -m 644 ${WORK_DIR}/wheelhouse/* ${STAGING_DIR}/share/wheelhouse/
 	install -m 755 -d $(STAGING_DIR)/var
-	debootstrap --foreign --arch $(DEBIAN_ARCH) wheezy $(STAGING_DIR)/var/chroottarget "http://ftp.debian.org/debian"
+	debootstrap --foreign --arch $(DEBIAN_ARCH) jessie $(STAGING_DIR)/var/chroottarget "http://ftp.debian.org/debian"
 	install -m 644 src/sources.list $(STAGING_DIR)/var/chroottarget/etc/apt/sources.list.default
 	install -m 644 src/preferences $(STAGING_DIR)/var/chroottarget/etc/apt/preferences.default
 	install -m 644 src/policy-rc.d $(STAGING_DIR)/var/chroottarget/usr/sbin/policy-rc.d

--- a/spk/debian-chroot/src/app/help/enu/index.html
+++ b/spk/debian-chroot/src/app/help/enu/index.html
@@ -24,8 +24,8 @@
             <b>/var/packages/debian-chroot/scripts/start-stop-status chroot</b>.</p>
         <p>On the first use, it is recommended to perform some configuration operations:</p>
         <ul>
-            <li>Update: type <b>aptitude update</b> followed by <b>aptitude upgrade</b></li>
-            <li>Locales: type <b>aptitude install locales</b> and then <b>dpkg-reconfigure locales</b></li>
+            <li>Update: type <b>apt-get update</b> followed by <b>apt-get upgrade</b></li>
+            <li>Locales: type <b>apt-get locales</b> and then <b>dpkg-reconfigure locales</b></li>
             <li>Timezone: execute <b>dpkg-reconfigure tzdata</b></li>
         </ul>
         <h3>Configure Services</h3>
@@ -46,7 +46,7 @@
         </ol>
         <h4>Example: SSH Server</h4>
         <ol>
-            <li>Install the SSH server: <b>aptitude install ssh</b></li>
+            <li>Install the SSH server: <b>apt-get install ssh</b></li>
             <li>Edit the configuration file: <b>/etc/ssh/sshd_config</b> in order
             to change the port number and other things if necessary</li>
             <li>Click on <b>Add</b> and put the name <b>SSHD</b>, the launch

--- a/spk/debian-chroot/src/app/help/fre/index.html
+++ b/spk/debian-chroot/src/app/help/fre/index.html
@@ -28,8 +28,8 @@
         <p>Lors de la première utilisation, il est conseillé d'effectuer quelques
             opérations de configuration:</p>
         <ul>
-            <li>Mise à jour: à l'aide de <b>aptitude update</b>puis <b>aptitude upgrade</b></li>
-            <li>Locales: avec <b>aptitude install locales</b>puis <b>dpkg-reconfigure locales</b></li>
+            <li>Mise à jour: à l'aide de <b>apt-get update</b>puis <b>apt-get upgrade</b></li>
+            <li>Locales: avec <b>apt-get install locales</b>puis <b>dpkg-reconfigure locales</b></li>
             <li>Fuseau horaire: en exécutant <b>dpkg-reconfigure tzdata</b></li>
         </ul>
         <h4><a href="services.html">Configurer les services</a></h4>

--- a/spk/debian-chroot/src/app/help/fre/services.html
+++ b/spk/debian-chroot/src/app/help/fre/services.html
@@ -22,7 +22,7 @@
         </ol>
         <h4>Exemple : Serveur SSH</h4>
         <ol>
-            <li>Installer du serveur SSH : <b>aptitude install ssh</b></li>
+            <li>Installer du serveur SSH : <b>apt-get install ssh</b></li>
             <li>Modifier le fichier de configuration : <b>/etc/ssh/sshd_config</b> afin de
                 changer le port et d'autres éléments si nécessaire</li>
             <li>Cliquer sur <b>Ajouter</b>et mettre le nom <b>SSHD</b>, le script

--- a/spk/debian-chroot/src/preferences
+++ b/spk/debian-chroot/src/preferences
@@ -11,10 +11,6 @@ Pin: release o=Debian,a=stable,l=Debian-Security
 Pin-Priority: 990
 
 Package: *
-Pin: release o=Unofficial Multimedia Packages,a=stable,l=Unofficial Multimedia Packages
-Pin-Priority: 980
-
-Package: *
 Pin: release o=Debian,a=stable,l=Debian
 Pin-Priority: 990
 
@@ -23,24 +19,12 @@ Pin: release o=Debian,a=testing,l=Debian-Security
 Pin-Priority: 90
 
 Package: *
-Pin: release o=Unofficial Multimedia Packages,a=testing,l=Unofficial Multimedia Packages
-Pin-Priority: 90
-
-Package: *
 Pin: release o=Debian,a=testing,l=Debian
 Pin-Priority: 90
 
 Package: *
-Pin: release o=Unofficial Multimedia Packages,a=unstable,l=Unofficial Multimedia Packages
-Pin-Priority: 50
-
-Package: *
 Pin: release o=Debian,a=unstable,l=Debian
 Pin-Priority: 50
-
-Package: *
-Pin: release o=Unofficial Multimedia Packages,a=experimental,l=Unofficial Multimedia Packages
-Pin-Priority: 10
 
 Package: *
 Pin: release o=Debian,a=experimental,l=Debian

--- a/spk/debian-chroot/src/sources.list
+++ b/spk/debian-chroot/src/sources.list
@@ -1,6 +1,6 @@
 # Whatever's uncommented first in this file counts as the "main" distribution
 # (unless you change the ordering). See /etc/apt/preferences for more
-# information on how pinning is set up.
+# information on how apt-pinning is set up.
 
 ################################################
 ## jessie
@@ -10,8 +10,8 @@ deb http://security.debian.org/ jessie/updates main contrib non-free
 deb-src http://security.debian.org/ jessie/updates main contrib non-free
 
 # jessie-updates - optional, but default
-deb http://ftp.fr.debian.org/ jessie-updates main contrib non-free
-deb-src http://ftp.fr.debian.org/ jessie-updates main contrib non-free
+deb http://ftp.fr.debian.org/debian/ jessie-updates main contrib non-free
+deb-src http://ftp.fr.debian.org/debian/ jessie-updates main contrib non-free
 
 ################################################
 ## testing
@@ -19,8 +19,8 @@ deb-src http://ftp.fr.debian.org/ jessie-updates main contrib non-free
 #deb-src http://ftp.fr.debian.org/debian/ testing main contrib non-free
 #deb http://security.debian.org/ testing/updates main contrib non-free
 #deb-src http://security.debian.org/ testing/updates main contrib non-free
-#deb http://ftp.fr.debian.org/ testing-updates main contrib non-free
-#deb-src http://ftp.fr.debian.org/ testing-updates main contrib non-free
+#deb http://ftp.fr.debian.org/debian/ testing-updates main contrib non-free
+#deb-src http://ftp.fr.debian.org/debian/ testing-updates main contrib non-free
 
 ################################################
 ## unstable

--- a/spk/debian-chroot/src/sources.list
+++ b/spk/debian-chroot/src/sources.list
@@ -4,30 +4,30 @@
 
 ################################################
 ## jessie
-deb http://ftp.debian.org/debian/ jessie main contrib non-free
-deb-src http://ftp.debian.org/debian/ jessie main contrib non-free
+deb http://ftp.fr.debian.org/debian/ jessie main contrib non-free
+deb-src http://ftp.fr.debian.org/debian/ jessie main contrib non-free
 deb http://security.debian.org/ jessie/updates main contrib non-free
 deb-src http://security.debian.org/ jessie/updates main contrib non-free
 
 # jessie-updates - optional, but default
-deb http://ftp.debian.org/ jessie-updates main contrib non-free
-deb-src http://ftp.debian.org/ jessie-updates main contrib non-free
+deb http://ftp.fr.debian.org/ jessie-updates main contrib non-free
+deb-src http://ftp.fr.debian.org/ jessie-updates main contrib non-free
 
 ################################################
 ## testing
-#deb http://ftp.debian.org/debian/ testing main contrib non-free
-#deb-src http://ftp.debian.org/debian/ testing main contrib non-free
+#deb http://ftp.fr.debian.org/debian/ testing main contrib non-free
+#deb-src http://ftp.fr.debian.org/debian/ testing main contrib non-free
 #deb http://security.debian.org/ testing/updates main contrib non-free
 #deb-src http://security.debian.org/ testing/updates main contrib non-free
-#deb http://ftp.debian.org/ testing-updates main contrib non-free
-#deb-src http://ftp.debian.org/ testing-updates main contrib non-free
+#deb http://ftp.fr.debian.org/ testing-updates main contrib non-free
+#deb-src http://ftp.fr.debian.org/ testing-updates main contrib non-free
 
 ################################################
 ## unstable
-#deb http://ftp.debian.org/debian/ unstable main contrib non-free
-#deb-src http://ftp.debian.org/debian/ unstable main contrib non-free
+#deb http://ftp.fr.debian.org/debian/ unstable main contrib non-free
+#deb-src http://ftp.fr.debian.org/debian/ unstable main contrib non-free
 
 ################################################
 ## experimental
-#deb http://ftp.debian.org/debian/ experimental main contrib non-free
-#deb-src http://ftp.debian.org/debian/ experimental main contrib non-free
+#deb http://ftp.fr.debian.org/debian/ experimental main contrib non-free
+#deb-src http://ftp.fr.debian.org/debian/ experimental main contrib non-free

--- a/spk/debian-chroot/src/sources.list
+++ b/spk/debian-chroot/src/sources.list
@@ -1,31 +1,33 @@
-################################################
-## wheezy
-deb http://ftp.fr.debian.org/debian/ wheezy main contrib non-free
-deb-src http://ftp.fr.debian.org/debian/ wheezy main contrib non-free
-
-## wheezy security
-deb http://security.debian.org/ wheezy/updates main contrib non-free
-deb-src http://security.debian.org/ wheezy/updates main contrib non-free
-
-# wheezy update
-deb http://ftp.fr.debian.org/debian/ wheezy-updates main contrib non-free
-deb-src http://ftp.fr.debian.org/debian/ wheezy-updates main contrib non-free
+# Whatever's uncommented first in this file counts as the "main" distribution
+# (unless you change the ordering). See /etc/apt/preferences for more
+# information on how pinning is set up.
 
 ################################################
 ## jessie
-deb http://ftp.fr.debian.org/debian/ jessie main contrib non-free
-deb-src http://ftp.fr.debian.org/debian/ jessie main contrib non-free
-
-## jessie security
+deb http://ftp.debian.org/debian/ jessie main contrib non-free
+deb-src http://ftp.debian.org/debian/ jessie main contrib non-free
 deb http://security.debian.org/ jessie/updates main contrib non-free
 deb-src http://security.debian.org/ jessie/updates main contrib non-free
 
+# jessie-updates - optional, but default
+deb http://ftp.debian.org/ jessie-updates main contrib non-free
+deb-src http://ftp.debian.org/ jessie-updates main contrib non-free
+
 ################################################
-## sid
-deb http://ftp.fr.debian.org/debian/ sid main contrib non-free
-deb-src http://ftp.fr.debian.org/debian/ sid main contrib non-free
+## testing
+#deb http://ftp.debian.org/debian/ testing main contrib non-free
+#deb-src http://ftp.debian.org/debian/ testing main contrib non-free
+#deb http://security.debian.org/ testing/updates main contrib non-free
+#deb-src http://security.debian.org/ testing/updates main contrib non-free
+#deb http://ftp.debian.org/ testing-updates main contrib non-free
+#deb-src http://ftp.debian.org/ testing-updates main contrib non-free
+
+################################################
+## unstable
+#deb http://ftp.debian.org/debian/ unstable main contrib non-free
+#deb-src http://ftp.debian.org/debian/ unstable main contrib non-free
 
 ################################################
 ## experimental
-deb http://ftp.fr.debian.org/debian/ experimental main contrib non-free
-deb-src http://ftp.fr.debian.org/debian/ experimental main contrib non-free
+#deb http://ftp.debian.org/debian/ experimental main contrib non-free
+#deb-src http://ftp.debian.org/debian/ experimental main contrib non-free


### PR DESCRIPTION
- Update version to 8.0-1
- Update base distro to Jessie
- Add commented-out testing entries in apt.sources, and comment out unstable
  and experimental. Apt-pinning is never 100% and should not be on by default.
- Clean preferences of references to obsolete third-party repos