### PR TITLE
Bring back PPC_ARCHES for Deluge

### DIFF
--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -10,7 +10,6 @@ WHEELS = characteristic chardet pyasn1-modules pyxdg Mako service-identity
 SPK_DEPENDS = "python>=2.7.6-8"
 
 REQUIRED_DSM = 5.0
-UNSUPPORTED_ARCHS = $(PPC_ARCHES)
 
 MAINTAINER = Safihre
 DESCRIPTION = Deluge is a full-featured  BitTorrent client for Linux, OS X, Unix and Windows. It uses libtorrent in its backend and features multiple user-interfaces including: GTK+, web and console. It has been designed using the client server model with a daemon process that handles all the bittorrent activity. The Deluge daemon is able to run on headless machines with the user-interfaces being able to connect remotely from any platform. This package is intended for advanced users.


### PR DESCRIPTION
_Motivation:_ I want to be able to run Deluge on my DS413 (qoriq)

I'm not sure what the issue was back in 4a9d7846001ca724aad5106391da0344f868c9a3, but it seems to have been resolved. Deluge compiles just fine and and works correctly at least on qoriq, the only platform I have available for testing.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
