### PR TITLE
Added rsync version 3.1.3 to synocli-net

### DIFF
--- a/cross/rsync/Makefile
+++ b/cross/rsync/Makefile
@@ -1,0 +1,16 @@
+PKG_NAME = rsync
+PKG_VERS = 3.1.3
+PKG_EXT = tar.gz
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+PKG_DIST_SITE = https://download.samba.org/pub/$(PKG_NAME)/src
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+
+# DEPENDS = cross/ncurses
+
+HOMEPAGE = https://rsync.samba.org/
+COMMENT  = Rsync is a fast and extraordinarily versatile file copying tool. It can copy locally, to/from another host over any remote shell, or to/from a remote rsync daemon. It offers a large number of options that control every aspect of its behavior and permit very flexible specification of the set of files to be copied. It is famous for its delta-transfer algorithm, which reduces the amount of data sent over the network by sending only the differences between the source files and the existing files in the destination. Rsync is widely used for backups and mirroring and as an improved copy command for everyday use. 
+LICENSE  = GPLv3
+
+GNU_CONFIGURE = 1
+
+include ../../mk/spksrc.cross-cc.mk

--- a/cross/rsync/PLIST
+++ b/cross/rsync/PLIST
@@ -1,0 +1,1 @@
+bin:bin/rsync

--- a/cross/rsync/digests
+++ b/cross/rsync/digests
@@ -1,0 +1,3 @@
+rsync-3.1.3.tar.gz SHA1 82e7829c0b3cefbd33c233005341e2073c425629
+rsync-3.1.3.tar.gz SHA256 55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0
+rsync-3.1.3.tar.gz MD5 1581a588fde9d89f6bc6201e8129afaf

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -1,11 +1,12 @@
 SPK_NAME = synocli-net
-SPK_VERS = 1.1
+SPK_VERS = 1.2
 SPK_REV = 2
 SPK_ICON = src/synocli-net.png
 
 include ../../mk/spksrc.common.mk
 
 DEPENDS = cross/screen cross/tmux cross/nmap cross/sshfs cross/mosh cross/socat
+DEPENDS += cross/rsync
 ifneq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
 DEPENDS += cross/fritzctl
 endif
@@ -14,10 +15,10 @@ endif
 SPK_DEPENDS = "Perl>=5.14"
 
 MAINTAINER = ymartin59
-DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilities: screen, tmux, mosh, socat, nmap, sshfs, fritzctl. Credits to Sebastian Schmidt \(publicarray\) for icons"
+DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilities: screen, tmux, mosh, socat, nmap, sshfs, fritzctl, rsync. Credits to Sebastian Schmidt \(publicarray\) for icons"
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
-CHANGELOG = "3. Build sshfs 2.10 with fuse updated to v2.9.9"
+CHANGELOG = "1. Add rsync"
 
 HOMEPAGE   = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliNet
 LICENSE    = Mixed

--- a/spk/synocli-net/src/service-setup.sh
+++ b/spk/synocli-net/src/service-setup.sh
@@ -1,5 +1,5 @@
 
-COMMANDS="nmap nping sshfs fusermount screen mosh mosh-client mosh-server socat procan filan fritzctl"
+COMMANDS="nmap nping sshfs fusermount screen mosh mosh-client mosh-server socat procan filan fritzctl rsync"
 
 service_postinst ()
 {


### PR DESCRIPTION
_Motivation:_ Synologys built-in rsync is old and have features that prohibits receiving data over ssh.


### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
