### PR TITLE
improve icon generation

### DIFF
--- a/mk/spksrc.icon.mk
+++ b/mk/spksrc.icon.mk
@@ -42,7 +42,7 @@ pre_icon_target: icon_msg
 $(ICON_DIR): $(PRE_ICON_TARGET)
 	@mkdir -p $@
 	@for size in 16 24 32 48 64 72 256; do \
-	  convert $(SPK_ICON) -thumbnail $${size}x$${size} \
+	  convert $(SPK_ICON) -thumbnail $${size}x$${size} -strip \
 	          $@/$(SPK_NAME)-$${size}.png ; \
 	done ; \
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -260,9 +260,9 @@ icons:
 ifneq ($(strip $(SPK_ICON)),)
 	$(create_target_dir)
 	@$(MSG) "Creating PACKAGE_ICON.PNG for $(SPK_NAME)"
-	(convert $(SPK_ICON) -thumbnail 72x72 - > $(WORK_DIR)/PACKAGE_ICON.PNG)
+	(convert $(SPK_ICON) -thumbnail 72x72 -strip - > $(WORK_DIR)/PACKAGE_ICON.PNG)
 	@$(MSG) "Creating PACKAGE_ICON_256.PNG for $(SPK_NAME)"
-	(convert $(SPK_ICON) -thumbnail 256x256 - > $(WORK_DIR)/PACKAGE_ICON_256.PNG)
+	(convert $(SPK_ICON) -thumbnail 256x256 -strip - > $(WORK_DIR)/PACKAGE_ICON_256.PNG)
 	$(eval SPK_CONTENT +=  PACKAGE_ICON.PNG PACKAGE_ICON_256.PNG)
 endif
 

--- a/spk/squidguard/Makefile
+++ b/spk/squidguard/Makefile
@@ -52,7 +52,7 @@ xz-compress:
 	install -m 644 src/app/blocked.gif $(STAGING_DIR)/share/www/squidguardmgr/
 	for size in 16 24 32 48 72 ; \
 	do \
-	    convert $(SPK_ICON) -thumbnail $${size}x$${size} -transparent white \
+	    convert $(SPK_ICON) -thumbnail $${size}x$${size} -transparent white -strip \
 	            $(STAGING_DIR)/share/www/squidguardmgr/images/icon$${size}.png ; \
 	done	
 	chmod 644 $(STAGING_DIR)/share/www/squidguardmgr/images/i*.png

--- a/spk/wallabag/Makefile
+++ b/spk/wallabag/Makefile
@@ -42,8 +42,3 @@ wallabag_extra_install:
 	install -m 644 src/parameters.yml $(STAGING_DIR)/share/${SPK_NAME}/app/config/parameters.yml
 	install -m 755 -d $(STAGING_DIR)/app
 	install -m 644 src/app/config $(STAGING_DIR)/app/config
-	install -m 755 -d $(STAGING_DIR)/app/images
-	for size in 16 24 32 48 72; do \
-		convert $(SPK_ICON) -thumbnail $${size}x$${size} \
-			$(STAGING_DIR)/app/images/$(SPK_NAME)-$${size}.png ; \
-	done


### PR DESCRIPTION
_Motivation:_ Each time a package is built, it is binary different.

I figured out, that the only difference in the packages is the content of the icons generated with convert.
The icons differ in metadata only (creation datetime).
With the option -strip the metadata is removed from the images. Unfortunately this works with newer versions of convert only.
The current spksrc Docker image based on jessie comes with convert based on imagemagick 6.8.9-9 and this version does not strip.
With an updated Docker image based on stretch and with convert based on imagemagick 6.9.7 icons are stripped as expected.