### PR TITLE
Fix duply script in duplicity package

### DIFF
--- a/cross/duply/patches/002-fix-erratic-bash-condition.patch
+++ b/cross/duply/patches/002-fix-erratic-bash-condition.patch
@@ -1,0 +1,11 @@
+--- duply.orig	2018-09-01 19:46:42.143830862 +0100
++++ duply	2018-09-01 19:39:20.402845754 +0100
+@@ -1884,7 +1884,7 @@
+ 
+ # pw set? 
+ # symmetric needs one, always
+-if gpg_symmetric && ( [ -z "$GPG_PW" ] || [ "$GPG_PW" == "${DEFAULT_GPG_PW}" ] ) \
++if gpg_symmetric && [ -z "$GPG_PW" ] \
+   ; then
+   error_gpg "Encryption passphrase GPG_PW (needed for symmetric encryption) 
+ is empty/not set or still default value in conf file 


### PR DESCRIPTION
_Motivation:_ Fix an unneeded and erratic condition in duply script

The duply script included in the duplicity packages includes this condition:

if gpg_symmetric && ( [ -z "$GPG_PW" ] || [ "$GPG_PW" == "${DEFAULT_GPG_PW}" ] )

With the bundled bash, the evaluation of this condition is erratic. It could be rewrited to fix it (with [[]]), but the last check is not needed because it is checked some lines earlier

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
