### PR TITLE
Update go-1.4 to latest version in order to build on Debian Stretch

### DIFF
--- a/native/go-1.4/Makefile
+++ b/native/go-1.4/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = go
-PKG_VERS = 1.4.2
+PKG_VERS = 1.4-bootstrap-20171003
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).src.$(PKG_EXT)
-PKG_DIST_SITE = https://storage.googleapis.com/golang
+PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://dl.google.com/go
 PKG_DIR = $(PKG_NAME)
 
 DEPENDS =
@@ -19,4 +19,4 @@ include ../../mk/spksrc.native-cc.mk
 
 myComp:
 	@$(MSG) "Building Go 1.4"
-	cd $(WORK_DIR)/$(PKG_NAME)/src && GOARCH="" ./make.bash
+	cd $(WORK_DIR)/$(PKG_NAME)/src && CGO_ENABLED=0 GOARCH="" ./make.bash

--- a/native/go-1.4/digests
+++ b/native/go-1.4/digests
@@ -1,3 +1,3 @@
-go1.4.2.src.tar.gz SHA1 460caac03379f746c473814a65223397e9c9a2f6
-go1.4.2.src.tar.gz SHA256 299a6fd8f8adfdce15bc06bde926e7b252ae8e24dd5b16b7d8791ed79e7b5e9b
-go1.4.2.src.tar.gz MD5 907f85c8fa765d31f7f955836fec4049
+go1.4-bootstrap-20171003.tar.gz SHA1 881f0c980a6d6f4e0427a86237298dd9717d8ecf
+go1.4-bootstrap-20171003.tar.gz SHA256 f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52
+go1.4-bootstrap-20171003.tar.gz MD5 dbf727a4b0e365bf88d97cbfde590016


### PR DESCRIPTION
_Motivation:_ Go compiler will not build on Debian Stretch with version 1.4.2
_Linked issues:_ none

### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [] New installation of package completed successfully

According to the official build from source instructions on <https://golang.org/doc/install/source>, version `go1.4-bootstrap-20171003` is needed for `Go compiler` to compile on current systems. Also `CGO_ENABLED=0` should be set. Since the build environment is based on `Debian`, this update is needed for `Go` to compile successfully on `Stretch`.
