### PR TITLE
Fix librsync 4GB bug

### DIFF
--- a/cross/librsync/4gb.patch
+++ b/cross/librsync/4gb.patch
@@ -1,0 +1,31 @@
+diff -urN librsync-0.9.7/mdfour.h librsync-0.9.7dev/mdfour.h
+--- librsync-0.9.7/mdfour.h	2004-02-07 18:17:57.000000000 -0500
++++ librsync-0.9.7dev/mdfour.h	2006-03-06 03:21:46.000000000 -0500
+@@ -24,7 +24,7 @@
+ #include "types.h"
+ 
+ struct rs_mdfour {
+-    int                 A, B, C, D;
++    unsigned int        A, B, C, D;
+ #if HAVE_UINT64
+     uint64_t            totalN;
+ #else
+diff -urN librsync-0.9.7/patch.c librsync-0.9.7dev/patch.c
+--- librsync-0.9.7/patch.c	2004-09-17 17:35:50.000000000 -0400
++++ librsync-0.9.7dev/patch.c	2006-03-06 03:21:06.000000000 -0500
+@@ -214,12 +214,12 @@
+     void            *buf, *ptr;
+     rs_buffers_t    *buffs = job->stream;
+ 
+-    len = job->basis_len;
+-    
+     /* copy only as much as will fit in the output buffer, so that we
+      * don't have to block or store the input. */
+-    if (len > buffs->avail_out)
++    if (job->basis_len > buffs->avail_out)
+         len = buffs->avail_out;
++    else
++        len = job->basis_len;
+ 
+     if (!len)
+         return RS_BLOCKED;


### PR DESCRIPTION
librsync 0.9.7 has a known bug with transfering files > 4GB that has been [fixed upstream](http://sourceforge.net/p/librsync/patches/8/) and [in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=355178) a few years ago, but there hasn't been a new upstream release.

This patch was applied in Optware/Optware-ng in October 2014 (Optware/Optware-ng@0f4e543b525127056d5a73a6b6b659664c27c7ea).

I couldn't actually get this to build this morning (Docker issues), but it looks like the patch should be applied.