### PR TITLE
[Openssl] Fix evansport regression

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -19,12 +19,12 @@ STAGING_INSTALL_PREFIX := $(INSTALL_DIR)
 
 include ../../mk/spksrc.cross-cc.mk
 
-OPENSSL_ARCH = 
+OPENSSL_ARCH =
 ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
 OPENSSL_ARCH = linux-x86_64
 endif
 ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
-OPENSSL_ARCH = linux-x32
+OPENSSL_ARCH = linux-generic32
 endif
 ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
 OPENSSL_ARCH = synology-armle


### PR DESCRIPTION
_Motivation:_ #3218 introduced a regression for the `evansport` platform, breaking compilation 
_Linked issues:_ N/A

### Checklist
- [x] Build rule `evansport-6.1` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
