### PR TITLE
Update pycurl download url and hashes

### DIFF
--- a/cross/pycurl/Makefile
+++ b/cross/pycurl/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = pycurl
 PKG_VERS = 7.43.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://pycurl.sourceforge.net/download
+PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/p/pycurl
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/curl

--- a/cross/pycurl/digests
+++ b/cross/pycurl/digests
@@ -1,3 +1,3 @@
-pycurl-7.19.5.3.tar.gz SHA1 1e5fcda2a5edb59e0cd47125a560c84ab1594cb6
-pycurl-7.19.5.3.tar.gz SHA256 24f6c4016b1dd2a5e29d1b025ac2ad61f80c17adfdcf8a7f47aefab63ace78d7
-pycurl-7.19.5.3.tar.gz MD5 611a5423d5c58d273294e5fdf61567e1
+pycurl-7.43.0.tar.gz SHA1 e8e9c7e9ae91ae32096b8c86cfc7d49976a66d1b
+pycurl-7.43.0.tar.gz SHA256 aa975c19b79b6aa6c0518c0cc2ae33528900478f0b500531dbcdbf05beec584c
+pycurl-7.43.0.tar.gz MD5 c94bdba01da6004fa38325e9bd6b9760


### PR DESCRIPTION
_Motivation:_ Pycurl's current version is no longer hosted at the url. The new url has been added.
_Linked issues:_ SynoCommunity/spksrc#2569

### Checklist
- [] Build rule `all-supported` completed successfully
- [ok] Package upgrade completed successfully
- [ok] New installation of package completed successfully

