### PR TITLE
Add spksrc.icon.mk

### DIFF
--- a/mk/spksrc.icon.mk
+++ b/mk/spksrc.icon.mk
@@ -1,0 +1,60 @@
+### Package Icon creation
+#   Create package icons for SPK
+#   Icons are created if DSM_UI_DIR is set in 
+#   spk/Makefile, otherwise skipped.
+
+# Targets are executed in the following order:
+#  icon_msg_target
+#  pre_icon_target   (override with PRE_ICON_TARGET)
+#  build_icon_target (override with ICON_TARGET)
+#  post_icon_target  (override with POST_ICON_TARGET)
+
+ICON_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)icon_done
+
+ifneq ($(strip $(DSM_UI_DIR)),)
+ICON_DIR = $(STAGING_DIR)/$(DSM_UI_DIR)/images
+endif
+
+ifeq ($(strip $(PRE_ICON_TARGET)),)
+PRE_ICON_TARGET = pre_icon_target
+else
+$(PRE_ICON_TARGET): icon_msg_target
+endif
+ifeq ($(strip $(ICON_TARGET)),)
+ICON_TARGET = $(ICON_DIR)
+else
+$(ICON_TARGET): $(ICON_DIR)
+endif
+ifeq ($(strip $(POST_ICON_TARGET)),)
+POST_ICON_TARGET = post_icon_target
+else
+$(POST_ICON_TARGET): $(ICON_TARGET)
+endif
+
+.PHONY: icon icon_msg
+.PHONY: $(PRE_ICON_TARGET) $(ICON_TARGET) $(POST_ICON_TARGET)
+
+icon_msg:
+	@$(MSG) "Creating package icons for $(NAME)"
+
+pre_icon_target: icon_msg
+
+$(ICON_DIR): $(PRE_ICON_TARGET)
+	@mkdir -p $@
+	@for size in 16 24 32 48 64 72 256; do \
+	  convert $(SPK_ICON) -thumbnail $${size}x$${size} \
+	          $@/$(SPK_NAME)-$${size}.png ; \
+        done ; \
+
+post_icon_target: $(ICON_TARGET)
+
+ifeq ($(wildcard $(ICON_COOKIE)),)
+icon: $(ICON_COOKIE)
+
+$(ICON_COOKIE): $(POST_ICON_TARGET)
+	$(create_target_dir)
+	@touch -f $@
+else
+icon: ;
+endif
+

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -51,9 +51,11 @@ include ../../mk/spksrc.copy.mk
 strip: copy
 include ../../mk/spksrc.strip.mk
 
+icon: strip
+include ../../mk/spksrc.icon.mk
 
 ### Packaging rules
-$(WORK_DIR)/package.tgz: strip
+$(WORK_DIR)/package.tgz: icon
 	$(create_target_dir)
 	@[ -f $@ ] && rm $@ || true
 	(cd $(STAGING_DIR) && tar cpzf $@ --owner=root --group=root *)

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -184,11 +184,11 @@ $(WORK_DIR)/PACKAGE_ICON.PNG: $(SPK_ICON)
 	@[ -f $@ ] && rm $@ || true
 	(convert $(SPK_ICON) -thumbnail 72x72 - >> $@)
 
-$(WORK_DIR)/PACKAGE_ICON_120.PNG: $(SPK_ICON)
+$(WORK_DIR)/PACKAGE_ICON_256.PNG: $(SPK_ICON)
 	$(create_target_dir)
-	@$(MSG) "Creating PACKAGE_ICON_120.PNG for $(SPK_NAME)"
+	@$(MSG) "Creating PACKAGE_ICON_256.PNG for $(SPK_NAME)"
 	@[ -f $@ ] && rm $@ || true
-	(convert $(SPK_ICON) -thumbnail 120x120 - >> $@)
+	(convert $(SPK_ICON) -thumbnail 256x256 - >> $@)
 
 # Scripts
 DSM_SCRIPTS_DIR = $(WORK_DIR)/scripts
@@ -245,7 +245,7 @@ $(DSM_SCRIPTS_DIR)/%.sc: $(filter %.sc,$(FWPORTS))
 $(DSM_SCRIPTS_DIR)/%: $(filter %.sh,$(ADDITIONAL_SCRIPTS))
 	@$(dsm_script_copy)
 
-SPK_CONTENT = package.tgz INFO PACKAGE_ICON.PNG PACKAGE_ICON_120.PNG scripts
+SPK_CONTENT = package.tgz INFO PACKAGE_ICON.PNG PACKAGE_ICON_256.PNG scripts
 
 .PHONY: checksum
 checksum:
@@ -276,7 +276,7 @@ ifneq ($(strip $(DSM_LICENSE)),)
 SPK_CONTENT += LICENSE
 endif
 
-$(SPK_FILE_NAME): $(WORK_DIR)/package.tgz $(WORK_DIR)/INFO checksum $(WORK_DIR)/PACKAGE_ICON.PNG $(WORK_DIR)/PACKAGE_ICON_120.PNG $(DSM_SCRIPTS) wizards $(DSM_LICENSE) conf
+$(SPK_FILE_NAME): $(WORK_DIR)/package.tgz $(WORK_DIR)/INFO checksum $(WORK_DIR)/PACKAGE_ICON.PNG $(WORK_DIR)/PACKAGE_ICON_256.PNG $(DSM_SCRIPTS) wizards $(DSM_LICENSE) conf
 	$(create_target_dir)
 	(cd $(WORK_DIR) && tar cpf $@ --group=root --owner=root $(SPK_CONTENT))
 

--- a/spk/adminer/Makefile
+++ b/spk/adminer/Makefile
@@ -37,8 +37,3 @@ include ../../mk/spksrc.spk.mk
 adminer_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-			$(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/bicbucstriim/Makefile
+++ b/spk/bicbucstriim/Makefile
@@ -37,8 +37,3 @@ include ../../mk/spksrc.spk.mk
 bicbucstriim_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/cops/Makefile
+++ b/spk/cops/Makefile
@@ -43,8 +43,3 @@ cops_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 666 src/config_local.php.synology $(STAGING_DIR)/config_local.php.synology
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/couchpotatoserver-custom/Makefile
+++ b/spk/couchpotatoserver-custom/Makefile
@@ -40,8 +40,3 @@ couchpotatoservercustom_extra_install:
 	install -m 600 src/settings.conf $(STAGING_DIR)/var/settings.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/couchpotatoserver/Makefile
+++ b/spk/couchpotatoserver/Makefile
@@ -41,11 +41,6 @@ couchpotatoserver_extra_install: $(STAGING_DIR)/share/CouchPotatoServer
 	install -m 600 src/settings.conf $(STAGING_DIR)/var/settings.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/CouchPotatoServer:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/darkstat/Makefile
+++ b/spk/darkstat/Makefile
@@ -32,8 +32,3 @@ darkstat_extra_install:
 	install -m 777 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	                $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -72,9 +72,3 @@ debian-chroot_extra_install:
 		install -m 755 -d $(STAGING_DIR)/app/texts/$${language}; \
 		install -m 644 src/app/texts/$${language}/strings $(STAGING_DIR)/app/texts/$${language}/strings; \
 	done
-	install -m 755 -d $(STAGING_DIR)/app/images
-	install -m 644 src/app/images/*.png $(STAGING_DIR)/app/images/
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -42,8 +42,3 @@ deluge_extra_install:
 	install -m 644 src/core.conf $(STAGING_DIR)/var/core.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/domoticz/Makefile
+++ b/spk/domoticz/Makefile
@@ -34,8 +34,3 @@ include ../../mk/spksrc.spk.mk
 domoticz_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/ejabberd/Makefile
+++ b/spk/ejabberd/Makefile
@@ -38,8 +38,3 @@ ejabberd_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/fengoffice/Makefile
+++ b/spk/fengoffice/Makefile
@@ -40,8 +40,3 @@ fengoffice_extra_install:
 	install -m 755 src/fengoffice.sh $(STAGING_DIR)/bin/
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/ffmpeg/Makefile
+++ b/spk/ffmpeg/Makefile
@@ -2,14 +2,12 @@ SPK_NAME = ffmpeg
 SPK_VERS = 3.1.2
 SPK_REV = 4
 SPK_ICON = src/ffmpeg.png
-DSM_UI_DIR = app
 CHANGELOG = "1. Update ffmpeg to 3.1<br>2. Support nasm 2.12.02 and yasm 1.3 added. Added 12 new libs/codecs and update all depends : fdk-acc 0.1.4, fontconfig 2.12.1, freetype 2.6.5, fribidi 0.19.7, lame 3.99.5, libass 0.13.2, libbluray 0.9.3, libnuma 2.0.11, libvorbis 1.3.5, libvpx 1.6.0, opencore-amr 0.1.3, openjpeg 2.1.0, opus 1.1.3, rtmdpdump 550a0ca, soxr 0.1.2, vo-amrwbenc 0.1.3, x264 20160816-2245-stable, x265 2.0"
 
 DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = cytec
 DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.
-RELOAD_UI = yes
 DISPLAY_NAME = ffmpeg
 STARTABLE = no
 
@@ -21,16 +19,4 @@ SSS_SCRIPT       = src/dsm-control.sh
 
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
-POST_STRIP_TARGET = ffmpeg_extra_install
-
-
 include ../../mk/spksrc.spk.mk
-
-.PHONY: ffmpeg_extra_install
-znc_extra_install:
-	install -m 755 -d $(STAGING_DIR)/app
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -41,14 +41,8 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: ffsync_extra_install
 ffsync_extra_install:
-	install -m 755 -d $(STAGING_DIR)/app
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 644 src/ffsync.ini $(STAGING_DIR)/var/
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-			$(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 	sed -i -e "s|https://github.com/mozilla-services/mozservices/archive/e00e1b68130423ad98d0f6185655bde650443da8.zip|mozsvc==0.8|g" \
 	       -e "s|https://github.com/mozilla-services/tokenserver/archive/d7e513e8a4f5c588b70d685a8df1d2e508c341c0.zip|tokenserver==1.2.7|g" \
 	       -e "s|http://github.com/mozilla-services/server-syncstorage/archive/1.5.5.zip|SyncStorage==1.5.5|g" \

--- a/spk/full-text-rss/Makefile
+++ b/spk/full-text-rss/Makefile
@@ -36,11 +36,6 @@ include ../../mk/spksrc.spk.mk
 full-text-rss_extra_install: $(STAGING_DIR)/share/full-text-rss
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/full-text-rss:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -42,8 +42,3 @@ gateone_extra_install:
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 644 src/90custom.conf $(STAGING_DIR)/var/conf.d/
 	install -m 644 src/95users.conf $(STAGING_DIR)/var/conf.d/
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/gentoo-chroot/Makefile
+++ b/spk/gentoo-chroot/Makefile
@@ -80,9 +80,3 @@ gentoo-chroot_extra_install:
 		install -m 755 -d $(STAGING_DIR)/app/texts/$${language}; \
 		install -m 644 src/app/texts/$${language}/strings $(STAGING_DIR)/app/texts/$${language}/strings; \
 	done
-	install -m 755 -d $(STAGING_DIR)/app/images
-	install -m 644 src/app/images/*.png $(STAGING_DIR)/app/images/
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/git-server/Makefile
+++ b/spk/git-server/Makefile
@@ -52,9 +52,3 @@ git_server_extra_install:
 	rm -rf $(STAGING_DIR)/share/gitolite/.git*
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		$(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -50,9 +50,3 @@ haproxy_extra_install:
 		install -m 755 -d $(STAGING_DIR)/app/texts/$${language}; \
 		install -m 644 src/app/texts/$${language}/strings $(STAGING_DIR)/app/texts/$${language}/strings; \
 	done
-	install -m 755 -d $(STAGING_DIR)/app/images
-	install -m 644 src/app/images/*.png $(STAGING_DIR)/app/images/
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/headphones-custom/Makefile
+++ b/spk/headphones-custom/Makefile
@@ -42,8 +42,3 @@ headphones-custom_extra_install:
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/headphones/Makefile
+++ b/spk/headphones/Makefile
@@ -39,11 +39,6 @@ headphones_extra_install: $(STAGING_DIR)/share/Headphones
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/Headphones:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -2,6 +2,7 @@ SPK_NAME = homeassistant
 SPK_VERS = $(shell date +%Y%m%d)
 SPK_REV = 1
 SPK_ICON = src/${SPK_NAME}.png
+DSM_UI_DIR = app
 
 BUILD_DEPENDS = cross/python3 cross/setuptools cross/pip cross/wheel
 DEPENDS = cross/busybox cross/nmap #for python-libnmap
@@ -12,7 +13,6 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = Home Assistant is an open-source home automation platform running on Python 3. Track and control all devices at home and automate control.
 ADMIN_PORT = 8123
 DISPLAY_NAME = Home Assistant
-DSM_UI_DIR = app
 CHANGELOG = "First release"
 
 BETA = 1
@@ -40,11 +40,6 @@ homeassistant_extra_install: $(STAGING_DIR)/share/homeassistant
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/homeassistant:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/horde/Makefile
+++ b/spk/horde/Makefile
@@ -43,8 +43,3 @@ horde_extra_install:
 	install -m 755 src/horde.sh $(STAGING_DIR)/bin/
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-			$(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/htpcmanager/Makefile
+++ b/spk/htpcmanager/Makefile
@@ -36,9 +36,3 @@ htpcmanager_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
-

--- a/spk/icecast/Makefile
+++ b/spk/icecast/Makefile
@@ -35,9 +35,3 @@ icecast_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/var/log
 	install -m 644 src/icecast.xml $(STAGING_DIR)/var/icecast.xml
-	install -m 755 -d $(STAGING_DIR)/app
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/jackett/Makefile
+++ b/spk/jackett/Makefile
@@ -41,9 +41,3 @@ jackett_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var/.config/Jackett
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/jappix/Makefile
+++ b/spk/jappix/Makefile
@@ -37,8 +37,3 @@ include ../../mk/spksrc.spk.mk
 jappix_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/lazylibrarian/Makefile
+++ b/spk/lazylibrarian/Makefile
@@ -39,11 +39,6 @@ lazylibrarian_extra_install: $(STAGING_DIR)/share/LazyLibrarian
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/LazyLibrarian:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/mantisbt/Makefile
+++ b/spk/mantisbt/Makefile
@@ -41,8 +41,3 @@ mantisbt_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 644 src/config_inc.php $(STAGING_DIR)/share/$(SPK_NAME)/config_inc.php
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/maraschino/Makefile
+++ b/spk/maraschino/Makefile
@@ -37,11 +37,6 @@ maraschino_extra_install: $(STAGING_DIR)/share/maraschino
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/maraschino:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/mediainfo/Makefile
+++ b/spk/mediainfo/Makefile
@@ -27,9 +27,3 @@ include ../../mk/spksrc.spk.mk
 .PHONY: mediainfo_extra_install
 mediainfo_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
-	install -m 755 -d $(STAGING_DIR)/app
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/memcached/Makefile
+++ b/spk/memcached/Makefile
@@ -35,8 +35,3 @@ include ../../mk/spksrc.spk.mk
 memcached_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/mercurial/Makefile
+++ b/spk/mercurial/Makefile
@@ -9,7 +9,6 @@ SPK_DEPENDS = "python>=2.7.6-8"
 
 MAINTAINER = Dr-Bean
 DESCRIPTION = Mercurial is a free, distributed source control management tool
-RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Mercurial
 CHANGELOG = Update to 4.0.1

--- a/spk/monit/Makefile
+++ b/spk/monit/Makefile
@@ -33,7 +33,6 @@ include ../../mk/spksrc.spk.mk
 monit_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/var/monit.d
 	install -m 755 -d $(STAGING_DIR)/var/events
@@ -42,7 +41,3 @@ monit_extra_install:
 	install -m 755 -d $(STAGING_DIR)/share
 	install -m 755 -d $(STAGING_DIR)/share/examples
 	install -m 644 src/examples/* $(STAGING_DIR)/share/examples/
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/mylar/Makefile
+++ b/spk/mylar/Makefile
@@ -38,11 +38,6 @@ mylar_extra_install: $(STAGING_DIR)/share/mylar
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/mylar:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/nzbget-testing/Makefile
+++ b/spk/nzbget-testing/Makefile
@@ -41,12 +41,6 @@ nzbget_extra_install: $(STAGING_DIR)/share/nzbget/scripts/nzbToMedia $(STAGING_D
 	install -m 644 src/nzbget.conf.template $(STAGING_DIR)/share/nzbget/nzbget.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/texts
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/nzbget/scripts/nzbToMedia:
 	cd $(STAGING_DIR)/share/nzbget/scripts && git clone https://github.com/clinton-hall/nzbToMedia.git

--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -40,12 +40,6 @@ nzbget_extra_install: $(STAGING_DIR)/share/nzbget/scripts/nzbToMedia $(STAGING_D
 	install -m 644 src/nzbget.conf.template $(STAGING_DIR)/share/nzbget/nzbget.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/texts
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/nzbget/scripts/nzbToMedia:
 	cd $(STAGING_DIR)/share/nzbget/scripts && git clone https://github.com/clinton-hall/nzbToMedia.git

--- a/spk/nzbhydra/Makefile
+++ b/spk/nzbhydra/Makefile
@@ -37,11 +37,6 @@ nzbhydra_extra_install: $(STAGING_DIR)/share/NZBHydra
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/NZBHydra:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/nzbmegasearch/Makefile
+++ b/spk/nzbmegasearch/Makefile
@@ -37,11 +37,6 @@ nzbmegasearch_extra_install: $(STAGING_DIR)/share/NZBmegasearch
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/NZBmegasearch:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/octoprint/Makefile
+++ b/spk/octoprint/Makefile
@@ -37,8 +37,3 @@ octoprint_extra_install:
 	install -m 600 src/config.yaml ${STAGING_DIR}/var/.octoprint/config.yaml
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-			$(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/oscam/Makefile
+++ b/spk/oscam/Makefile
@@ -34,9 +34,3 @@ oscam_extra_install:
 	install -m 644 src/oscam.conf $(STAGING_DIR)/var/oscam.conf
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 755 src/app/oscam.cgi.pl $(STAGING_DIR)/app/oscam.cgi
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/owncloud/Makefile
+++ b/spk/owncloud/Makefile
@@ -44,8 +44,3 @@ owncloud_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 644 src/autoconfig.php $(STAGING_DIR)/share/$(SPK_NAME)/config/autoconfig.php
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/plexivity/Makefile
+++ b/spk/plexivity/Makefile
@@ -39,11 +39,6 @@ plexivity_extra_install: $(STAGING_DIR)/share/plexivity
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/plexivity:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/plowshare/Makefile
+++ b/spk/plowshare/Makefile
@@ -2,7 +2,6 @@ SPK_NAME = plowshare
 SPK_VERS = 2.1.2
 SPK_REV = 3
 SPK_ICON = src/plowshare.png
-DSM_UI_DIR = app
 
 DEPENDS = cross/bash cross/libcaca cross/screen cross/plowshare
 

--- a/spk/pyload/Makefile
+++ b/spk/pyload/Makefile
@@ -41,8 +41,3 @@ pyload_extra_install:
 	install -m 644 src/pyload_init.sql $(STAGING_DIR)/etc/pyload_init.sql
 	install -m 644 src/htaccess.example $(STAGING_DIR)/etc/htaccess.example
 	install -m 755 -d $(STAGING_DIR)/var
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 64 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/roundcube/Makefile
+++ b/spk/roundcube/Makefile
@@ -38,8 +38,3 @@ include ../../mk/spksrc.spk.mk
 roundcube_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -45,8 +45,3 @@ rutorrent_extra_install:
 	install -m 775 -d $(STAGING_DIR)/tmp
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/sabnzbd-testing/Makefile
+++ b/spk/sabnzbd-testing/Makefile
@@ -47,8 +47,3 @@ sabnzbd-testing_extra_install:
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -46,8 +46,3 @@ sabnzbd_extra_install:
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/saltpad/Makefile
+++ b/spk/saltpad/Makefile
@@ -35,12 +35,6 @@ include ../../mk/spksrc.spk.mk
 .PHONY: saltpad_extra_install
 saltpad_extra_install: $(STAGING_DIR)/share/saltpad
 	install -m 755 -d $(STAGING_DIR)/var
-	install -m 755 -d $(STAGING_DIR)/app
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/saltpad:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/selfoss/Makefile
+++ b/spk/selfoss/Makefile
@@ -40,8 +40,3 @@ selfoss_extra_install:
 	install -m 755 src/selfoss.sh $(STAGING_DIR)/bin/
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/sickbeard-custom/Makefile
+++ b/spk/sickbeard-custom/Makefile
@@ -40,8 +40,3 @@ sickbeard-custom_extra_install:
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/sickrage/Makefile
+++ b/spk/sickrage/Makefile
@@ -39,8 +39,3 @@ sickrage_extra_install:
 	install -m 600 src/config.ini $(STAGING_DIR)/var/config.ini
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -45,9 +45,3 @@ sonarr_extra_install:
 	install -m 644 src/config.xml $(STAGING_DIR)/var/.config/NzbDrone/config.xml
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/subliminal/Makefile
+++ b/spk/subliminal/Makefile
@@ -56,7 +56,3 @@ subliminal_extra_install:
 	install -m 644 src/app/images/*.png $(STAGING_DIR)/app/images/
 	install -m 755 -d $(STAGING_DIR)/app/images/superboxselect
 	install -m 644 src/app/images/superboxselect/*.png $(STAGING_DIR)/app/images/superboxselect/
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -38,8 +38,3 @@ syncthing_extra_install:
 	install -m 600 src/config.xml $(STAGING_DIR)/var/config.xml
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -39,9 +39,3 @@ transmission_extra_install:
 	install -m 644 src/settings.json $(STAGING_DIR)/var/settings.json
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/tt-rss/Makefile
+++ b/spk/tt-rss/Makefile
@@ -40,8 +40,3 @@ tt-rss_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -40,9 +40,3 @@ tvheadend_extra_install:
 	install -m 755 src/app/tvheadend.cgi.pl $(STAGING_DIR)/app/tvheadend.cgi
 	install -m 755 -d $(STAGING_DIR)/var/accesscontrol
 	install -m 700 src/accesscontrol.json $(STAGING_DIR)/var/accesscontrol/1
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/umurmur/Makefile
+++ b/spk/umurmur/Makefile
@@ -36,9 +36,3 @@ umurmur_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
 	install -m 755 src/app/umurmur.cgi.pl $(STAGING_DIR)/app/umurmur.cgi
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72 ; \
-	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-	            $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done

--- a/spk/xdm/Makefile
+++ b/spk/xdm/Makefile
@@ -36,11 +36,6 @@ xdm_extra_install: $(STAGING_DIR)/share/XDM
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done
 
 $(STAGING_DIR)/share/XDM:
 	install -m 755 -d $(STAGING_DIR)/share

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -42,8 +42,3 @@ znc_extra_install:
 	install -m 644 src/znc.conf $(STAGING_DIR)/var/configs/znc.conf
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-		        $(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done


### PR DESCRIPTION
_Motivation:_ Improve icon handling
- Replace deprecated `PACKAGE_ICON_120.PNG` with `PACKAGE_ICON_256.PNG`
- Removes the need to add additional lines to `_extra_install` to convert `SPK_ICON` to various sizes
- When Synology decides to add a new size, we only have to change it in one centralized location.
_Linked issues:_ https://github.com/SynoCommunity/spksrc/pull/2528

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
