### PR TITLE
Update Tcl8.6.6-1 to Tcl8.6.6-2

### DIFF
--- a/spk/tcl/Makefile
+++ b/spk/tcl/Makefile
@@ -1,9 +1,9 @@
-SPK_NAME = tcl
-SPK_VERS = 8.6.6
-SPK_REV = 1
-SPK_ICON = src/tcl.png
+SPK_NAME	= tcl
+SPK_VERS	= 8.6.6
+SPK_REV		= 2
+SPK_ICON	= src/tcl.png
 
-DEPENDS = cross/$(SPK_NAME)
+DEPENDS		= cross/$(SPK_NAME)
 
 MAINTAINER	= Tcl developer Xchange
 MAINTAINER_URL	= https://www.tcl.tk/
@@ -11,19 +11,19 @@ DISTRIBUTOR	= SynoCommunity
 DISTRIBUTOR_URL	= https://synocommunity.com/
 HELPURL		= https://www.tcl.tk/doc/
 
-DESCRIPTION = Tcl \(Tool Command Language\) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more. Open source and business-friendly, Tcl is a mature yet evolving language that is truly cross platform, easily deployed and highly extensible.
-RELOAD_UI = no
-DISPLAY_NAME = Tcl
-STARTABLE = no
-CHANGELOG = "First Synology package release"
+DESCRIPTION	= Tcl \(Tool Command Language\) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more. Open source and business-friendly, Tcl is a mature yet evolving language that is truly cross platform, easily deployed and highly extensible.
+RELOAD_UI	= no
+DISPLAY_NAME	= Tcl
+STARTABLE	= no
+CHANGELOG	= "1. First Synology package release<br>2. Added symlink /usr/local/tcl, Changed symlinks to /var/packages/tcl/, Removed export LD_LIBRARY_PATH"
 
-HOMEPAGE = http://www.tcl.tk
-LICENSE = Custom
+HOMEPAGE	= http://www.tcl.tk
+LICENSE		= Custom
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh
 
-INSTALL_PREFIX = /usr/local/$(SPK_NAME)
+INSTALL_PREFIX	= /usr/local/$(SPK_NAME)
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/tcl/src/installer.sh
+++ b/spk/tcl/src/installer.sh
@@ -6,6 +6,9 @@ DNAME="Tcl"
 
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
+PACKAGE_DIR="/var/packages/${PACKAGE}/target"
+LOG_FILE="/tmp/${PACKAGE}-sss.log"
+
 
 
 preinst ()
@@ -16,11 +19,12 @@ preinst ()
 postinst ()
 {
 	# Create symlinks
-	ln -s ${SYNOPKG_PKGDEST}/bin/tclsh8.6 /usr/local/bin/tclsh
-	ln -s ${SYNOPKG_PKGDEST}/lib/libtcl8.6.so /usr/local/lib/libtcl.so
-	ln -s ${SYNOPKG_PKGDEST}/lib/libtcl8.6.so /usr/local/lib/libtcl8.6.so
-	ln -s ${SYNOPKG_PKGDEST}/lib/tcl8.6/ /usr/local/lib/tcl8.6
-	export LD_LIBRARY_PATH=/usr/local/lib/
+	mkdir -p /usr/local/lib/ >> ${LOG_FILE} 2>&1
+	ln -s ${PACKAGE_DIR}/bin/tclsh8.6 /usr/local/bin/tclsh >> ${LOG_FILE} 2>&1
+	ln -s ${PACKAGE_DIR}/lib/libtcl8.6.so /usr/local/lib/libtcl.so >> ${LOG_FILE} 2>&1
+	ln -s ${PACKAGE_DIR}/lib/libtcl8.6.so /usr/local/lib/libtcl8.6.so >> ${LOG_FILE} 2>&1
+	ln -s ${PACKAGE_DIR}/lib/tcl8.6/ /usr/local/lib/tcl8.6 >> ${LOG_FILE} 2>&1
+	ln -s ${PACKAGE_DIR}/ /usr/local/${PACKAGE} >> ${LOG_FILE} 2>&1
 
 	exit 0
 }
@@ -33,10 +37,14 @@ preuninst ()
 postuninst ()
 {
 	# Remove symlinks
+	rm -f /usr/local/${PACKAGE}
 	rm -f /usr/local/bin/tclsh
 	rm -f /usr/local/lib/libtcl.so
 	rm -f /usr/local/lib/libtcl8.6.so
 	rm -f /usr/local/lib/tcl8.6
+
+	# Remove logfile
+	rm -f ${LOG_FILE}
 
 	exit 0
 }


### PR DESCRIPTION
See #2479 : This is the second release of the Tcl8.6.6 package. Changes are:
* Removed 'export LD_LIBRARY_PATH'
* Added symlink /usr/local/tcl/ --> /var/packages/tcl/target/
* Changed all symlinks to point to /var/packages/tcl/ (was: /volume1/@appstore/tcl)
* Results from the installer script are now sent to a logfile
* A bit of code cleaning

This has been tested on a DS214+ (armadaxp, DSM6.0), DS213+ (qoriq, DSM6.0) and DS412+ (cedarview DS5.2)