### PR TITLE
Updated to push latest statically compiled par2cmdline

### DIFF
--- a/cross/par2cmdline/Makefile
+++ b/cross/par2cmdline/Makefile
@@ -11,7 +11,8 @@ COMMENT  = par2cmdline is a PAR 2.0 compatible file verification and repair tool
 LICENSE  = GPL
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --disable-openmp
+CONFIGURE_ARGS =
+ADDITIONAL_LDFLAGS =-static
 
 POST_INSTALL_TARGET = myPostInstall
 PRE_CONFIGURE_TARGET = myPreConfigure

--- a/spk/sabnzbd-testing/Makefile
+++ b/spk/sabnzbd-testing/Makefile
@@ -1,6 +1,10 @@
 SPK_NAME = sabnzbd-testing
 SPK_VERS = 2.1.0RC1
+<<<<<<< HEAD
 SPK_REV = 27
+=======
+SPK_REV = 28
+>>>>>>> Updated to push latest statically compiled par2cmdline
 SPK_ICON = src/sabnzbd-testing.png
 DSM_UI_DIR = app
 BETA = 1

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sabnzbd
 SPK_VERS = 2.0.1
-SPK_REV = 27
+SPK_REV = 28
 SPK_ICON = src/sabnzbd.png
 DSM_UI_DIR = app
 


### PR DESCRIPTION
_Motivation:_ Statically linked par2cmdline so that multicore support is available
_Linked issues:_ https://github.com/SynoCommunity/spksrc/issues/2735

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Notes
There is a larger memory overhead for this, so for low memory or single core systems, we can look to disable per architecture (I'm guessing mainly ARM devices)