### PR TITLE
Updated to restore par2cmdline build parameters

### DIFF
--- a/cross/par2cmdline/Makefile
+++ b/cross/par2cmdline/Makefile
@@ -21,9 +21,9 @@ PAR2_TOOLS = par2create par2repair par2verify
 
 .PHONY: myPreConfigure
 myPreConfigure:
-	#$(RUN) aclocal
-	#$(RUN) automake --add-missing
-	#$(RUN) autoconf
+	$(RUN) aclocal
+	$(RUN) automake --add-missing
+	$(RUN) autoconf
 	
 	
 myPostInstall:

--- a/spk/sabnzbd-testing/Makefile
+++ b/spk/sabnzbd-testing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sabnzbd-testing
 SPK_VERS = 2.1.0RC1
-SPK_REV = 25
+SPK_REV = 26
 SPK_ICON = src/sabnzbd-testing.png
 DSM_UI_DIR = app
 BETA = 1

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sabnzbd
 SPK_VERS = 2.0.1
-SPK_REV = 26
+SPK_REV = 27
 SPK_ICON = src/sabnzbd.png
 DSM_UI_DIR = app
 


### PR DESCRIPTION
_Motivation:_ Attempting to fix broken par2cmdline
_Linked issues:_ https://github.com/SynoCommunity/spksrc/issues/2735

### Checklist
- [x] Build rule `all-archs` completed successfully
