### PR TITLE
Fixes for SRM 1.1 and package description

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -76,7 +76,7 @@ ifneq ($(strip $(SPK_USER)),)
 	@echo USER=\"$(SPK_USER)\" >> $@
 	@echo "PRIV_PREFIX=sc-" >> $@
 	@echo "SYNOUSER_PREFIX=svc-" >> $@
-	@echo 'if [ $${SYNOPKG_DSM_VERSION_MAJOR} -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
+	@echo 'if [ -n "$${SYNOPKG_DSM_VERSION_MAJOR}" -a "$${SYNOPKG_DSM_VERSION_MAJOR}" -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
 endif
 ifneq ($(strip $(SERVICE_WIZARD_GROUP)),)
 	@echo "# Group name from UI if provided" >> $@

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -26,7 +26,7 @@ start_daemon ()
         else
             OUT="${LOG_FILE}"
         fi
-        if [ -n "${USER}" -a $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+        if [ -n "${USER}" -a -n "${SYNOPKG_DSM_VERSION_MAJOR}" -a "$SYNOPKG_DSM_VERSION_MAJOR" -lt 6 ]; then
             if [ -z "${SERVICE_SHELL}" ]; then
                 SERVICE_SHELL=/bin/sh
             fi

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -102,7 +102,7 @@ $(WORK_DIR)/INFO:
 	@echo dsmappname=\"com.synocommunity.$(SPK_NAME)\" >> $@
 	@echo thirdparty=\"yes\" >> $@
 	@echo version=\"$(SPK_VERS)-$(SPK_REV)\" >> $@
-	@echo description=\"$(DESCRIPTION)\" >> $@
+	@echo description=\""$(DESCRIPTION)"\" >> $@
 	@echo $(foreach LANGUAGE, $(LANGUAGES), \
 	    $(shell [ ! -z "$(DESCRIPTION_$(shell echo $(LANGUAGE) | tr [:lower:] [:upper:]))" ] && \
 	            echo -n description_$(LANGUAGE)=\\\"$(DESCRIPTION_$(shell echo $(LANGUAGE) | tr [:lower:] [:upper:]))\\\" \


### PR DESCRIPTION
_Motivation:_ These changes where needed to run general service packages on a RT2600ac 
It also allows package descriptions to contain characters that would otherwise be interpreted eg. `(` and `)`. 

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [x] New installation of package completed successfully
