### PR TITLE
fixed version number of tmux package

### DIFF
--- a/spk/tmux/Makefile
+++ b/spk/tmux/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = tmux
-SPK_VERS = 2.3
-SPK_REV = 3
+SPK_VERS = 2.8
+SPK_REV = 4
 SPK_ICON = src/tmux.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -10,7 +10,7 @@ DESCRIPTION = tmux is a terminal multiplexer, it enables a number of terminals o
 RELOAD_UI = no
 DISPLAY_NAME = Tmux
 STARTABLE = no
-CHANGELOG = Update to 2.3
+CHANGELOG = Update to 2.8
 
 HOMEPAGE   = http://tmux.github.io
 LICENSE    = BSD License


### PR DESCRIPTION
_Motivation:_ Fixed package version number of tmux, tmux version is already 2.8
_Linked issues:_ #3574 

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
