### PR TITLE
One shot spk arch convenience func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ spk-clean:
 %-clean: spk/%/Makefile
 	cd $(dir $^) && env $(MAKE) clean
 
+# define a template that instantiates a 'python3-avoton-6.1' -style target for
+# every ($2) arch, every ($1) spk
+define SPK_ARCH_template =
+$(1)-$(2): spk/$(1)/Makefile setup
+	cd spk/$(1) && env $(MAKE) arch-$(2)
+endef
+$(foreach arch,$(AVAILABLE_ARCHS),$(foreach spk,$(SUPPORTED_SPKS),$(eval $(call SPK_ARCH_template,$(spk),$(arch)))))
+
 prepare: downloads
 	@for tc in $(dir $(wildcard toolchains/*/Makefile)) ; \
 	do \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ spk-clean:
 # define a template that instantiates a 'python3-avoton-6.1' -style target for
 # every ($2) arch, every ($1) spk
 define SPK_ARCH_template =
-$(1)-$(2): spk/$(1)/Makefile setup
+spk-$(1)-$(2): spk/$(1)/Makefile setup
 	cd spk/$(1) && env $(MAKE) arch-$(2)
 endef
 $(foreach arch,$(AVAILABLE_ARCHS),$(foreach spk,$(SUPPORTED_SPKS),$(eval $(call SPK_ARCH_template,$(spk),$(arch)))))


### PR DESCRIPTION
_Motivation:_ 

In looking at build instructions, it makes me think that there must be a more trivial set of instructions.

Instead of:

```
# sudo docker run -it -v $(pwd):/spksrc -w /spksrc synocommunity/spksrc /bin/bash
$ make setup
$ cd spk/python3
$ make arch-XXXX
$ exit
```

The resulting command is:

`sudo docker run -it --rm -v $(pwd):/spksrc -w /spksrc  synocommunity/spksrc  make  python3-avoton-6.1`

_Linked issues:_

Can make home-assistant/home-assistant.io#7861 more trivial

### Checklist  (none apply, so checked all that were required)
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

