### PR TITLE
Set package maintainers based on `maintainer` branch

### DIFF
--- a/spk/bicbucstriim/Makefile
+++ b/spk/bicbucstriim/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = BicBucStriim streams books, digital books. It fills a gap in the functionality of current NAS devices, which provide access to your collection of music, videos and photos -- but not books. BicBucStriim covers that area and provides web-based access to your e-book collection.
 ADMIN_URL = /bbs/
 RELOAD_UI = yes

--- a/spk/bitlbee/Makefile
+++ b/spk/bitlbee/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/bitlbee.png
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = BitlBee brings IM \(instant messaging\) to IRC clients. It\'s a great solution for people who have an IRC client running all the time and don\'t want to run an additional MSN/AIM/whatever client.
 DESCRIPTION_FRE = BitlBee permet d\\\'accèder à sa messagerie instantanée depuis un client IRC. C\\\'est la solution idéale pour les personnes ayant un client IRC connecté en permanence et qui ne veulent pas de programmes supplémentaires comme MSN, AIM ou autre.
 DISPLAY_NAME = BitlBee

--- a/spk/cops/Makefile
+++ b/spk/cops/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Calibre OPDS and HTML PHP Server : light alternative to Calibre content server / Calibre2OPDS.
 DESCRIPTION_FRE = Calibre OPDS et HTML PHP Serveur : alternative légère au serveur de contenu de Calibre et à Calibre2OPDS.
 ADMIN_URL = /cops/

--- a/spk/couchpotatoserver-custom/Makefile
+++ b/spk/couchpotatoserver-custom/Makefile
@@ -4,10 +4,10 @@ SPK_REV = 4
 SPK_ICON = src/couchpotatoserver-custom.png
 DSM_UI_DIR = app
 
-DEPENDS  = 
+DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3:git"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = CouchPotato Custom allows you to run the fork of your choice of CouchPotato. You will be asked for the fork\'s git URL during install.
 DESCRIPTION_FRE = CouchPotato Custom vous permet d\\\'exécuter le fork de votre choix de CouchPotato. Vous aurez besoin de saisir l\\\'URL git du fork durant l\\\'installation.
 ADMIN_PORT = 5053

--- a/spk/couchpotatoserver/Makefile
+++ b/spk/couchpotatoserver/Makefile
@@ -4,10 +4,10 @@ SPK_REV = 6
 SPK_ICON = src/couchpotatoserver.png
 DSM_UI_DIR = app
 
-DEPENDS  = 
+DEPENDS =
 SPK_DEPENDS = "python>2.7.3-3:git"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = CouchPotato is an automatic NZB and torrent downloader for movies. You can keep a \"want to watch\"-list and it will search for NZBs/torrents of these items every X hours. Once a correct release is found, matching the correct quality, it will send it to SABnzbd/NZBGet or download the .nzb or .torrent to a specified directory. The downloaded movie can then be automatically moved and renamed to your liking as well as indexed by your DiskStation.
 DESCRIPTION_FRE = CouchPotato permet le téléchargement automatique de films via NZB ou torrent. Vous pouvez créer une \\\"liste de films à voir\\\", CouchPotato ira alors automatiquement rechercher les NZBs ou torrents correspondants toutes les X heures. Une fois qu\\\'une release correcte est trouvée, correspondant à la qualité demandé, elle sera ajouté a SABnzbd/NZBGet, ou téléchargée sous forme de .nzb ou de .torrent dans le répertoire indiqué. Les films téléchargés peuvent être déplacé et renommés selon vos préférences ainsi qu\\\'indexés par votre DiskStation.
 DESCRIPTION_SPN = CouchPotato es un sistema automático de descarga de peliculas via NZB y torrent. Puedes tener una \"lista de películas para ver\" y el sistema buscará automáticamente cada X horas. Cuando el release es encotrado con la calidad que especificaste el sistema la enviará al programa de descargas SABnzbd/NZBGet/Transmision o descargá el .nzb o .torrent al directorio que especifiques. Cuando la pelicula se termine de descargar será movida y renombrada automaticamente a tu gusto, además de ser indexada por tu DiskStation. 

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -8,7 +8,7 @@ DEPENDS  =
 WHEELS = pyextdirect==0.3.1 flask Werkzeug Jinja2 itsdangerous
 SPK_DEPENDS = "python>=2.7.6-8"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Debian is a free operating system \(OS\) that comes with over 29000 packages, precompiled software bundled up in a nice format for easy installation on your DiskStation. Debian Chroot allows you to benefit from the Debian OS inside your DiskStation, alongside DSM. This package is intended for advanced users only.
 DESCRIPTION_FRE = Debian est un système d\\\'exploitation \\\(SE\\\) qui rend disponible plus de 29000 paquets, logiciels précompilés et empaquetés dans un joli format pour rendre son installation facile sur votre DiskStation. Debian Chroot vous permet de bénéficier du SE Debian au sein de votre DiskStation, aux cotés de DSM. Ce paquet est destiné aux utilisateurs avancés uniquement.
 RELOAD_UI = yes

--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -13,7 +13,7 @@ SPK_DEPENDS = "python>=2.7.6-8"
 REQUIRED_DSM = 5.0
 UNSUPPORTED_ARCHS = $(PPC_ARCHES)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Deluge is a full-featured  BitTorrent client for Linux, OS X, Unix and Windows. It uses libtorrent in its backend and features multiple user-interfaces including: GTK+, web and console. It has been designed using the client server model with a daemon process that handles all the bittorrent activity. The Deluge daemon is able to run on headless machines with the user-interfaces being able to connect remotely from any platform.
 ADMIN_PORT = 8112
 RELOAD_UI = yes

--- a/spk/diskutils/Makefile
+++ b/spk/diskutils/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/diskutils.png
 
 DEPENDS  = cross/e2fsprogs cross/screen
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Low level utilities to manage your hard disk drives. This package contains e2fsprogs and screen.
 DESCRIPTION_FRE = Utilitaires bas niveau pour gérer vos disques durs. Ce package contient e2fsprogs et screen.
 RELOAD_UI = yes

--- a/spk/domoticz/Makefile
+++ b/spk/domoticz/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Domoticz is a Home Automation System that lets you monitor and configure various devices like: Lights, Switches, various sensors/meters like Temperature, Rain, Wind, UV, Electra, Gas, Water and much more. Notifications/Alerts can be sent to any mobile device.
 DESCRIPTION_FRE = Domoticz est un système domotique qui vous permet de surveiller et de configurer différents périphériques tels que: Lumières, Interrupteurs, divers capteurs/compteurs  afin de surveiller température, pluie, vent, UV, électricité, gaz, eau et bien plus encore. Notifications et alertes peuvent être envoyées à n\\\'importe quel appareil mobile.
 ADMIN_PORT = 8084

--- a/spk/fengoffice/Makefile
+++ b/spk/fengoffice/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = Feng Office is a Collaboration Platform and Project Management System.
 ADMIN_URL = /fengoffice/
 RELOAD_UI = yes

--- a/spk/flexget/Makefile
+++ b/spk/flexget/Makefile
@@ -6,7 +6,7 @@ SPK_ICON = src/flexget.png
 WHEELS = src/requirements.txt
 SPK_DEPENDS = "python>=2.7.8-11"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = FlexGet is a multipurpose automation tool for content like torrents, nzbs, podcasts, comics, series, movies, etc. It can use different kinds of sources like RSS-feeds, html pages, csv files, search engines and there are even plugins for sites that do not provide any kind of useful feeds.
 DISPLAY_NAME = FlexGet
 BETA = 1

--- a/spk/full-text-rss/Makefile
+++ b/spk/full-text-rss/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  =
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = Create full-text feed from feed or webpage URL.
 ADMIN_URL = /full-text-rss/
 RELOAD_UI = yes

--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -8,7 +8,7 @@ DEPENDS  = cross/busybox cross/dtach cross/$(SPK_NAME)
 WHEELS = certifi backports.ssl-match-hostname tornado html5lib
 SPK_DEPENDS = "python>=2.7.6-8"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Gate One is an HTML5-powered terminal emulator and SSH client
 DESCRIPTION_FRE = Gate One est un émulateur de terminal et un client SSH fonctionnant en HTML5
 ADMIN_PROTOCOL = https

--- a/spk/git-server/Makefile
+++ b/spk/git-server/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS = cross/dropbear cross/mktemp cross/busybox
 SPK_DEPENDS = "git>1.8.2"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Git Server turns your DiskStation into a powerfull server for the popular DSCM git. It supports git-daemon, a themed gitweb, gitolite and ssh through a dedicated daemon.
 DESCRIPTION_FRE = Git Server transforme votre DiskStation en puissant serveur pour le DSCM populaire git. Il apporte git-daemon, gitweb avec un thème, gitolite et ssh à travers un daemon dédié.
 DISPLAY_NAME = Git Server

--- a/spk/git/Makefile
+++ b/spk/git/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/git.png
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
 DESCRIPTION_FRE = Git est un logiciel de gestion de version décentralisée gratuit et open source destiné à gérer aussi bien les petits que les très gros projets avec vitesse et efficacité.
 STARTABLE = no

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -8,7 +8,7 @@ DEPENDS = cross/$(SPK_NAME)
 WHEELS = pyextdirect==0.3.1 flask Werkzeug Jinja2 itsdangerous
 SPK_DEPENDS = "python>2.7.3-3"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 DESCRIPTION_FRE = HAProxy est un produit libre, performant et fiable qui permet la haute disponibilité, la répartition de charge et le proxy de services TCP ou HTTP.
 ADMIN_PORT = 8280

--- a/spk/headphones/Makefile
+++ b/spk/headphones/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3:git"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Headphones is an automatic NZB and torrent downloader for music. Mark albums as wanted and have them downloaded as soon as they are available. Different quality settings are possible, including lossless. With Headphones you can also manage your music library automatically: move, tag, rename and index for your DiskStation.
 DESCRIPTION_FRE = Headphones permet le téléchargement automatique de musique via NZB ou torrent. Indiquez les albums que vous désirez et ils seront téléchargés dès que possible. Pous pouvez choisir entre différentes qualités, dont le lossless. Avec Headphones, vous pouvez aussi gérer votre bibliothèque musicale automatiquement: déplacement, tag, renommage et indexation pour votre DiskStation.
 DESCRIPTION_SPN = Headphones permite descargar automáticamente música mediante NZB o torrent. Puedes marcar albumes y estos serán descargados en cuanto estén disponibles. Es posible utilizar diferentes calidades, incluido lossless \\\(sin pedida\\\). Con Headphones tambien puedes administrar tu libreria: mover, taguear, renombrar e indexar en el DiskStation

--- a/spk/horde/Makefile
+++ b/spk/horde/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = Horde Groupware Webmail Edition is a free, enterprise ready, browser based communication suite. Users can read, send and organize email messages and manage and share calendars, contacts, tasks and notes with the standards compliant components from the Horde Project.
 ADMIN_URL = /horde/
 RELOAD_UI = yes

--- a/spk/lazylibrarian/Makefile
+++ b/spk/lazylibrarian/Makefile
@@ -8,7 +8,7 @@ BETA=1
 DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = LazyLibrarian is an automated book downloader for SABnzbd.
 DESCRIPTION_FRE = LazyLibrarian est un téléchargeur automatique de livre pour SABnzbd.
 ADMIN_PORT = 8082

--- a/spk/mantisbt/Makefile
+++ b/spk/mantisbt/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = Mantis is an easily deployable, web based bugtracker to aid product bug tracking. It requires PHP, MySQL and a web server. It is simpler than Bugzilla and easily editable.
 DESCRIPTION_FRE = Mantis est un bugtracker web aisément déployable pour faciliter le suivi des bogues. Il nécessite PHP, MySQL et un serveur web. Il est plus simple d'accès que Bugzilla et facilement modifiable.
 ADMIN_URL = /mantisbt/

--- a/spk/maraschino/Makefile
+++ b/spk/maraschino/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3:git"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Maraschino is a simple web interface that acts as a nice overview/front page for your XBMC HTPC. It has many modules: Media library browser, SABnzbd+, SickBeard, XBMC controller, Diskspace, Weather, Transmission and so on.
 DESCRIPTION_FRE = Maraschino est une interface web qui sert de vue d\\\'ensemble/page d\\\'accueil à votre HTPC XBMC. Il dispose de multiple modules: Bibliothèque multimédia, SABnzbd+, SickBeard, Controlleur XBMC, Espace disque, Météo, Transmission et bien d\\\'autres.
 ADMIN_PORT = 8260

--- a/spk/memcached/Makefile
+++ b/spk/memcached/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/phpmemcachedadmin cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Free \& open source, high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load. It comes with phpMemcachedAdmin, a graphic stand-alone administration for memcached to monitor and debug purpose.
 ADMIN_URL = /phpMemcachedAdmin/
 RELOAD_UI = yes

--- a/spk/museek-plus/Makefile
+++ b/spk/museek-plus/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/museek+.png
 
 DEPENDS = cross/busybox cross/museek+
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Museek+ is an open source file-sharing application for the ​Soulseek peer-to-peer network.
 DESCRIPTION_FRE = Museek+ est une application de partage de fichier open source pour le réseau peer-to-peer Soulseek.
 RELOAD_UI = yes

--- a/spk/mylar/Makefile
+++ b/spk/mylar/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Mylar is an automatic Comic Book downloader \(cbr/cbz\)
 DESCRIPTION_FRE = Mylar permet le téléchargement automatique de Comic Book \\\(cbr/cbz\\\)
 ADMIN_PORT = 8090

--- a/spk/newznab/Makefile
+++ b/spk/newznab/Makefile
@@ -6,7 +6,7 @@ SPK_ICON = src/newznab.png
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
 SPK_DEPENDS = "PEAR"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Newznab is a usenet indexing application, that makes building a usenet community easy.
 DESCRIPTION_FRE = Newznab est une application d\\\'indexation des newsgroups rendant facile la création d\\\'une communauté usenet.
 ADMIN_URL = /newznab/www/

--- a/spk/nzbget-testing/Makefile
+++ b/spk/nzbget-testing/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/unrar cross/p7zip cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = NZBGet is a command-line based binary newsgrabber for nzb files, written in C++. It supports client/server mode, automatic par-check/-repair, unpack and web-interface. NZBGet requires low system resources.
 DESCRIPTION_FRE = NZBGet est un récupérateur de news en ligne de commande écrit en C++ pour les fichiers nzb. Il intègre un mode client/serveur, la vérification, réparation et décompression automatique ainsi qu\\\'une interface web. NZBGet requiert peu de ressources système.
 DESCRIPTION_SPN = NZBGet es una aplicación de linea de comandos escrita en C++ para descargar binarios, desde servidores de noticias, utilizando archivos nzb. Soporta modo cliente y servidor, verificación y descompresión automática y una interfaz web. NZBGet utiliza pocos recursos de sistema.

--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/unrar cross/p7zip cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = NZBGet is a command-line based binary newsgrabber for nzb files, written in C++. It supports client/server mode, automatic par-check/-repair, unpack and web-interface. NZBGet requires low system resources.
 DESCRIPTION_FRE = NZBGet est un récupérateur de news en ligne de commande écrit en C++ pour les fichiers nzb. Il intègre un mode client/serveur, la vérification, réparation et décompression automatique ainsi qu\\\'une interface web. NZBGet requiert peu de ressources système.
 DESCRIPTION_SPN = NZBGet es una aplicación de linea de comandos escrita en C++ para descargar binarios, desde servidores de noticias, utilizando archivos nzb. Soporta modo cliente y servidor, verificación y descompresión automática y una interfaz web. NZBGet utiliza pocos recursos de sistema.

--- a/spk/oscam/Makefile
+++ b/spk/oscam/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = OSCam is a multi-protocol and cross-platform card server. A card server is a software which acts as a key host for card clients. A card server usually has one or more smartcard readers and ethernet interface. It emulates conditional access module \(CAM\) for accessing smartcard and offers virtual common interface to the clients. OSCam has a card client and a web interface
 DESCRIPTION_FRE = OSCam est un card server multi-protocole et mutli-plateforme. Un card server est un logiciel qui agit comme une clé d\\\'hôte pour les card clients. Un card server a généralement un ou plusieurs lecteur de cartes à puce et une interface Ethernet. Il émule un Conditional Access Module \\\(CAM\\\) pour accéder à la carte à puce virtuelle et offre une interface commune pour les clients. OSCam a un card client et une interface web
 ADMIN_PORT = 83

--- a/spk/owncloud/Makefile
+++ b/spk/owncloud/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = ownCloud is a personal cloud which runs on your own server and gives you freedom and control over your own data.
 ADMIN_URL = /owncloud/
 RELOAD_UI = yes

--- a/spk/python/Makefile
+++ b/spk/python/Makefile
@@ -15,7 +15,7 @@ DEPENDS += cross/msgpack-python cross/psutil cross/pymongo cross/pyyaml cross/uw
 
 WHEELS = psutil uwsgi
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Python Programming Language.
 DESCRIPTION_FRE = Langage de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.

--- a/spk/python3/Makefile
+++ b/spk/python3/Makefile
@@ -14,7 +14,7 @@ DEPENDS += cross/sqlalchemy cross/zope.interface
 PIP = pip3
 WHEELS = psutil
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Python Programming Language.
 DESCRIPTION_FRE = Langage de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.

--- a/spk/redis/Makefile
+++ b/spk/redis/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/redis.png
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Redis is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 RELOAD_UI = yes
 DISPLAY_NAME = Redis

--- a/spk/roundcube/Makefile
+++ b/spk/roundcube/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = Roundcube is a free and open source webmail solution with a desktop-like user interface which is easy to install/configure and that runs on a standard LAMPP server. It is the same software Synology offers as Mail Station except this does not depend on Mail Server package.
 ADMIN_URL = /roundcube/
 RELOAD_UI = yes

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/rtorrent cross/rutorrent cross/rutorrent-plugins cross/busybox cross/screen cross/procps-ng cross/mediainfo
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorrent. rTorrent is a BitTorrent client for ncurses, using the libtorrent library. The client and library is written in C++ with emphasis on speed and efficiency, while delivering equivalent features to those found in GUI based clients in an ncurses client.
 ADMIN_URL = /rutorrent/
 RELOAD_UI = yes

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS  = cross/busybox cross/par2cmdline cross/unrar cross/$(SPK_NAME)
 SPK_DEPENDS = "python>=2.7.6-8"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb. SABnzbd takes over from there, where it will be automatically downloaded, verified, repaired, extracted and filed away with zero human interaction.
 DESCRIPTION_FRE = SABnzbd rend Usenet aussi simple et automatisé que possible. Vous n\\\'avez qu\\\'a ajouter un .nzb, SABnzbd s\\\'occupera du reste sans aucune intervention de votre part : téléchargement, vérification, réparation, extraction et déplacement.
 DESCRIPTION_SPN = SABnzbd hace que Usenet sea lo más simple posible, automatizando todo lo que se puede. Todo lo que tienes que hacer es agregar un archivo .nzb. SABnzbd empieza desde ahí. Tus archivos serán automáticamente descargados, verificados, reparados, descomprimidos y archivados.

--- a/spk/selfoss/Makefile
+++ b/spk/selfoss/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = moneytoo
 DESCRIPTION = The new multipurpose rss reader, live stream, mashup, aggregation web application.
 ADMIN_URL = /selfoss/
 RELOAD_UI = yes

--- a/spk/sickbeard-custom/Makefile
+++ b/spk/sickbeard-custom/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3:git"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = SickBeard Custom allows you to run the fork of your choice of SickBeard. You will be asked for the fork\'s git URL during install.
 DESCRIPTION_FRE = SickBeard Custom vous permet d\\\'exécuter le fork de votre choix de SickBeard. Vous aurez besoin de saisir l\\\'URL git du fork durant l\\\'installation.
 ADMIN_PORT = 8083

--- a/spk/sickbeard/Makefile
+++ b/spk/sickbeard/Makefile
@@ -7,7 +7,7 @@ DSM_UI_DIR = app
 DEPENDS  =
 SPK_DEPENDS = "python>2.7.3-3"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = SickBeard is a PVR for newsgroup users \(with limited torrent support\). It watches for new episodes of your favorite shows and when they are posted it downloads them, sorts and renames them automatically. New episodes can also be indexed for your DiskStation.
 DESCRIPTION_FRE = L\\\'application ultime pour télécharger et gérer vos séries TV via NZB ou torrent. Il surveille la sortie de nouveaux épisodes et les télécharge, classe, renomme automatiquement. Les nouveaux épisodes peuvent être indexés pour votre DiskStation.
 DESCRIPTION_SPN = SickBeard es una aplicación para descargar series de televisión de manera automática. Busca por nuevos episodios de tus series favoritas y cuando estos están disponibles los descarga, ordena y renombra. Los nuevos episodios puedes ser indexados en tu DiskStation.

--- a/spk/subliminal/Makefile
+++ b/spk/subliminal/Makefile
@@ -9,7 +9,7 @@ BETA = 1
 WHEELS = src/requirements.txt
 SPK_DEPENDS = "python>=2.7.6-8"
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Subliminal allows you automatically download best-matching subtitles for your movies and tv shows on your DiskStation. This package is named after Subliminal, the Python library used to search and download subtitles.
 DESCRIPTION_FRE = Subliminal vous permet de télécharger automatiquement les meilleurs sous-titres pour vos films et séries sur votre DiskStation. Ce paquet est nommé d\\\'après Subliminal, la librairie Python utilisée pour rechercher et télécharger les sous-titres.
 RELOAD_UI = yes

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Transmission is an easy and fast BitTorrent client. You can control it remotely with its web interface or dedicated applications.
 DESCRIPTION_FRE = Transmission est un client BitTorrent simple et rapide. Vous pouvez le contrôler à distance grâce à son interface web ou des applications dédiées.
 DESCRIPTION_SPN = Transmission es un cliente BitTorrent simple y rápido. Puedes controlarlo remotamente mediante su interfaz web o alguna aplicación dedicada.

--- a/spk/tt-rss/Makefile
+++ b/spk/tt-rss/Makefile
@@ -5,7 +5,8 @@ SPK_ICON = src/tt-rss.png
 DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
-MAINTAINER = SynoCommunity
+
+MAINTAINER = moneytoo
 DESCRIPTION = Tiny Tiny RSS is an open source web-based news feed \(RSS/Atom\) reader and aggregator, designed to allow you to read news from any location, while feeling as close to a real desktop application as possible.
 DESCRIPTION_FRE = Tiny Tiny RSS est un agrégateur et lecteur web de flux RSS et Atom open source conçu pour vous permettre de lire des nouvelles de n\\\'importe quel endroit, tout en se sentant aussi proche d\\\'une application de bureau que possible.
 ADMIN_URL = /tt-rss/

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = ZI660
 DESCRIPTION = Tvheadend is a TV streaming server for Linux supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV and Analog video \(V4L\) as input sources. It also comes with a powerful and easy to use web interface both used for configuration and day-to-day operations, such as searching the EPG and scheduling recordings. Even so, the most notable feature of Tvheadend is how easy it is to set up: Install it, navigate to the web user interface, drill into the TV adapters tab, select your current location and Tvheadend will start scanning channels and present them to you in just a few minutes
 DESCRIPTION_FRE = Tvheadend est un serveur de streaming pour linux gérant les sources DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV et video analogique \\\(V4L\\\). Il possède aussi une interface web puissante et ergonomique pour la configuration tout comme l\\\'utilisation au quotidien : recherche EPG ou plannification d\\\'enregistrements. Le principal point fort de Tvheadend réside avant tout dans sa facilité d\\\'utilisation : installez-le, naviguez au travers de son interface web, choisissez votre adaptateur TV dans l\\\'onglet dédié ainsi que votre localisation et Tvheadend recherchera les cannaux et vous les affichera en seulement quelques minutes
 ADMIN_PORT = 9981

--- a/spk/umurmur/Makefile
+++ b/spk/umurmur/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/openssl cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = uMurmur is a minimalistic VoIP server based on the open source software Mumble. It allows simultaneous communications between multiple users. Its low latency makes it especially suitable for communications during online gaming. The Mumble client is available at http://mumble.sourceforge.net/ \(Windows, Mac, Linux and iOS\).
 DESCRIPTION_FRE = uMurmur est un serveur minimaliste de voix sur IP basé sur le logiciel libre Mumble. Il rend possible la communication entre plusieurs interlocuteurs de manière simultanée. Sa faible latence le rend particulièrement adapté aux communications pendant les parties de jeux en réseau. Le client Mumble est téléchargeable à l\\\'adresse http://mumble.sourceforge.net/ \\\(Windows, Mac, Linux et iOS\\\).
 DESCRIPTION_SPN = uMurmur es un servidor VoIP minimalista basado en el software de codigo abierto Mumble. Permite comunicaciones simultáneas entre múltiples usuarios. Su baja latencia lo hace especialmente adecuado para comunicarse durante un juego en linea. El cliente Mumble está disponible en http://mumble.sourceforge.net/ \\\(Windows, Mac, Linux and iOS\\\).

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = Diaoul
 DESCRIPTION = Advanced IRC bouncer. An IRC bouncer is nothing more than an IRC proxy. ZNC will always be connected in your chat rooms, and will be the gateway between your clients, and your IRC servers. You can, for instance, consult messages while you were offline or hide your identity.
 DESCRIPTION_FRE = Bouncer IRC avancé. Un bouncer IRC n\\\’est en fait qu\\\’un proxy IRC. ZNC restera connecté en permanence à vos salons de discussions et fera office de passerelle entre vos clients et vos serveurs IRC. Vous pourrez, par exemple, consultez des messages diffusés en votre absence ou masquer votre identité.
 DESCRIPTION_SPN = IRC bouncer avanzado. Un IRC bouncer no es más que un proxy para IRC. ZNC estará siempre conectado a tus canales, y hará de puerta de enlace entre tus clientes y tus servidores IRC. Puedes, por ejemplo, consultar mensajes mientras estuviste desconectado o esconder tu identidad.


### PR DESCRIPTION
As per https://github.com/SynoCommunity/spksrc/issues/2007, setting the maintainers to their original authors for a number of packages, based upon the `spksrc/maintainer` branch.

New branch due to merge conflicts. We can delete the `spksrc/maintainer` branch after merging this.