### PR TITLE
Changes to Generic service

### DIFF
--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -112,16 +112,22 @@ syno_group_remove ()
 }
 
 # Sets recursive permissions for ${GROUP} on specified directory
-# Usage: set_syno_permissions "${SHARE_FOLDER}"
+# Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
     DIRNAME=$1
+    GROUP=$2
     echo "Granting '$GROUP' group permissions on $DIRNAME" >> ${INST_LOG}
-    VOLUME=$(echo "$DIRNAME" | awk -F/ '{print "/"$2}')
+
+    # Set read/write permissions for GROUP
+    if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:rwxpdDaARWcC-:fd--"`" ]; then
+        synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
+    fi
 
     # Walk up the tree and set traverse permissions up to VOLUME
+    VOLUME=$(echo "$DIRNAME" | awk -F/ '{print "/"$2}')
     while [ "${DIRNAME}" != "${VOLUME}" ]; do
-        # Set read/write permissions for GROUP
+        # Set execute permissions for GROUP
         if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:..x"`" ]; then
             synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:--x----------:---n" >> ${INST_LOG} 2>&1
         fi
@@ -202,17 +208,19 @@ postinst ()
             synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG}
         fi
 
-        # Add user/group permissions depending if GROUP is set in UI
-        if [ -n "$GROUP" ]; then
-            synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}",@"${GROUP}" >> ${INST_LOG} 2>&1
-        else
+        # Add user permission if no GROUP is set in UI
+        # GROUP permission will be added in set_syno_permissions
+        if [ ! -n "$GROUP" ]; then
             synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
         fi
         synoshare --build
 
         $MKDIR "${SHARE_PATH}"
-        # Permissions
-        set_syno_permissions "${SHARE_PATH}"
+
+        # Permissions for folder, up to volume
+        if [ -n "$GROUP" ]; then
+            set_syno_permissions "${SHARE_PATH}" "${GROUP}"
+        fi
     fi
 
     call_func "service_postinst"

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -217,16 +217,16 @@ postinst ()
 
     call_func "service_postinst"
     $MKDIR "${INST_VAR}"
-    cp "${INST_LOG}" "${INST_VAR}"
+    $CP "${INST_LOG}" "${INST_VAR}"
     if [ -n "${LOG_FILE}" ]; then
         echo "Installation log: ${INST_VAR}/${SYNOPKG_PKGNAME}_install.log" >> ${LOG_FILE}
     fi
     if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
         # On DSM 5 set package files permissions
-        chown -R ${EFF_USER}:root "${SYNOPKG_PKGDEST}" >> $INST_LOG 2>&1
+        chown -R ${EFF_USER}:root "${SYNOPKG_PKGDEST}" >> ${INST_LOG} 2>&1
     else
         # On DSM 6 only var is concerned
-        chown -R ${EFF_USER}:${USER} "${INST_VAR}" >> $INST_LOG 2>&1
+        chown -R ${EFF_USER}:${USER} "${INST_VAR}" >> ${INST_LOG} 2>&1
     fi
     exit 0
 }
@@ -312,5 +312,8 @@ postupgrade ()
     $RM "$TMP_DIR" >> ${INST_LOG}
 
     call_func "service_postupgrade"
+
+    # Make sure we also have the logging for this step
+    $CP "${INST_LOG}" "${INST_VAR}"
     exit 0
 }

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -19,7 +19,6 @@ else
     TMP_DIR="${SYNOPKG_TEMP_UPGRADE_FOLDER}/var"
 fi
 
-
 # Source package specific variable and functions
 SVC_SETUP=`dirname $0`"/service-setup"
 if [ -r "${SVC_SETUP}" ]; then
@@ -47,10 +46,10 @@ if [ -n "${SHARE_PATH}" ]; then
     SHARE_NAME=$(echo "${SHARE_PATH}" | awk -F/ '{print $3}')
 fi
 
-
 # Tools shortcuts
 MV="/bin/mv -f"
 RM="/bin/rm -rf"
+CP="/bin/cp -rfp"
 MKDIR="/bin/mkdir -p"
 LN="/bin/ln -nsf"
 TEE="/usr/bin/tee -a"
@@ -289,15 +288,24 @@ preupgrade ()
         syno_remove_user "${SYNOUSER_PREFIX}${USER}"
     fi
 
-    $MV "${TO_SAVE_DIR}/*" "$TMP_DIR" >> ${INST_LOG}
+    # Beware of /* outside the quotes, fails otherwise!
+    $MV "${INST_VAR}"/* "$TMP_DIR" >> ${INST_LOG}
     exit 0
 }
 
 postupgrade ()
 {
     log_step "postupgrade"
-    # Restore some stuff
-    $MV "$TMP_DIR" "$TO_SAVE_DIR" >> ${INST_LOG}
+
+    # Restore some stuff, has to be cp otherwise fails on directories
+    $CP "${TMP_DIR}"/* "${INST_VAR}" >> ${INST_LOG}
+
+    # Correct permissions of var folder
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+        chown -R ${EFF_USER}:root "${INST_VAR}" >> $INST_LOG 2>&1
+    else
+        chown -R ${EFF_USER}:${USER} "${INST_VAR}" >> $INST_LOG 2>&1
+    fi
 
     call_func "service_restore"
 


### PR DESCRIPTION
2 bugfixes and the option to use `set_syno_permissions` to correct permissions specific to package.
Tested with `spk/sabnzbd` and works as expected.

Would suggest not to squash into single commit to preserve easier commit-history reading.