### PR TITLE
Update openssl to 1.0.2l

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2k
+PKG_VERS = 1.0.2l
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = ftp://ftp.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2k.tar.gz SHA1 5f26a624479c51847ebd2f22bb9f84b3b44dcb44
-openssl-1.0.2k.tar.gz SHA256 6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0
-openssl-1.0.2k.tar.gz MD5 f965fc0bf01bf882b31314b61391ae65
+openssl-1.0.2l.tar.gz SHA1 b58d5d0e9cea20e571d903aafa853e2ccd914138
+openssl-1.0.2l.tar.gz SHA256 07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c
+openssl-1.0.2l.tar.gz MD5 f85123cd390e864dfbe517e7616e6566


### PR DESCRIPTION
_Motivation:_ Update openssl to the latest version. Reasoning: I wanted to start a new package, but since it depends (indirectly) on openssl, and the version in the package is no longer available (except in the old/ folder), I updated this one.

_Linked issues:_ N/A

### Checklist
- [x] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [] New installation of package completed successfully

I'm not entirely certain how I can properly test this - there seems to be no package built, or I'm utterly looking in the wrong spot.
