### PR TITLE
add dockerx64 to generic toolchain

### DIFF
--- a/toolchains/syno-x64-6.1/Makefile
+++ b/toolchains/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton grantley kvmx64 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley kvmx64 x86 x86_64
 TC_VERS = 6.1
 TC_FIRMWARE = 6.1-15047
 


### PR DESCRIPTION
_Motivation:_ dockex64 arch is compatible to syno-x64
_Linked issues:_ #2872

### Checklist (validated with mc, midnight commander)
- [x] Build rule `all-supported` completed successfully 
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

as supposed by @ymartin59 dockex64 arch is compatible to syno-x64
after testing with mc (based on /cross/mc) I saw that the toolchains of syno-x64 and syno-dockerx64 are almost binary the same - only 3 header files (.h) are different and one of them is autogenerated kernel configuration.