### PR TITLE
Fix Transmission startup function

### DIFF
--- a/spk/transmission/src/dsm-control.sh
+++ b/spk/transmission/src/dsm-control.sh
@@ -15,7 +15,7 @@ PID_FILE="${INSTALL_DIR}/var/transmission.pid"
 
 start_daemon ()
 {
-    su - ${USER} -c "PATH=${PATH} ${TRANSMISSION} -g ${INSTALL_DIR}/var/ -x ${PID_FILE}"
+    su -s /bin/sh - ${USER} -c "PATH=${PATH} ${TRANSMISSION} -g ${INSTALL_DIR}/var/ -x ${PID_FILE}"
 }
 
 stop_daemon ()


### PR DESCRIPTION
Pass in "-s /bin/sh" explicitly so that it still works even if
the transmission user has a different shell, e.g. /sbin/nologin.

I found that I've had to implement the workaround described
in step 5 of https://forum.synology.com/enu/viewtopic.php?t=87386#p330119
to get the Transmission package to start up correctly. However,
this lasts only until the next reboot, which wipes out the changes
to /etc/passwd.

But instead, it suffices to just pass in "-s /bin/sh" directly to
the start command in dsm-control.sh. Keeping the default
home directory doesn't seem to hurt.