### PR TITLE
ownCloud minor upgrade to 8.1.12

### DIFF
--- a/cross/owncloud/Makefile
+++ b/cross/owncloud/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = owncloud
-PKG_VERS = 8.1.1
+PKG_VERS = 8.1.12
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://download.owncloud.org/community

--- a/cross/owncloud/digests
+++ b/cross/owncloud/digests
@@ -1,3 +1,3 @@
-owncloud-8.1.1.tar.bz2 SHA1 e04f515bae04fa38e8770acad05007325d9f4ad0
-owncloud-8.1.1.tar.bz2 SHA256 91f39cbb2f542c9f5f949d02f31e6379ce9e3b7b6b4ae7b093c19e81d069c7d1
-owncloud-8.1.1.tar.bz2 MD5 b588309e0c10e2fe0e57653bdc7ea6e4
+owncloud-8.1.12.tar.bz2 SHA1 07f7338fddc972acce3967f68b87b07141c039dc
+owncloud-8.1.12.tar.bz2 SHA256 e6a544dedbd118edc10ac3e2d858c7646c5b365c5ada23f028d37b06770b329e
+owncloud-8.1.12.tar.bz2 MD5 d12c661faa502cd36caafe9a9aef5724

--- a/spk/owncloud/Makefile
+++ b/spk/owncloud/Makefile
@@ -1,17 +1,17 @@
 SPK_NAME = owncloud
-SPK_VERS = 8.1.1
-SPK_REV = 7
+SPK_VERS = 8.1.12
+SPK_REV = 8
 SPK_ICON = src/owncloud.png
 DSM_UI_DIR = app
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
 
-MAINTAINER = moneytoo
+MAINTAINER = ymartin59
 DESCRIPTION = ownCloud is a personal cloud which runs on your own server and gives you freedom and control over your own data.
 ADMIN_URL = /owncloud/
 RELOAD_UI = yes
 DISPLAY_NAME = ownCloud
-CHANGELOG = "1. Update ownCloud to 8.1.1"
+CHANGELOG = "1. Update ownCloud to 8.1.12"
 
 HOMEPAGE   = http://owncloud.org/
 LICENSE    = AGPL


### PR DESCRIPTION
_Motivation:_ End-of-Life for 8.1 version. Prepare to upgrade to 9.1
_Linked issues:_ #2710

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully (tested on XPEnology 5.2)
- [x] New installation of package completed successfully (tested on XPEnology 5.2)

Works on DSM 6.0.2 only IF:
- packages Web Station, Apache 2.2 and PHP 5.6 have to be installed first
- PHP extensions must be enabled: https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites-label
- PHP customized `open_basedir` must be appended with `:/dev/urandom:/volume1/owncloud`