### PR TITLE
Add permissions for "administrators" group to Linux-permissions folders

### DIFF
--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -144,6 +144,12 @@ set_syno_permissions ()
         # Walk up the tree and set traverse execute permissions for GROUP up to VOLUME
         while [ "${DIRNAME}" != "${VOLUME}" ]; do
             if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:..x\"`" ]; then
+                # If it is linux mode (due to old package) we need to add "administrators"-group,
+                # otherwise the folder is not accessible from File Station anymore!
+                if [ "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
+                    synoacltool -add "${DIRNAME}" "group:administrators:allow:rwxpdDaARWc--:fd--" >> ${INST_LOG} 2>&1
+                fi
+                # Add the new group permissions
                 echo "Granting '${GROUP}' group basic permissions on ${DIRNAME}" >> ${INST_LOG}
                 synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:--x----------:---n" >> ${INST_LOG} 2>&1
             fi


### PR DESCRIPTION
Doing the extensive testing of the new packages I found another problem:
For some reason on DSM5.2 running and using the old-style-package results in a mix of Linux permissions ~~(due to being run as a non-Synology-user maybe?)~~ (see below) and the dropping of ACL permissions:
```
DSM52> synoacltool -get "/volume1/sabtest5"
(synoacltool.c, 350)It's Linux mode
DSM52> ls -al /volume1
drwxrwx---    4 root     users         4096 Feb 23 10:42 sabtest5
```
As mentioned before, using `synoacltool` on folders that used to have Linux permissions causes them to get `000` permissions.
So when we run `set_syno_permissions` on `/volume1/sabtest5/incomplete` (extracted from SABnzbd's config) during the new-style update , this happens:
```
DSM52> synoacltool -get "/volume1/sabtest5"
ACL version: 1
Archive: has_ACL,is_support_ACL
Owner: [svc-sabnzbd(user)]
---------------------
         [0] group:sc-download:allow:--x----------:---n  (level:0)
DSM52> ls -al /volume1
d---------    4 root     users         4096 Feb 23 10:13 sabtest5
```
And.. the shared folder disappears from File Station and cannot be accessed by the user anymore 😨 

I tried for example to first apply `set_unix_permissions` before this, but it doesn't work. In that case I also tried to use `${EFF_USER}:users` instead of `${EFF_USER}:root`. No luck.

So this is the only thing I could come up with: 
Give the `administrators` group the same rights as given when creating a new share. This works very well on DSM5.2 and also 6.
