### PR TITLE
Remove wrong requirement in rdiff-backup package

### DIFF
--- a/spk/rdiff-backup/src/requirements.txt
+++ b/spk/rdiff-backup/src/requirements.txt
@@ -1,2 +1,0 @@
-# Cross compiled packages dependencies
-rdiff-backup


### PR DESCRIPTION
_Motivation:_ Fix package rdiff-backup

The rdiff-backup package has a incorrect requirement that breaks the package build process
This PR removes that requirement

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
