### PR TITLE
Updated transmission source URL (as old appears to be down)

### DIFF
--- a/cross/transmission/Makefile
+++ b/cross/transmission/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = transmission
 PKG_VERS = 2.92
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://download.transmissionbt.com/files
+PKG_DIST_SITE = https://github.com/transmission/transmission-releases/raw/master
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib cross/openssl cross/curl cross/libevent


### PR DESCRIPTION
The old transmission source URL is no longer valid and they are now using GitHub - updated to reflect this.

No other changes, packages will be unaffected, however building them will no longer fail.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

