### PR TITLE
Various dependency fixes (fribidi, openssl, x264)

### DIFF
--- a/cross/fribidi/Makefile
+++ b/cross/fribidi/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = fribidi
 PKG_VERS = 0.19.7
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://fribidi.org/download
+PKG_DIST_SITE = https://download.videolan.org/contrib/fribidi
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2l
+PKG_VERS = 1.0.2n
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2l.tar.gz SHA1 b58d5d0e9cea20e571d903aafa853e2ccd914138
-openssl-1.0.2l.tar.gz SHA256 ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c
-openssl-1.0.2l.tar.gz MD5 f85123cd390e864dfbe517e7616e6566
+openssl-1.0.2n.tar.gz SHA1 0ca2957869206de193603eca6d89f532f61680b1
+openssl-1.0.2n.tar.gz SHA256 370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
+openssl-1.0.2n.tar.gz MD5 13bdc1b1d1ff39b6fd42a255e74676a4

--- a/cross/x264/Makefile
+++ b/cross/x264/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = x264
 PKG_VERS = 20170730-2245-stable
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-snapshot-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://ftp.videolan.org/pub/videolan/x264/snapshots
+PKG_DIST_SITE = https://download.videolan.org/x264/snapshots
 PKG_DIR = $(PKG_NAME)-snapshot-$(PKG_VERS)
 
 DEPENDS =


### PR DESCRIPTION
### Motivation
When experimenting with travis-CI on my private `spksrc` repo, I encountered several compile issues due to outdated cross-packages. This PR addresses those issues. 

### Issues
- fribidi: Download location for sources no longer available. Replaced by alternative source (same package).
- openssl: No issue actually, but realized that we are running two releases behind. Updated to 1.0.2n.
- x264: The old download location still worked, but required the `--no-check-certificate` option for `wget` to work. Adapting the download location to the (new) official source URL fixes the issue.

### Note
I conducted runtime-tests but only on individual packages for individual platforms. Based on the nature of the changes I would not expect any kind of issues though...

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully