### PR TITLE
Update Syncthing-Inotify to 0.8.5

### DIFF
--- a/cross/syncthing-inotify/Makefile
+++ b/cross/syncthing-inotify/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing-inotify
-PKG_VERS = 0.8.4
+PKG_VERS = 0.8.5
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing-inotify/archive

--- a/cross/syncthing-inotify/digests
+++ b/cross/syncthing-inotify/digests
@@ -1,3 +1,3 @@
-syncthing-inotify-v0.8.4.tar.gz SHA1 0ef6becd734d1cedd088d650bed3a7c1602d6f18
-syncthing-inotify-v0.8.4.tar.gz SHA256 c8215c8bc8a52a043ae3bcba6ff94ef572159ca5d7808b44deeb31eb3b2ce295
-syncthing-inotify-v0.8.4.tar.gz MD5 27931680092614d69c3cc1327b65c1a5
+syncthing-inotify-v0.8.5.tar.gz SHA1 b50a414385a265a9eff4a3777916eea1ccdcb37c
+syncthing-inotify-v0.8.5.tar.gz SHA256 552db71ddd086ffd21390e3bca4ceb2de53e0d4383a9321b8be17611ddb92aa4
+syncthing-inotify-v0.8.5.tar.gz MD5 2f5ea185807f3ed08ac88e007c0083fa

--- a/spk/syncthing-inotify/Makefile
+++ b/spk/syncthing-inotify/Makefile
@@ -1,20 +1,20 @@
 SPK_NAME = syncthing-inotify
-SPK_VERS = 0.8.4
-SPK_REV = 1
+SPK_VERS = 0.8.5
+SPK_REV = 2
 SPK_ICON = src/${SPK_NAME}.png
 BETA = 1
 
 UNSUPPORTED_ARCHS = $(PPC_ARCHES)
 
 DEPENDS = cross/$(SPK_NAME)
-SPK_DEPENDS = "syncthing>=0.14.21-10"
+SPK_DEPENDS = "syncthing>=0.14.23-11"
 START_DEP_SERVICES = syncthing
 
 MAINTAINER = o0v7r0o
 DESCRIPTION = File watcher intended for use with Syncthing. Syncthing uses a rescan interval to detect changes in folders. Syncthing-inotify uses OS primitives to detect changes as soon as they happen. Therefore, near real-time synchronisation can be achieved.
 RELOAD_UI = no
 DISPLAY_NAME = Syncthing-Inotify
-CHANGELOG = "Initial release"
+CHANGELOG = "Update to 0.8.5"
 HOMEPAGE = https://github.com/syncthing/syncthing-inotify
 LICENSE = MPL-2.0
 


### PR DESCRIPTION
_Motivation:_ This is an important update because syncthing 0.14.22+ will no longer work with syncthing-inotify 0.8.4 (see https://github.com/syncthing/syncthing-inotify/issues/154)
_Linked issues:_ no

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
