### PR TITLE
Make Python3 build again; bump to 3.5.5

### DIFF
--- a/cross/acl/Makefile
+++ b/cross/acl/Makefile
@@ -6,6 +6,7 @@ PKG_DIST_SITE = http://download.savannah.gnu.org/releases/acl
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/attr
+ADDITIONAL_CFLAGS = -I$(STAGING_INSTALL_PREFIX)/include/
 
 HOMEPAGE = http://kernel.org/
 COMMENT  = 
@@ -14,8 +15,23 @@ LICENSE  =
 GNU_CONFIGURE = 1
 INSTALL_TARGET = myInstall
 
+CONFIGURE_ARGS  = --exec_prefix=/ CPPFLAGS=-I$(STAGING_INSTALL_PREFIX)/include LDFLAGS=-L$(STAGING_INSTALL_PREFIX)/lib
+
 include ../../mk/spksrc.cross-cc.mk
 
 .PHONY: myInstall
+# special-case the install for python3.5.5 avoiding breaking borgbackup (this
+# logic says "is 'python3' in the path?" via "if I replace python3 with garbage,
+# is it a different path?"
+#
+# note: borgbackup may also need install/install-* re-orderd: installer now
+# fails if a depencent lib is not already installed
 myInstall:
+ifneq ($(subst python3,garbage,$(STAGING_DIR)),$(STAGING_DIR))
+	$(RUN) $(MAKE) DIST_ROOT=$(STAGING_INSTALL_PREFIX) LN_S=ln install-dev install-lib install
+	@echo fail fast
+	test -e $(STAGING_INSTALL_PREFIX)/lib/libacl.la*
+	test -f $(STAGING_INSTALL_PREFIX)/bin/chacl
+else
 	$(RUN) $(MAKE) DIST_ROOT=$(INSTALL_DIR) install install-lib install-dev
+endif

--- a/cross/acl/patches/builddefs-include.patch
+++ b/cross/acl/patches/builddefs-include.patch
@@ -1,0 +1,13 @@
+--- include/builddefs.in	2013-05-19 01:58:24.000000000 +0000
++++ include/builddefs.in	2018-05-24 05:33:58.140812552 +0000
+@@ -81,9 +81,9 @@
+ endif
+ 
+ GCFLAGS = $(OPTIMIZER) $(DEBUG) -funsigned-char -fno-strict-aliasing -Wall \
+ 	  -DVERSION=\"$(PKG_VERSION)\" -DLOCALEDIR=\"$(PKG_LOCALE_DIR)\"  \
+-	  -DPACKAGE=\"$(PKG_NAME)\" -I$(TOPDIR)/include
++	  -DPACKAGE=\"$(PKG_NAME)\" -I$(TOPDIR)/include @CPPFLAGS@
+ 
+ # Global, Platform, Local CFLAGS
+ CFLAGS += $(GCFLAGS) $(PCFLAGS) $(LCFLAGS)
+ 

--- a/cross/acl/patches/install-softlinks-full-path-always.patch
+++ b/cross/acl/patches/install-softlinks-full-path-always.patch
@@ -1,0 +1,11 @@
+--- include/install-sh	2018-05-26 06:40:01.019250161 +0000
++++ include/install-sh	2018-05-26 06:40:08.031272501 +0000
+@@ -185,7 +185,7 @@
+     else
+ 	target=$DIST_ROOT/$1
+     fi
+-    $LN -s -f $symlink $target
++    $LN -s -f $DIST_ROOT/$symlink $target
+     status=$?
+     $MANIFEST l $symlink ${target#$DIST_ROOT}
+ elif $Tflag

--- a/cross/acl/patches/old-libtool-workaround.patch
+++ b/cross/acl/patches/old-libtool-workaround.patch
@@ -1,0 +1,87 @@
+diff -rU 4 /home/bob/src/spksrc-allanc/spk/python3/work/acl-2.2.52/chacl/Makefile /home/bob/src/spksrc-allanc/spk/python3/acl-2.2.52-fixed/chacl/Makefile
+--- chacl/Makefile	2013-04-30 15:20:43.000000000 +0000
++++ chacl/Makefile	2018-05-24 06:59:51.352327115 +0000
+@@ -30,6 +30,10 @@
+ include $(BUILDRULES)
+ 
++# -D is added redundantly because acl-2.2.52 is really old, needs an autoreconf,
++# but that's techdebt for later; now, this -D is harmless but causes the current
++# install binary to actually install the file rather than silently fail
++
+ install: default
+ 	$(INSTALL) -m 755 -d $(PKG_BIN_DIR)
+-	$(LTINSTALL) -m 755 $(LTCOMMAND) $(PKG_BIN_DIR)
++	$(LTINSTALL) -o $(shell id -un) -m 755 $(LTCOMMAND) $(PKG_BIN_DIR)
+ install-dev install-lib:
+diff -rU 4 /home/bob/src/spksrc-allanc/spk/python3/work/acl-2.2.52/debian/Makefile /home/bob/src/spksrc-allanc/spk/python3/acl-2.2.52-fixed/debian/Makefile
+--- debian/Makefile	2013-04-30 15:20:43.000000000 +0000
++++ debian/Makefile	2018-05-24 06:59:51.360327714 +0000
+@@ -27,25 +27,29 @@
+ default:
+ 
+ include $(BUILDRULES)
+ 
++# -D is added redundantly because acl-2.2.52 is really old, needs an autoreconf,
++# but that's techdebt for later; now, this -D is harmless but causes the current
++# install binary to actually install the file rather than silently fail
++
+ install: default
+ ifeq ($(PKG_DISTRIBUTION), debian)
+ 	$(INSTALL) -m 755 -d $(PKG_DOC_DIR)
+-	$(INSTALL) -m 644 changelog $(PKG_DOC_DIR)/changelog.Debian
++	$(INSTALL) -D -m 644 changelog $(PKG_DOC_DIR)/changelog.Debian
+ endif
+ 
+ install-dev: default
+ ifeq ($(PKG_DISTRIBUTION), debian)
+ 	$(INSTALL) -m 755 -d $(PKG_DOC_DIR)
+ 	$(INSTALL) -m 755 -d $(DEV_DOC_DIR)
+-	$(INSTALL) -m 644 copyright $(DEV_DOC_DIR)
+-	$(INSTALL) -m 644 changelog $(DEV_DOC_DIR)/changelog.Debian
++	$(INSTALL) -D -m 644 copyright $(DEV_DOC_DIR)
++	$(INSTALL) -D -m 644 changelog $(DEV_DOC_DIR)/changelog.Debian
+ endif
+ 
+ install-lib: default
+ ifeq ($(PKG_DISTRIBUTION), debian)
+ 	$(INSTALL) -m 755 -d $(PKG_DOC_DIR)
+ 	$(INSTALL) -m 755 -d $(LIB_DOC_DIR)
+-	$(INSTALL) -m 644 copyright $(LIB_DOC_DIR)
+-	$(INSTALL) -m 644 changelog $(LIB_DOC_DIR)/changelog.Debian
++	$(INSTALL) -D -m 644 copyright $(LIB_DOC_DIR)
++	$(INSTALL) -D -m 644 changelog $(LIB_DOC_DIR)/changelog.Debian
+ endif
+diff -rU 4 /home/bob/src/spksrc-allanc/spk/python3/work/acl-2.2.52/getfacl/Makefile /home/bob/src/spksrc-allanc/spk/python3/acl-2.2.52-fixed/getfacl/Makefile
+--- getfacl/Makefile	2013-04-30 15:20:43.000000000 +0000
++++ getfacl/Makefile	2018-05-24 06:59:51.356327527 +0000
+@@ -29,8 +29,12 @@
+ default: $(LTCOMMAND)
+ 
+ include $(BUILDRULES)
+ 
++# -D is added redundantly because acl-2.2.52 is really old, needs an autoreconf,
++# but that's techdebt for later; now, this -D is harmless but causes the current
++# install binary to actually install the file rather than silently fail
++
+ install: default
+ 	$(INSTALL) -m 755 -d $(PKG_BIN_DIR)
+-	$(LTINSTALL) -m 755 $(LTCOMMAND) $(PKG_BIN_DIR)
++	$(LTINSTALL) -D -m 755 $(LTCOMMAND) $(PKG_BIN_DIR)
+ install-dev install-lib:
+diff -rU 4 /home/bob/src/spksrc-allanc/spk/python3/work/acl-2.2.52/setfacl/Makefile /home/bob/src/spksrc-allanc/spk/python3/acl-2.2.52-fixed/setfacl/Makefile
+--- setfacl/Makefile	2013-04-30 15:20:43.000000000 +0000
++++ setfacl/Makefile	2018-05-24 06:59:51.356327527 +0000
+@@ -29,8 +29,12 @@
+ default: $(LTCOMMAND)
+ 
+ include $(BUILDRULES)
+ 
++# -D is added redundantly because acl-2.2.52 is really old, needs an autoreconf,
++# but that's techdebt for later; now, this -D is harmless but causes the current
++# install binary to actually install the file rather than silently fail
++
+ install: default
+ 	$(INSTALL) -m 755 -d $(PKG_BIN_DIR)
+-	$(LTINSTALL) -m 755 $(LTCOMMAND) $(PKG_BIN_DIR)
++	$(LTINSTALL) -D -m 755 $(LTCOMMAND) $(PKG_BIN_DIR)
+ install-dev install-lib:

--- a/cross/libgpg-error/Makefile
+++ b/cross/libgpg-error/Makefile
@@ -13,6 +13,9 @@ LICENSE  = LGPL
 
 GNU_CONFIGURE = 1
 
+# if for python3, replace the -config path with abspath
+POST_INSTALL_TARGET = python3PostInstall
+
 include ../../mk/spksrc.cross-cc.mk
 
 ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
@@ -21,3 +24,7 @@ endif
 ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
 CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
 endif
+
+.PHONY: python3PostInstall
+python3PostInstall:
+	sed -i -e 's|^prefix=$(INSTALL_PREFIX)$$|prefix=$(STAGING_INSTALL_PREFIX)|' $(STAGING_INSTALL_PREFIX)/bin/gpg-error-config

--- a/cross/libxslt/Makefile
+++ b/cross/libxslt/Makefile
@@ -15,4 +15,12 @@ CONFIGURE_ARGS  = --without-python --with-libxml-prefix=$(STAGING_INSTALL_PREFIX
 CONFIGURE_ARGS += --with-libxml-include-prefix=$(STAGING_INSTALL_PREFIX)/include/libxml2
 GNU_CONFIGURE = 1
 
+# if for libgcrypt, replace the -config path with abspath
+POST_INSTALL_TARGET = python3PostInstall
+
 include ../../mk/spksrc.cross-cc.mk
+
+.PHONY: python3PostInstall
+python3PostInstall:
+	sed -i -e 's|^prefix=$(INSTALL_PREFIX)$$|prefix=$(STAGING_INSTALL_PREFIX)|' $(STAGING_INSTALL_PREFIX)/bin/xslt-config
+

--- a/cross/pycrypto/Makefile
+++ b/cross/pycrypto/Makefile
@@ -13,4 +13,6 @@ LICENSE  = Public domain
 
 ENV += cross_compiling=yes
 
-include ../../mk/spksrc.python-wheel.mk
+include ../../mk/spksrc.python-module.mk
+
+ADDITIONAL_LDFLAGS = -L$(STAGING_INSTALL_PREFIX)/lib

--- a/cross/python3/Makefile
+++ b/cross/python3/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = python3
 PKG_VERS_MAJOR = 3
 PKG_VERS_MINOR = 5
-PKG_VERS_PATCH = 2
+PKG_VERS_PATCH = 5
 PKG_VERS = $(PKG_VERS_MAJOR).$(PKG_VERS_MINOR).$(PKG_VERS_PATCH)
 PKG_EXT = tar.xz
 PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
@@ -16,8 +16,8 @@ COMMENT  = Python Programming Language
 LICENSE  = PSF
 
 GNU_CONFIGURE = 1
-ADDITIONAL_CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
-CONFIGURE_ARGS  = --enable-shared --enable-ipv6 --without-ensurepip PYTHON_FOR_BUILD=$(HOSTPYTHON) PGEN_FOR_BUILD=$(HOSTPGEN)
+ADDITIONAL_CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -L $(WORK_DIR)/install/usr/local/python3/lib -I $(WORK_DIR)/install/usr/local/python3/include
+CONFIGURE_ARGS  = --enable-shared --enable-ipv6 --without-ensurepip --enable-loadable-sqlite-extensions PYTHON_FOR_BUILD=$(HOSTPYTHON) PGEN_FOR_BUILD=$(HOSTPGEN)
 CONFIGURE_ARGS += ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no ac_cv_have_long_long_format=yes
 
 POST_PATCH_TARGET = myPostPatch
@@ -51,6 +51,13 @@ myPreConfigure:
 	cp $(PYTHON_NATIVE) $(HOSTPYTHON)
 	cp $(PGEN_NATIVE) $(HOSTPGEN)
 	$(RUN) autoreconf
+	# create phantom header and library to succeed add_dir_to_list in setup.py
+	# so that future-promised libsqlite3.so and sqlite3.h will be used.  Yep,
+	# it's a bit hokey, but avoids editing upstream pristine source
+	mkdir -p $(WORK_DIR)/install/usr/local/python3/lib $(WORK_DIR)/install/usr/local/python3/include
+	mkdir -p $(WORK_DIR)/Python-$(PKG_VERS)/Include $(WORK_DIR)/Python-$(PKG_VERS)/lib
+	test -h $(WORK_DIR)/Python-$(PKG_VERS)/Include/sqlite3.h || ln -fs $(WORK_DIR)/install/usr/local/python3/include/sqlite3.h $(WORK_DIR)/Python-$(PKG_VERS)/Include/sqlite3.h
+	test -h $(WORK_DIR)/Python-$(PKG_VERS)/lib/libsqlite3.so || ln -fs $(WORK_DIR)/install/usr/local/python3/lib/libsqlite3.so $(WORK_DIR)/Python-$(PKG_VERS)/lib/
 
 .PHONY: myCompile
 myCompile:
@@ -64,6 +71,7 @@ myInstall:
 
 .PHONY: myPostInstall
 myPostInstall: $(WORK_DIR)/python-cc.mk
+	mkdir -p $(PYTHON_LIB_CROSS)
 	cp -R $(HOSTPYTHON_LIB_NATIVE) $(PYTHON_LIB_CROSS)/../
 ifneq ($(PYTHON_LIB_NATIVE),$(PYTHON_LIB_CROSS))
 	cp $(PYTHON_LIB_CROSS)/_sysconfigdata.py* $(PYTHON_LIB_NATIVE)/

--- a/cross/python3/PLIST
+++ b/cross/python3/PLIST
@@ -15,3 +15,6 @@ lnk:lib/libpython3.5m.so
 lib:lib/libpython3.5m.so.1.0
 lib:lib/libpython3.so
 rsc:lib/python3.5
+lnk:lib/libsqlite3.so
+lnk:lib/libsqlite3.so.0
+lib:lib/libsqlite3.so.0.*

--- a/cross/python3/digests
+++ b/cross/python3/digests
@@ -1,3 +1,3 @@
-Python-3.5.2.tar.xz SHA1 4843aabacec5bc0cdd3e1f778faa926e532794d2
-Python-3.5.2.tar.xz SHA256 0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40
-Python-3.5.2.tar.xz MD5 8906efbacfcdc7c3c9198aeefafd159e
+Python-3.5.5.tar.xz SHA1 66c4cfc0f64b545ee5a7725f26a2fd834cdf1682
+Python-3.5.5.tar.xz SHA256 063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009
+Python-3.5.5.tar.xz MD5 f3763edf9824d5d3a15f5f646083b6e0

--- a/cross/python3/patches/001-mimetypes.patch
+++ b/cross/python3/patches/001-mimetypes.patch
@@ -1,3 +1,10 @@
+
+DSM does not have the default mime-type files available,
+need to bring our own for the module to work.
+
+Equivalent of cross/python/patches/004-mimetypes.patch
+Added by Diaoul 2013-03-24_23:25:49+0100
+
 --- Lib/mimetypes.py.orig	2011-10-16 21:07:51.000000000 +0200
 +++ Lib/mimetypes.py	2011-10-16 21:07:58.000000000 +0200
 @@ -38,15 +38,7 @@

--- a/cross/python3/patches/002-xcompile.patch
+++ b/cross/python3/patches/002-xcompile.patch
@@ -1,3 +1,9 @@
+
+In Cross-compile, we need to regenerate -- if needed -- using a native-built
+Python.  This patch includes additional vebose output and fail-fast logic for
+when the PGEN determination is incorrectly done to avoid the 55-minute build
+that ultimately fails
+
 --- configure.ac.orig	2016-06-25 23:38:39.000000000 +0200
 +++ configure.ac	2016-12-05 22:06:40.183563868 +0100
 @@ -72,6 +72,8 @@
@@ -39,12 +45,17 @@
  
  PSRCS=		\
  		Parser/acceler.c \
-@@ -792,7 +793,7 @@
+@@ -769,11 +769,11 @@
+ 		$(CC) $(OPT) $(PY_LDFLAGS) $(PGENOBJS) $(LIBS) -o $(PGEN)
+ 
+ .PHONY: regen-grammar
+-regen-grammar: $(PGEN)
++regen-grammar: $(PGEN_FOR_BUILD)
+ 	# Regenerate Include/graminit.h and Python/graminit.c
+ 	# from Grammar/Grammar using pgen
  	@$(MKDIR_P) Include
- 	# Avoid copying the file onto itself for an in-tree build
- 	if test "$(cross_compiling)" != "yes"; then \
--		$(PGEN) $(GRAMMAR_INPUT) $(GRAMMAR_H) $(GRAMMAR_C); \
-+		$(PGEN_FOR_BUILD) $(GRAMMAR_INPUT) $(GRAMMAR_H) $(GRAMMAR_C) ; \
- 	else \
- 		cp $(srcdir)/Include/graminit.h $(GRAMMAR_H).tmp; \
- 		mv $(GRAMMAR_H).tmp $(GRAMMAR_H); \
+-	$(PGEN) $(srcdir)/Grammar/Grammar \
++	$(PGEN_FOR_BUILD) $(srcdir)/Grammar/Grammar \
+ 		$(srcdir)/Include/graminit.h \
+ 		$(srcdir)/Python/graminit.c
+ 

--- a/cross/python3/patches/003-rpath.patch
+++ b/cross/python3/patches/003-rpath.patch
@@ -1,0 +1,45 @@
+
+Synology library path is a formulaic but atypical.  Register an RPATH to avoid
+requiring an additional LD_LIBRARY_PATH everywhere it's used.  Editing both the
+build configure plus the upstream .ac in case it's regenerated
+
+diff -cr Python-3.5.5/configure x/configure
+*** configure	2018-06-16 07:30:43.000454610 +0000
+--- configure	2018-06-16 08:34:50.801838237 +0000
+***************
+*** 5971,5977 ****
+            ;;
+      Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
+  	  LDLIBRARY='libpython$(LDVERSION).so'
+! 	  BLDLIBRARY='-L. -lpython$(LDVERSION)'
+  	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  	  INSTSONAME="$LDLIBRARY".$SOVERSION
+  	  if test "$with_pydebug" != yes
+--- 5971,5977 ----
+            ;;
+      Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
+  	  LDLIBRARY='libpython$(LDVERSION).so'
+! 	  BLDLIBRARY='-Wl,-rpath,$(LIBDIR) -L. -lpython$(LDVERSION)'
+  	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  	  INSTSONAME="$LDLIBRARY".$SOVERSION
+  	  if test "$with_pydebug" != yes
+diff -cr /home/bob/src/spksrc-allanc/spk/homeassistant/work/Python-3.5.5/configure.ac x/configure.ac
+*** configure.ac	2018-06-16 07:30:38.048438143 +0000
+--- configure.ac	2018-06-16 08:35:34.921999207 +0000
+***************
+*** 1127,1133 ****
+            ;;
+      Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
+  	  LDLIBRARY='libpython$(LDVERSION).so'
+! 	  BLDLIBRARY='-L. -lpython$(LDVERSION)'
+  	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  	  INSTSONAME="$LDLIBRARY".$SOVERSION
+  	  if test "$with_pydebug" != yes
+--- 1127,1133 ----
+            ;;
+      Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
+  	  LDLIBRARY='libpython$(LDVERSION).so'
+! 	  BLDLIBRARY='-Wl,-rpath,$(LIBDIR) -L. -lpython$(LDVERSION)'
+  	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  	  INSTSONAME="$LDLIBRARY".$SOVERSION
+  	  if test "$with_pydebug" != yes

--- a/cross/python3/patches/004-xcompile-paths.patch
+++ b/cross/python3/patches/004-xcompile-paths.patch
@@ -1,0 +1,56 @@
+
+When compiling x86/x64 toolchains the setup.py script will
+automatically try to add library-dirs of the compile host.
+This results in failures to compile modules on those platforms.
+This first block is copied from
+cross/python/patches/002-no-system-multiarch.patch
+
+The second block allows custom -I and -L to survive into the cross environment.
+
+*** setup.py	2018-02-04 15:40:56.000000000 -0800
+--- setup.py	2018-06-24 00:01:06.695850717 -0700
+***************
+*** 493,505 ****
+          if not cross_compiling:
+              add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+              add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
+          # only change this for cross builds for 3.3, issues on Mageia
+          if cross_compiling:
+              self.add_gcc_paths()
+-         self.add_multiarch_paths()
+  
+          # Add paths specified in the environment variables LDFLAGS and
+          # CPPFLAGS for header and library files.
+          # We must get the values from the Makefile and not the environment
+          # directly since an inconsistently reproducible issue comes up where
+          # the environment variable is not set even though the value were passed
+--- 493,504 ----
+***************
+*** 569,581 ****
+              lib_dirs += ['/usr/ccs/lib']
+  
+          # HP-UX11iv3 keeps files in lib/hpux folders.
+          if host_platform == 'hp-ux11':
+              lib_dirs += ['/usr/lib/hpux64', '/usr/lib/hpux32']
+  
+!         if host_platform == 'darwin':
+              # This should work on any unixy platform ;-)
+              # If the user has bothered specifying additional -I and -L flags
+              # in OPT and LDFLAGS we might as well use them here.
+              #
+              # NOTE: using shlex.split would technically be more correct, but
+              # also gives a bootstrap problem. Let's hope nobody uses
+--- 568,580 ----
+              lib_dirs += ['/usr/ccs/lib']
+  
+          # HP-UX11iv3 keeps files in lib/hpux folders.
+          if host_platform == 'hp-ux11':
+              lib_dirs += ['/usr/lib/hpux64', '/usr/lib/hpux32']
+  
+!         if host_platform == 'darwin' or cross_compiling:
+              # This should work on any unixy platform ;-)
+              # If the user has bothered specifying additional -I and -L flags
+              # in OPT and LDFLAGS we might as well use them here.
+              #
+              # NOTE: using shlex.split would technically be more correct, but
+              # also gives a bootstrap problem. Let's hope nobody uses

--- a/native/python3/Makefile
+++ b/native/python3/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = python
-PKG_VERS = 3.5.2
+PKG_VERS = 3.5.5
 PKG_EXT = tar.xz
 PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.python.org/ftp/python/$(PKG_VERS)
@@ -32,7 +32,7 @@ myPostInstall: $(WORK_DIR)/python-native.mk
 	@$(MSG) Installing setuptools, pip and cffi
 	@$(RUN) wget https://bootstrap.pypa.io/ez_setup.py -O - | $(PYTHON)
 	@$(RUN) wget https://bootstrap.pypa.io/get-pip.py -O - | $(PYTHON)
-	@$(PIP) install "cffi==1.9.1"
+	@$(PIP) install "cffi==1.11.1"
 
 $(WORK_DIR)/python-native.mk:
 	@echo PIP=$(PIP_NATIVE) >> $@

--- a/native/python3/digests
+++ b/native/python3/digests
@@ -1,3 +1,3 @@
-Python-3.5.2.tar.xz SHA1 4843aabacec5bc0cdd3e1f778faa926e532794d2
-Python-3.5.2.tar.xz SHA256 0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40
-Python-3.5.2.tar.xz MD5 8906efbacfcdc7c3c9198aeefafd159e
+Python-3.5.5.tar.xz SHA1 66c4cfc0f64b545ee5a7725f26a2fd834cdf1682
+Python-3.5.5.tar.xz SHA256 063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009
+Python-3.5.5.tar.xz MD5 f3763edf9824d5d3a15f5f646083b6e0

--- a/spk/python3/Makefile
+++ b/spk/python3/Makefile
@@ -1,27 +1,27 @@
 SPK_NAME = python3
 SPK_SHORT_VERS = 3.5
-SPK_VERS = $(SPK_SHORT_VERS).2
-SPK_REV = 6
+SPK_VERS = $(SPK_SHORT_VERS).5
+SPK_REV = 7
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
 #Build-time dependencies
 DEPENDS += cross/setuptools cross/pip cross/wheel
-DEPENDS += cross/cffi cross/bcrypt
+DEPENDS += cross/cffi cross/bcrypt cross/sqlite
 # Cross-compiled wheels
 DEPENDS += cross/lxml cross/pycrypto cross/pycurl cross/pyyaml
 DEPENDS += cross/msgpack-python cross/attr cross/acl cross/lz4
 
 WHEELS = src/requirements.txt
 
-MAINTAINER = Diaoul
+MAINTAINER = Allan Clark
 DESCRIPTION = Python Programming Language.
 DESCRIPTION_FRE = Langage de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.
 RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python3
-CHANGELOG = "1. Update to Python 3.5.2<br>2. Update modules<br>3. Added msgpack libattr libacl liblz4"
+CHANGELOG = "1. Update to Python 3.5.5<br>2. Added sqlite3 module, lxml module"
 
 HOMEPAGE = http://www.python.org
 LICENSE  = PSF
@@ -46,3 +46,6 @@ python3_extra_install:
 	rm -f $(STAGING_DIR)/$(PYTHON_LIB_DIR)/config/libpython*.a
 	rm -fr $(STAGING_DIR)/$(PYTHON_LIB_DIR)/test/
 	find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' | xargs rm -f
+	mkdir -p $(STAGING_DIR)/usr/bin
+	ln -sf /usr/local/$(SPK_NAME)/bin/python3 $(STAGING_DIR)/usr/bin/python3
+	ln -sf /usr/local/$(SPK_NAME)/bin/python3 $(STAGING_DIR)/usr/bin/python$(SPK_SHORT_VERS)


### PR DESCRIPTION
_Motivation:_ I'm a fan of Home Assistant which needs 3.5.3 or later, and it's a real dependency, not just a "we don't know whether it'll work with 3.5.2".

The intention is to move through to 3.7.0 once this lands so that the logic here and the logic to move to 3.7.0 are separate.  The upgrade to 3.7.0 should be fairly straightforward after this diff.

_Linked issues:_ Scratching my own itch, I've seen this mentioned in chats.  I saw #3379 filed a few days ago by @ymartin59 

### Checklist
- [] Build rule `all-supported` completed successfully
    - openssl does not seem to support all ARM:
        arm_arch.h:46:6: error: #error "unsupported ARM architecture"
    - (cd spk/python3 && make all-supported) ongoing (keep running out of space)
- [x] Package upgrade completed successfully. (my tests have typically been upgrades)
- [x] New installation of package completed successfully. (both cmdline and by web UI) -- note that some users may be confused that this updates python3, not python nor py3k, so there may be three similar icons in the "installed" list.

I've been granted permission by my employer to contribute to spksrc without risk of IP confusion.  I am required to explicitly write that my contribution to this project is solely in my personal capacity, and I am not conveying any rights to any intellectual property of any third parties.  I'm not a fan of boiler-plate, but I'm glad I'm able to finally release this work.

The test case I'm using to validate a clean, good install -- before going forward with a home assistant install -- is the following code:

```
import time
import sqlite3
from lxml import etree
from ctypes import c_bool
from threading import Thread

def myfunc(i):
    print ("sleeping 5 sec from thread %d" % i)
    time.sleep(5)
    print ("finished sleeping from thread %d" % i)

for i in range(10):
    t = Thread(target=myfunc, args=(i,))
    t.start()
```

You'll notice that this includes an explicit import of `ctypes`, `lxml`, and `sqlite3`, as well as imports/exercises some `threading`.  `types` tends to show where the resulting Python cannot do wheels or CFFI, which in turn would make `lxml` fail.  `sqlite3` and threading are my initial requirements.

Output of the test code is as expected:
```
bash-4.3$ python3 ~/test.py
sleeping 5 sec from thread 0
sleeping 5 sec from thread 1
sleeping 5 sec from thread 2
sleeping 5 sec from thread 3
sleeping 5 sec from thread 4
sleeping 5 sec from thread 5
sleeping 5 sec from thread 6
sleeping 5 sec from thread 7
sleeping 5 sec from thread 8
sleeping 5 sec from thread 9
finished sleeping from thread 2
finished sleeping from thread 1
finished sleeping from thread 4
finished sleeping from thread 6
finished sleeping from thread 0
finished sleeping from thread 3
finished sleeping from thread 5
finished sleeping from thread 7
finished sleeping from thread 9
finished sleeping from thread 8
```

Note also that the `python3` binary is appended to `$PATH`, and needs to `LD_LIBRARY_PATH` nor wrapper.