### PR TITLE
Add set_unix_permissions and syno_user_add_to_legacy_group

### DIFF
--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -124,10 +124,15 @@ set_syno_permissions ()
 
     # Ensure directory resides in /volumeX before setting GROUP permissions
     if [ "`echo ${VOLUME} | cut -c2-7`" = "volume" ]; then
-        echo "Granting '${GROUP}' group permissions on ${DIRNAME}" >> ${INST_LOG}
-
         # Set read/write permissions for GROUP for folder and subfolders
         if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:rwxpdDaARWcC-:fd--\"`" ]; then
+            # First Unix permissions, but only if it's in Linux mode
+            if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
+                set_unix_permissions "${DIRNAME}"
+            fi
+
+            # Then fix the Synology permissions
+            echo "Granting '${GROUP}' group permissions on ${DIRNAME}" >> ${INST_LOG}
             synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
             find "${DIRNAME}" -type d -exec synoacltool -enforce-inherit "{}" \; >> ${INST_LOG} 2>&1
         fi
@@ -144,6 +149,39 @@ set_syno_permissions ()
         echo "Skip granting '${GROUP}' group permissions on ${DIRNAME} as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}
     fi
 }
+
+# Sets recurivse permissions using chown
+set_unix_permissions ()
+{
+    DIRNAME=$1
+    echo "Granting '${EFF_USER}' unix permissions on ${DIRNAME}" >> ${INST_LOG}
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+        chown -R ${EFF_USER}:root "${DIRNAME}" >> $INST_LOG 2>&1
+    else
+        chown -R ${EFF_USER}:${USER} "${DIRNAME}" >> $INST_LOG 2>&1
+    fi
+}
+
+# If package was moved to new group, we need to add the new package user
+# also to the old group. Only if the legacy user was in the old group.
+# Usage: syno_user_add_to_legacy_group "${NEW_USER}" "${LEGACY_USER}" "${LEGACY_GROUP}"
+syno_user_add_to_legacy_group () {
+    NEW_USER=$1
+    LEGACY_USER=$2
+    LEGACY_GROUP=$3
+
+    # Check if user in old group
+    if synogroup --get "$LEGACY_GROUP" | grep "^[0-9]:\[${LEGACY_USER}\]" &> /dev/null; then
+        # Add new user and remove old one
+        echo "Adding '${NEW_USER}' to '${LEGACY_GROUP}' for backwards compatibility" >> ${INST_LOG}
+        MEMBERS="$(synogroup --get $LEGACY_GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
+        MEMBERS=${MEMBERS//$LEGACY_USER}
+        # The "synogroup --member" command clears all users before adding new ones
+        # so all the users must be listed on the command line
+        synogroup --member "$LEGACY_GROUP" $MEMBERS "${NEW_USER}" >> ${INST_LOG}
+    fi
+}
+
 
 ### Generic package behaviors
 
@@ -197,8 +235,9 @@ postinst ()
         fi
         if synogroup --get "$GROUP" &> /dev/null; then
             # Check user already in group
-            if ! synogroup --get "$GROUP" | grep '^[0-9]:\[${EFF_USER}\]' &> /dev/null; then
+            if ! synogroup --get "$GROUP" | grep "^[0-9]:\[${EFF_USER}\]" &> /dev/null; then
                 # Add user, not in group yet
+                echo "Adding '${EFF_USER}' to '${GROUP}'" >> ${INST_LOG}
                 MEMBERS="$(synogroup --get $GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
                 # The "synogroup --member" command clears all users before adding new ones
                 # so all the users must be listed on the command line
@@ -214,7 +253,7 @@ postinst ()
         echo "Configuring ${SHARE_PATH}" >> ${INST_LOG}
         # Create share if does not exist
         #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
-        if ! synoshare --get "${SHARE_NAME}"  &> /dev/null ; then
+        if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
             synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG}
         fi
 
@@ -313,11 +352,7 @@ postupgrade ()
     $CP "${TMP_DIR}"/. "${INST_VAR}" >> ${INST_LOG}
 
     # Correct permissions of var folder
-    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
-        chown -R ${EFF_USER}:root "${INST_VAR}" >> $INST_LOG 2>&1
-    else
-        chown -R ${EFF_USER}:${USER} "${INST_VAR}" >> $INST_LOG 2>&1
-    fi
+    set_unix_permissions "${INST_VAR}"
 
     call_func "service_restore"
 

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -93,23 +93,27 @@ syno_remove_user ()
 syno_group_create ()
 {
     EFF_USER=$1
-    echo "Creating group ${GROUP}" >> ${INST_LOG}
-    # Create syno group
-    synogroup --add "${GROUP}" "${EFF_USER}" >> ${INST_LOG}
-    # Set description of the syno group
-    synogroup --descset "${GROUP}" "${GROUP_DESC}" >> ${INST_LOG}
+    if [ -n "${EFF_USER}" ]; then
+        echo "Creating group ${GROUP}" >> ${INST_LOG}
+        # Create syno group
+        synogroup --add "${GROUP}" "${EFF_USER}" >> ${INST_LOG}
+        # Set description of the syno group
+        synogroup --descset "${GROUP}" "${GROUP_DESC}" >> ${INST_LOG}
+    fi
 }
 
 # Delete syno group if empty
 syno_group_remove ()
 {
     RM_GROUP=$1
-    # Check if syno group is empty
-    if ! synogroup --get "${RM_GROUP}" | grep -q "0:\["; then
-        echo "Removing group ${RM_GROUP}" >> ${INST_LOG}
-        # Remove syno group
-        synogroup --del "${RM_GROUP}" >> ${INST_LOG} 2>&1
-        synogroup --rebuild all
+    if [ -n "${RM_GROUP}" ]; then
+        # Check if syno group is empty
+        if ! synogroup --get "${RM_GROUP}" | grep -q "0:\["; then
+            echo "Removing group ${RM_GROUP}" >> ${INST_LOG}
+            # Remove syno group
+            synogroup --del "${RM_GROUP}" >> ${INST_LOG} 2>&1
+            synogroup --rebuild all
+        fi
     fi
 }
 
@@ -154,11 +158,13 @@ set_syno_permissions ()
 set_unix_permissions ()
 {
     DIRNAME=$1
-    echo "Granting '${EFF_USER}' unix permissions on ${DIRNAME}" >> ${INST_LOG}
-    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
-        chown -R ${EFF_USER}:root "${DIRNAME}" >> $INST_LOG 2>&1
-    else
-        chown -R ${EFF_USER}:${USER} "${DIRNAME}" >> $INST_LOG 2>&1
+    if [ -n "${EFF_USER}" ]; then
+        echo "Granting '${EFF_USER}' unix permissions on ${DIRNAME}" >> ${INST_LOG}
+        if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+            chown -R ${EFF_USER}:root "${DIRNAME}" >> $INST_LOG 2>&1
+        else
+            chown -R ${EFF_USER}:${USER} "${DIRNAME}" >> $INST_LOG 2>&1
+        fi
     fi
 }
 
@@ -216,7 +222,7 @@ postinst ()
     fi
 
     # DSM 5 specific operations
-    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ] && [ -n "${EFF_USER}" ]; then
         # Create prefixed synouser
         if ! cat /etc/passwd | grep "${EFF_USER}:x:" &> /dev/null; then
             synouser --add "${EFF_USER}" "" "$USER_DESC" 0 "" 0 >> ${INST_LOG} 2>&1
@@ -259,7 +265,7 @@ postinst ()
 
         # Add user permission if no GROUP is set in UI
         # GROUP permission will be added in set_syno_permissions
-        if [ ! -n "$GROUP" ]; then
+        if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
             synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
         fi
         synoshare --build
@@ -282,10 +288,10 @@ postinst ()
     fi
     if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
         # On DSM 5 set package files permissions
-        chown -R ${EFF_USER}:root "${SYNOPKG_PKGDEST}" >> ${INST_LOG} 2>&1
+        set_unix_permissions "${SYNOPKG_PKGDEST}"
     else
         # On DSM 6 only var is concerned
-        chown -R ${EFF_USER}:${USER} "${INST_VAR}" >> ${INST_LOG} 2>&1
+        set_unix_permissions "${INST_VAR}"
     fi
     exit 0
 }
@@ -315,9 +321,8 @@ postuninst ()
         $RM "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG}
 
         # Remove syno group if empty
-        if [ -n "${GROUP}" ]; then
-            syno_group_remove "${GROUP}"
-        fi
+        syno_group_remove "${GROUP}"
+
         # Remove user
         syno_remove_user "${EFF_USER}"
     fi

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -272,8 +272,10 @@ postinst ()
         fi
     fi
 
-    call_func "service_postinst"
     $MKDIR "${INST_VAR}"
+
+    call_func "service_postinst"
+
     $CP "${INST_LOG}" "${INST_VAR}"
     if [ -n "${LOG_FILE}" ]; then
         echo "Installation log: ${INST_VAR}/${SYNOPKG_PKGNAME}_install.log" >> ${LOG_FILE}

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -59,7 +59,7 @@ TEE="/usr/bin/tee -a"
 log_step ()
 {
     date >> ${INST_LOG}
-    echo "Step $1. USER=$USER GROUP=$GROUP SHARE_PATH=${SHARE_PATH}" >> ${INST_LOG}
+    echo "===> Step $1. USER=$USER GROUP=$GROUP SHARE_PATH=${SHARE_PATH}" >> ${INST_LOG}
 }
 
 save_wizard_variables ()


### PR DESCRIPTION
Support functions needed to:
- Correct permissions on folders during upgrade in Linux mode.
- For transfer for download-related packages from 'sc-media' to 'sc-download'

@ymartin59 This separate PR to keep package PR's clean. But all my other PR's kind of depend on it.
After this is merged, I can rebase #3092 #3153 #3053 on `master` after that so they are package-only.
