### PR TITLE
framework: new docker image based on Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER SynoCommunity <https://synocommunity.com>
 
 ENV LANG C.UTF-8
@@ -6,9 +6,13 @@ ENV LANG C.UTF-8
 # Manage i386 arch
 RUN dpkg --add-architecture i386
 
+# Include backports for recent Meson build tool
+RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" > /etc/apt/sources.list.d/stretch-backports.list
+
 # Install required packages
 RUN apt-get update && \
-    apt-get install -y automake \
+    apt-get install --no-install-recommends -y automake \
+        libtool \
         bc \
         bison \
         build-essential \
@@ -34,18 +38,21 @@ RUN apt-get update && \
         libpcre3-dev \
         libssl-dev \
         libunistring-dev \
+        unzip \
         lzip \
         mercurial \
         ncurses-dev \
-        php5 \
+        php \
         pkg-config \
         python3 \
         subversion \
         swig \
         xmlto \
         zlib1g-dev && \
+    apt-get -t stretch-backports -y install meson && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# recent meson for fuse and sshfs
 
 # Install setuptools, wheel and pip for Python3
 RUN wget https://bootstrap.pypa.io/get-pip.py -O - | python3


### PR DESCRIPTION
_Motivation:_ Get recent Meson to build recent fuse for sshfs (synocli-net)

Docker image is far lighter that previous one on Jessie because I discarded most documentation tooling (mainly latex) with `--no-install-recommends`