### PR TITLE
[Duplicity] Add missing 'six' dependency

### DIFF
--- a/spk/duplicity/src/requirements.txt
+++ b/spk/duplicity/src/requirements.txt
@@ -22,4 +22,5 @@ python-novaclient==2.25.0
 python-swiftclient==2.3.1
 pytz==2015.4
 requests==2.7.0
+six==1.10.0
 stevedore==1.5.0


### PR DESCRIPTION
six is a missing dependency of pyrax module