### PR TITLE
Update SABnzbd to 2.3.3

### DIFF
--- a/cross/sabnzbd/Makefile
+++ b/cross/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = SABnzbd
-PKG_VERS = 2.3.2
+PKG_VERS = 2.3.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-src.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/sabnzbd/sabnzbd/releases/download/$(PKG_VERS)

--- a/cross/sabnzbd/digests
+++ b/cross/sabnzbd/digests
@@ -1,3 +1,3 @@
-SABnzbd-2.3.2-src.tar.gz SHA1 27d6257c16ded6d1b4339b46a448f27ee83db55a
-SABnzbd-2.3.2-src.tar.gz SHA256 8a38d3a630aecd71e3cda140828bda8d062c69d6f09ca6246dfb998abffbfb50
-SABnzbd-2.3.2-src.tar.gz MD5 1020709cce35bc69b5dc2a04d9ebde1b
+SABnzbd-2.3.3-src.tar.gz SHA1 c9a6191aa71e4ccc7dbdab342384e86aafde98d8
+SABnzbd-2.3.3-src.tar.gz SHA256 6e40472cb75c2abfdb7d3d1e896fc240aa1293685ff9f0dad976ada9e255ef1b
+SABnzbd-2.3.3-src.tar.gz MD5 785d0208be0dbad6549df1b4afe37f6e

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = sabnzbd
-SPK_VERS = 2.3.2
+SPK_VERS = 2.3.3
 SPK_REV = 34
 SPK_ICON = src/sabnzbd.png
 
@@ -15,7 +15,7 @@ DESCRIPTION_SPN = SABnzbd hace que Usenet sea lo más simple posible, automatiza
 RELOAD_UI = yes
 DISPLAY_NAME = SABnzbd
 STARTABLE = yes
-CHANGELOG = "1) Update SABnzbd to 2.3.2. 2) Update par2cmdline to 0.8.0. 3) Use DSM 5+6 generic service approach for correct permissions."
+CHANGELOG = "1) Update SABnzbd to 2.3.3. 2) Update par2cmdline to 0.8.0. 3) Use DSM 5+6 generic service approach for correct permissions."
 
 HOMEPAGE   = http://sabnzbd.org
 LICENSE    = GPL

--- a/spk/sabnzbd/src/requirements.txt
+++ b/spk/sabnzbd/src/requirements.txt
@@ -1,1 +1,1 @@
-sabyenc==3.3.2
+sabyenc==3.3.5

--- a/spk/sabnzbd/src/wizard/install_uifile
+++ b/spk/sabnzbd/src/wizard/install_uifile
@@ -24,7 +24,7 @@
         "desc": "If the specified share does not exist, it will be created. You can use an existing share by specifying the full path to the folder. Make sure to specify paths to existing shares correctly, for example external USB-drive paths are of the form <em>/volumeUSB1/usbshare</em>."
       },
       {
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
       }
     ]
   }

--- a/spk/sabnzbd/src/wizard/install_uifile_fre
+++ b/spk/sabnzbd/src/wizard/install_uifile_fre
@@ -24,7 +24,7 @@
         "desc": "Si le partage saisi n'existe pas, il sera créé. Vous pouvez indiquer un partage existant en précisant le chemin absolu du répertoire. Vérifiez que votre saisie soit correcte, par exemple un disque USB externe est pointé par <em>/volumeUSB1/usbshare</em>."
       },
       {
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
       }
     ]
   }

--- a/spk/sabnzbd/src/wizard/upgrade_uifile
+++ b/spk/sabnzbd/src/wizard/upgrade_uifile
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within SABnzbd, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."

--- a/spk/sabnzbd/src/wizard/upgrade_uifile_fre
+++ b/spk/sabnzbd/src/wizard/upgrade_uifile_fre
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! Permissions DSM,
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans SABnzbd, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."


### PR DESCRIPTION
I contributed to this repo in order to get my project SABnzbd available for DSM6. But even though it was the first package I converted to Generic service approach, it's _still_ not published many months later.
Because SABnzbd is still not published while NZBGet, Sonarr/Radarr and Transmission were published, I have lost motivation in the past few weeks to contribute to this project.

I have not asked for it in a few months.. so I hope now you will finally publish my project @ymartin59.


### Checklist
- [x] Build rule `all-supported` completed successfully ([Travis](https://travis-ci.org/Safihre/spksrc/builds/372030428) / [output](https://github.com/Safihre/spksrc/releases/tag/sabnzbd-all))
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
