### PR TITLE
Migrate to 64bit build env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM 32bit/debian:jessie
+FROM debian:jessie
 MAINTAINER SynoCommunity <https://synocommunity.com>
 
 ENV LANG C.UTF-8
+
+# Manage i386 arch
+RUN dpkg --add-architecture i386
 
 # Install required packages
 RUN apt-get update && \
@@ -20,6 +23,7 @@ RUN apt-get update && \
         gperf \
         imagemagick \
         intltool \
+        libc6-i386 \
         libffi-dev \
         libgc-dev \
         libltdl-dev \

--- a/toolchains/syno-88f6281-5.2/Makefile
+++ b/toolchains/syno-88f6281-5.2/Makefile
@@ -13,9 +13,9 @@ TC_BASE_DIR = arm-marvell-linux-gnueabi
 TC_PREFIX = arm-marvell-linux-gnueabi
 TC_TARGET = arm-marvell-linux-gnueabi
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/lib
 
 include ../../mk/spksrc.tc.mk

--- a/toolchains/syno-armada370-5.2/Makefile
+++ b/toolchains/syno-armada370-5.2/Makefile
@@ -13,9 +13,9 @@ TC_BASE_DIR = arm-marvell-linux-gnueabi
 TC_PREFIX = arm-marvell-linux-gnueabi
 TC_TARGET = arm-marvell-linux-gnueabi
 
-TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/include -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -DSYNO_MARVELL_ARMADA370 -DSYNO_PLATFORM=MARVELL_ARMADA370
-TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/include -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -DSYNO_MARVELL_ARMADA370 -DSYNO_PLATFORM=MARVELL_ARMADA370
-TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/include -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -DSYNO_MARVELL_ARMADA370 -DSYNO_PLATFORM=MARVELL_ARMADA370
-TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/lib -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3-d16
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3-d16
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3-d16
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/lib -mhard-float -mfpu=vfpv3-d16
 
 include ../../mk/spksrc.tc.mk

--- a/toolchains/syno-armada375-5.2/Makefile
+++ b/toolchains/syno-armada375-5.2/Makefile
@@ -13,4 +13,9 @@ TC_BASE_DIR = arm-marvell-linux-gnueabi
 TC_PREFIX = arm-marvell-linux-gnueabi
 TC_TARGET = arm-marvell-linux-gnueabi
 
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/lib -mhard-float -mfpu=vfpv3
+
 include ../../mk/spksrc.tc.mk

--- a/toolchains/syno-armadaxp-5.2/Makefile
+++ b/toolchains/syno-armadaxp-5.2/Makefile
@@ -13,9 +13,9 @@ TC_BASE_DIR = arm-marvell-linux-gnueabi
 TC_PREFIX = arm-marvell-linux-gnueabi
 TC_TARGET = arm-marvell-linux-gnueabi
 
-TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/include -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -DSYNO_MARVELL_ARMADA370 -DSYNO_PLATFORM=MARVELL_ARMADA370
-TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/include -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -DSYNO_MARVELL_ARMADA370 -DSYNO_PLATFORM=MARVELL_ARMADA370
-TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/include -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -DSYNO_MARVELL_ARMADA370 -DSYNO_PLATFORM=MARVELL_ARMADA370
-TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/lib -mcpu=marvell-pj4 -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3-d16
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3-d16
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/include -mhard-float -mfpu=vfpv3-d16
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/libc/usr/lib -mhard-float -mfpu=vfpv3-d16
 
 include ../../mk/spksrc.tc.mk

--- a/toolchains/syno-avoton-5.2/Makefile
+++ b/toolchains/syno-avoton-5.2/Makefile
@@ -13,10 +13,10 @@ TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
 TC_TARGET = x86_64-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-braswell-5.2/Makefile
+++ b/toolchains/syno-braswell-5.2/Makefile
@@ -13,10 +13,10 @@ TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
 TC_TARGET = x86_64-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-bromolow-5.2/Makefile
+++ b/toolchains/syno-bromolow-5.2/Makefile
@@ -13,10 +13,10 @@ TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
 TC_TARGET = x86_64-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-cedarview-5.2/Makefile
+++ b/toolchains/syno-cedarview-5.2/Makefile
@@ -13,10 +13,11 @@ TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
 TC_TARGET = x86_64-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
+
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-comcerto2k-5.2/Makefile
+++ b/toolchains/syno-comcerto2k-5.2/Makefile
@@ -13,10 +13,11 @@ TC_BASE_DIR = arm-cortexa9-linux-gnueabi
 TC_PREFIX = arm-cortexa9-linux-gnueabi
 TC_TARGET = arm-cortexa9-linux-gnueabi
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include -mcpu=cortex-a9 -march=armv7a -mfpu=neon -mfloat-abi=hard -mthumb
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include -mcpu=cortex-a9 -march=armv7a -mfpu=neon -mfloat-abi=hard -mthumb
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include -mcpu=cortex-a9 -march=armv7a -mfpu=neon -mfloat-abi=hard -mthumb
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/lib -mfloat-abi=hard -mtune=cortex-a15 -mfpu=neon-vfpv4 -mthumb
+
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-evansport-5.2/Makefile
+++ b/toolchains/syno-evansport-5.2/Makefile
@@ -13,10 +13,10 @@ TC_BASE_DIR = i686-pc-linux-gnu
 TC_PREFIX = i686-pc-linux-gnu
 TC_TARGET = i686-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-monaco-5.2/Makefile
+++ b/toolchains/syno-monaco-5.2/Makefile
@@ -7,7 +7,8 @@ TC_FIRMWARE = 5.2-5644
 TC_DIST_NAME = monaco-gcc483_glibc219_hard-GPL.txz
 
 TC_EXT = txz
-TC_DIST_SITE = http://sourceforge.net/projects/dsgpl/files/DSM%205.2%20Tool%20Chains/STMicroelectronics%20Monaco%20Linux%203.10.35
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/DSM%205.2%20Tool%20Chains/STMicroelectronics%20Monaco%20Linux%203.10.35
+               #https://sourceforge.net/projects/dsgpl/files/DSM%205.2%20Tool%20Chains/STMicroelectronics%20Monaco%20Linux%203.10.35/monaco-gcc483_glibc219_hard-GPL.txz/download
 
 TC_BASE_DIR = arm-cortexa9hf-linux-gnueabi
 TC_PREFIX = arm-cortexa9hf-linux-gnueabi
@@ -16,7 +17,7 @@ TC_TARGET = arm-cortexa9hf-linux-gnueabi
 TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include -mcpu=cortex-a9 -march=armv7-a -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9
 TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include -mcpu=cortex-a9 -march=armv7-a -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9
 TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include -mcpu=cortex-a9 -march=armv7-a -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9
-TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/lib -mcpu=cortex-a9 -march=armv7-a -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/lib -mcpu=cortex-a9 -march=armv7-a -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-x64-5.2/Makefile
+++ b/toolchains/syno-x64-5.2/Makefile
@@ -13,10 +13,10 @@ TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
 TC_TARGET = x86_64-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
 
 FIX_TARGET = myFix
 

--- a/toolchains/syno-x86-5.2/Makefile
+++ b/toolchains/syno-x86-5.2/Makefile
@@ -13,10 +13,10 @@ TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
 TC_TARGET = x86_64-pc-linux-gnu
 
-TC_CFLAGS =
-TC_CPPFLAGS =
-TC_CXXFLAGS =
-TC_LDFLAGS =
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
 
 FIX_TARGET = myFix
 


### PR DESCRIPTION
- Changes the Dockerfile to be based on a 64bit version of Debian.
- In most cases, the toolchains also need adjustments to ensure the correct libc is used (not all packages need it, but the Python SPK does, for example) This PR includes those changes for the 5.2 toolchains. 
Presumably older toolchains can be made to work with similar changes.

I have not tested the resulting packages, imo if compilation works, we're on the right track.

Todo separately:
- Edit the README to fix the VM instructions
- Fix older toolchains
- Fix (cross) packages that are broken on 64b. Go/Syncthing is one, there could be others, can't recall.