### PR TITLE
Upgrade zlib to 1.2.11

### DIFF
--- a/cross/zlib/Makefile
+++ b/cross/zlib/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = zlib
-PKG_VERS = 1.2.10
+PKG_VERS = 1.2.11
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://zlib.net

--- a/cross/zlib/PLIST
+++ b/cross/zlib/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libz.so
 lnk:lib/libz.so.1
-lib:lib/libz.so.1.2.10
+lib:lib/libz.so.1.2.11

--- a/cross/zlib/digests
+++ b/cross/zlib/digests
@@ -1,3 +1,3 @@
-zlib-1.2.10.tar.gz SHA1 76af0bfb4d17fad1d8bda13cb5593c311f59adee
-zlib-1.2.10.tar.gz SHA256 8d7e9f698ce48787b6e1c67e6bff79e487303e66077e25cb9784ac8835978017
-zlib-1.2.10.tar.gz MD5 d9794246f853d15ce0fcbf79b9a3cf13
+zlib-1.2.11.tar.gz SHA1 e6d119755acdf9104d7ba236b1242696940ed6dd
+zlib-1.2.11.tar.gz SHA256 c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+zlib-1.2.11.tar.gz MD5 1c9f62f0778697a09d36121ead88e08e


### PR DESCRIPTION
Fixes #2607

_Motivation:_ zlib archive for 1.2.10 is no longer available
