### PR TITLE
Fix permission setting in spksrc.service.installer

### DIFF
--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -135,7 +135,7 @@ set_syno_permissions ()
             if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:..x\"`" ]; then
                 synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:--x----------:---n" >> ${INST_LOG} 2>&1
             fi
-            DIRNAME="$(dirname \"${DIRNAME}\")"
+            DIRNAME="$(dirname "${DIRNAME}")"
         done
     else
         echo "Skip granting '${GROUP}' group permissions on ${DIRNAME} as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}


### PR DESCRIPTION
_Motivation:_ Lost an important fixup commit when rebasing for #3084. Without it, infinite loops can occur.  
_Linked issues:_ #3084 

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
