### PR TITLE
Fix rdiff-backup and duply script

### DIFF
--- a/cross/duply/patches/002-fix-erratic-bash-condition.patch
+++ b/cross/duply/patches/002-fix-erratic-bash-condition.patch
@@ -1,0 +1,11 @@
+--- duply.orig	2018-09-01 19:46:42.143830862 +0100
++++ duply	2018-09-01 19:39:20.402845754 +0100
+@@ -1884,7 +1884,7 @@
+ 
+ # pw set? 
+ # symmetric needs one, always
+-if gpg_symmetric && ( [ -z "$GPG_PW" ] || [ "$GPG_PW" == "${DEFAULT_GPG_PW}" ] ) \
++if gpg_symmetric && [ -z "$GPG_PW" ] \
+   ; then
+   error_gpg "Encryption passphrase GPG_PW (needed for symmetric encryption) 
+ is empty/not set or still default value in conf file 

--- a/spk/rdiff-backup/src/requirements.txt
+++ b/spk/rdiff-backup/src/requirements.txt
@@ -1,2 +1,2 @@
 # Cross compiled packages dependencies
-rdiff-backup
+#rdiff-backup


### PR DESCRIPTION
_Motivation:_ Fix rdiff-backup and duply script

This PR fixes two different simple bugs:
1. building rdiff-backup package fails due to an incorrect requirement
2. The duply bash script (included in the duplicity package) has a condition that is not correctly evaluated in bash. This PR removes one of the conditions because that case is already checked some lines earlier

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
