### PR TITLE
Upgrade node to v4.2.1 (LTS) - no architectures supported?

### DIFF
--- a/cross/node/Makefile
+++ b/cross/node/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = node
-PKG_VERS = 0.12.2
+PKG_VERS = 4.2.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://nodejs.org/dist/v$(PKG_VERS)/

--- a/cross/node/digests
+++ b/cross/node/digests
@@ -1,3 +1,3 @@
-node-v0.12.2.tar.gz SHA1 a969f17a0a6c9238584f8946d96e8d39be8eb957
-node-v0.12.2.tar.gz SHA256 ac7e78ade93e633e7ed628532bb8e650caba0c9c33af33581957f3382e2a772d
-node-v0.12.2.tar.gz MD5 b7f4a9f2e361a7026789a7d6c45a6d30
+node-v4.2.1.tar.gz SHA1 ba4ae3d1bb02f80289575be56aa7bbb8fa4f0ec6
+node-v4.2.1.tar.gz SHA256 8861b9f4c3b4db380fcda19a710c0430c3d62d03ee176c64db63eef95a672663
+node-v4.2.1.tar.gz MD5 41d2b9fb5220af3fd98dd70fb33a2a10


### PR DESCRIPTION
As requested here: https://github.com/SynoCommunity/spksrc/issues/1872