### PR TITLE
Tvheadend 4.2.7 transcoding fix

### DIFF
--- a/cross/tvheadend/patches/002-tmp-transcoding-high.patch
+++ b/cross/tvheadend/patches/002-tmp-transcoding-high.patch
@@ -1,0 +1,12 @@
+# Fixes 'high' errors with software transcoding in TVH 4.2.7. Addressed in master. Will be obsolete with 4.2.8+ and 4.3.x 
+--- src/plumbing/transcoding.c.orig	2018-11-27 08:34:47.347891754 +0100
++++ src/plumbing/transcoding.c	2018-11-27 08:35:40.262228361 +0100
+@@ -1348,7 +1348,7 @@
+       tvhinfo(LS_TRANSCODE, "%04X: Using preset %s", shortid(t), t->t_props.tp_vcodec_preset);
+ 
+       // All modern devices should support "high" profile
+-      av_dict_set(&opts, "profile", "high", 0);
++      //av_dict_set(&opts, "profile", "high", 0);
+ 
+       if (t->t_props.tp_vbitrate < 64) {
+         // encode with specified quality and optimize for low latency

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -3,7 +3,6 @@ SPK_VERS = 4.2.7
 SPK_REV = 15
 SPK_ICON = src/tvheadend.png
 DSM_UI_DIR = app
-BETA = 1
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = tvheadend
 SPK_VERS = 4.2.7
-SPK_REV = 14
+SPK_REV = 15
 SPK_ICON = src/tvheadend.png
 DSM_UI_DIR = app
 BETA = 1


### PR DESCRIPTION
_Motivation:_

1. Software transcoding with h264 broken in 4.2.7 maintenance release 
2. Beta flag of TVH package to be removed

_Linked issues:_ 
- https://tvheadend.org/boards/5/topics/27780?r=35267#message-35267
- Fix has been identified upstream: https://github.com/tvheadend/tvheadend/commit/55acbe1cf95c565d8bf3f76560cb8d4633f90c5a

_Changes:_
1. Cherry-picked transcoding fix and added as temporary patch file. Can be removed on next regular upgrade (4.2.8 or 4.4.0).
2. Beta flag removed.

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [x] Build of `braswell` test package completed successfully
- [x] Package upgrade completed successfully
- [ ] New installation of package completed successfully
- [x] Transcoding problem reported as fixed