### PR TITLE
Correct openssl download location

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = openssl
 PKG_VERS = 1.0.2l
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.openssl.org/source
+PKG_DIST_SITE = https://www.openssl.org/source
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib


### PR DESCRIPTION
The current download location is no longer valid which breaks build.