### PR TITLE
Added usleep usage to sqlite

### DIFF
--- a/cross/sqlite/Makefile
+++ b/cross/sqlite/Makefile
@@ -13,6 +13,6 @@ LICENSE  = http://www.sqlite.org/copyright.html
 
 GNU_CONFIGURE = 1
 
-ADDITIONAL_CFLAGS = -DSQLITE_ENABLE_COLUMN_METADATA
+ADDITIONAL_CFLAGS = -DSQLITE_ENABLE_COLUMN_METADATA -DHAVE_USLEEP=1
 
 include ../../mk/spksrc.cross-cc.mk


### PR DESCRIPTION
Without HAVE_USLEEP, xSleep on unix is implemented using sleep() which means that sqlite3_sleep() will have a minimum wait interval of 1000 milliseconds regardless of its argument,
causing the [sqlite nightmare](http://beets.radbox.org/blog/sqlite-nightmare.html).