### PR TITLE
Docker image: add zlib1g-dev:i386 required by some toolchains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && \
         subversion \
         swig \
         xmlto \
+        zlib1g-dev:i386 \
         zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
_Motivation:_ there is no reason not to provide it by default for powerpc toolchains to work
