### PR TITLE
Include recent architectures to x64 5.2 toolchain

### DIFF
--- a/toolchains/syno-x64-5.2/Makefile
+++ b/toolchains/syno-x64-5.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = x86_64 braswell bromolow cedarview avoton
+TC_ARCH = x86_64 x86 braswell bromolow cedarview avoton apollolake broadwell denverton grantley
 TC_VERS = 5.2
 TC_FIRMWARE = 5.0-4458
 


### PR DESCRIPTION
Target: apollolake broadwell denverton grantley
Even if these never run DSM 5, this change allows to deliver
DSM 5+6 compatible binaries in a single x64 package.

