### PR TITLE
Update zlib PKG_DIST_SITE to new URL

### DIFF
--- a/cross/zlib/Makefile
+++ b/cross/zlib/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = zlib
 PKG_VERS = 1.2.8
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://zlib.net
+PKG_DIST_SITE = http://zlib.net/fossils
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =


### PR DESCRIPTION
_Motivation:_ The zlib website stores all package archives at http://zlib.net/fossils/ - so version 1.2.8 is located at http://zlib.net/fossils/zlib-1.2.8.tar.gz, not http://zlib.net/zlib-1.2.8.tar.gz (error 404 as this is no long the most recent version). This pull request updates the cross/zlib makefile to point to the new URL to avoid wget & build failures.
_Linked issues:_ Not applicable.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
