### PR TITLE
Determine and build affected spks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,3 +126,14 @@ setup-synocommunity: setup
 		-e "s|REPORT_URL=.*|REPORT_URL=https://github.com/SynoCommunity/spksrc/issues|" \
 		local.mk
 
+all-affected-spks-from-master:
+	for spk in $(git diff --stat upstream/master...HEAD | bash mk/build-target-determinator.bash | sort) ; \
+	do \
+	    env $(MAKE) $${spk}-all-supported ; \
+	done
+
+# "make python3-all-supported" causes "make all-supported" to run in that spk
+%-all-supported: spk/%/Makefile
+	cd $(dir $^) && env $(MAKE) all-supported
+
+

--- a/mk/build-target-determinator.bash
+++ b/mk/build-target-determinator.bash
@@ -1,0 +1,52 @@
+#!bash
+#
+# A fairly-reliable method of determining the SPKs that need to be rebuild based on the files that
+# changed in the last commit.  Only looks at cross/* native/* and spk/* because, well, mk/* might
+# be a bit harder, and toolchains/* would require a rebuild of the world.
+#
+# I did this as a script rather than inside a mk/spksrc.spk.mk target to ensure I'm not evaluating
+# this on every run, only when needed.
+
+# test via:  git diff --stat HEAD^^^ | bash mk/build-target-determinator.bash
+# expected output is a list of subdirs of spk dir
+awk '
+func getdeps(depdir) {
+	checked[depdir]++
+
+	# somewhat reliable shell-exec grep for Makefiles referring to what we have
+	command = "grep -l \"DEPENDS .*"depdir"\" {cross,native,spk}/*/Makefile"
+	while ((command | getline line) > 0) {
+		split(line,path,"/");
+		dep[path[1]"/"path[2]]++;
+	}
+	close(command)
+}
+
+BEGIN {
+    # This is effectively a typedef, avoids errors when check has no elements
+	checked[2]="bogus"; delete checked[2];
+}
+
+/^ (cross|native|spk)\// {
+	split($1,path,"/");
+	dep[path[1]"/"path[2]]++;
+}
+
+END {
+	max_cycles = 30  # avoid infinite loop
+	while ((length(checked) < length(dep)) && (max_cycles--)) {
+		# easier with re-entrant code :)
+		# but instead we loop until the checked == depends
+		for (d in dep) {
+			# simplified "if (d not in checked) { getdeps(d)}"
+			found=0;
+			for (c in checked) if (c == d) found++;
+			if (1 > found) {
+			   getdeps(d)
+			}
+		}
+	}
+	# print the collected dependents, spk subdirs only
+	for (d in dep) if (d ~ "^spk/") { gsub("^spk/","",d); printf "%s ",d; } printf "\n";
+}'
+


### PR DESCRIPTION
_Motivation:_
(I think) @Safihre mentioned that it can be difficult to determine what SPKs are affected by a change.  This diff gives the build target and script support to determine the SPKs affected by the changes in the most recent commit.  The build target "all-affected-spks" leverages this to build all the SPKs that directly and indirectly use an edited file in `cross/*`, `native/*`, and of course `spk/*`.

Why aren't I building the world with this?  It's not a change to any shipping SPK, but a tool to make building them trivial.  Consider:

`docker run ... SynoCommunity/spksrc:latest -w /spksrc  make   all-affected-spks-from-master`

...I could just push all rebuilt SPKs, but that might be biting off too much at once.

@Safihre @ymartin59 looking for feedback


### Checklist
- [n/a] Build rule `all-supported` completed successfully.
- [n/a] Package upgrade completed successfully
- [n/a] New installation of package completed successfully


I've been granted permission by my employer to contribute to spksrc without risk of IP confusion. I am required to explicitly write that my contribution to this project is solely in my personal capacity, and I am not conveying any rights to any intellectual property of any third parties.