### PR TITLE
Add hi3535 to ARMv7 archs

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -34,7 +34,7 @@ ARCHS_DUPES = $(filter-out avoton% braswell% broadwell% bromolow% cedarview% gra
 
 # Available Arches
 ARM5_ARCHES = 88f5281 88f6281
-ARM7_ARCHES = alpine armada370 armada375 armada38x armadaxp comcerto2k monaco
+ARM7_ARCHES = alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535
 ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq


### PR DESCRIPTION
As described in #3080 the `hi3535` arch couldn't compile Python because of a problem with `libgpg-error`. 
Turns out all that was needed was to add it to the ARMv7 arches. Now Python builds for `hi3535` [without a problem](https://travis-ci.org/Safihre/spksrc/builds/326366000).

_Not a Python-specific issue, so separate PR._
  