### PR TITLE
Add ipq806x architecture for SRM 1.1

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -34,7 +34,7 @@ ARCHS_DUPES = $(filter-out apollolake% avoton% braswell% broadwell% bromolow% ce
 
 # Available Arches
 ARM5_ARCHES = 88f6281
-ARM7_ARCHES = alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535
+ARM7_ARCHES = alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535 ipq806x
 ARM8_ARCHES = rtd1296
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq

--- a/toolchains/syno-ipq806x-1.1/Makefile
+++ b/toolchains/syno-ipq806x-1.1/Makefile
@@ -1,0 +1,29 @@
+TC_NAME = syno-$(TC_ARCH)
+
+TC_ARCH = ipq806x
+TC_VERS = 1.1
+TC_FIRMWARE = 1.1.6-6931
+
+TC_DIST = gcc493_glibc220_hard-GPL
+TC_EXT = tgz
+TC_DIST_NAME = $(TC_DIST).$(TC_EXT)
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/SRM%201.1%20Tool%20Chains/QUALCOMM%20IPQ806X%20Linux%203.4.103
+
+TC_BASE_DIR = arm-unknown-linux-gnueabi
+TC_PREFIX = arm-unknown-linux-gnueabi
+TC_TARGET = arm-unknown-linux-gnueabi
+
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/usr/include
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/lib
+
+FIX_TARGET = myFix
+
+include ../../mk/spksrc.tc.mk
+
+.PHONY: myFix
+myFix:
+	chmod -R u+w $(WORK_DIR)
+	@find $(WORK_DIR)/$(TC_BASE_DIR) -type f -name '*.la' -exec sed -i -e "s|^libdir=.*$$|libdir='$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sysroot/lib'|" {} \;
+

--- a/toolchains/syno-ipq806x-1.1/digests
+++ b/toolchains/syno-ipq806x-1.1/digests
@@ -1,0 +1,3 @@
+gcc493_glibc220_hard-GPL.tgz SHA1 b7c17c215d773834ab8dff7ab1050ddaea405c55
+gcc493_glibc220_hard-GPL.tgz SHA256 a760d9ecd51ba54dd6689c06e7f4ddc8cb68e4ab984131012a41789fa4b02e13
+gcc493_glibc220_hard-GPL.tgz MD5 8502dbcbbfc72b276a7b8efb2c7701a4


### PR DESCRIPTION
_Motivation:_ Make it easier to get started and build for the RT2600ac Router (ipq806x).
_Related issues:_ #2951

Not sure if this is wanted due to it being listed as [No longer recieving packages updates](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model#models-no-longer-recieving-packages-updates). But I thought a pull request at least gives visibility and can help people if they want to do it themselves.

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [x] New installation of package completed successfully
