### PR TITLE
python 2.7: fix cryptography wheel for ARM

### DIFF
--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -55,14 +55,14 @@ build_wheel_target: $(PRE_WHEEL_TARGET)
 		$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e))) \
 		if [ ! -z "$(CROSS_COMPILE_WHEELS)" ] ; then \
 			$(MSG) "Force cross-compile" ; \
-			$(RUN) CFLAGS="$(CFLAGS) -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR)" $(PIP_WHEEL) ; \
+			$(RUN) CFLAGS="$(CFLAGS) -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) $(WHEELS_CFLAGS)" LDFLAGS="$(LDFLAGS) $(WHEELS_LDFLAGS)" $(PIP_WHEEL) ; \
 		else \
 			$(MSG) "Force pure-python" ; \
 			export LD= LDSHARED= CPP= NM= CC= AS= RANLIB= CXX= AR= STRIP= OBJDUMP= READELF= CFLAGS= CPPFLAGS= CXXFLAGS= LDFLAGS= && \
 			  $(RUN) $(PIP_WHEEL) ; \
 		fi ; \
 	fi
-	
+
 
 post_wheel_target: $(WHEEL_TARGET)
 	@if [ -d "$(WORK_DIR)/wheelhouse" ] ; then \

--- a/spk/python/Makefile
+++ b/spk/python/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python
 SPK_SHORT_VERS = 2.7
 SPK_VERS = $(SPK_SHORT_VERS).14
-SPK_REV = 18
+SPK_REV = 19
 SPK_ICON = src/python.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
@@ -15,6 +15,7 @@ DEPENDS += cross/pyalsa cross/pyaudio cross/pycrypto cross/pycurl
 DEPENDS += cross/pyyaml cross/pyzmq cross/uwsgi
 
 WHEELS = src/requirements.txt
+
 
 MAINTAINER = Safihre
 DESCRIPTION = Python 2.7 Programming Language.
@@ -40,6 +41,12 @@ BUSYBOX_CONFIG = usrmng nice daemon
 ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
 
 include ../../mk/spksrc.spk.mk
+
+# Wheel "cryptography" lacks libpthread when cross-compile for ARM
+ifeq ($(findstring $(ARCH),$(ARM_ARCHES)),$(ARCH))
+WHEELS_CFLAGS = "-pthread"
+WHEELS_LDFLAGS = "-lpthread"
+endif
 
 .PHONY: python_extra_install
 python_extra_install:


### PR DESCRIPTION
Add WHEELS_CFLAGS and WHEELS_LDFLAGS to pass additional cross-compilation options to "pip wheel"

_Motivation:_ Update and fix cryptography wheel
_Linked issues:_ #3246 #3201

### Checklist
- [X] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully
