### PR TITLE
Updated for mosquitto 1.4.8 and DSM 6.0

### DIFF
--- a/cross/libwebsockets/Makefile
+++ b/cross/libwebsockets/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = libwebsockets
 PKG_VERS = 1.4-chrome43-firefox-36
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/snapshot
+PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/warmcat/libwebsockets/archive
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/openssl

--- a/cross/libwebsockets/digests
+++ b/cross/libwebsockets/digests
@@ -1,3 +1,3 @@
-libwebsockets-1.4-chrome43-firefox-36.tar.gz SHA1 f2c4cb05abb3ddac09a61f63cbd018665da2d450
-libwebsockets-1.4-chrome43-firefox-36.tar.gz SHA256 e11492477e582ef0b1a6ea2f18d81a9619b449170a3a5c43f32a9468461a9798
-libwebsockets-1.4-chrome43-firefox-36.tar.gz MD5 0452c278a5cd4349135df2a693f35c28
+v1.4-chrome43-firefox-36.tar.gz SHA1 f2c4cb05abb3ddac09a61f63cbd018665da2d450
+v1.4-chrome43-firefox-36.tar.gz SHA256 e11492477e582ef0b1a6ea2f18d81a9619b449170a3a5c43f32a9468461a9798
+v1.4-chrome43-firefox-36.tar.gz MD5 0452c278a5cd4349135df2a693f35c28

--- a/cross/mosquitto/Makefile
+++ b/cross/mosquitto/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = mosquitto
-PKG_VERS = 1.4.2
+PKG_VERS = 1.4.8
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://mosquitto.org/files/source

--- a/cross/mosquitto/digests
+++ b/cross/mosquitto/digests
@@ -1,3 +1,3 @@
-mosquitto-1.4.2.tar.gz SHA1 208ce5f01fcf25fff6b241b22add055ba2884822
-mosquitto-1.4.2.tar.gz SHA256 5ebc3800a0018bfbec62dcc3748fb29f628df068acd39c62c4ef651d9276647e
-mosquitto-1.4.2.tar.gz MD5 2c3b19686c04849ed4b183c63149bfe1
+mosquitto-1.4.8.tar.gz SHA1 e8a0c512649275daadce125dc3a5e58a988319fc
+mosquitto-1.4.8.tar.gz SHA256 d96eb5610e57cc3e273f4527d3f54358ab7711459941a9e64bc4d0a85c2acfda
+mosquitto-1.4.8.tar.gz MD5 d859cd474ffa61a6197bdabe007b9027

--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2g
+PKG_VERS = 1.0.2h
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = ftp://ftp.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2g.tar.gz SHA1 36af23887402a5ea4ebef91df8e61654906f58f2
-openssl-1.0.2g.tar.gz SHA256 b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
-openssl-1.0.2g.tar.gz MD5 f3c710c045cdee5fd114feb69feba7aa
+openssl-1.0.2h.tar.gz SHA1 577585f5f5d299c44dd3c993d3c0ac7a219e4949
+openssl-1.0.2h.tar.gz SHA256 1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
+openssl-1.0.2h.tar.gz MD5 9392e65072ce4b614c1392eefc1f23d0

--- a/spk/mosquitto/Makefile
+++ b/spk/mosquitto/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mosquitto
-SPK_VERS = 1.4.2
-SPK_REV = 4
+SPK_VERS = 1.4.8
+SPK_REV = 1
 SPK_ICON = src/mosquitto.png
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
@@ -9,7 +9,7 @@ DESCRIPTION = Mosquitto is an open source message broker that implements the MQ 
 RELOAD_UI = yes
 DISPLAY_NAME = Mosquitto
 STARTABLE = yes
-CHANGELOG = "Add websockets support"
+CHANGELOG = "Update to 1.4.8 - Websocket on by default"
 HOMEPAGE = http://www.mosquitto.org/
 LICENSE  = BSD licensed
 

--- a/spk/mosquitto/src/dsm-control.sh
+++ b/spk/mosquitto/src/dsm-control.sh
@@ -7,7 +7,6 @@ DNAME="Mosquitto"
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
 PATH="${INSTALL_DIR}/bin:${PATH}"
-USER="mosquitto"
 MOSQUITTO="${INSTALL_DIR}/sbin/mosquitto"
 PID_FILE="${INSTALL_DIR}/var/mosquitto.pid"
 CFG_FILE="${INSTALL_DIR}/var/mosquitto.conf"

--- a/spk/mosquitto/src/mosquitto.conf
+++ b/spk/mosquitto/src/mosquitto.conf
@@ -133,7 +133,7 @@ pid_file /usr/local/mosquitto/var/mosquitto.pid
 #bind_address
 
 # Port to use for the default listener.
-#port 1883
+port 1883
 
 # The maximum number of client connections to allow. This is 
 # a per listener setting.
@@ -264,6 +264,10 @@ pid_file /usr/local/mosquitto/var/mosquitto.pid
 # to all topics for any clients connected to this listener. This prefixing only
 # happens internally to the broker; the client will not see the prefix.
 #mount_point
+
+# Enable a WebSocket listener by default
+listener 9001
+protocol websockets
 
 # -----------------------------------------------------------------
 # Certificate based SSL/TLS support

--- a/spk/mosquitto/src/mosquitto.sc
+++ b/spk/mosquitto/src/mosquitto.sc
@@ -2,4 +2,4 @@
 title="Mosquitto"
 desc="Mosquitto"
 port_forward="yes"
-dst.ports="1883/tcp"
+dst.ports="1883,9001/tcp"


### PR DESCRIPTION
 - updated to latest version from upstream (closes #2297)
 - fix a bug in the startup script that prevented the service to
   start on DSM 6.0 (as discussed in #2207)
 - enable webservice listener by default (#1723)
 - updated libopenssl from 1.0.2g to 1.0.2h because the earlier is not
   available anymore for download
 - update the source for libwebsockets because the previous source
   caused TLS error in the docker container (note that the checksums
   have NOT changed)

Tested on a DS414 running DSM 6.0-7321.

NOT tested on DSM 5.x. Not sure if the `dsm-control.sh` will break
anything. Maintainers please advise!