### PR TITLE
Update to libconfig 1.7.1

### DIFF
--- a/cross/libconfig/Makefile
+++ b/cross/libconfig/Makefile
@@ -1,17 +1,16 @@
 PKG_NAME = libconfig
-PKG_VERS = 1.4.9
+PKG_VERS = 1.7.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://www.hyperrealm.com/libconfig
+PKG_DIST_SITE = https://hyperrealm.github.io/libconfig/dist
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 
-HOMEPAGE = http://www.hyperrealm.com/libconfig/
+HOMEPAGE = https://hyperrealm.github.io/libconfig/
 COMMENT  = Simple library for processing structured configuration files
 LICENSE  =
 
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk
-

--- a/cross/libconfig/PLIST
+++ b/cross/libconfig/PLIST
@@ -1,6 +1,6 @@
 lnk:lib/libconfig.so
-lnk:lib/libconfig.so.9
-lib:lib/libconfig.so.9.1.3
+lnk:lib/libconfig.so.11
+lib:lib/libconfig.so.11.0.1
 lnk:lib/libconfig++.so
-lnk:lib/libconfig++.so.9
-lib:lib/libconfig++.so.9.1.3
+lnk:lib/libconfig++.so.11
+lib:lib/libconfig++.so.11.0.1

--- a/cross/libconfig/digests
+++ b/cross/libconfig/digests
@@ -1,3 +1,3 @@
-libconfig-1.4.9.tar.gz SHA1 b7a3c307dfb388e57d9a35c7f13f6232116930ec
-libconfig-1.4.9.tar.gz SHA256 09c8979252e60193e2969e9b0e1cd597f7820087867989b2f0939ad164473041
-libconfig-1.4.9.tar.gz MD5 b6ee0ce2b3ef844bad7cac2803a90634
+libconfig-1.7.1.tar.gz SHA1 cd86d1ef332ec4e29b48f74d3448b4de398ce1e1
+libconfig-1.7.1.tar.gz SHA256 7b5b63f5ea046704481ce2e4c1d8cf28c13c3ca3387b84fd06901d2c4e6c037d
+libconfig-1.7.1.tar.gz MD5 67403b87fedff95be99e46d48757c52d


### PR DESCRIPTION
Update to libconfig 1.7.1 and also update homepage of libconfig project.

Motivation: compilation error for umurmur due to libconfig links broken.

