### PR TITLE
Increase max icon resolution to 256

### DIFF
--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -40,7 +40,7 @@ transmission_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
+	for size in 16 24 32 48 72 128 256; \
 	do \
 	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
 	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \


### PR DESCRIPTION
_Motivation:_ Increase max icon resolution (for better support of Retina and other HD displays)
