### PR TITLE
Updated the openssl version to the current one 1.0.2f

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2e
+PKG_VERS = 1.0.2f
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = ftp://ftp.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2e.tar.gz SHA1 2c5691496761cb18f98476eefa4d35c835448fb6
-openssl-1.0.2e.tar.gz SHA256 e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff
-openssl-1.0.2e.tar.gz MD5 5262bfa25b60ed9de9f28d5d52d77fc5
+openssl-1.0.2f.tar.gz SHA1 2047c592a6e5a42bd37970bdb4a931428110a927
+openssl-1.0.2f.tar.gz SHA256 932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
+openssl-1.0.2f.tar.gz MD5 b3bf73f507172be9292ea2a8c28b659d


### PR DESCRIPTION
Version 1.0.2e is not anymore on ftp://ftp.openssl.org/source/. This makes it use the new f version