### PR TITLE
WIP Update mediainfo to 0.7.99 and dependencies

### DIFF
--- a/cross/libmediainfo/Makefile
+++ b/cross/libmediainfo/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libmediainfo
-PKG_VERS = 0.7.93
+PKG_VERS = 0.7.99
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://mediaarea.net/download/source/$(PKG_NAME)/$(PKG_VERS)

--- a/cross/libmediainfo/digests
+++ b/cross/libmediainfo/digests
@@ -1,3 +1,3 @@
-libmediainfo_0.7.93.tar.xz SHA1 0d8d369978ea866c5650d14ce7184968246a6961
-libmediainfo_0.7.93.tar.xz SHA256 3624a187c7159a055805a475e4bbcfd3d55b77b765507fd066b205cd55902114
-libmediainfo_0.7.93.tar.xz MD5 c0227c881dcf05515534c159c0dadc59
+libmediainfo_0.7.99.tar.xz SHA1 341b860a56c0c6741650cdfae05eed4a89b00c63
+libmediainfo_0.7.99.tar.xz SHA256 ec9a8f2e081eefda05ddb841a3ffc838bf6ef8aedaf40f47fdbd19fd739fd688
+libmediainfo_0.7.99.tar.xz MD5 9e707fe59f87525fc9880ffec06297e2

--- a/cross/libzen/Makefile
+++ b/cross/libzen/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libzen
-PKG_VERS = 0.4.34
+PKG_VERS = 0.4.37
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://mediaarea.net/download/source/$(PKG_NAME)/$(PKG_VERS)

--- a/cross/libzen/digests
+++ b/cross/libzen/digests
@@ -1,3 +1,3 @@
-libzen_0.4.34.tar.bz2 SHA1 ee93c0210dfc86064fc55a0d5a2adba3aafbd992
-libzen_0.4.34.tar.bz2 SHA256 83774fe093bd14fb72da9c537021a8ffc3f6ff952a1401cd6f91de6628ac790a
-libzen_0.4.34.tar.bz2 MD5 d554f97a5f1b54e36a8d2ff5c5361f1b
+libzen_0.4.37.tar.bz2 SHA1 6e04cf73b0fef1741857f6fc4b470c400eb3c7d0
+libzen_0.4.37.tar.bz2 SHA256 d6e9b7084bbb828536b47698e0c60e381cf0cefc4a8d712bb81dac826ccd9ac1
+libzen_0.4.37.tar.bz2 MD5 3e1752083aaed9a7b1ebcadbc1871ecf

--- a/cross/mediainfo/Makefile
+++ b/cross/mediainfo/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = mediainfo
-PKG_VERS = 0.7.93
+PKG_VERS = 0.7.99
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://mediaarea.net/download/source/$(PKG_NAME)/$(PKG_VERS)

--- a/cross/mediainfo/digests
+++ b/cross/mediainfo/digests
@@ -1,3 +1,3 @@
-mediainfo_0.7.93.tar.xz SHA1 271fe2695b6542c4919b445c54f29f1f72bf559f
-mediainfo_0.7.93.tar.xz SHA256 a268b190febc5fbf54a6cfcf0769fcb65c0d888920e6a52ef020822cefec4bae
-mediainfo_0.7.93.tar.xz MD5 8f78c8343507419d7529de14ecc2a188
+mediainfo_0.7.99.tar.xz SHA1 d4e922e4ec6cd8eda37d09d75b267824331e2fab
+mediainfo_0.7.99.tar.xz SHA256 ca308d3fd1ded0baad62be2388f65c98949ab9111589b5561c8f0f9c3537ed88
+mediainfo_0.7.99.tar.xz MD5 2545767b22dd582242677a8ac7a8674c

--- a/spk/mediainfo/Makefile
+++ b/spk/mediainfo/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mediainfo
-SPK_VERS = 0.7.93
-SPK_REV = 3
+SPK_VERS = 0.7.99
+SPK_REV = 5
 SPK_ICON = src/mediainfo.png
 
 DEPENDS  = cross/$(SPK_NAME)


### PR DESCRIPTION
_Motivation:_ provide a package update, published for `broadwell` architecture for testing
_Linked issues:_ #2718 

### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [] New installation of package completed successfully
