### PR TITLE
enable unicode support for Midnight Commander et al. (PCRE)

### DIFF
--- a/cross/pcre/Makefile
+++ b/cross/pcre/Makefile
@@ -12,5 +12,8 @@ COMMENT  = The PCRE library is a set of functions that implement regular express
 LICENSE  = BSD
 
 GNU_CONFIGURE = 1
+# enable UTF-8 support
+# pcre is used by: mc, sshfs, irssi, bitlbee, museek-plus
+CONFIGURE_ARGS = --enable-utf --enable-unicode-properties
 
 include ../../mk/spksrc.cross-cc.mk


### PR DESCRIPTION
enable unicode support in regex library pcre
related packages: mc, sshfs, irssi, bitlbee, museek-plus

_Motivation:_ 
Midnight Commander is the first package I created for my DS918+. Installation worked fine, but in special folders an error appeared about pcre not compiled with unicode support.

Did not find documentation how to configure parameters for dependent module of a single spk, so update the makefile in cross/pcre. Therefore all related packages get unicode support for pcre.
### Checklist
- [x] Build rule `all-supported` completed successfully (mc, sshfs, irssi, bitlbee, museek-plus)
- [x] sshfs does not compile for rtd1296-6.1 and ppc-853x-5.2 (did not build fuse before, not pcre related)
- [x] bitlbee does not compile for ppc-853x-5.2 (did not build before, not pcre related)
- [x] Package upgrade completed successfully (mc)
- [x] New installation of package completed successfully (mc)
