### PR TITLE
Fix GnuPG cross-compile on rtd1296 and other ARM architectures

### DIFF
--- a/cross/gmp/Makefile
+++ b/cross/gmp/Makefile
@@ -14,15 +14,15 @@ LICENSE  = LGPL
 include ../../mk/spksrc.cross-cc.mk
 
 GNU_CONFIGURE = 1
-ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi --disable-assembly
+endif
+ifeq ($(findstring $(ARCH), $(ARM7_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi
 endif
-ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
-CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
-endif
-ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM8_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
 endif
-ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
-CONFIGURE_ARGS += --disable-assembly
+ifeq ($(findstring $(ARCH), $(PPC_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
 endif

--- a/cross/gmp/Makefile
+++ b/cross/gmp/Makefile
@@ -17,3 +17,6 @@ GNU_CONFIGURE = 1
 ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --disable-assembly
 endif
+ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+CONFIGURE_ARGS += --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+endif

--- a/cross/gmp/Makefile
+++ b/cross/gmp/Makefile
@@ -14,9 +14,15 @@ LICENSE  = LGPL
 include ../../mk/spksrc.cross-cc.mk
 
 GNU_CONFIGURE = 1
-ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
-CONFIGURE_ARGS = --disable-assembly
+ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi
+endif
+ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
+CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
 endif
 ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
-CONFIGURE_ARGS += --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+CONFIGURE_ARGS = --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+endif
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS += --disable-assembly
 endif

--- a/cross/libgpg-error/Makefile
+++ b/cross/libgpg-error/Makefile
@@ -14,13 +14,15 @@ LICENSE  = LGPL
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk
-
-ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi --disable-assembly
+endif
+ifeq ($(findstring $(ARCH), $(ARM7_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi
 endif
-ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
-CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
-endif
-ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM8_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+endif
+ifeq ($(findstring $(ARCH), $(PPC_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
 endif

--- a/cross/libgpg-error/Makefile
+++ b/cross/libgpg-error/Makefile
@@ -21,3 +21,6 @@ endif
 ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
 CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
 endif
+ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+CONFIGURE_ARGS = --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+endif

--- a/cross/nettle/Makefile
+++ b/cross/nettle/Makefile
@@ -14,16 +14,16 @@ LICENSE  = GPLv2
 include ../../mk/spksrc.cross-cc.mk
 
 GNU_CONFIGURE = 1
-ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi --disable-assembly
+endif
+ifeq ($(findstring $(ARCH), $(ARM7_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi
 endif
-ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
-CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
-endif
-ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+ifeq ($(findstring $(ARCH), $(ARM8_ARCHES)),$(ARCH))
 CONFIGURE_ARGS = --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
 endif
-ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
-CONFIGURE_ARGS += --disable-assembler
+ifeq ($(findstring $(ARCH), $(PPC_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
 endif
 CONFIGURE_ARGS += --enable-shared

--- a/cross/nettle/Makefile
+++ b/cross/nettle/Makefile
@@ -14,10 +14,16 @@ LICENSE  = GPLv2
 include ../../mk/spksrc.cross-cc.mk
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --enable-shared
+ifeq ($(findstring $(ARCH), $(ARM_ARCHES)),$(ARCH))
+CONFIGURE_ARGS = --target=arm-unknown-linux-gnueabi --host=arm-unknown-linux-gnueabi
+endif
+ifeq ($(findstring $(ARCH),ppc853x qoriq),$(ARCH))
+CONFIGURE_ARGS = --target=powerpc-unknown-linux-gnu --host=powerpc-unknown-linux-gnu
+endif
+ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+CONFIGURE_ARGS = --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+endif
 ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
 CONFIGURE_ARGS += --disable-assembler
 endif
-ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
-CONFIGURE_ARGS += --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
-endif
+CONFIGURE_ARGS += --enable-shared

--- a/cross/nettle/Makefile
+++ b/cross/nettle/Makefile
@@ -18,3 +18,6 @@ CONFIGURE_ARGS = --enable-shared
 ifeq ($(findstring $(ARCH), $(ARM5_ARCHES)),$(ARCH))
 CONFIGURE_ARGS += --disable-assembler
 endif
+ifeq ($(findstring $(ARCH),rtd1296),$(ARCH))
+CONFIGURE_ARGS += --target=aarch64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
+endif


### PR DESCRIPTION
_Motivation:_ Fix GnuPG package cross-compile on ARM architectures

The Makefile in three GnuPG dependencies didn't define the correct **host** and **target** to cross-compile on several ARM architectures (and maybe non-ARM also)
The affected libraries where: gmp, libgpg-error and nettle

This PR fixes the Makefiles to allow cross-compile on (hopefully) all archs

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
