### PR TITLE
Removed SSL Repo Verification

### DIFF
--- a/cross/libpng/Makefile
+++ b/cross/libpng/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = libpng
 PKG_VERS = 1.6.24
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16
+PKG_DIST_SITE = http://download.sourceforge.net/libpng
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -290,7 +290,7 @@ endif
 ifeq ($(PUBLISH_API_KEY),)
 	$(error Set PUBLISH_API_KEY in local.mk)
 endif
-	http --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME)
+	http --verify=no --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME)
 
 
 ### Clean rules


### PR DESCRIPTION
Updated to not verify the remote repository API SSL as api.synocomminity.com is currently expired