### PR TITLE
Allow to define a set of ARCH-DSM as unsupported

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -41,6 +41,14 @@ ifneq ($(REQUIRED_DSM),)
   endif
 endif
 
+# Check if package supports ARCH-DSM
+ifneq ($(UNSUPPORTED_ARCHS_DSM),)
+  ifneq (,$(findstring $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_DSM)))
+    @$(error '$(ARCH)-$(TCVERSION)' is not a supported )
+  endif
+endif
+
+
 #####
 
 include ../../mk/spksrc.cross-env.mk

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -35,6 +35,13 @@ ifneq ($(REQUIRED_DSM),)
   endif
 endif
 
+# Check if package supports ARCH-DSM
+ifneq ($(UNSUPPORTED_ARCHS_DSM),)
+  ifneq (,$(findstring $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_DSM)))
+    @$(error '$(ARCH)-$(TCVERSION)' is not a supported )
+  endif
+endif
+
 #####
 
 # Even though this makefile doesn't cross compile, we need this to setup the cross environment.
@@ -236,7 +243,7 @@ $(DSM_SCRIPTS_DIR)/preupgrade:
 $(DSM_SCRIPTS_DIR)/postupgrade:
 	@$(dsm_script_redirect)
 
-$(DSM_SCRIPTS_DIR)/start-stop-status: $(SSS_SCRIPT) 
+$(DSM_SCRIPTS_DIR)/start-stop-status: $(SSS_SCRIPT)
 	@$(dsm_script_copy)
 $(DSM_SCRIPTS_DIR)/installer: $(INSTALLER_SCRIPT)
 	@$(dsm_script_copy)


### PR DESCRIPTION
_Motivation:_ Allow to define a set of ARCH-DSM as unsupported 
### Checklist
- [X] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully
