### PR TITLE
Update openssl to 1.0.2j

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2i
+PKG_VERS = 1.0.2j
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = ftp://ftp.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
 openssl-1.0.2j.tar.gz SHA1 bdfbdb416942f666865fa48fe13c2d0e588df54f
 openssl-1.0.2j.tar.gz SHA256 e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431
-openssl-1.0.2j.tar.gz MD5 96322138f0b69e61b7212bc53d5e912b 
+openssl-1.0.2j.tar.gz MD5 96322138f0b69e61b7212bc53d5e912b

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2i.tar.gz SHA1 25a92574ebad029dcf2fa26c02e10400a0882111
-openssl-1.0.2i.tar.gz SHA256 9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f
-openssl-1.0.2i.tar.gz MD5 678374e63f8df456a697d3e5e5a931fb
+openssl-1.0.2j.tar.gz SHA1 bdfbdb416942f666865fa48fe13c2d0e588df54f
+openssl-1.0.2j.tar.gz SHA256 e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431
+openssl-1.0.2j.tar.gz MD5 96322138f0b69e61b7212bc53d5e912b 


### PR DESCRIPTION
OpenSSL version with 1.0.2i is not avaliable for download. Replacing with 1.0.2j

