### PR TITLE
[DSM6] Add support for apollolake and denverton toolchains (6.1)

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -39,7 +39,7 @@ ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq
 x86_ARCHES = evansport
-x64_ARCHES = avoton braswell broadwell bromolow cedarview dockerx64 grantley kvm64 x86 x64 x86_64
+x64_ARCHES = apollolake avoton braswell broadwell bromolow cedarview dockerx64 grantley kvm64 x86 x64 x86_64
 
 # Load local configuration
 LOCAL_CONFIG_MK = ../../local.mk

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -39,7 +39,7 @@ ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq
 x86_ARCHES = evansport
-x64_ARCHES = apollolake avoton braswell broadwell bromolow cedarview dockerx64 grantley kvm64 x86 x64 x86_64
+x64_ARCHES = apollolake avoton braswell broadwell bromolow cedarview denverton dockerx64 grantley kvm64 x86 x64 x86_64
 
 # Load local configuration
 LOCAL_CONFIG_MK = ../../local.mk

--- a/toolchains/syno-apollolake-6.1/Makefile
+++ b/toolchains/syno-apollolake-6.1/Makefile
@@ -1,0 +1,28 @@
+TC_NAME = syno-$(TC_ARCH)
+
+TC_ARCH = apollolake
+TC_VERS = 6.1
+TC_FIRMWARE = 6.1-15047
+
+TC_DIST = apollolake-gcc493_glibc220_linaro_x86_64-GPL
+TC_EXT = txz
+TC_DIST_NAME = $(TC_DIST).$(TC_EXT)
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/DSM%206.1%20Tool%20Chains/Intel%20x86%20Linux%204.4.15%20%28Apollolake%29
+
+TC_BASE_DIR = x86_64-pc-linux-gnu
+TC_PREFIX = x86_64-pc-linux-gnu
+TC_TARGET = x86_64-pc-linux-gnu
+
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
+
+FIX_TARGET = myFix
+
+include ../../mk/spksrc.tc.mk
+
+.PHONY: myFix
+myFix:
+	chmod -R u+w $(WORK_DIR)
+	@find $(WORK_DIR)/$(TC_BASE_DIR) -type f -name '*.la' -exec sed -i -e "s|^libdir=.*$$|libdir='$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib'|" {} \;

--- a/toolchains/syno-apollolake-6.1/digests
+++ b/toolchains/syno-apollolake-6.1/digests
@@ -1,0 +1,3 @@
+apollolake-gcc493_glibc220_linaro_x86_64-GPL.txz SHA1 5f69a10faaec67ceb600be34ffd54bb44b162dfe
+apollolake-gcc493_glibc220_linaro_x86_64-GPL.txz SHA256 12195a6925685f63e0aadd7cb91a35f105926d523657ff9386cfe27f85254941
+apollolake-gcc493_glibc220_linaro_x86_64-GPL.txz MD5 ab21b8aa64d81d5e783b734dd2eb60e1

--- a/toolchains/syno-denverton-6.1/Makefile
+++ b/toolchains/syno-denverton-6.1/Makefile
@@ -1,0 +1,28 @@
+TC_NAME = syno-$(TC_ARCH)
+
+TC_ARCH = denverton
+TC_VERS = 6.1
+TC_FIRMWARE = 6.1-15047
+
+TC_DIST = denverton-gcc493_glibc220_linaro_x86_64-GPL
+TC_EXT = txz
+TC_DIST_NAME = $(TC_DIST).$(TC_EXT)
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/DSM%206.1%20Tool%20Chains/Intel%20x86%20Linux%204.4.15%20%28Denverton%29
+
+TC_BASE_DIR = x86_64-pc-linux-gnu
+TC_PREFIX = x86_64-pc-linux-gnu
+TC_TARGET = x86_64-pc-linux-gnu
+
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
+
+FIX_TARGET = myFix
+
+include ../../mk/spksrc.tc.mk
+
+.PHONY: myFix
+myFix:
+	chmod -R u+w $(WORK_DIR)
+	@find $(WORK_DIR)/$(TC_BASE_DIR) -type f -name '*.la' -exec sed -i -e "s|^libdir=.*$$|libdir='$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib'|" {} \;

--- a/toolchains/syno-denverton-6.1/digests
+++ b/toolchains/syno-denverton-6.1/digests
@@ -1,0 +1,3 @@
+denverton-gcc493_glibc220_linaro_x86_64-GPL.txz SHA1 92293eb0e918b4961943592261f7c4a96843fe71
+denverton-gcc493_glibc220_linaro_x86_64-GPL.txz SHA256 e507a8a168c0729b6180d58271dd5bd71ea7fc7032031a33855c1c25efcf2a84
+denverton-gcc493_glibc220_linaro_x86_64-GPL.txz MD5 7ec1c8009ebba7eef6ae945db2960b35

--- a/toolchains/syno-x64-6.1/Makefile
+++ b/toolchains/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = avoton braswell broadwell bromolow cedarview grantley x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell bromolow cedarview denverton grantley x86 x86_64
 TC_VERS = 6.1
 TC_FIRMWARE = 6.1-15047
 


### PR DESCRIPTION
_Motivation:_ Adds toolchain support for NASs with apollolake and denverton architecture
_Linked issues:_ #2939 (apollolake) and on request of @ymartin59 (denverton).

### Checklist
- [x] Successfully compiled `ffmpeg` package with apollolake toolchain
- [x] Successfully compiled `ffmpeg` package with denverton toolchain