### PR TITLE
Gateone revision update to 1d0e803

### DIFF
--- a/cross/gateone/Makefile
+++ b/cross/gateone/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = gateone
 PKG_EXT = tar.gz
 PKG_DOWNLOAD_METHOD = git
-PKG_GIT_HASH = 2ddbd05
+PKG_GIT_HASH = 1d0e803
 PKG_DIST_SITE = https://github.com/liftoff/GateOne.git
 PKG_DIST_FILE = $(PKG_NAME)-git$(PKG_GIT_HASH).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-git$(PKG_GIT_HASH)

--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = gateone
-SPK_VERS = 20150311
-SPK_REV = 5
+SPK_VERS = 20151116
+SPK_REV = 6
 SPK_ICON = src/gateone.png
 DSM_UI_DIR = app
 

--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -15,7 +15,7 @@ ADMIN_PROTOCOL = https
 ADMIN_PORT = 8271
 RELOAD_UI = yes
 DISPLAY_NAME = GateOne
-CHANGELOG = "Update to revision 2ddbd05"
+CHANGELOG = "Update to revision 1d0e803"
 
 HOMEPAGE   = http://liftoffsoftware.com/Products/GateOne
 LICENSE    = AGPLv3


### PR DESCRIPTION
This patch will resolve some issues related to special key handling that were resolved in `11ce067` and `56a0409`. There are also some less critical browser compatibility fixes in this latest revision. 

Since gateone development has slowed down lately (due to improved stability) and no new changes have been committed since November 22nd, 2015 it is a good idea to push an update to the syno community to bring these changes in for other synology users.