### PR TITLE
Disable go.mod module support to avoid disqualifying standard libraries

### DIFF
--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -21,4 +21,5 @@ include ../../mk/spksrc.native-cc.mk
 
 myComp:
 	@$(MSG) "Building Go for host system"
-	cd $(WORK_DIR)/$(PKG_NAME)/src && GOARCH="" GOROOT_BOOTSTRAP=$(GOROOT_BOOTSTRAP14) ./make.bash
+	# GO111MODULE disable go.mod per https://github.com/golang/go/issues/26996
+	cd $(WORK_DIR)/$(PKG_NAME)/src && GO111MODULE=off GOARCH="" GOROOT_BOOTSTRAP=$(GOROOT_BOOTSTRAP14) ./make.bash


### PR DESCRIPTION
_Motivation:_

I was working with a go tool, and wanted to build it.  I found that the build was failing due to inability to find some fairly standard libraries.

A quick google, and it seems go-1.11's handling of modules via  `go.mod` can interfere.  What `go.mod` offers to magically upgrade everyone's working code is to put in a redundant `go.mod` during compile so that it's there when they need it.  This is awesome except for system libraries -- it seems to be that they're in a reserved location, and a `go.mod` that calls out bad locations (except specifically this case) is bad.

The solution seems to be not to leave `GO111MODULE` undefined but to define `off` it to deactivate `go.mod` support when building so that the system libraries are not invalidated.  Magically, the build of `native/go` leveraging `native/go-1.4` succeeds.

... but I wanted to make sure, so I built all three current go `cross` libraries:

`cross/dnscrypt-proxy`
`cross/fritzctl`
`cross/syncthing`

... then build the 3 `spk` that use them:

`dnscrypt-proxy`
`spk/synocli-net`
`syncthing`
 
_Linked issues:_

I don't think it'll affect #3386

### Checklist
- [n/a] Build rule `all-supported` completed successfully
- [n/a] Package upgrade completed successfully
- [n/a] New installation of package completed successfully
- [x] Built all cross targets using toolchain
- [x] Built all spks using cross targets that use this toolchain