### PR TITLE
Update: Syncthing to 0.14.21, Go (dependence) to 1.7.4

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 0.13.4
+PKG_VERS = 0.14.21
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)
@@ -9,7 +9,7 @@ DEPENDS = native/go
 
 HOMEPAGE = http://www.syncthing.net/
 COMMENT  = Syncthing replaces Dropbox and BitTorrent Sync with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how ...
-LICENSE  =
+LICENSE  = MPL-2.0
 
 CONFIGURE_TARGET = nope
 COMPILE_TARGET = myComp
@@ -21,7 +21,7 @@ CGO_ENABLED=0
 # set this to 1 to create static linked binaries
 STATIC_BINARIES = 0
 
-# Define SYNCTHING_ARCH as per SyncThing standards
+# Define SYNCTHING_ARCH as per Syncthing standards
 ifeq ($(findstring $(ARCH),88f5281 88f6281 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco),$(ARCH))
 SYNCTHING_ARCH = arm
 ENV += GOARM=5

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-source-v0.13.4.tar.gz SHA1 35fa3d7810f80a6e00be99d410b0cb9d2aa7402f
-syncthing-source-v0.13.4.tar.gz SHA256 19e113fe00f8166f6811b01ffaa06a546884d767eea79bea9b7907a2a35ca67b
-syncthing-source-v0.13.4.tar.gz MD5 eabf036d050fe148f8c8feadd5c5fd08
+syncthing-source-v0.14.21.tar.gz SHA1 824175a895f86b5e86b055ba6041103dee1fef21
+syncthing-source-v0.14.21.tar.gz SHA256 e5fe49b85425679fec3d08127cd4fcf40e474ff70ccec587ee21f306c0c36085
+syncthing-source-v0.14.21.tar.gz MD5 b81c093bf3630d43ed23e6e19163ad82

--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.6.2
+PKG_VERS = 1.7.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).src.$(PKG_EXT)
 PKG_DIST_SITE = https://storage.googleapis.com/golang

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,12 +1,12 @@
 SPK_NAME = syncthing
-SPK_VERS = 0.13.4
-SPK_REV = 9
+SPK_VERS = 0.14.21
+SPK_REV = 10
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
 UNSUPPORTED_ARCHS = $(PPC_ARCHES)
 
-DEPENDS  = cross/busybox cross/$(SPK_NAME)
+DEPENDS = cross/busybox cross/$(SPK_NAME)
 
 MAINTAINER = cytec
 DESCRIPTION = Automatically sync files via secure, distributed technology.
@@ -14,14 +14,13 @@ DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie s√
 ADMIN_PORT = 7070
 RELOAD_UI = yes
 DISPLAY_NAME = Syncthing
-CHANGELOG = "Update to 0.13.4"
-
-HOMEPAGE   = http://www.syncthing.net
-LICENSE    = MPLv2.0
+CHANGELOG = "Update to 0.14.21"
+HOMEPAGE = http://www.syncthing.net
+LICENSE = MPLv2.0
 
 INSTALLER_SCRIPT = src/installer.sh
-SSS_SCRIPT       = src/dsm-control.sh
-FWPORTS          = src/${SPK_NAME}.sc
+SSS_SCRIPT = src/dsm-control.sh
+FWPORTS = src/${SPK_NAME}.sc
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
@@ -36,6 +35,7 @@ include ../../mk/spksrc.spk.mk
 syncthing_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 600 src/config.xml $(STAGING_DIR)/var/config.xml
+	install -m 644 src/options.conf $(STAGING_DIR)/var/options.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 755 -d $(STAGING_DIR)/app/images

--- a/spk/syncthing/src/config.xml
+++ b/spk/syncthing/src/config.xml
@@ -1,25 +1,19 @@
-<configuration version="12">
+<configuration version="17">
     <gui enabled="true" tls="false">
         <address>0.0.0.0:7070</address>
     </gui>
     <options>
-        <listenAddress>tcp://0.0.0.0:22000</listenAddress>
+        <listenAddress>default</listenAddress>
         <globalAnnounceServer>default</globalAnnounceServer>
         <globalAnnounceEnabled>true</globalAnnounceEnabled>
         <localAnnounceEnabled>true</localAnnounceEnabled>
         <localAnnouncePort>21027</localAnnouncePort>
-        <relayServer>dynamic+https://relays.syncthing.net/endpoint</relayServer>
         <maxSendKbps>0</maxSendKbps>
         <maxRecvKbps>0</maxRecvKbps>
         <reconnectionIntervalS>60</reconnectionIntervalS>
         <relaysEnabled>true</relaysEnabled>
         <relayReconnectIntervalM>10</relayReconnectIntervalM>
-        <relayWithoutGlobalAnn>false</relayWithoutGlobalAnn>
         <startBrowser>false</startBrowser>
-        <upnpEnabled>true</upnpEnabled>
-        <upnpLeaseMinutes>60</upnpLeaseMinutes>
-        <upnpRenewalMinutes>30</upnpRenewalMinutes>
-        <upnpTimeoutSeconds>10</upnpTimeoutSeconds>
         <urAccepted>0</urAccepted>
         <urUniqueID></urUniqueID>
         <urURL>https://data.syncthing.net/newdata</urURL>
@@ -33,6 +27,8 @@
         <symlinksEnabled>true</symlinksEnabled>
         <limitBandwidthInLan>false</limitBandwidthInLan>
         <minHomeDiskFreePct>1</minHomeDiskFreePct>
-        <releasesURL>https://api.github.com/repos/syncthing/syncthing/releases?per_page=30</releasesURL>
+        <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
+        <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
+        <tempIndexMinBlocks>10</tempIndexMinBlocks>
     </options>
 </configuration>

--- a/spk/syncthing/src/dsm-control.sh
+++ b/spk/syncthing/src/dsm-control.sh
@@ -9,12 +9,17 @@ INSTALL_DIR="/usr/local/${PACKAGE}"
 PATH="${INSTALL_DIR}/bin:${PATH}"
 USER="syncthing"
 SYNCTHING="${INSTALL_DIR}/bin/syncthing"
-CONFIG_DIR="${INSTALL_DIR}/var/"
+CONFIG_DIR="${INSTALL_DIR}/var"
+SYNCTHING_OPTIONS="-home=${CONFIG_DIR}"
 
+# Read additional startup options from /usr/local/syncthing/var/options.conf
+if [ -f ${CONFIG_DIR}/options.conf ]; then
+	source ${CONFIG_DIR}/options.conf
+fi
 
 start_daemon ()
 {
-    start-stop-daemon -b -o -c ${USER} -S -u ${USER} -x env HOME=${CONFIG_DIR} ${SYNCTHING} -- --home ${CONFIG_DIR}
+    start-stop-daemon -b -o -c ${USER} -S -u ${USER} -x env HOME=${CONFIG_DIR} ${SYNCTHING} -- ${SYNCTHING_OPTIONS}
 }
 
 stop_daemon ()
@@ -25,7 +30,7 @@ stop_daemon ()
 
 daemon_status ()
 {
-    start-stop-daemon -K -q -t -u ${USER}
+    start-stop-daemon -K -q -t -u ${USER} -x ${SYNCTHING}
     [ $? -eq 0 ] || return 1
 }
 

--- a/spk/syncthing/src/options.conf
+++ b/spk/syncthing/src/options.conf
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This file will be added to start-stop-status script
+# For possible options see syncthing --help
+
+# Example: uncomment this to start syncthing with all devices paused
+# SYNCTHING_OPTIONS="${SYNCTHING_OPTIONS} -paused"


### PR DESCRIPTION
_Motivation:_ My aim was to share integration syncthing-inotify to the package, as I didn't like any other startup options. By the way, I also updated Syncthing and Go to the latest version, just to keep track recent changes in them.
_Linked issues:_ #2142 

### Checklist
- [OK] Build rule `all-supported` completed successfully
- [OK] Package upgrade completed successfully (tested at 88f6281, ds111)
- [OK] New installation of package completed successfully (tested at 88f6281, ds111)
