### PR TITLE
Update Syncthing to 0.14.23

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 0.14.21
+PKG_VERS = 0.14.23
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-source-v0.14.21.tar.gz SHA1 824175a895f86b5e86b055ba6041103dee1fef21
-syncthing-source-v0.14.21.tar.gz SHA256 e5fe49b85425679fec3d08127cd4fcf40e474ff70ccec587ee21f306c0c36085
-syncthing-source-v0.14.21.tar.gz MD5 b81c093bf3630d43ed23e6e19163ad82
+syncthing-source-v0.14.23.tar.gz SHA1 551d88cad890a27cd43b4c4f7a5d1ef865353a80
+syncthing-source-v0.14.23.tar.gz SHA256 78be407b4f9f166aab30e002b741f80f60c5e6a12c7167ce12322bf36501fd82
+syncthing-source-v0.14.23.tar.gz MD5 22a966dc518496eb54febd84629b97ca

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 0.14.21
-SPK_REV = 10
+SPK_VERS = 0.14.23
+SPK_REV = 11
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -14,7 +14,7 @@ DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie s√
 ADMIN_PORT = 7070
 RELOAD_UI = yes
 DISPLAY_NAME = Syncthing
-CHANGELOG = "Update to 0.14.21"
+CHANGELOG = "Update to 0.14.23"
 HOMEPAGE = http://www.syncthing.net
 LICENSE = MPLv2.0
 

--- a/spk/syncthing/src/config.xml
+++ b/spk/syncthing/src/config.xml
@@ -1,4 +1,4 @@
-<configuration version="17">
+<configuration version="18">
     <gui enabled="true" tls="false">
         <address>0.0.0.0:7070</address>
     </gui>
@@ -21,6 +21,7 @@
         <urInitialDelayS>1800</urInitialDelayS>
         <restartOnWakeup>true</restartOnWakeup>
         <autoUpgradeIntervalH>12</autoUpgradeIntervalH>
+        <upgradeToPreReleases>false</upgradeToPreReleases>
         <keepTemporariesH>24</keepTemporariesH>
         <cacheIgnoredFiles>true</cacheIgnoredFiles>
         <progressUpdateIntervalS>5</progressUpdateIntervalS>
@@ -30,5 +31,6 @@
         <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
         <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
         <tempIndexMinBlocks>10</tempIndexMinBlocks>
+        <weakHashSelectionMethod>auto</weakHashSelectionMethod>
     </options>
 </configuration>


### PR DESCRIPTION
_Motivation:_ Update syncthing to 0.14.23 mainly because a) 0.14.21 has bug with restart after update; b) set release channel to 'stable' in default config.
_Linked issues:_ *no*

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
