### PR TITLE
bzip2: use debian repository as download source

### DIFF
--- a/cross/bzip2/Makefile
+++ b/cross/bzip2/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = bzip2
 PKG_VERS = 1.0.6
-PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://bzip.org/$(PKG_VERS)
+PKG_EXT = tar.bz2
+PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS).orig.$(PKG_EXT)
+PKG_DIST_SITE = http://http.debian.net/debian/pool/main/b/bzip2
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/bzip2/digests
+++ b/cross/bzip2/digests
@@ -1,3 +1,3 @@
-bzip2-1.0.6.tar.gz SHA1 3f89f861209ce81a6bab1fd1998c0ef311712002
-bzip2-1.0.6.tar.gz SHA256 a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
-bzip2-1.0.6.tar.gz MD5 00b516f4704d4a7cb50a1d97e6e8e15b
+bzip2_1.0.6.orig.tar.bz2 SHA1 3725a0554fa6bb654ef2728fef36bc06aed4e388
+bzip2_1.0.6.orig.tar.bz2 SHA256 d70a9ccd8bdf47e302d96c69fecd54925f45d9c7b966bb4ef5f56b770960afa7
+bzip2_1.0.6.orig.tar.bz2 MD5 2a1df12bd405cc86790291797673753c


### PR DESCRIPTION
Domain bzip.org is no longer registered

Resolves #3425
