### PR TITLE
update syncthing to 0.13.4

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -37,7 +37,7 @@ $(error Unsupported ARCH $(ARCH))
 endif
 
 SYNCTHING_DIR = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)
-EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)/../
+EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)/
 SYNCTHING_BIN = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)/syncthing
 
 include ../../mk/spksrc.cross-cc.mk
@@ -53,11 +53,8 @@ ifeq ($(strip $(STATIC_BINARIES)),1)
 CONF_ARGS += -no-upgrade
 endif
 
-#overwrite the RUN arg to the correct location
-RUN = cd $(SYNCTHING_DIR) && env $(ENV)
-
 myComp:
-	$(RUN) go run build.go $(CONF_ARGS) build
+	cd $(SYNCTHING_DIR) && env $(ENV) go run build.go $(CONF_ARGS) build
 
 myInstall:
 	mkdir -p $(STAGING_INSTALL_PREFIX)/bin

--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 0.12.21
+PKG_VERS = 0.13.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)
@@ -16,7 +16,7 @@ COMPILE_TARGET = myComp
 INSTALL_TARGET = myInstall
 
 GOOS = linux
-CGO_ENABLED=1
+CGO_ENABLED=0
 
 # set this to 1 to create static linked binaries
 STATIC_BINARIES = 0
@@ -24,7 +24,6 @@ STATIC_BINARIES = 0
 # Define SYNCTHING_ARCH as per SyncThing standards
 ifeq ($(findstring $(ARCH),88f5281 88f6281 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco),$(ARCH))
 SYNCTHING_ARCH = arm
-CGO_ENABLED = 0
 ENV += GOARM=5
 endif
 ifeq ($(findstring $(ARCH),evansport),$(ARCH))
@@ -37,21 +36,14 @@ ifeq ($(SYNCTHING_ARCH),)
 $(error Unsupported ARCH $(ARCH))
 endif
 
-ifeq ($(findstring $(SYNCTHING_ARCH),amd64),$(SYNCTHING_ARCH))
-SYNCTHING_BIN = $(WORK_DIR)/$(PKG_DIR)/bin/syncthing
-endif
-
-ifeq ($(findstring $(SYNCTHING_ARCH),386),$(SYNCTHING_ARCH))
-SYNCTHING_BIN = $(WORK_DIR)/$(PKG_DIR)/bin/linux_386/syncthing
-endif
-
-ifeq ($(findstring $(SYNCTHING_ARCH),arm),$(SYNCTHING_ARCH))
-SYNCTHING_BIN = $(WORK_DIR)/$(PKG_DIR)/bin/linux_arm/syncthing
-endif
+SYNCTHING_DIR = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)
+EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)/../
+SYNCTHING_BIN = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)/syncthing
 
 include ../../mk/spksrc.cross-cc.mk
 
-ENV += GOPATH=$(WORK_DIR)/../../../native/go/work-native/go/
+# use workdir as gopath 
+ENV += GOPATH=$(WORK_DIR)/
 ENV += CGO_ENABLED=$(CGO_ENABLED)
 ENV += PATH=$(WORK_DIR)/../../../native/go/work-native/go/bin/:$$PATH
 
@@ -61,12 +53,11 @@ ifeq ($(strip $(STATIC_BINARIES)),1)
 CONF_ARGS += -no-upgrade
 endif
 
+#overwrite the RUN arg to the correct location
+RUN = cd $(SYNCTHING_DIR) && env $(ENV)
+
 myComp:
-	#go is particular about file locations so we have to link it to the native directory to work!
-	rm -rf $(WORK_DIR)/../../../native/go/work-native/go/src/github.com/syncthing
-	mkdir -p $(WORK_DIR)/../../../native/go/work-native/go/src/github.com/syncthing
-	ln -sf $(WORK_DIR)/$(PKG_DIR) $(WORK_DIR)/../../../native/go/work-native/go/src/github.com/syncthing/syncthing
-	$(RUN) go run build.go $(CONF_ARGS)
+	$(RUN) go run build.go $(CONF_ARGS) build
 
 myInstall:
 	mkdir -p $(STAGING_INSTALL_PREFIX)/bin

--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -37,13 +37,13 @@ $(error Unsupported ARCH $(ARCH))
 endif
 
 SYNCTHING_DIR = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)
-EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)/
+EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)
 SYNCTHING_BIN = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)/syncthing
 
 include ../../mk/spksrc.cross-cc.mk
 
-# use workdir as gopath 
-ENV += GOPATH=$(WORK_DIR)/
+# use workdir as gopath
+ENV += GOPATH=$(WORK_DIR)
 ENV += CGO_ENABLED=$(CGO_ENABLED)
 ENV += PATH=$(WORK_DIR)/../../../native/go/work-native/go/bin/:$$PATH
 

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-source-v0.12.21.tar.gz SHA1 fb7cea43515f12279c3bbfe0fbd226a79068659a
-syncthing-source-v0.12.21.tar.gz SHA256 39e5fb83c6bebb7fe14df7d765077fa6dc625d1bfef7f8f193bb5308a9ac246c
-syncthing-source-v0.12.21.tar.gz MD5 54a30ab7742c25a0d0eceddf505a696a
+syncthing-source-v0.13.4.tar.gz SHA1 35fa3d7810f80a6e00be99d410b0cb9d2aa7402f
+syncthing-source-v0.13.4.tar.gz SHA256 19e113fe00f8166f6811b01ffaa06a546884d767eea79bea9b7907a2a35ca67b
+syncthing-source-v0.13.4.tar.gz MD5 eabf036d050fe148f8c8feadd5c5fd08

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,12 +1,12 @@
 SPK_NAME = syncthing
-SPK_VERS = 0.12.21
-SPK_REV = 8
+SPK_VERS = 0.13.4
+SPK_REV = 9
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
 UNSUPPORTED_ARCHS = $(PPC_ARCHES)
 
-DEPENDS  = cross/busybox cross/$(SPK_NAME)
+DEPENDS  = cross/$(SPK_NAME) cross/busybox
 
 MAINTAINER = cytec
 DESCRIPTION = Automatically sync files via secure, distributed technology.
@@ -14,7 +14,7 @@ DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie s√
 ADMIN_PORT = 7070
 RELOAD_UI = yes
 DISPLAY_NAME = Syncthing
-CHANGELOG = "Update to 0.12.21"
+CHANGELOG = "Update to 0.13.4"
 
 HOMEPAGE   = http://www.syncthing.net
 LICENSE    = MPLv2.0

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 UNSUPPORTED_ARCHS = $(PPC_ARCHES)
 
-DEPENDS  = cross/$(SPK_NAME) cross/busybox
+DEPENDS  = cross/busybox cross/$(SPK_NAME)
 
 MAINTAINER = cytec
 DESCRIPTION = Automatically sync files via secure, distributed technology.


### PR DESCRIPTION
_Motivation:_ update syncthing to 13.4 and cleanup.
_Linked issues:_ https://github.com/SynoCommunity/spksrc/issues/2343

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

I've changed syncthing to use current work-dir as GOPATH which seemed to work pretty well... that sould make sure that we don't get conflicts with other go related tools as every package uses the work dir as GOPATH and links/downloads go source there

Tested installation/upgrade only on cedarview arch!

EDIT: @Dr-Bean for some reason i had to put `cross/busybox` after `cross/$(SPK_NAME)` as it seems that otherwise my custom `$(EXTRACT_PATH)` in `cross/syncthing` was overwritten by the default