### PR TITLE
Improve permission setting for shared folders in generic service scripts

### DIFF
--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -115,24 +115,31 @@ syno_group_remove ()
 # Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
-    DIRNAME=$1
+    DIRNAME=`realpath $1`
     GROUP=$2
-    echo "Granting '$GROUP' group permissions on $DIRNAME" >> ${INST_LOG}
 
-    # Set read/write permissions for GROUP
-    if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:rwxpdDaARWcC-:fd--"`" ]; then
-        synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
-    fi
-
-    # Walk up the tree and set traverse permissions up to VOLUME
     VOLUME=$(echo "$DIRNAME" | awk -F/ '{print "/"$2}')
-    while [ "${DIRNAME}" != "${VOLUME}" ]; do
-        # Set execute permissions for GROUP
-        if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:..x"`" ]; then
-            synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:--x----------:---n" >> ${INST_LOG} 2>&1
+
+    # Ensure directory resides in /volumeX before setting GROUP permissions
+    if [ "`echo $VOLUME | cut -c2-7`" = "volume" ]; then
+        echo "Granting '$GROUP' group permissions on $DIRNAME" >> ${INST_LOG}
+
+        # Set read/write permissions for GROUP
+        if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:rwxpdDaARWcC-:fd--"`" ]; then
+            synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
         fi
-        DIRNAME="$(dirname "${DIRNAME}")"
-    done
+
+        # Walk up the tree and set traverse permissions up to VOLUME
+        while [ "${DIRNAME}" != "${VOLUME}" ]; do
+            # Set execute permissions for GROUP
+            if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:..x"`" ]; then
+                synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:--x----------:---n" >> ${INST_LOG} 2>&1
+            fi
+            DIRNAME="$(dirname "${DIRNAME}")"
+        done
+    else
+        echo "Skip granting '$GROUP' group permissions on $DIRNAME as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}
+    fi
 }
 
 ### Generic package behaviors

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -115,30 +115,30 @@ syno_group_remove ()
 # Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
-    DIRNAME=`realpath $1`
-    GROUP=$2
+    DIRNAME=`realpath "${1}"`
+    GROUP="${2}"
 
-    VOLUME=$(echo "$DIRNAME" | awk -F/ '{print "/"$2}')
+    VOLUME=$(echo "${DIRNAME}" | awk -F/ '{print "/"$2}')
 
     # Ensure directory resides in /volumeX before setting GROUP permissions
-    if [ "`echo $VOLUME | cut -c2-7`" = "volume" ]; then
-        echo "Granting '$GROUP' group permissions on $DIRNAME" >> ${INST_LOG}
+    if [ "`echo ${VOLUME} | cut -c2-7`" = "volume" ]; then
+        echo "Granting '${GROUP}' group permissions on ${DIRNAME}" >> ${INST_LOG}
 
-        # Set read/write permissions for GROUP
-        if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:rwxpdDaARWcC-:fd--"`" ]; then
+        # Set read/write permissions for GROUP for folder and subfolders
+        if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:rwxpdDaARWcC-:fd--\"`" ]; then
             synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
+            find "${DIRNAME}" -type d -exec synoacltool -enforce-inherit "{}" \; >> ${INST_LOG} 2>&1
         fi
 
-        # Walk up the tree and set traverse permissions up to VOLUME
+        # Walk up the tree and set traverse execute permissions for GROUP up to VOLUME
         while [ "${DIRNAME}" != "${VOLUME}" ]; do
-            # Set execute permissions for GROUP
-            if [ ! "`synoacltool -get "${DIRNAME}"| grep "group:${GROUP}:allow:..x"`" ]; then
+            if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:..x\"`" ]; then
                 synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:--x----------:---n" >> ${INST_LOG} 2>&1
             fi
-            DIRNAME="$(dirname "${DIRNAME}")"
+            DIRNAME="$(dirname \"${DIRNAME}\")"
         done
     else
-        echo "Skip granting '$GROUP' group permissions on $DIRNAME as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}
+        echo "Skip granting '${GROUP}' group permissions on ${DIRNAME} as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}
     fi
 }
 


### PR DESCRIPTION
_Motivation:_ While working on adapting the Tvheadend package for generic service use, I have encountered two issues with automatic permission setting for shared directories within `mk/spksrc.service.installer`:
1. The paths of shared directories containing symbolic links are not resolved.
2. If the path of a shared directory does not reside in a `/volume[X]` folder, the permission setting function can recurse into system directories, which is certainly not wanted. 

This PR addresses those issues.

### Checklist
- Tested via automatic permission setting on directories with and without symbolic links, within and outside of `/volume[X]` directories.
