### PR TITLE
Fix bug with certain arches (e.g., qoriq) and xdl_fast_hash

### DIFF
--- a/cross/git/patches/git-remove-xdl_fast_hash-check.patch
+++ b/cross/git/patches/git-remove-xdl_fast_hash-check.patch
@@ -1,0 +1,12 @@
+--- config.mak.uname.orig	2016-03-22 11:13:28.842072683 -0400
++++ config.mak.uname	2016-03-22 11:12:15.698069794 -0400
+@@ -17,9 +17,6 @@
+ # because maintaining the nesting to match is a pain.  If
+ # we had "elif" things would have been much nicer...
+ 
+-ifeq ($(uname_M),x86_64)
+-	XDL_FAST_HASH = YesPlease
+-endif
+ ifeq ($(uname_S),OSF1)
+ 	# Need this for u_short definitions et al
+ 	BASIC_CFLAGS += -D_OSF_SOURCE

--- a/spk/git/Makefile
+++ b/spk/git/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = git
 SPK_VERS = 2.7.4
-SPK_REV = 7
+SPK_REV = 8
 SPK_ICON = src/git.png
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
@@ -10,7 +10,7 @@ DESCRIPTION = Git is a free and open source distributed version control system d
 DESCRIPTION_FRE = Git est un logiciel de gestion de version décentralisée gratuit et open source destiné à gérer aussi bien les petits que les très gros projets avec vitesse et efficacité.
 STARTABLE = no
 DISPLAY_NAME = Git
-CHANGELOG = Update Git to 2.7.4
+CHANGELOG = "1. Correct error in some powerpc compiles (e.g., DS413) <br> 2. Update Git to 2.7.4"
 
 HOMEPAGE = http://git-scm.com
 LICENSE  = GPLv2


### PR DESCRIPTION
Quick Fix for https://github.com/SynoCommunity/spksrc/issues/2202

Still not ideal as we are losing functionality for X64 hosts as I'm just patching this out for all build types.

My limitation of Make and configs show.  I tried calling TC_TARGET (to try and and at least do the if statement for X64 arches) but it was a blank variable in git/config.mak.uname (the culprit).  ARCH works but $(x64_ARCHES) was not returning anything.  

I'm open for ideas - I'm trying to replace `ifeq ($(uname_M),x86_64)` (which is always true because uname_M is based on the build environment) with something that will only be true for x64 host builds (e.g., ARCH of type x64, avoton etc.)