### PR TITLE
xiph.org cosmetic changes: iscecast+speex+libogg/theora/vorbis

### DIFF
--- a/cross/icecast/Makefile
+++ b/cross/icecast/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = icecast
 PKG_VERS = 2.4.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.xiph.org/releases/icecast
+PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libxml2 cross/openssl cross/curl cross/libvorbis cross/libxslt cross/speex cross/libtheora

--- a/cross/libogg/Makefile
+++ b/cross/libogg/Makefile
@@ -1,8 +1,10 @@
-PKG_NAME = libogg
+PKG_NAME_PREFIX = lib
+PKG_NAME_SHORT = ogg
+PKG_NAME = $(PKG_NAME_PREFIX)$(PKG_NAME_SHORT)
 PKG_VERS = 1.3.2
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.xiph.org/releases/ogg
+PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME_SHORT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/libtheora/Makefile
+++ b/cross/libtheora/Makefile
@@ -1,8 +1,10 @@
-PKG_NAME = libtheora
+PKG_NAME_PREFIX = lib
+PKG_NAME_SHORT = theora
+PKG_NAME = $(PKG_NAME_PREFIX)$(PKG_NAME_SHORT)
 PKG_VERS = 1.1.1
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.xiph.org/releases/theora
+PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME_SHORT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libogg cross/libvorbis

--- a/cross/libvorbis/Makefile
+++ b/cross/libvorbis/Makefile
@@ -1,8 +1,10 @@
-PKG_NAME = libvorbis
+PKG_NAME_PREFIX = lib
+PKG_NAME_SHORT = vorbis
+PKG_NAME = $(PKG_NAME_PREFIX)$(PKG_NAME_SHORT)
 PKG_VERS = 1.3.3
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.xiph.org/releases/vorbis
+PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME_SHORT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libogg

--- a/cross/speex/Makefile
+++ b/cross/speex/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = speex
 PKG_VERS = 1.2rc2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.xiph.org/releases/speex
+PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libogg


### PR DESCRIPTION
PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME)
unless package name has (lib) prefix:
PKG_NAME_PREFIX = #i.e. lib 
PKG_NAME_SHORT = #i.e. ogg 
PKG_NAME = $(PKG_NAME_PREFIX)$(PKG_NAME_SHORT) 
PKG_DIST_SITE = http://downloads.xiph.org/releases/$(PKG_NAME_SHORT)