### PR TITLE
toolchain of broadwellnk arch

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -39,7 +39,7 @@ ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq
 x86_ARCHES = evansport
-x64_ARCHES = apollolake avoton braswell broadwell bromolow cedarview denverton dockerx64 grantley kvm64 x86 x64 x86_64
+x64_ARCHES = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley kvm64 x86 x64 x86_64
 
 # Load local configuration
 LOCAL_CONFIG_MK = ../../local.mk

--- a/toolchains/syno-broadwellnk-6.2/Makefile
+++ b/toolchains/syno-broadwellnk-6.2/Makefile
@@ -1,0 +1,28 @@
+TC_NAME = syno-$(TC_ARCH)
+
+TC_ARCH = broadwellnk
+TC_VERS = 6.2
+TC_FIRMWARE = 6.2-22259
+
+TC_DIST = broadwellnk-gcc493_glibc220_linaro_x86_64-GPL
+TC_EXT = txz
+TC_DIST_NAME = $(TC_DIST).$(TC_EXT)
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/DSM%206.2%20Tool%20Chains/Intel%20x86%20Linux%204.4.59%20%28Broadwellnk%29
+
+TC_BASE_DIR = x86_64-pc-linux-gnu
+TC_PREFIX = x86_64-pc-linux-gnu
+TC_TARGET = x86_64-pc-linux-gnu
+
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib
+
+FIX_TARGET = myFix
+
+include ../../mk/spksrc.tc.mk
+
+.PHONY: myFix
+myFix:
+	chmod -R u+w $(WORK_DIR)
+	@find $(WORK_DIR)/$(TC_BASE_DIR) -type f -name '*.la' -exec sed -i -e "s|^libdir=.*$$|libdir='$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib'|" {} \;

--- a/toolchains/syno-broadwellnk-6.2/digests
+++ b/toolchains/syno-broadwellnk-6.2/digests
@@ -1,0 +1,3 @@
+broadwellnk-gcc493_glibc220_linaro_x86_64-GPL.txz SHA1 5364396ba238abf5be0d6b0cdca24691d0157fa6
+broadwellnk-gcc493_glibc220_linaro_x86_64-GPL.txz SHA256 a0e2fe42fa680246e0409a176e5fb0faa37850c9ad49c3253dafb325b454a501
+broadwellnk-gcc493_glibc220_linaro_x86_64-GPL.txz MD5 b136d2c610efa8c5b78ceb45afb57ab5

--- a/toolchains/syno-x64-5.2/Makefile
+++ b/toolchains/syno-x64-5.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = x86_64 x86 braswell bromolow cedarview avoton apollolake broadwell denverton grantley
+TC_ARCH = x86_64 x86 braswell bromolow cedarview avoton apollolake broadwell broadwellnk denverton grantley
 TC_VERS = 5.2
 TC_FIRMWARE = 5.0-4458
 

--- a/toolchains/syno-x64-6.1/Makefile
+++ b/toolchains/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell bromolow cedarview denverton grantley x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton grantley x86 x86_64
 TC_VERS = 6.1
 TC_FIRMWARE = 6.1-15047
 


### PR DESCRIPTION
this is the toolchain of broadwellnk for the new DS3018x and FS1018 that support DSM 6.2 only.
even the DSM 6.2 is still beta, the toolchain on sourceforge.net is not named beta

_Motivation:_ DS3018x, FS1018 support DSM 6.2 only.
_Linked issues:_ #3041

### Checklist
- [x] Build rule `all-supported` completed successfully (umurmur)
- [n/a] Package upgrade completed successfully
- [x] New installation of package completed successfully (umurmur)
