### PR TITLE
Remove references to deprecated arch 88f5281

### DIFF
--- a/cross/alsa-lib/Makefile
+++ b/cross/alsa-lib/Makefile
@@ -13,7 +13,7 @@ LICENSE  =
 
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --disable-python
-ifeq ($(findstring $(ARCH),88f5281 ppc853x ppc854x),$(ARCH))
+ifeq ($(findstring $(ARCH), ppc853x ppc854x),$(ARCH))
 ADDITIONAL_CFLAGS = -DNO_TLS_PFX
 endif
 

--- a/cross/alsa-lib/patches/001-no-tls-pfx.patch
+++ b/cross/alsa-lib/patches/001-no-tls-pfx.patch
@@ -1,9 +1,9 @@
-# Disable thread for arch 88f5281, ppc853x and ppc854x
+# Disable thread for arch ppc853x and ppc854x
 --- src/error.c.orig	2014-06-17 14:34:19.000000000 +0200
 +++ src/error.c	2014-09-05 13:51:20.249180589 +0200
 @@ -61,7 +61,7 @@
  }
- 
+
  #ifndef DOC_HIDDEN
 -#ifdef HAVE___THREAD
 +#if defined(HAVE___THREAD) && !defined(NO_TLS_PFX)

--- a/cross/bison/Makefile
+++ b/cross/bison/Makefile
@@ -12,7 +12,7 @@ COMMENT  = General-purpose parser generator
 LICENSE  = GNU GPL
 
 GNU_CONFIGURE = 1
-ifeq ($(findstring $(ARCH),88f5281 powerpc ppc824x ppc853x ppc854x),$(ARCH))
+ifeq ($(findstring $(ARCH), powerpc ppc824x ppc853x ppc854x),$(ARCH))
 CONFIGURE_ARGS = gl_cv_func_signbit_gcc=no
 endif
 

--- a/cross/erlang/Makefile
+++ b/cross/erlang/Makefile
@@ -11,17 +11,18 @@ HOMEPAGE = http://www.erlang.org
 COMMENT  = Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability.
 LICENSE  = Erlang Public License
 
+# Get arch-defs now
+include ../../mk/spksrc.cross-cc.mk
+
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS += --with-ssl=$(STAGING_INSTALL_PREFIX) erl_xcomp_sysroot=$(INSTALL_DIR)
-ifeq ($(findstring $(ARCH),88f5281 88f6281),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
 CONFIGURE_ARGS += --disable-smp-require-native-atomics
 endif
 
 INSTALL_TARGET = myInstall
 
 ENV += PATH=$(WORK_DIR)/../../../native/$(PKG_NAME)/work-native/install/usr/local/bin:$$PATH
-
-include ../../mk/spksrc.cross-cc.mk
 
 .PHONY: myInstall
 myInstall:

--- a/cross/gmp/Makefile
+++ b/cross/gmp/Makefile
@@ -11,10 +11,9 @@ HOMEPAGE = http://gmplib.org/
 COMMENT  = GMP is a free library for arbitrary precision arithmetic, operating on signed integers, rational numbers, and floating point numbers
 LICENSE  = LGPL
 
-GNU_CONFIGURE = 1
-ifeq ($(findstring $(ARCH),88f5281 88f6281),$(ARCH))
-CONFIGURE_ARGS = --disable-assembly
-endif
-
 include ../../mk/spksrc.cross-cc.mk
 
+GNU_CONFIGURE = 1
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --disable-assembly
+endif

--- a/cross/gnutls/Makefile
+++ b/cross/gnutls/Makefile
@@ -14,8 +14,5 @@ LICENSE  = LGPL
 
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --disable-doc --without-p11-kit --disable-nls gl_cv_func_gettimeofday_clobber=no gl_cv_func_signbit_gcc=no
-ifeq ($(findstring $(ARCH),88f5281),$(ARCH))
-CONFIGURE_ARGS += gl_cv_socket_ipv6=no
-endif
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/libxml2/Makefile
+++ b/cross/libxml2/Makefile
@@ -14,10 +14,6 @@ LICENSE  = MIT
 CONFIGURE_ARGS = --without-python --with-zlib=$(STAGING_INSTALL_PREFIX)
 GNU_CONFIGURE = 1
 ADDITIONAL_CFLAGS = -O3
-ifeq ($(findstring $(ARCH),88f5281),$(ARCH))
-ADDITIONAL_CFLAGS = -O2
-endif
-
 POST_INSTALL_TARGET = myPostInstall
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/lxml/Makefile
+++ b/cross/lxml/Makefile
@@ -13,8 +13,5 @@ LICENSE  = BSD
 
 BUILD_ARGS = --with-xslt-config=$(STAGING_INSTALL_PREFIX)/bin/xslt-config
 ADDITIONAL_CFLAGS = -I $(STAGING_INSTALL_PREFIX)/include/libxml2
-ifeq ($(findstring $(ARCH),88f5281),$(ARCH))
-ADDITIONAL_CFLAGS += -O1
-endif
 
 include ../../mk/spksrc.python-wheel.mk

--- a/cross/nettle/Makefile
+++ b/cross/nettle/Makefile
@@ -11,11 +11,10 @@ HOMEPAGE = http://www.lysator.liu.se/~nisse/nettle/
 COMMENT  = Nettle is a cryptographic library that is designed to fit easily in more or less any context
 LICENSE  = GPLv2
 
-GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --enable-shared
-ifeq ($(findstring $(ARCH),88f5281 88f6281),$(ARCH))
-CONFIGURE_ARGS += --disable-assembler
-endif
-
 include ../../mk/spksrc.cross-cc.mk
 
+GNU_CONFIGURE = 1
+CONFIGURE_ARGS = --enable-shared
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS += --disable-assembler
+endif

--- a/cross/rtorrent/Makefile
+++ b/cross/rtorrent/Makefile
@@ -6,7 +6,7 @@ PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/rakshasa/rtorrent/archive
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-UNSUPPORTED_ARCHS = 88f5281 powerpc ppc824x ppc854x
+UNSUPPORTED_ARCHS = powerpc ppc824x ppc854x
 
 DEPENDS = cross/ncurses cross/libsigc++ cross/curl cross/libtorrent-rakshasa cross/xmlrpc-c
 
@@ -26,7 +26,7 @@ include ../../mk/spksrc.cross-cc.mk
 .PHONY: myPreConfigure
 myPreConfigure:
 	cp src/linux-atomic.c $(WORK_DIR)/$(PKG_DIR)/src
-	
+
 .PHONY: myPrePatch
 myPrePatch:
 	@$(RUN) ./autogen.sh

--- a/cross/syncthing-inotify/Makefile
+++ b/cross/syncthing-inotify/Makefile
@@ -22,16 +22,19 @@ CGO_ENABLED=0
 # set this to 1 to create static linked binaries
 STATIC_BINARIES = 0
 
+# Need arch-defs now
+include ../../mk/spksrc.cross-cc.mk
+
 # Define SYNCTHING_INOTIFY_ARCH as per Syncthing standards
-ifeq ($(findstring $(ARCH),88f5281 88f6281 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
 SYNCTHING_INOTIFY_ARCH = arm
 ENV += GOARM=5
 endif
-ifeq ($(findstring $(ARCH),evansport),$(ARCH))
+ifeq ($(findstring $(ARCH), $(x86_ARCHES)),$(ARCH))
 SYNCTHING_INOTIFY_ARCH = 386
 ENV += GO386=387
 endif
-ifeq ($(findstring $(ARCH),avoton braswell bromolow cedarview x86 x64),$(ARCH))
+ifeq ($(findstring $(ARCH), $(x64_ARCHES)),$(ARCH))
 SYNCTHING_INOTIFY_ARCH = amd64
 endif
 ifeq ($(SYNCTHING_INOTIFY_ARCH),)
@@ -40,8 +43,6 @@ endif
 
 SYNCTHING_INOTIFY_DIR = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERS)
 EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)
-
-include ../../mk/spksrc.cross-cc.mk
 
 # use workdir as gopath
 ENV += GOPATH=$(WORK_DIR)

--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -21,15 +21,18 @@ CGO_ENABLED=0
 # set this to 1 to create static linked binaries
 STATIC_BINARIES = 0
 
+# Need arch-defs now
+include ../../mk/spksrc.cross-cc.mk
+
 # Define SYNCTHING_ARCH as per Syncthing standards
-ifeq ($(findstring $(ARCH),88f5281 88f6281 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM_ARCHES)),$(ARCH))
 SYNCTHING_ARCH = arm
 ENV += GOARM=5
 endif
-ifeq ($(findstring $(ARCH),evansport),$(ARCH))
+ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
 SYNCTHING_ARCH = 386
 endif
-ifeq ($(findstring $(ARCH),avoton braswell bromolow cedarview x86 x64),$(ARCH))
+ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
 SYNCTHING_ARCH = amd64
 endif
 ifeq ($(SYNCTHING_ARCH),)
@@ -39,8 +42,6 @@ endif
 SYNCTHING_DIR = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)
 EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)
 SYNCTHING_BIN = $(WORK_DIR)/src/github.com/$(PKG_NAME)/$(PKG_NAME)/syncthing
-
-include ../../mk/spksrc.cross-cc.mk
 
 # use workdir as gopath
 ENV += GOPATH=$(WORK_DIR)

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -25,7 +25,7 @@ AVAILABLE_TCS = $(notdir $(wildcard ../../toolchains/syno-*))
 AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))
 
 # Toolchain filters
-SUPPORTED_ARCHS = $(sort $(filter-out 88f5281% powerpc% ppc824% ppc854x%, $(AVAILABLE_ARCHS)))
+SUPPORTED_ARCHS = $(sort $(filter-out powerpc% ppc824% ppc854x%, $(AVAILABLE_ARCHS)))
 LEGACY_ARCHS = $(sort $(filter-out $(SUPPORTED_ARCHS), $(AVAILABLE_ARCHS)))
 
 # Use x64 when kernels are not needed
@@ -33,7 +33,7 @@ ARCHS_NO_KRNLSUPP = $(filter-out x64%, $(SUPPORTED_ARCHS))
 ARCHS_DUPES = $(filter-out avoton% braswell% broadwell% bromolow% cedarview% grantley% x86%, $(SUPPORTED_ARCHS))
 
 # Available Arches
-ARM5_ARCHES = 88f5281 88f6281
+ARM5_ARCHES = 88f6281
 ARM7_ARCHES = alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535
 ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -4,8 +4,6 @@ SPK_REV = 3
 SPK_ICON = src/ffsync.png
 BETA = 1
 
-UNSUPPORTED_ARCHS = 88f5281
-
 BUILD_DEPENDS = cross/python cross/setuptools cross/pip cross/wheel
 BUILD_DEPENDS += cross/gevent cross/greenlet
 

--- a/spk/lirc/Makefile
+++ b/spk/lirc/Makefile
@@ -7,7 +7,7 @@ FIRMWARE = 4.3-3776
 LIRC_SUPPORTED_DRIVERS =
 
 # Abort for ARCHs that won't compile LIRC cleanly
-ifneq ($(findstring $(ARCH),powerpc 88f5281),)
+ifneq ($(findstring $(ARCH),powerpc),)
 $(error Sorry, this package does not support the $(ARCH) architecture)
 endif
 
@@ -15,7 +15,7 @@ endif
 include ../../mk/spksrc.common.mk
 
 # Use older LIRC build for ARCHs with kernel < 2.6.36
-ifneq ($(findstring $(ARCH),88f6281 $(PPC_ARCHES)),)
+ifneq ($(findstring $(ARCH), $(ARM5_ARCHES) $(PPC_ARCHES)),)
 SPK_VERS = 0.8.7
 LIRC_SUPPORTED_DRIVERS = mceusb uirt uirt2
 endif


### PR DESCRIPTION
The `88f5281` arch was depcreated a while ago, now all reference to it can be removed.
Also replaced some arch-specific selections to the definitions from `*_ARCHS`.

@ymartin59: I was added to the SynoCommunity group by @Diaoul (to my surprise). Will try to contain my desires to just commit-commit-commit and use the PR's to get double checks! I might close some issues, since I really like cleaning 🥇 