### PR TITLE
Updated Transmission to 2.92

### DIFF
--- a/cross/transmission/Makefile
+++ b/cross/transmission/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = transmission
-PKG_VERS = 2.84
+PKG_VERS = 2.92
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://download.transmissionbt.com/files

--- a/cross/transmission/PLIST
+++ b/cross/transmission/PLIST
@@ -1,4 +1,3 @@
-bin:bin/transmission-cli
 bin:bin/transmission-create
 bin:bin/transmission-daemon
 bin:bin/transmission-edit

--- a/cross/transmission/digests
+++ b/cross/transmission/digests
@@ -1,3 +1,3 @@
-transmission-2.84.tar.xz SHA1 455359bc1fa34aeecc1bac9255ad0c884b94419c
-transmission-2.84.tar.xz SHA256 a9fc1936b4ee414acc732ada04e84339d6755cd0d097bcbd11ba2cfc540db9eb
-transmission-2.84.tar.xz MD5 411aec1c418c14f6765710d89743ae42
+transmission-2.92.tar.xz SHA1 2140feba45c4471392033d21b86b6f3ef780d88e
+transmission-2.92.tar.xz SHA256 3a8d045c306ad9acb7bf81126939b9594553a388482efa0ec1bfb67b22acd35f
+transmission-2.92.tar.xz MD5 3fce404a436e3cd7fde80fb6ed61c264

--- a/cross/transmission/patches/no-debug.patch
+++ b/cross/transmission/patches/no-debug.patch
@@ -1,11 +1,12 @@
---- configure.orig	2011-07-21 01:39:42.000000000 +0200
-+++ configure	2011-09-21 20:39:01.000000000 +0200
-@@ -15421,7 +15421,7 @@
+--- configure.orig	2016-03-07 20:37:38.167985408 -0500
++++ configure	2016-03-07 20:39:44.967987326 -0500
+@@ -17126,8 +17126,7 @@
  
  if test "x$GCC" = "xyes" ; then
  
--    CFLAGS="$CFLAGS -std=gnu99 -ggdb3 -Wall -W -Wpointer-arith -Wformat-security -Wcast-align -Wundef -Wcast-align -Wstrict-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wnested-externs -Wunused-parameter -Wwrite-strings -Winline -Wfloat-equal"
+-    CFLAGS="$CFLAGS -std=gnu99 -ggdb3 -Wall -W -Wpointer-arith -Wformat-security -Wundef -Wcast-align -Wstrict-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wnested-externs -Wunused-parameter -Wwrite-strings -Winline -Wfloat-equal"
+-
 +    CFLAGS="$CFLAGS -std=gnu99 -Wall -W -Wpointer-arith -Wformat-security -Wcast-align -Wundef -Wcast-align -Wstrict-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wnested-externs -Wunused-parameter -Wwrite-strings -Winline -Wfloat-equal"
- 
          { $as_echo "$as_me:${as_lineno-$LINENO}: checking gcc version" >&5
  $as_echo_n "checking gcc version... " >&6; }
+     GCC_VERSION=`$CC -dumpversion`

--- a/cross/transmission/patches/no-debug.patch
+++ b/cross/transmission/patches/no-debug.patch
@@ -1,12 +1,11 @@
---- configure.orig	2016-03-07 20:37:38.167985408 -0500
-+++ configure	2016-03-07 20:39:44.967987326 -0500
-@@ -17126,8 +17126,7 @@
- 
+--- configure.orig      2016-03-07 20:37:38.167985408 -0500
++++ configure   2016-03-08 13:13:18.948888908 -0500
+@@ -17126,7 +17126,7 @@
+
  if test "x$GCC" = "xyes" ; then
- 
+
 -    CFLAGS="$CFLAGS -std=gnu99 -ggdb3 -Wall -W -Wpointer-arith -Wformat-security -Wundef -Wcast-align -Wstrict-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wnested-externs -Wunused-parameter -Wwrite-strings -Winline -Wfloat-equal"
--
-+    CFLAGS="$CFLAGS -std=gnu99 -Wall -W -Wpointer-arith -Wformat-security -Wcast-align -Wundef -Wcast-align -Wstrict-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wnested-externs -Wunused-parameter -Wwrite-strings -Winline -Wfloat-equal"
++    CFLAGS="$CFLAGS -std=gnu99 -Wall -W -Wpointer-arith -Wformat-security -Wundef -Wcast-align -Wstrict-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wnested-externs -Wunused-parameter -Wwrite-strings -Winline -Wfloat-equal"
+
          { $as_echo "$as_me:${as_lineno-$LINENO}: checking gcc version" >&5
  $as_echo_n "checking gcc version... " >&6; }
-     GCC_VERSION=`$CC -dumpversion`

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = transmission
-SPK_VERS = 2.84
-SPK_REV = 11
+SPK_VERS = 2.92
+SPK_REV = 12
 SPK_ICON = src/transmission.png
 DSM_UI_DIR = app
 
@@ -13,7 +13,7 @@ DESCRIPTION_SPN = Transmission es un cliente BitTorrent simple y rápido. Puedes
 ADMIN_PORT = 9091
 RELOAD_UI = yes
 DISPLAY_NAME = Transmission
-CHANGELOG = "Enable sc-download group"
+CHANGELOG = "Update Transmission to 2.92"
 
 HOMEPAGE = http://www.transmissionbt.com
 LICENSE  = GPLv2/GPLv3

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -13,7 +13,7 @@ DESCRIPTION_SPN = Transmission es un cliente BitTorrent simple y rápido. Puedes
 ADMIN_PORT = 9091
 RELOAD_UI = yes
 DISPLAY_NAME = Transmission
-CHANGELOG = "Update Transmission to 2.92"
+CHANGELOG = "1. Update Transmission to 2.92<br>2. Enable sc-download group"
 
 HOMEPAGE = http://www.transmissionbt.com
 LICENSE  = GPLv2/GPLv3


### PR DESCRIPTION
Updated Transmission to 2.92

In addition to standard version number changes:

1. Had to update the patch file (Is this still needed?) to reflect line changes
2. Remove transmission-cli from the PLIST file - See 2.92 change log: _"[Don't build transmission-cli by default (it's long deprecated)](https://trac.transmissionbt.com/wiki/Changes)"_

Test compiled on Avoton and qoriq and compiled fine.  Test installed on a DS1515+ and ran fine.