### PR TITLE
Put the Usage section back into README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,50 @@ A virtual machine based on an 64-bit version of Debian stable OS is recommended.
 
 For further instructions, refer to Pull Requests section of `CONTRIBUTING`_.
 
+Usage
+-----
+Lets start with an example::
+
+    git clone https://github.com/SynoCommunity/spksrc.git
+    cd spksrc/
+    make setup
+    cd spk/transmission
+    make arch-88f6281
+
+What have I done?
+^^^^^^^^^^^^^^^^^
+ 
+ 
+* You cloned the repository
+* Went into the directory of the SPK for transmission
+* Started building the SPK for the architecture 88f6281
+
+  * To list all available architectures use ``ls toolchains`` from within the ``spksrc`` directory. Remove the prefix syno- to have the actual architecture.
+  * An overview of which architecture is used per Synology model can be found on the wiki page `Architecture per Synology model`_
+
+At the end of the process, the SPK will be available in ``spksrc/packages/``
+
+What is spksrc doing?
+^^^^^^^^^^^^^^^^^^^^^
+
+* First spksrc will read ``spksrc/spk/transmission/Makefile`` 
+* Download the adequate toolchain for the chosen architecture
+* Recursively:
+
+  * Process dependencies if any
+  * Download the source in ``spksrc/distrib/``
+  * Extract the source
+  * ``configure``
+  * ``make``
+  * ``make install``
+  * Package all the requirements into a SPK under ``spksrc/packages/``:
+  * Binaries
+  * Installer script
+  * Start/Stop/Status script
+  * Package icon
+  * Wizards (optional)
+  * Help files (optional)
+
 
 Donate
 ------


### PR DESCRIPTION
See #2503 I believe this was deleted accidentally, as now there's no reference at all how to use spksrc to build any of the packages in any document of this repository.