### PR TITLE
Remove useless flags on native python

### DIFF
--- a/native/python/Makefile
+++ b/native/python/Makefile
@@ -12,7 +12,6 @@ COMMENT    = Python Programming Language
 LICENSE    = PSF
 
 GNU_CONFIGURE = 1
-ADDITIONAL_CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 CONFIGURE_ARGS = --enable-unicode=ucs4 --enable-ipv6
 
 POST_INSTALL_TARGET = myPostInstall

--- a/native/python3/Makefile
+++ b/native/python3/Makefile
@@ -12,7 +12,6 @@ COMMENT    = Python Programming Language
 LICENSE    =
 
 GNU_CONFIGURE = 1
-ADDITIONAL_CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 CONFIGURE_ARGS = --enable-ipv6 --without-ensurepip
 
 COMPILE_TARGET = myCompile


### PR DESCRIPTION
_Motivation:_ These flags are automatically defined

define _LARGEFILE_SOURCE 1
define _FILE_OFFSET_BITS 64

### Checklist
- [X] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully

