### PR TITLE
Adding Sonarr v3 compatibility

### DIFF
--- a/cross/libmediainfo/Makefile
+++ b/cross/libmediainfo/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libmediainfo
-PKG_VERS = 17.12
+PKG_VERS = 18.08.1
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://mediaarea.net/download/source/$(PKG_NAME)/$(PKG_VERS)

--- a/cross/libmediainfo/digests
+++ b/cross/libmediainfo/digests
@@ -1,3 +1,3 @@
-libmediainfo_17.12.tar.xz SHA1 928650e8ee3b131eb1a7ad9b8ec71985788b1f95
-libmediainfo_17.12.tar.xz SHA256 b482bb34df5d59ae8b735b9631ad0ad150dc71b715e851f1d3155ceb4921a452
-libmediainfo_17.12.tar.xz MD5 18556e9e6b14e537aeab6eaac7b9b3f3
+libmediainfo_18.08.1.tar.xz SHA1 13a6ea8d83e4fd4d6e239d5a6b3f71f4766c0599
+libmediainfo_18.08.1.tar.xz SHA256 7a237f35257fadf2796c02161e87330dedca74d0fb914259be3d8d88d2cbcbc0
+libmediainfo_18.08.1.tar.xz MD5 c5fba877164fa5654373b59fa68b9590

--- a/cross/mediainfo/Makefile
+++ b/cross/mediainfo/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = mediainfo
-PKG_VERS = 17.12
+PKG_VERS = 18.08.1
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://mediaarea.net/download/source/$(PKG_NAME)/$(PKG_VERS)

--- a/cross/mediainfo/digests
+++ b/cross/mediainfo/digests
@@ -1,3 +1,3 @@
-mediainfo_17.12.tar.xz SHA1 dfbdbf61ab8304579669de434557d0f28482639c
-mediainfo_17.12.tar.xz SHA256 ce14ae3b15fb36e9cd21c73ac1b4c58bcc7d9f52b1fd110a7d68b0e12d70addf
-mediainfo_17.12.tar.xz MD5 6d29665de2630b0d1b0f4e4bc242f0d2
+mediainfo_18.08.1.tar.xz SHA1 d2d663b8850208b22c9b0db3ab18fa08a010e7df
+mediainfo_18.08.1.tar.xz SHA256 49773d0b13cb13818a7727b59f0124186fd96b3ffd22a6402ccf082c3f6b0267
+mediainfo_18.08.1.tar.xz MD5 3b0ce00cbf110e6c496c14641df59737

--- a/cross/sonarr/Makefile
+++ b/cross/sonarr/Makefile
@@ -1,11 +1,11 @@
 PKG_NAME = NzbDrone
-PKG_VERS = 2.0.0.4689
+PKG_VERS = 2.0.0.5252
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME).master.$(PKG_VERS).mono.$(PKG_EXT)
 PKG_DIST_SITE = http://download.sonarr.tv/v2/master/mono
 PKG_DIR = NzbDrone
 
-DEPENDS = 
+DEPENDS =
 
 HOMEPAGE = https://sonarr.tv
 COMMENT  = Sonarr is a PVR for newsgroup users. It can monitor multiple RSS feeds for new episodes of your favourite shows and will grab, sorts and rename them. It can also be configured to automatically upgrade the quality of files already downloaded if a better quality format becomes available.
@@ -20,4 +20,3 @@ include ../../mk/spksrc.cross-cc.mk
 myInstall:
 	mkdir -p $(STAGING_INSTALL_PREFIX)/share/$(PKG_DIR)
 	tar -cf - -C $(WORK_DIR)/$(PKG_DIR) . | tar -xf - -C $(STAGING_INSTALL_PREFIX)/share/$(PKG_DIR)
-

--- a/cross/sonarr/digests
+++ b/cross/sonarr/digests
@@ -1,3 +1,3 @@
-NzbDrone.master.2.0.0.4689.mono.tar.gz SHA1 d87cac0fe5e98b2898bb3df575296ea75f1d9284
-NzbDrone.master.2.0.0.4689.mono.tar.gz SHA256 93afe3a5e7bd4c285aacb6d3c94fb4251c0de845761b82e37cc6fa85926dd614
-NzbDrone.master.2.0.0.4689.mono.tar.gz MD5 9a6ff66d6e1e3e1a7ac68dba3cdf0f5c
+NzbDrone.master.2.0.0.5252.mono.tar.gz SHA1 cf1bef592f51a9d95c91ea59611d9522682b9cf2
+NzbDrone.master.2.0.0.5252.mono.tar.gz SHA256 d70d6e236dbbdcd54692b3f71f12bf97465608f954d985c71e1b5ae905d74667
+NzbDrone.master.2.0.0.5252.mono.tar.gz MD5 4b988b1b249ee274479a3d159170bc84

--- a/spk/mediainfo/Makefile
+++ b/spk/mediainfo/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mediainfo
-SPK_VERS = 17.12
-SPK_REV = 6
+SPK_VERS = 18.08.1
+SPK_REV = 7
 SPK_ICON = src/mediainfo.png
 
 DEPENDS  = cross/$(SPK_NAME)

--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbdrone
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 14
+SPK_REV = 15
 SPK_ICON = src/sonarr.png
 
 REQUIRED_DSM = 5.0
@@ -42,4 +42,3 @@ include ../../mk/spksrc.spk.mk
 .PHONY: sonarr_extra_install
 sonarr_extra_install:
 	install -m 755 -d $(STAGING_DIR)/app
-	install -m 644 src/config.xml $(STAGING_DIR)/app/config.xml

--- a/spk/sonarr/src/config.xml
+++ b/spk/sonarr/src/config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<Config>
-  <Branch>master</Branch>
-  <UpdateMechanism>BuiltIn</UpdateMechanism>
-  <LaunchBrowser>False</LaunchBrowser>
-</Config>

--- a/spk/sonarr/src/service-setup.sh
+++ b/spk/sonarr/src/service-setup.sh
@@ -2,14 +2,29 @@ PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
 MONO_PATH="/usr/local/mono/bin"
 MONO="${MONO_PATH}/mono"
 
-# Check versions during upgrade
-SONARR="${SYNOPKG_PKGDEST}/share/NzbDrone/NzbDrone.exe"
-SPK_SONARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/NzbDrone/NzbDrone.exe"
-
 # Sonarr uses the home directory to store it's ".config"
 HOME_DIR="${SYNOPKG_PKGDEST}/var"
 CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
-PID_FILE="${CONFIG_DIR}/NzbDrone/nzbdrone.pid"
+
+# Sonarr v2 -> v3 compatibility:
+if [ -f "${SYNOPKG_PKGDEST}/share/NzbDrone/NzbDrone.exe" ]; then
+    # v2 installed
+    SONARR="${SYNOPKG_PKGDEST}/share/NzbDrone/NzbDrone.exe"
+    PID_FILE="${CONFIG_DIR}/NzbDrone/nzbdrone.pid"
+else
+    # v3 installed
+    SONARR="${SYNOPKG_PKGDEST}/share/Sonarr/Sonarr.exe"
+    PID_FILE="${CONFIG_DIR}/Sonarr/sonarr.pid"
+fi
+
+# Allow correct Sonarr SPK version checking (v2 or v3)
+if [ -f "${SYNOPKG_PKGINST_TEMP_DIR}/share/NzbDrone/NzbDrone.exe" ]; then
+    # v2 SPK
+    SPK_SONARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/NzbDrone/NzbDrone.exe"
+else
+    # v3 SPK
+    SPK_SONARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/Sonarr/Sonarr.exe"
+fi
 
 # Some have it stored in the root of package
 LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/.config"
@@ -22,12 +37,9 @@ SVC_BACKGROUND=y
 
 service_postinst ()
 {
-    # Move config.xml to .config
-    mkdir -p ${CONFIG_DIR}/NzbDrone
-    mv ${SYNOPKG_PKGDEST}/app/config.xml ${CONFIG_DIR}/NzbDrone/config.xml
     set_unix_permissions "${CONFIG_DIR}"
 
-    # If nessecary, add user also to the old group before removing it
+    # If necessary, add user also to the old group before removing it
     syno_user_add_to_legacy_group "${EFF_USER}" "${USER}" "${LEGACY_GROUP}"
     syno_user_add_to_legacy_group "${EFF_USER}" "${USER}" "users"
 
@@ -56,7 +68,8 @@ service_preupgrade ()
     echo "Installed Sonarr Binary: ${CUR_VER}" >> ${INST_LOG}
     SPK_VER=$(${MONO_PATH}/monodis --assembly ${SPK_SONARR} | grep "Version:" | awk '{print $2}')
     echo "Requested Sonarr Binary: ${SPK_VER}" >> ${INST_LOG}
-    if [ "${CUR_VER//.}" -ge "${SPK_VER//.}" ]; then
+    function version_compare() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+    if version_compare $CUR_VER $SPK_VER; then
         echo 'KEEP_CUR="yes"' > ${CONFIG_DIR}/KEEP_VAR
         echo "[KEEPING] Installed Sonarr Binary - Upgrading Package Only" >> ${INST_LOG}
         mv ${SYNOPKG_PKGDEST}/share ${INST_VAR}
@@ -76,6 +89,7 @@ service_postupgrade ()
         mv ${INST_VAR}/share ${SYNOPKG_PKGDEST}/ >> $INST_LOG 2>&1
         set_unix_permissions "${SYNOPKG_PKGDEST}/share"
     fi
+
     set_unix_permissions "${CONFIG_DIR}"
 
     # If backup was created before new-style packages


### PR DESCRIPTION
_Motivation:_ This PR adds compatibility to upgrade successfully to Sonarr v3 (when released.) Sonarr v3 changes the executable name (NzbDrone.exe --> Sonarr.exe) and data folder/filenames (NzbDrone --> Sonarr.) This package allows proper package upgrades when installing to a v2 or v3 install (or vice versa.)

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
