### PR TITLE
Correct logging redirection

### DIFF
--- a/mk/spksrc.service.start-stop-daemon
+++ b/mk/spksrc.service.start-stop-daemon
@@ -54,6 +54,7 @@ wait_for_status ()
     return 1
 }
 
+
 case $1 in
     start)
         if daemon_status; then
@@ -86,7 +87,12 @@ case $1 in
         ;;
     log)
         if [ -n "${LOG_FILE}" -a -r "${LOG_FILE}" ]; then
-            echo "${LOG_FILE}"
+            # Shorten long logs to last 100 lines
+            TEMP_LOG_FILE="${SYNOPKG_PKGDEST}/var/${SYNOPKG_PKGNAME}_temp.log"
+            # Clear any previous log
+            echo "Full log: ${LOG_FILE}" > "${TEMP_LOG_FILE}"
+            tail -n100 "${LOG_FILE}" >> "${TEMP_LOG_FILE}"
+            echo "${TEMP_LOG_FILE}"
         fi
         exit 0
         ;;

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -131,7 +131,12 @@ case $1 in
         ;;
     log)
         if [ -n "${LOG_FILE}" -a -r "${LOG_FILE}" ]; then
-            echo "${LOG_FILE}"
+            # Shorten long logs to last 100 lines
+            TEMP_LOG_FILE="${SYNOPKG_PKGDEST}/var/${SYNOPKG_PKGNAME}_temp.log"
+            # Clear any previous log
+            echo "Full log: ${LOG_FILE}" > "${TEMP_LOG_FILE}"
+            tail -n100 "${LOG_FILE}" >> "${TEMP_LOG_FILE}"
+            echo "${TEMP_LOG_FILE}"
         fi
         exit 0
         ;;

--- a/spk/couchpotatoserver-custom/src/service-setup.sh
+++ b/spk/couchpotatoserver-custom/src/service-setup.sh
@@ -6,6 +6,7 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 GIT="${GIT_DIR}/bin/git"
 COUCHPOTATOSERVER="${SYNOPKG_PKGDEST}/var/CouchPotatoServer/CouchPotato.py"
 CFG_FILE="${SYNOPKG_PKGDEST}/var/settings.conf"
+LOG_FILE="${SYNOPKG_PKGDEST}/var/logs/CouchPotato.log"
 
 GROUP="sc-download"
 LEGACY_GROUP="sc-media"
@@ -30,6 +31,9 @@ service_postinst ()
         # Clone the repository
          ${GIT} clone -q -b ${wizard_fork_branch:=master} ${wizard_fork_url:=git://github.com/CouchPotato/CouchPotatoServer.git} ${SYNOPKG_PKGDEST}/var/CouchPotatoServer >> ${INST_LOG} 2>&1
     fi
+
+    # Create logs directory, otherwise it might not start
+    mkdir "$(dirname ${LOG_FILE})" >> ${INST_LOG} 2>&1
 
     # If nessecary, add user also to the old group
     syno_user_add_to_legacy_group "${EFF_USER}" "${USER}" "${LEGACY_GROUP}"

--- a/spk/couchpotatoserver/src/service-setup.sh
+++ b/spk/couchpotatoserver/src/service-setup.sh
@@ -5,6 +5,7 @@ PYTHON="${SYNOPKG_PKGDEST}/env/bin/python"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 COUCHPOTATOSERVER="${SYNOPKG_PKGDEST}/share/CouchPotatoServer/CouchPotato.py"
 CFG_FILE="${SYNOPKG_PKGDEST}/var/settings.conf"
+LOG_FILE="${SYNOPKG_PKGDEST}/var/logs/CouchPotato.log"
 
 GROUP="sc-download"
 LEGACY_GROUP="sc-media"
@@ -15,6 +16,9 @@ service_postinst ()
 {
     # Create a Python virtualenv
     ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env >> ${INST_LOG} 2>&1
+
+    # Create logs directory, otherwise it might not start
+    mkdir "$(dirname ${LOG_FILE})" >> ${INST_LOG} 2>&1
 
     # If nessecary, add user also to the old group
     syno_user_add_to_legacy_group "${EFF_USER}" "${USER}" "${LEGACY_GROUP}"

--- a/spk/sabnzbd/src/service-setup.sh
+++ b/spk/sabnzbd/src/service-setup.sh
@@ -3,6 +3,7 @@ PATH="${SYNOPKG_PKGDEST}/bin:${SYNOPKG_PKGDEST}/env/bin:${PYTHON_DIR}/bin:${PATH
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 PYTHON="${SYNOPKG_PKGDEST}/env/bin/python"
 SABNZBD="${SYNOPKG_PKGDEST}/share/SABnzbd/SABnzbd.py"
+LOG_FILE="${SYNOPKG_PKGDEST}/var/logs/sabnzbd.log"
 CFG_FILE="${SYNOPKG_PKGDEST}/var/config.ini"
 LANGUAGE="env LANG=en_US.UTF-8"
 
@@ -22,6 +23,9 @@ service_postinst ()
         # Edit the configuration according to the wizard
         sed -i -e "s|@download_dir@|${wizard_download_dir:=/volume1/downloads}|g" ${CFG_FILE}
     fi
+
+    # Create logs directory, otherwise it might not start
+    mkdir "$(dirname ${LOG_FILE})" >> ${INST_LOG} 2>&1
 
     # Discard legacy obsolete busybox user account
     BIN=${SYNOPKG_PKGDEST}/bin

--- a/spk/sickrage/src/service-setup.sh
+++ b/spk/sickrage/src/service-setup.sh
@@ -6,6 +6,7 @@ VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 GIT="${GIT_DIR}/bin/git"
 PYTHON="${SYNOPKG_PKGDEST}/env/bin/python"
 SICKRAGE="${SYNOPKG_PKGDEST}/var/SickRage/SiCKRAGE.py"
+LOG_FILE="${SYNOPKG_PKGDEST}/var/logs/sickrage.log"
 CFG_FILE="${SYNOPKG_PKGDEST}/var/config.ini"
 UPGRADE_CFG_FILE="${TMP_DIR}/config.ini"
 
@@ -40,6 +41,9 @@ service_postinst ()
     cp ${SYNOPKG_PKGDEST}/var/SickRage/sickrage/autoProcessTV/autoProcessTV.cfg.sample ${SYNOPKG_PKGDEST}/var/SickRage/sickrage/autoProcessTV/autoProcessTV.cfg
     chmod 777 ${SYNOPKG_PKGDEST}/var/SickRage/sickrage/autoProcessTV
     chmod 600 ${SYNOPKG_PKGDEST}/var/SickRage/sickrage/autoProcessTV/autoProcessTV.cfg
+
+    # Create logs directory, otherwise it might not start
+    mkdir "$(dirname ${LOG_FILE})" >> ${INST_LOG} 2>&1
 
     # If nessecary, add user also to the old group before removing it
     syno_user_add_to_legacy_group "${EFF_USER}" "${USER}" "${LEGACY_GROUP}"

--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -7,7 +7,7 @@ TRANSMISSION="${SYNOPKG_PKGDEST}/bin/transmission-daemon"
 
 GROUP="sc-download"
 
-SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGDEST}/var/ -x ${PID_FILE}"
+SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGDEST}/var/ -x ${PID_FILE} -e ${LOG_FILE}"
 
 
 service_preinst ()


### PR DESCRIPTION
Due to #3138 I noticed not all packages have correct `LOG_FILE` set and as such users can't get the log from Package Center.
@ymartin59 This includes Transmission, maybe this can go in before you publish?