### PR TITLE
Add Web Station/PHP5.6 as dependency

### DIFF
--- a/spk/rutorrent/src/conf/PKG_DEPS
+++ b/spk/rutorrent/src/conf/PKG_DEPS
@@ -1,0 +1,5 @@
+[WebStation]
+dsm_min_ver=6.0
+
+[PHP5.6]
+dsm_min_ver=6.0


### PR DESCRIPTION
_Motivation:_ Add required dependencies to ruTorrent
_Linked issues:_ #2215 

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

Can't `make all` on a Windows host?
```
debootstrap --foreign --arch powerpc jessie /spksrc/spk/debian-chroot/work/staging/var/chroottarget "http://ftp.debian.org/debian"
mknod: '/spksrc/spk/debian-chroot/work/staging/var/chroottarget/test-dev-null': Operation not permitted
E: Cannot install into target '/spksrc/spk/debian-chroot/work/staging/var/chroottarget' mounted with noexec or nodev
Makefile:55: recipe for target 'debian-chroot_extra_install' failed
```

Sorry :(
