### PR TITLE
add kvmx64 arch (DSM 6.1 toolchain and kernel)

### DIFF
--- a/kernel/syno-kvmx64-6.1/Makefile
+++ b/kernel/syno-kvmx64-6.1/Makefile
@@ -1,0 +1,16 @@
+ARCH ?= kvmx64
+TCVERSION ?= 6.1
+PKG_NAME = kvmx64
+PKG_BRANCH = 15152
+PKG_ARCH = $(PKG_NAME)
+PKG_EXT = txz
+PKG_DIST_NAME = linux-4.4.x.$(PKG_EXT)
+PKG_DIST_SITE = http://downloads.sourceforge.net/project/dsgpl/Synology%20NAS%20GPL%20Source/$(PKG_BRANCH)branch/$(PKG_ARCH)-source
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_DIST_NAME)
+PKG_EXTRACT = linux-4.4.x
+SYNO_CONFIG = synoconfigs/$(ARCH)
+BASE_ARCH = x86
+
+HOMEPAGE = http://www.synology.com/
+
+include ../../mk/spksrc.kernel-modules.mk

--- a/kernel/syno-kvmx64-6.1/digests
+++ b/kernel/syno-kvmx64-6.1/digests
@@ -1,0 +1,3 @@
+kvmx64-linux-4.4.x.txz SHA1 376354113b65aa410fce404853898dbc53e7affc
+kvmx64-linux-4.4.x.txz SHA256 1fac97d6791de43166adee13c82c521e4c25cb06f9cedc4e620976c963653f09
+kvmx64-linux-4.4.x.txz MD5 e54ec71fa4e475d99cc9d701ea30e07c

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -39,7 +39,7 @@ ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq
 x86_ARCHES = evansport
-x64_ARCHES = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley kvm64 x86 x64 x86_64
+x64_ARCHES = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley kvmx64 x86 x64 x86_64
 
 # Load local configuration
 LOCAL_CONFIG_MK = ../../local.mk

--- a/toolchains/syno-kvmx64-6.1/Makefile
+++ b/toolchains/syno-kvmx64-6.1/Makefile
@@ -1,13 +1,13 @@
-TC_NAME = syno-x64
+TC_NAME = syno-$(TC_ARCH)
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton grantley kvmx64 x86 x86_64
-TC_VERS = 5.2
-TC_FIRMWARE = 5.0-4458
+TC_ARCH = kvmx64
+TC_VERS = 6.1
+TC_FIRMWARE = 6.1-15047
 
-TC_DIST_NAME = x64-gcc473_glibc217_x86_64-GPL.txz
-
+TC_DIST = kvmx64-gcc493_glibc220_linaro_x86_64-GPL
 TC_EXT = txz
-TC_DIST_SITE = http://sourceforge.net/projects/dsgpl/files/DSM%205.2%20Tool%20Chains/Intel%20x86%20Linux%203.2.40%20%28Pineview%29
+TC_DIST_NAME = $(TC_DIST).$(TC_EXT)
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/DSM%206.1%20Tool%20Chains/Intel%20x86%20Linux%203.10.102%20%28Kvmx64%29/
 
 TC_BASE_DIR = x86_64-pc-linux-gnu
 TC_PREFIX = x86_64-pc-linux-gnu
@@ -25,4 +25,4 @@ include ../../mk/spksrc.tc.mk
 .PHONY: myFix
 myFix:
 	chmod -R u+w $(WORK_DIR)
-	@find $(WORK_DIR)/$(TC_BASE_DIR) -type f -name '*.la' -exec sed -i -e "s|^libdir=.*$$|libdir='$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/lib'|" {} \;
+	@find $(WORK_DIR)/$(TC_BASE_DIR) -type f -name '*.la' -exec sed -i -e "s|^libdir=.*$$|libdir='$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/lib'|" {} \;

--- a/toolchains/syno-kvmx64-6.1/digests
+++ b/toolchains/syno-kvmx64-6.1/digests
@@ -1,0 +1,3 @@
+kvmx64-gcc493_glibc220_linaro_x86_64-GPL.txz SHA1 3e8b9de2defa851778b081a6f2c4e61b94503a5d
+kvmx64-gcc493_glibc220_linaro_x86_64-GPL.txz SHA256 85c0c0c1b3079368a81fcafb838d7a02f25cd74d91c93805ffe4fec27969e71c
+kvmx64-gcc493_glibc220_linaro_x86_64-GPL.txz MD5 ecd3308e49f18343747b2601cd2a2198

--- a/toolchains/syno-x64-6.1/Makefile
+++ b/toolchains/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton grantley x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton grantley kvmx64 x86 x86_64
 TC_VERS = 6.1
 TC_FIRMWARE = 6.1-15047
 


### PR DESCRIPTION
_Motivation:_ Synology Virtual DSM is not yet supported by SynoCommunity
_Linked issues:_ #3142

As commented in #3142, synology names the arch of Virtual DSM kvmx64 (fixed in mk/spksrc.common.mk)
Maybe the synology DSM package manager is not yet ready for this...

### Checklist
- [x] Build rule `all-supported` completed successfully
- [n/a] Package upgrade completed successfully
- [ ] New installation of package completed successfully: TODO @rheckly

TODO:
- Test kvmx64 arch with DSM package manager

