### PR TITLE
Updated LibTIFF locations

### DIFF
--- a/cross/libtiff/Makefile
+++ b/cross/libtiff/Makefile
@@ -2,12 +2,12 @@ PKG_NAME = tiff
 PKG_VERS = 4.0.6
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.remotesensing.org/pub/libtiff
+PKG_DIST_SITE = http://http://download.osgeo.org/libtiff/
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 
-HOMEPAGE = http://www.remotesensing.org/libtiff/
+HOMEPAGE = http://www.linuxfromscratch.org/blfs/view/svn/general/libtiff.html
 COMMENT  = LibTIFF provides support for the Tag Image File Format (TIFF), a widely used format for storing image data.
 LICENSE  =
 


### PR DESCRIPTION
Updated LibTIFF locations, as the originating site is no longer available