### PR TITLE
Updated default port for Radarr to 8310

### DIFF
--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = radarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/radarr.png
 DSM_UI_DIR = app
 BETA = 1
@@ -14,7 +14,7 @@ SPK_DEPENDS = "mono>3.6"
 
 MAINTAINER = ressu
 DESCRIPTION  = Radarr is a movie manager like Couchpotato, but based on the Sonarr codebase. It can monitor multiple RSS feeds for new movie releases and will grab, sorts and rename them. It can also be configured to automatically upgrade the quality of files already downloaded if a better quality format becomes available.
-ADMIN_PORT = 7878
+ADMIN_PORT = 8310
 RELOAD_UI = yes
 DISPLAY_NAME = Radarr
 CHANGELOG = "1. Initial release"

--- a/spk/radarr/src/app/config
+++ b/spk/radarr/src/app/config
@@ -6,7 +6,7 @@
             "icon": "images/radarr-{0}.png",
             "type": "url",
             "protocol": "http",
-            "port": "7878",
+            "port": "8310",
             "url": "/",
             "allUsers": true,
             "grantPrivilege": "local"

--- a/spk/radarr/src/radarr.sc
+++ b/spk/radarr/src/radarr.sc
@@ -2,5 +2,5 @@
 title="Radarr"
 desc="Radarr"
 port_forward="yes"
-dst.ports="7878/tcp"
+dst.ports="8310/tcp"
 


### PR DESCRIPTION
_Motivation:_ Updated the default port so it doesn't clash with High Availability

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
