### PR TITLE
added libutempter

### DIFF
--- a/cross/libutempter/Makefile
+++ b/cross/libutempter/Makefile
@@ -1,0 +1,22 @@
+PKG_NAME = libutempter
+PKG_VERS = 1.1.5
+PKG_EXT = tar.bz2
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = ftp://ftp.altlinux.org/pub/people/ldv/utempter/
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+CONFIGURE_TARGET = nop
+DEPENDS =
+
+POST_PATCH_TARGET = libutempter_post_patch
+
+HOMEPAGE = http://freshmeat.sourceforge.net/projects/libutempter
+COMMENT  = libutempter provides a library interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files.
+LICENSE  = LGPLv2
+
+include ../../mk/spksrc.cross-cc.mk
+
+.PHONY: libutempter_post_patch
+libutempter_post_patch:
+	$(RUN) sed -e 's#@INSTALL_PREFIX@#$(STAGING_INSTALL_PREFIX)#' -i Makefile
+

--- a/cross/libutempter/PLIST
+++ b/cross/libutempter/PLIST
@@ -1,0 +1,3 @@
+lnk:lib/libutempter.so
+lnk:lib/libutempter.so.0
+lib:lib/libutempter.so.1.1.5

--- a/cross/libutempter/digests
+++ b/cross/libutempter/digests
@@ -1,0 +1,3 @@
+libutempter-1.1.5.tar.bz2 SHA1 fd250c317c92a300508365593bf68fbd5f2b9e9a
+libutempter-1.1.5.tar.bz2 SHA256 73d0576b16caeb22874dc80d0ce7a6aeebb3181b117e95c147cd8d29df99e70e
+libutempter-1.1.5.tar.bz2 MD5 d62a93ba9f3796a91cf03be5ef25a9a1

--- a/cross/libutempter/patches/Makefile.patch
+++ b/cross/libutempter/patches/Makefile.patch
@@ -1,0 +1,18 @@
+--- Makefile	2007-02-19 12:14:08.000000000 +0000
++++ Makefile.new	2019-01-17 08:33:09.000000000 +0000
+@@ -30,9 +30,12 @@
+ TARGETS = $(PROJECT) $(SHAREDLIB) $(STATICLIB)
+ 
+ INSTALL = install
+-libdir = /usr/lib
+-libexecdir = /usr/lib
+-includedir = /usr/include
++prefix = @INSTALL_PREFIX@
++exec_prefix =${prefix}
++libdir =${exec_prefix}/lib
++libexecdir =${exec_prefix}/lib
++sharedlibdir =${libdir}
++includedir =${prefix}/include
+ DESTDIR =
+ 
+ WARNINGS = -W -Wall -Waggregate-return -Wcast-align -Wconversion \

--- a/cross/mosh/Makefile
+++ b/cross/mosh/Makefile
@@ -5,7 +5,7 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/mobile-shell/mosh/releases/download/$(PKG_DIR)
 
-DEPENDS = cross/zlib cross/openssl cross/protobuf cross/ncurses
+DEPENDS = cross/zlib cross/openssl cross/protobuf cross/ncurses cross/libutempter
 
 HOMEPAGE = https://mosh.org
 COMMENT  = Mosh: the mobile shell


### PR DESCRIPTION
mosh now builds against libutempter, this is a requirement for adding support for displaying detached sessions.

_Motivation:_ Trying to add support to show detached sessions upon connection.
_Linked issues:_ https://github.com/SynoCommunity/spksrc/issues/3582

### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [] New installation of package completed successfully