### PR TITLE
mercurial: update to 4.8.1

### DIFF
--- a/cross/mercurial/Makefile
+++ b/cross/mercurial/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = mercurial
-PKG_VERS = 4.0.1
+PKG_VERS = 4.8.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.mercurial-scm.org/release

--- a/cross/mercurial/digests
+++ b/cross/mercurial/digests
@@ -1,3 +1,3 @@
-mercurial-4.0.1.tar.gz SHA1 95c32626bd8f02d2803f915ef639723e830c6ee0
-mercurial-4.0.1.tar.gz SHA256 6aa4ade93c1b5e11937820880a466ebf1c824086d443cd799fc46e2617250d40
-mercurial-4.0.1.tar.gz MD5 22a9b1d7c0c06a53f0ae5b386d536d08
+mercurial-4.8.1.tar.gz SHA1 108254a9f2dddd9478cdbc7d3127108b22facb7c
+mercurial-4.8.1.tar.gz SHA256 48a45f5cde9104fbc2daf310d710d4ebf286d879b89fa327d24b005434b0fa21
+mercurial-4.8.1.tar.gz MD5 2da7ead4517ddb65f997bc27c6483686

--- a/spk/mercurial/Makefile
+++ b/spk/mercurial/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mercurial
-SPK_VERS = 4.0.1
-SPK_REV = 4
+SPK_VERS = 4.8.1
+SPK_REV = 5
 SPK_ICON = src/mercurial.png
 
 BUILD_DEPENDS = cross/python cross/setuptools cross/pip cross/wheel cross/$(SPK_NAME)
@@ -11,7 +11,7 @@ MAINTAINER = Dr-Bean
 DESCRIPTION = Mercurial is a free, distributed source control management tool
 STARTABLE = no
 DISPLAY_NAME = Mercurial
-CHANGELOG = Update to 4.0.1
+CHANGELOG = Update to 4.8.1
 
 HOMEPAGE = http://mercurial.selenic.com/
 LICENSE  = MPL1.1


### PR DESCRIPTION
_Motivation:_ Update Mercurial to 4.8.1.
_Linked issues:_ none

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

I'm not sure what the `all-supported` rule is? (`make all-supported` isn't a valid target). But I did build the package for `avoton-6.1` and upgraded it on my NAS, then uninstalled it and re-installed it from scratch.