### PR TITLE
itools: udev rules and mount/umount scripts

### DIFF
--- a/spk/itools/Makefile
+++ b/spk/itools/Makefile
@@ -1,10 +1,11 @@
 SPK_NAME = itools
-SPK_VERS = 1.0
-SPK_REV = 1
+SPK_VERS = 1.1
+SPK_REV = 2
 SPK_ICON = src/itools.png
 
 DEPENDS = cross/usbmuxd cross/ifuse
 UNSUPPORTED_ARCHS = $(PPC_ARCHES)
+SPK_DEPENDS = "PythonModule"
 
 MAINTAINER = bxxxjxxg
 MAINTAINER_URL = https://www.linkedin.com/in/bingjing-chang/
@@ -12,9 +13,8 @@ DISTRIBUTOR = SynoCommunity
 DISTRIBUTOR_URL = https://synocommunity.com
 DESCRIPTION = A collection toolkit for connecting iOS devices.
 RELOAD_UI = n
-DISPLAY_NAME = iTools
-BETA = 1
-CHANGELOG = First Release
+DISPLAY_NAME = iOS Access
+CHANGELOG = Added udev rules and python scripts to auto-detect and mount/umount iOS devices into/from FileStation. 
 
 HOMEPAGE   = https://www.libimobiledevice.org
 LICENSE    = LGPL 2.1
@@ -23,4 +23,18 @@ SERVICE_SETUP   = src/service-setup.sh
 SERVICE_COMMAND = $${SYNOPKG_PKGDEST}/sbin/usbmuxd
 STARTABLE       = yes
 
+POST_STRIP_TARGET = itools_extra_install
+
 include ../../mk/spksrc.spk.mk
+
+.PHONY: itools_extra_install
+itools_extra_install:
+	install -m 755 -d $(STAGING_DIR)/var
+	install -m 755 -d $(STAGING_DIR)/var/run/
+	install -m 755 -d $(STAGING_DIR)/var/log/
+	install -m 644 src/39-libimobiledevice.rules $(STAGING_DIR)/39-libimobiledevice.rules
+	install -m 755 src/on-inserted.sh $(STAGING_DIR)/on-inserted.sh
+	install -m 755 src/on-removed.sh $(STAGING_DIR)/on-removed.sh
+	install -m 755 src/common.py $(STAGING_DIR)/common.py
+	install -m 755 src/mounting.py $(STAGING_DIR)/mounting.py
+	install -m 755 src/umounting.py $(STAGING_DIR)/umounting.py

--- a/spk/itools/src/39-libimobiledevice.rules
+++ b/spk/itools/src/39-libimobiledevice.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[9a][0-9a-f]", RUN+="/usr/local/itools/on-inserted.sh"
+ACTION=="remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*", RUN+="/usr/local/itools/on-removed.sh"

--- a/spk/itools/src/common.py
+++ b/spk/itools/src/common.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+
+"""
+Copyright (c) 2018 BingJing Chang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import os
+import sys
+import time
+import logging
+import subprocess
+from lockfile import locked
+from logging.handlers import RotatingFileHandler
+
+INSTALL_DIR = '/usr/local/itools'
+VOLUME_DIR = os.path.join(INSTALL_DIR, 'volume')
+LOGFILE = os.path.join(INSTALL_DIR, 'var/log/access.log')
+LOCKFILE = os.path.join(INSTALL_DIR, 'var/run/access.lock')
+
+logger = logging.getLogger('Rotating Log')
+logger.setLevel(logging.INFO)
+handler = RotatingFileHandler(LOGFILE, maxBytes=102400, backupCount=5)
+logger.addHandler(handler)
+
+
+def run(cmd):
+    global logger
+    try:
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate()
+        logger.info('subprocess.call {%s}' % cmd)
+        logger.info('return code: %d' % p.returncode)
+        logger.info('stdout: %s' % out)
+        logger.info('stderr: %s' % err)
+        return p.returncode
+    except Exception as e:
+        logger.error('exception: %s' % e.message)
+    return -1
+
+
+def notify(message):
+    return run('/usr/syno/bin/synodsmnotify @users iOS "%s"' % message)
+
+
+def add_share(name, path):
+    return run(
+        '/usr/syno/sbin/synoshare --add %s "iOS Access" %s "" "" "@users" 1 0'
+        % (name, path))
+
+
+def del_share(path):
+    return run(
+        '/usr/syno/sbin/synoshare -del TRUE %s' % os.path.basename(path))
+
+
+def ifuse_mount(path):
+    return run('/usr/local/bin/ifuse -o nonempty -o allow_other %s' % path)
+
+
+def umount(path):
+    return run('/bin/umount %s' % path)

--- a/spk/itools/src/mounting.py
+++ b/spk/itools/src/mounting.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+
+"""
+Copyright (c) 2018 BingJing Chang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import os
+import sys
+import time
+import logging
+from lockfile import locked
+from logging.handlers import RotatingFileHandler
+from common import *
+
+
+@locked(LOCKFILE)
+def main():
+    time.sleep(3)
+    for i in xrange(12):
+        output = os.popen('ideviceinfo | grep DeviceName').read()
+        if output.find('DeviceName: ') == 0:
+            break
+        if i == 1:
+            notify('An iOS device is plugged. Wait for device agreement.')
+        logger.error(
+            'Could not get device info. ' +
+            "Maybe it's prompting user agreement." +
+            'Sleep 5 seconds. Try Count: (%d/12)' % (i + 1, 12))
+        time.sleep(5)
+
+    if output.find('DeviceName: ') != 0:
+        logger.error('Failed to get device info!')
+        return
+
+    device_name = output.split(' ')[1].strip()
+    mount_dir = os.path.join(VOLUME_DIR, device_name)
+    output = os.popen('mount | grep %s' % device_name).read().strip()
+    if len(output) > 0:
+        logger.error('%s is already mounted! (%s)' % (device_name, output))
+        return
+
+    output = os.popen(
+        'synoshare --get %s | grep Comment' % device_name).read().strip()
+    if output.find('Comment') >= 0:
+        logger.info('Share - %s exists. (%s)' % (device_name, output))
+        if output.find('iOS Access') < 0:
+            logger.error('Share - %s is not created by this package!')
+            return
+    else:
+        logger.info('Creating a DSM share - %s for it...' % device_name)
+        if add_share(device_name, mount_dir) < 0:
+            logger.error('Failed to create DSM share - %s!' % device_name)
+            return
+
+    logger.info('Mounting iOS directory into %s...' % mount_dir)
+    if ifuse_mount(mount_dir) < 0:
+        logger.error('Failed to mount iOS directory. Cleaning up...')
+        logger.info('Deleting DSM share named %s...' % device_name)
+        del_share(device_name)
+        return
+
+    # magic: we have to enter the folder first time
+    os.system('cd %s && ls' % mount_dir)
+    notify('%s is ready to be access in FileStation.' % device_name)
+
+if __name__ == '__main__':
+    logger.info('--- mounting.py started ---')
+    try:
+        main()
+    except Exception as e:
+        logger.error(str(e))
+    logger.info('--- mounting.py end ---')

--- a/spk/itools/src/on-inserted.sh
+++ b/spk/itools/src/on-inserted.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/local/itools/mounting.py &

--- a/spk/itools/src/on-removed.sh
+++ b/spk/itools/src/on-removed.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/local/itools/umounting.py &

--- a/spk/itools/src/service-setup.sh
+++ b/spk/itools/src/service-setup.sh
@@ -1,10 +1,16 @@
 
+PACKAGE="itools"
+INSTALL_DIR="/usr/local/${PACKAGE}"
+VOLUME_DIR="${INSTALL_DIR}/volume"
+
 SVC_CWD="${SYNOPKG_PKGDEST}"
 SVC_BACKGROUND=y
 SVC_WRITE_PID=y
 
 service_postinst ()
 {
+    easy_install lockfile
+    ln -s ${SYNOPKG_PKGDEST_VOL} ${VOLUME_DIR}
     ln -s ${SYNOPKG_PKGDEST}/bin/idevicebackup /usr/local/bin/idevicebackup
     ln -s ${SYNOPKG_PKGDEST}/bin/idevicebackup2 /usr/local/bin/idevicebackup2
     ln -s ${SYNOPKG_PKGDEST}/bin/idevicecrashreport /usr/local/bin/idevicecrashreport
@@ -29,6 +35,7 @@ service_postinst ()
 
 service_postuninst ()
 {
+    rm -f ${VOLUME_DIR}
     rm -f /usr/local/bin/idevicebackup
     rm -f /usr/local/bin/idevicebackup2
     rm -f /usr/local/bin/idevicecrashreport
@@ -49,4 +56,17 @@ service_postuninst ()
     rm -f /usr/local/bin/ifuse
     rm -f /usr/local/bin/iproxy
     rm -f /usr/local/bin/plistutil
+}
+
+service_prestart ()
+{
+    cp ${SYNOPKG_PKGDEST}/39-libimobiledevice.rules /usr/lib/udev/rules.d/
+    udevadm control --reload-rules
+}
+
+service_poststop ()
+{
+    ${INSTALL_DIR}/umounting.py
+    rm -f /usr/lib/udev/rules.d/39-libimobiledevice.rules
+    udevadm control --reload-rules
 }

--- a/spk/itools/src/umounting.py
+++ b/spk/itools/src/umounting.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+"""
+Copyright (c) 2018 BingJing Chang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import os
+import sys
+import time
+import logging
+from lockfile import locked
+from logging.handlers import RotatingFileHandler
+from common import *
+
+
+@locked(LOCKFILE)
+def main():
+    if os.fork() != 0:
+        sys.exit()
+    time.sleep(3)
+    output = os.popen('mount').read()
+    for line in filter(lambda x: x.find('ifuse') == 0, output.split('\n')):
+        path = line.split()[2]
+        logger.info('Unmounting %s ...' % path)
+        umount(path)
+        logger.info('Deleting DSM share named %s...' % os.path.basename(path))
+        del_share(path)
+
+if __name__ == '__main__':
+    logger.info('--- umounting.py started ---')
+    try:
+        main()
+    except Exception as e:
+        logger.error(str(e))
+    logger.info('--- umounting.py end ---')


### PR DESCRIPTION
Hello

I have finished including those scripts into itools package.
I also modified the version and rename it to be "iOS Access".
Please help me on reviewing this pull request. Thanks!

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully
  (Since it have different names now, there are no upgrade cases. As a result, it will stop the previous package, and the new package works fine.)

Here are udev rules and scripts to detect the hotplug events of
iOS devices and run python scripts to mount/umount into/from
FileStation.

Signed-off-by: BingJing Chang <bxxxjxxg@gmail.com>
