### PR TITLE
Update digests openssl to Version 1.0.2e

### DIFF
--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2d.tar.gz SHA1 d01d17b44663e8ffa6a33a5a30053779d9593c3d
-openssl-1.0.2d.tar.gz SHA256 671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8
-openssl-1.0.2d.tar.gz MD5 38dd619b2e77cbac69b99f52a053d25a
+openssl-1.0.2e.tar.gz SHA1 2c5691496761cb18f98476eefa4d35c835448fb6
+openssl-1.0.2e.tar.gz SHA256 e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff
+openssl-1.0.2e.tar.gz MD5 5262bfa25b60ed9de9f28d5d52d77fc5


### PR DESCRIPTION
OpenSSL Version has changed to 1.0.2e so Makefile and digests had to be updated to work correctly