### PR TITLE
Updates to syncthing / go

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 0.14.23
+PKG_VERS = 0.14.30
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-source-v0.14.23.tar.gz SHA1 551d88cad890a27cd43b4c4f7a5d1ef865353a80
-syncthing-source-v0.14.23.tar.gz SHA256 78be407b4f9f166aab30e002b741f80f60c5e6a12c7167ce12322bf36501fd82
-syncthing-source-v0.14.23.tar.gz MD5 22a966dc518496eb54febd84629b97ca
+syncthing-source-v0.14.30.tar.gz SHA1 d70f92d8486ad5f9f47aa5fe65ddf8a0a9523107
+syncthing-source-v0.14.30.tar.gz SHA256 cc1ad821f184eeeb183b6dff0736f54ed5e3e4310f75d8d83d1ff6f460f7ca9f
+syncthing-source-v0.14.30.tar.gz MD5 b45d06c87585490fdcbf0a4aaca367fc

--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.7.4
+PKG_VERS = 1.8.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).src.$(PKG_EXT)
 PKG_DIST_SITE = https://storage.googleapis.com/golang

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 0.14.23
-SPK_REV = 12
+SPK_VERS = 0.14.30
+SPK_REV = 13
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 


### PR DESCRIPTION
I've updated Syncthing to the latest stable - 0.40.30, and also pulled in the latest go release (1.8.3), so we are a bit more uptodate again on that field.

Tested on my DS.