### PR TITLE
Update par2cmdline to 0.7.4 (faster verification)

### DIFF
--- a/cross/par2cmdline/Makefile
+++ b/cross/par2cmdline/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = par2cmdline
-PKG_VERS = 0.7.2
+PKG_VERS = 0.7.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Parchive/par2cmdline/releases/download/v$(PKG_VERS)

--- a/cross/par2cmdline/digests
+++ b/cross/par2cmdline/digests
@@ -1,3 +1,3 @@
-par2cmdline-0.7.2.tar.gz SHA1 53a9b34f1fa989f7712964a09de1da6c43527510
-par2cmdline-0.7.2.tar.gz SHA256 c71e6de1baf8ba56198266494647ba6d10923c8d2da244fb58da04ca358f8e8c
-par2cmdline-0.7.2.tar.gz MD5 8f2b20381bc203ff1286836b150a5acf
+par2cmdline-0.7.4.tar.gz SHA1 23aa03a5ec203438da42c5ec6691b56ab84bc1a1
+par2cmdline-0.7.4.tar.gz SHA256 b8f1e3bbe72cd298228332e67d353706c3da16cc4523c62f6fd053f49c54b1d0
+par2cmdline-0.7.4.tar.gz MD5 f5411d11609758ba7dc54b804eea6cb0


### PR DESCRIPTION
_Motivation:_ Update par2cmdline to 0.7.4 (faster verification)
_Linked issues:_ None

### Checklist
- [x] Build rule `all-supported` completed successfully: https://travis-ci.org/Safihre/spksrc/builds/273470159

@ymartin59 You said you wanted separate pull-requests, so here it is.
SABnzbd is the only package using par2cmdline. 