### PR TITLE
Add support for parallel make compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ local.mk:
 	@echo "DISTRIBUTOR_URL=" >> $@
 	@echo "REPORT_URL=" >> $@
 	@echo "DEFAULT_TC=" >> $@
+	@echo "#PARALLEL_MAKE=max" >> $@
 
 dsm-%: local.mk
 	@echo "Setting default toolchain version to DSM-$*"

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -48,3 +48,15 @@ LOCAL_CONFIG_MK = ../../local.mk
 ifneq ($(wildcard $(LOCAL_CONFIG_MK)),)
 include $(LOCAL_CONFIG_MK)
 endif
+
+# Relocate to set conditionally according to existing parallel options in caller
+ifneq ($(PARALLEL_MAKE),)
+ifeq ($(PARALLEL_MAKE),max)
+NCPUS = $(shell grep -c ^processor /proc/cpuinfo)
+else
+NCPUS = $(PARALLEL_MAKE)
+endif
+ifeq ($(filter $(NCPUS),0 1),)
+COMPILE_MAKE_OPTIONS = -j$(NCPUS)
+endif
+endif

--- a/mk/spksrc.compile.mk
+++ b/mk/spksrc.compile.mk
@@ -1,5 +1,5 @@
 ### Compile rules
-#   Invoke make to (cross-) compile the software. 
+#   Invoke make to (cross-) compile the software.
 # Target are executed in the following order:
 #  compile_msg_target
 #  pre_compile_target   (override with PRE_COMPILE_TARGET)
@@ -32,8 +32,8 @@ compile_msg:
 
 pre_compile_target: compile_msg
 
-compile_target:  $(PRE_COMPILE_TARGET) 
-	@$(RUN) $(MAKE)
+compile_target:  $(PRE_COMPILE_TARGET)
+	@$(RUN) $(MAKE) $(COMPILE_MAKE_OPTIONS)
 
 post_compile_target: $(COMPILE_TARGET)
 

--- a/mk/spksrc.cross-env.mk
+++ b/mk/spksrc.cross-env.mk
@@ -25,3 +25,7 @@ $(TC_VARS_MK):
 ENV += TC=$(TC)
 ENV += $(TC_ENV)
 endif
+
+#ifneq ($(COMPILE_MAKE_OPTIONS),)
+#ENV += MAKEFLAGS="$(COMPILE_MAKE_OPTIONS)"
+#endif

--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -29,7 +29,15 @@ endif
 STAGING_DIR = $(WORK_DIR)/staging
 
 ifndef INSTALL_PREFIX
+ifneq ($(strip $(SPK_NAME)),)
 INSTALL_PREFIX = /var/packages/$(SPK_NAME)/target
+else
+ifneq ($(strip $(PKG_NAME)),)
+INSTALL_PREFIX = /usr/local/$(PKG_NAME)
+else
+INSTALL_PREFIX = /usr/local
+endif
+endif
 endif
 
 ifndef KERNEL_DIR


### PR DESCRIPTION
_Motivation:_ when building package for a single architecture, top level `-jX` option is useless
_Linked issues:_ #49 

### Tests
- [X] FFmpeg
- [X] Mono
- [ ] Python
- [ ] ...