### PR TITLE
Updated wallabag package to 2.3.0

### DIFF
--- a/cross/wallabag/Makefile
+++ b/cross/wallabag/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = wallabag
-PKG_VERS = 2.2.3
+PKG_VERS = 2.3.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-release-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
@@ -9,7 +9,7 @@ PKG_DIR = release-$(PKG_VERS)
 DEPENDS =
 
 HOMEPAGE = https://www.wallabag.org/
-COMMENT  = Wallabag is a self hostable application allowing you to save an offline copy of your favorite articles. Click, save, read it when you can. It extracts content so that you can read it when you have time.
+COMMENT  = wallabag is a self hostable application allowing you to save an offline copy of your favorite articles. Click, save, read it when you can. It extracts content so that you can read it when you have time.
 LICENSE  = MIT
 
 CONFIGURE_TARGET = nop

--- a/cross/wallabag/digests
+++ b/cross/wallabag/digests
@@ -1,3 +1,3 @@
-wallabag-2.2.3.tar.gz SHA1 496e6c7d980c078e42d3bab7b0e978bd0af02b96
-wallabag-2.2.3.tar.gz SHA256 13fe5cb7cfc741abee08312f0055e9549e60590daff2fac41be5266f7956d857
-wallabag-2.2.3.tar.gz MD5 63f4cc85397fd6db3e0e3d5f3fa11e02
+wallabag-2.3.0.tar.gz SHA1 5f492f04bc9caa7911e6c9ff135946c3c9cbbdcd
+wallabag-2.3.0.tar.gz SHA256 9726b17a3cff73a0f2d7acfa08cb5d4abe8b2b07992f9a763f62868225108c20
+wallabag-2.3.0.tar.gz MD5 571bed3c419723c5097c1b1707d24fd5


### PR DESCRIPTION
_Motivation:_ wallabag 2.3.0 was released.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

I don't know how Synology users can handle the update of wallabag: there are some database migrations to execute to upgrade wallabag from 2.2.x to 2.3.0. Any idea?