### PR TITLE
[TVH] Prevent concurrent installation with tvheadend-testing

### DIFF
--- a/spk/tvheadend/src/conf/PKG_CONX
+++ b/spk/tvheadend/src/conf/PKG_CONX
@@ -1,0 +1,1 @@
+[tvheadend-testing]


### PR DESCRIPTION
_Motivation:_ Running TVheadend concurrently with a TVheadend-testing package can create problems. They might want to use the same ports or lock the same tuners. This might(!) also solve package the presisting publication issues on the Synocommunity build platform (cannot test).

### Checklist
- [x] Build rule `evansport` completed successfully with 6.1-toolchains
- [x] Confirmed that installation is blocked if tvheadend-testing is already installed with above build
- [ ] New installation of package completed successfully