### PR TITLE
Updated Jackett to new version to stop breaking change in Jackett

### DIFF
--- a/cross/jackett/Makefile
+++ b/cross/jackett/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = Jackett
-PKG_VERS = 0.7.713
+PKG_VERS = 0.7.806
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME).Binaries.Mono.$(PKG_EXT)
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)

--- a/cross/jackett/digests
+++ b/cross/jackett/digests
@@ -1,3 +1,3 @@
-Jackett-0.7.713.tar.gz SHA1 c65f644c80ef1a50bd302da37ce9055df093db52
-Jackett-0.7.713.tar.gz SHA256 b8cd1ae1c1aadaebeb7ff110a719d0e37d4ff661f7182fe2b936e31f746fe747
-Jackett-0.7.713.tar.gz MD5 24a96eb994b0eb7bf76ee5e32ed4c528
+Jackett-0.7.806.tar.gz SHA1 4e7000f380dad88e7c3ac2df7ed717218757e912
+Jackett-0.7.806.tar.gz SHA256 ccb7c6ec9d54d200decbcfad5274c06e7bba85729b1559ac49791222f70dbc2c
+Jackett-0.7.806.tar.gz MD5 eb978db1673058d15207baaa48a8f031

--- a/spk/jackett/Makefile
+++ b/spk/jackett/Makefile
@@ -13,7 +13,7 @@ ADMIN_PORT = 9117
 RELOAD_UI = yes
 DISPLAY_NAME = Jackett
 BETA = 1
-CHANEGLOG = Updated to version 0.7.806
+CHANGELOG = Updated to version 0.7.806
 
 HOMEPAGE = https://github.com/Jackett/Jackett
 LICENSE  = GPLv2

--- a/spk/jackett/Makefile
+++ b/spk/jackett/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = jackett
-SPK_VERS = 0.7.713
-SPK_REV = 2
+SPK_VERS = 0.7.806
+SPK_REV = 3
 SPK_ICON = src/jackett.png
 DSM_UI_DIR = app
 
@@ -13,6 +13,7 @@ ADMIN_PORT = 9117
 RELOAD_UI = yes
 DISPLAY_NAME = Jackett
 BETA = 1
+CHANEGLOG = Updated to version 0.7.806
 
 HOMEPAGE = https://github.com/Jackett/Jackett
 LICENSE  = GPLv2


### PR DESCRIPTION
_Motivation: Update version to a working version to users can access torrentday
_Linked issues: https://github.com/SynoCommunity/spksrc/issues/2559

### Checklist
- [] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
