### PR TITLE
Updated ZSH to build with Regex Support. Also installed ZSH dynamic modules

### DIFF
--- a/cross/zsh/Makefile
+++ b/cross/zsh/Makefile
@@ -12,6 +12,7 @@ COMMENT  = Zsh is a shell designed for interactive use, although it is also a po
 LICENSE  = Custom
 
 GNU_CONFIGURE = 1
+CONFIGURE_ARGS = --enable-cap --enable-pcre
 
 INSTALL_TARGET = myInstall
 
@@ -20,3 +21,4 @@ include ../../mk/spksrc.cross-cc.mk
 .PHONY: myInstall
 myInstall:
 	umask 022; $(RUN) $(MAKE) install DESTDIR=$(INSTALL_DIR)
+	umask 022; $(RUN) $(MAKE) install.modules DESTDIR=$(INSTALL_DIR)

--- a/spk/zsh/Makefile
+++ b/spk/zsh/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = zsh
 SPK_VERS = 5.2
-SPK_REV = 3
+SPK_REV = 4
 SPK_ICON = src/zsh.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -11,7 +11,7 @@ DESCRIPTION_FRE = Zsh est un shell conçu pour un usage intéractif, mais il est
 RELOAD_UI = no
 DISPLAY_NAME = Z shell
 STARTABLE = no
-CHANGELOG = "Update to 5.2"
+CHANGELOG = "Added Regex compatibility. Update to 5.2."
 
 HOMEPAGE = http://www.zsh.org
 LICENSE = Custom


### PR DESCRIPTION
As requested here: https://github.com/SynoCommunity/spksrc/issues/2449

ZSH was being built without dynamic module or PCRE support, which meant no Regex could be used (and it is used in lots of ZSH scripts)

_Linked issues:_ 
https://github.com/SynoCommunity/spksrc/issues/2449

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully