### PR TITLE
Updated to require a minimum python 2.7.9 in preparation for 1.2.x

### DIFF
--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -6,7 +6,7 @@ DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/par2cmdline cross/unrar cross/unzip cross/$(SPK_NAME)
 WHEELS = src/requirements.txt
-SPK_DEPENDS = "python>=2.7.6-8"
+SPK_DEPENDS = "python>=2.7.9-12"
 
 MAINTAINER = Diaoul
 DESCRIPTION = SABnzbd makes Usenet as simple and streamlined as possible by automating everything we can. All you have to do is add an .nzb. SABnzbd takes over from there, where it will be automatically downloaded, verified, repaired, extracted and filed away with zero human interaction.


### PR DESCRIPTION
Updated to ensure that the python minimum requirement won't be missed, ensuring that the new SSL functionality in the 1.2.x versions won't complain

### Checklist
- [x] Build rule `all-supported` completed successfully
