### PR TITLE
nzbget publish again because of corrupted package

### DIFF
--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbget
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 23
+SPK_REV = 25
 SPK_ICON = src/nzbget.png
 
 DEPENDS = cross/busybox cross/p7zip cross/unrar


### PR DESCRIPTION
Related to #3237 and #3241
