### PR TITLE
Add issue and package request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+_[For package requests, click here](https://github.com/SynoCommunity/spksrc/blob/master/.github/PACKAGE_REQUEST_TEMPLATE.md)_.
+
+### Setup
+Package Name:  
+Package Version:  
+
+NAS Model:  
+NAS Architecture: _See [Architecture per Synology model](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model)_  
+DSM version:  
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Steps to reproduce
+1.  
+2.  
+3.  
+
+### Log files
+_Limit to relevant parts. Use gist.github.com or pastebin for longer log files_
+#### Package log
+_Check Package Center or `/usr/local/{package}/var/`_
+```
+Insert the package log here
+```
+#### Other logs
+_E.g. `/var/log/messages` or `/var/log/synopkg.log`_
+```
+Insert log here
+```

--- a/.github/PACKAGE_REQUEST_TEMPLATE.md
+++ b/.github/PACKAGE_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+_See [CONTRIBUTING](https://github.com/SynoCommunity/spksrc/blob/master/CONTRIBUTING.md#package-requests) for more information._  
+
+Website: _Link to website of software_  
+Description: _Provide a description of the software_  
+Documentation: _Link to general documentation_  
+Build/Installation documentation: _Link to build instructions, prerequisites etc._  
+Source code: _Link to source code_  
+License: _GPL, Apache, etc._  

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+Motivation: _Explain here what the reason for the pull request is._  
+Linked issues: _Optionally, add links to existing issues or other PR's_  
+
+### Checklist
+- [] Build rule `all-supported` completed successfully  
+- [] Build rule `all-legacy` completed successfully  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,6 @@ Issue content
 
 When you open a new issue to ask a question about a package, or want to report a bug, be sure to provide as much details as possible for someone else to reproduce what you experienced.
 
-Include at least the following information or use [this link](https://github.com/SynoCommunity/spksrc/issues/new?title=[package]%3A%20Description%20&body=Issue%20description%3A%0AModel%3A%0AArchitecture%3A%0ADSM%20version%3A%0ALog%20file%3A) as a starting point.
-
 Title:
 
 [package name] Short description of question or bug
@@ -35,8 +33,8 @@ Title:
 Content:
 
 * In the issue body, describe what you did, what you expected to happen and what actually happened;
-* Model and arch of your NAS. See [Architecture per Synology model](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model);
-* DSM version;
+* Which steps to perform to reproduce what happened;
+* Model, arch and DSM version of your NAS. See [Architecture per Synology model](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model);
 * Provide log files if available. Sometimes a log is shown in Package Center for that package. There might be a log available at `/usr/local/{package}/var/`;
 * Wrap larger logs between triple backticks (```). Log files over ten lines should be placed on gist.github.com, Pastebin etc., and linked in the issue;
 * If the package doesn't start, try to start the package via the command line: `/var/packages/{package}/scripts/start-stop-status start`, and provide the output.
@@ -50,7 +48,7 @@ Note that opening a request does not mean it will be honored, so please do not a
 You can show your support with a +1, or by adding a bounty via Bountysource.
 
 Before opening a Package Request, make sure that there are no existing requests for the same software.
-As part of your request, some basic information should be included. Contributors use that information as a starting point for packaging. Use the format below, or use the following link to open a request: [New Package Request](https://github.com/SynoCommunity/spksrc/issues/new?title=[request]%20&body=Description%3A%0AWebsite%3A%0ADocumentation%3A%0ABuild%2FInstallation%20documentation%3A%0ASource Code%3A%0ALicense%3A) and fill out the fields.
+As part of your request, some basic information should be included. Contributors use that information as a starting point for packaging. Use the format as shown below.
 
 Title:
 


### PR DESCRIPTION
Via https://github.com/SynoCommunity/spksrc/issues/2299.

We can move CONTRIBUTING.md to the same dir, and we can adjust its contents to directly point to the templates instead of the link I added in there a while back.