### PR TITLE
[Gateone] Change service protocol type to https

### DIFF
--- a/spk/gateone/Makefile
+++ b/spk/gateone/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = gateone
 SPK_VERS = 20171125
-SPK_REV = 7
+SPK_REV = 8
 SPK_ICON = src/gateone.png
 DSM_UI_DIR = app
 
@@ -24,6 +24,7 @@ SERVICE_SETUP = src/service-setup.sh
 
 # Service configuration
 SERVICE_PORT = 8271
+SERVICE_PORT_PROTOCOL = https
 SERVICE_PORT_TITLE = Gateone (HTTPS)
 
 # Admin link


### PR DESCRIPTION
_Motivation:_ Service protocol type is incorrectly set to http, but should be https.
_Linked issues:_ #2340 

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [x] Build rule `apollolake` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
- [x] Confirmed working by user. See #2340.