### PR TITLE
borgbackup: update to 1.1.6

### DIFF
--- a/cross/borgbackup/Makefile
+++ b/cross/borgbackup/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = borgbackup
-PKG_VERS = 1.1.5
+PKG_VERS = 1.1.6
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/b/$(PKG_NAME)

--- a/cross/borgbackup/digests
+++ b/cross/borgbackup/digests
@@ -1,3 +1,3 @@
-borgbackup-1.1.5.tar.gz SHA1 0dec8c69617eb5a3ea9a4d340df5116dd1d434ea
-borgbackup-1.1.5.tar.gz SHA256 4356e6c712871f389e3cb1d6382e341ea635f9e5c65de1cd8fcd103d0fb66d3d
-borgbackup-1.1.5.tar.gz MD5 38736d939d39fa0f5523b58dc3e135d5
+borgbackup-1.1.6.tar.gz SHA1 cfc0ff8d9a55c68e8de0b2536bbfb21fbf7cd4d3
+borgbackup-1.1.6.tar.gz SHA256 a1d2e474c85d3ad3d59b3f8209b5549653c88912082ea0159d27a2e80c910930
+borgbackup-1.1.6.tar.gz MD5 428861a85fab3ab7fd608931e0125246

--- a/cross/msgpack-python/Makefile
+++ b/cross/msgpack-python/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = msgpack-python
-PKG_VERS = 0.4.8
+PKG_VERS = 0.5.6
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/m/$(PKG_NAME)

--- a/cross/msgpack-python/digests
+++ b/cross/msgpack-python/digests
@@ -1,3 +1,3 @@
-msgpack-python-0.4.8.tar.gz SHA1 59d4af5f0598bd31469cad7df316d70e6b492b1d
-msgpack-python-0.4.8.tar.gz SHA256 1a2b19df0f03519ec7f19f826afb935b202d8979b0856c6fb3dc28955799f886
-msgpack-python-0.4.8.tar.gz MD5 dcd854fb41ee7584ebbf35e049e6be98
+msgpack-python-0.5.6.tar.gz SHA1 3522e33c8cd3c68d4cfedd9aa5defd177710da6a
+msgpack-python-0.5.6.tar.gz SHA256 378cc8a6d3545b532dfd149da715abae4fda2a3adb6d74e525d0d5e51f46909b
+msgpack-python-0.5.6.tar.gz MD5 6d644c06a87a5a111bbbf5b34b4be440

--- a/spk/borgbackup/Makefile
+++ b/spk/borgbackup/Makefile
@@ -1,20 +1,20 @@
 SPK_NAME = borgbackup
-SPK_VERS = 1.1.5
-SPK_REV = 2
+SPK_VERS = 1.1.6
+SPK_REV = 1
 SPK_ICON = src/$(SPK_NAME).png
 
 BUILD_DEPENDS = cross/python3 cross/setuptools cross/pip cross/wheel
 BUILD_DEPENDS += cross/$(SPK_NAME)
 DEPENDS = cross/bash
 WHEELS = src/requirements.txt
-SPK_DEPENDS = "python3>=3.5.2-6"
+SPK_DEPENDS = "python3>=3.5.2-7"
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Deduplicating backup program with compression and authenticated encryption.
 RELOAD_UI = no
 DISPLAY_NAME = Borg
 STARTABLE = no
-CHANGELOG = Update to 1.1.5
+CHANGELOG = Update to 1.1.6
 
 HOMEPAGE = https://borgbackup.readthedocs.io
 LICENSE  = BSD-3-Clause

--- a/spk/borgbackup/src/requirements.txt
+++ b/spk/borgbackup/src/requirements.txt
@@ -1,6 +1,6 @@
 # Cross compiled packages dependencies
-#borgbackup==1.1.5
-#msgpack-python==0.4.8
+#borgbackup==1.1.6
+#msgpack-python==0.5.6
 
 # Downloaded dependencies
 borgmatic==1.0.3

--- a/spk/python/Makefile
+++ b/spk/python/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python
 SPK_SHORT_VERS = 2.7
 SPK_VERS = $(SPK_SHORT_VERS).14
-SPK_REV = 19
+SPK_REV = 20
 SPK_ICON = src/python.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)

--- a/spk/python/src/requirements.txt
+++ b/spk/python/src/requirements.txt
@@ -3,7 +3,7 @@
 # Included for reference
 #lxml==3.7.2
 #m2crypto==0.25.0
-#msgpack-python==0.4.8
+#msgpack-python==0.5.6
 #pillow==4.0.0
 #pyalsa==1.0.29
 #pyaudio==0.2.9

--- a/spk/python3/Makefile
+++ b/spk/python3/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python3
 SPK_SHORT_VERS = 3.5
 SPK_VERS = $(SPK_SHORT_VERS).2
-SPK_REV = 6
+SPK_REV = 7
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
@@ -21,7 +21,7 @@ DESCRIPTION_SPN = Lenguaje de programación Python.
 RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python3
-CHANGELOG = "1. Update to Python 3.5.2<br>2. Update modules<br>3. Added msgpack libattr libacl liblz4"
+CHANGELOG = "1. Update to Python 3.5.2<br>2. Update modules<br>3. Added msgpack libattr libacl liblz4<br>4. Update msgpack"
 
 HOMEPAGE = http://www.python.org
 LICENSE  = PSF


### PR DESCRIPTION
_Motivation:_ Update borgbackup to 1.1.6
_Linked issues:_ #3334

The update requires update to python-msgpack, so I had to modify also python and python3 packages that are using msgpack.

### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [*] New installation of package completed successfully

Little testing on DS212+ with DSM-6.0.2:
* verify data of a backup repo done with previous version of borgbackup
* append new data to backup repo