### PR TITLE
Update sslh pkg download URL

### DIFF
--- a/cross/sslh/Makefile
+++ b/cross/sslh/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = sslh
 PKG_VERS = 1.17
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://www.rutschle.net/tech
+PKG_DIST_SITE = http://www.rutschle.net/tech/sslh
 PKG_DIR = $(PKG_NAME)-v$(PKG_VERS)
 
 DEPENDS = cross/libconfig


### PR DESCRIPTION
URL changed from "http://www.rutschle.net/tech/sslh-v1.17.tar.gz" to "http://www.rutschle.net/tech/sslh/sslh-v1.17.tar.gz"

_Motivation:_ While trying to compile sslh for arch-apollolake-6.1, I found the URL to the package had changed.
To successfully compile the package I also needed to update the dockerfile to use debian:stretch rather than debian:jessie and added texinfo package (makefile 1.15 and makeconfig were required); these are not included in the pull request.

### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [x] New installation of package completed successfully
