### PR TITLE
Update Tvheadend to 4.2.8 and remove beta flag of package

### DIFF
--- a/cross/tvheadend/Makefile
+++ b/cross/tvheadend/Makefile
@@ -20,15 +20,15 @@ CONFIGURE_ARGS += --disable-ffmpeg_static --enable-libav
 CONFIGURE_ARGS += --disable-libfdkaac_static --disable-libopus_static --disable-libtheora --disable-libtheora_static
 CONFIGURE_ARGS += --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static
 
-INSTALL_TARGET = myInstall
 POST_PATCH_TARGET = post_patch_target_tvheadend
+
+ifeq ($(wildcard $(FFMPEG_DIR)),)
+DEPENDS += cross/ffmpeg
+endif
 
 include ../../mk/spksrc.cross-cc.mk
 
-
-.PHONY: myInstall
-myInstall:
-	$(RUN) make install DESTDIR=$(INSTALL_DIR)
+.PHONY: post_patch_target_tvheadend
 
 post_patch_target_tvheadend:
 	@if [ "$(ARCH)" = "ppc853x" ] || [ "$(ARCH)" = "qoriq" ]; then \

--- a/cross/tvheadend/Makefile
+++ b/cross/tvheadend/Makefile
@@ -1,13 +1,12 @@
 PKG_NAME = tvheadend
-PKG_VERS = 4.2.7
+PKG_VERS = 4.2.8
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/tvheadend/tvheadend/archive
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 
-DEPENDS = cross/openssl cross/libhdhomerun cross/uriparser cross/libdvbcsa
-DEPENDS += cross/pcre2 cross/ffmpeg
+DEPENDS = cross/openssl cross/libhdhomerun cross/uriparser cross/libdvbcsa cross/pcre2
 
 HOMEPAGE = https://www.lonelycoder.com/tvheadend/
 COMMENT  = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT IP and HDHomeRun as input sources. Tvheadend offers HTTP, HTSP and SAT IP streaming.
@@ -18,6 +17,8 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --enable-imagecache --disable-avahi --enable-dvbcsa --enable-bundle --release
 CONFIGURE_ARGS += --disable-hdhomerun_static --enable-hdhomerun_client
 CONFIGURE_ARGS += --disable-ffmpeg_static --enable-libav
+CONFIGURE_ARGS += --disable-libfdkaac_static --disable-libopus_static --disable-libtheora --disable-libtheora_static
+CONFIGURE_ARGS += --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static
 
 INSTALL_TARGET = myInstall
 POST_PATCH_TARGET = post_patch_target_tvheadend
@@ -32,4 +33,5 @@ myInstall:
 post_patch_target_tvheadend:
 	@if [ "$(ARCH)" = "ppc853x" ] || [ "$(ARCH)" = "qoriq" ]; then \
 		cat $(PWD)/patches/ppc/isoc9x.patch | ($(RUN) patch -p0) ;\
+		cat $(PWD)/patches/ppc/hts_strtab-undo-inlining-of-functions.patch | ($(RUN) patch -p0) ;\
 	fi;

--- a/cross/tvheadend/digests
+++ b/cross/tvheadend/digests
@@ -1,3 +1,3 @@
-tvheadend-4.2.7.tar.gz SHA1 78f65617c6101e952607bc64963f59648234b2a7
-tvheadend-4.2.7.tar.gz SHA256 8383990895be767a1b8f6d3a9356c2d5b2ea5d686d2293fbdb1552ffc6ea0640
-tvheadend-4.2.7.tar.gz MD5 db025d4672253019c59cd4f60beccd06
+tvheadend-4.2.8.tar.gz SHA1 4f9f6472b5c55b19c33b505357912929f53d9a9b
+tvheadend-4.2.8.tar.gz SHA256 1aef889373d5fad2a7bd2f139156d4d5e34a64b6d38b87b868a2df415f01f7ad
+tvheadend-4.2.8.tar.gz MD5 b9571efa46dd489f9fe87acdb391d591

--- a/cross/tvheadend/patches/ppc/hts_strtab-undo-inlining-of-functions.patch
+++ b/cross/tvheadend/patches/ppc/hts_strtab-undo-inlining-of-functions.patch
@@ -1,0 +1,29 @@
+--- src/hts_strtab.h.orig	2019-01-21 22:12:06.237926589 +0100
++++ src/hts_strtab.h	2019-01-21 22:15:29.746113112 +0100
+@@ -42,7 +42,7 @@
+ static int str2val0(const char *str, const struct strtab tab[], int l)
+      __attribute((unused));
+ 
+-static inline int
++static int
+ str2val0(const char *str, const struct strtab tab[], int l)
+ {
+   int i;
+@@ -60,7 +60,7 @@
+ static int str2val0_def(const char *str, struct strtab tab[], int l, int def)
+      __attribute((unused));
+ 
+-static inline int
++static int
+ str2val0_def(const char *str, struct strtab tab[], int l, int def)
+ {
+   int i;
+@@ -78,7 +78,7 @@
+ static const char * val2str0(int val, const struct strtab tab[], int l)
+      __attribute__((unused));
+ 
+-static inline const char *
++static const char *
+ val2str0(int val, const struct strtab tab[], int l)
+ {
+   int i;

--- a/cross/uriparser/Makefile
+++ b/cross/uriparser/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = uriparser
-PKG_VERS = 0.8.4
+PKG_VERS = 0.9.1
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://downloads.sourceforge.net/project/$(PKG_NAME)/Sources/$(PKG_VERS)

--- a/cross/uriparser/PLIST
+++ b/cross/uriparser/PLIST
@@ -1,4 +1,4 @@
 bin:bin/uriparse
 lnk:lib/liburiparser.so
 lnk:lib/liburiparser.so.1
-lib:lib/liburiparser.so.1.0.20
+lib:lib/liburiparser.so.1.0.24

--- a/cross/uriparser/digests
+++ b/cross/uriparser/digests
@@ -1,3 +1,3 @@
-uriparser-0.8.4.tar.bz2 SHA1 7a1948c20bed54b04dad0e1d7d2fa8f80fc7b2b3
-uriparser-0.8.4.tar.bz2 SHA256 ce7ccda4136974889231e8426a785e7578e66a6283009cfd13f1b24a5e657b23
-uriparser-0.8.4.tar.bz2 MD5 9aabdc3611546f553f4af372167de6d6
+uriparser-0.9.1.tar.bz2 SHA1 35b0f326bad6749c6a08da854e8ad0638d2fd198
+uriparser-0.9.1.tar.bz2 SHA256 75248f3de3b7b13c8c9735ff7b86ebe72cbb8ad043291517d7d53488e0893abe
+uriparser-0.9.1.tar.bz2 MD5 c00ac34aaf4ab66c69d1100db3b79a62

--- a/cross/util-linux/Makefile
+++ b/cross/util-linux/Makefile
@@ -15,6 +15,12 @@ LICENSE  = GPL
 
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --without-ncurses --without-python
-CONFIGURE_ARGS += --disable-all-programs --enable-schedutils --enable-libuuid
+CONFIGURE_ARGS += --disable-all-programs --enable-libuuid
+
+ifeq ($(findstring $(ARCH), hi3535),$(ARCH))
+CONFIGURE_ARGS += --disable-schedutils
+else
+CONFIGURE_ARGS += --enable-schedutils
+endif
 
 include ../../mk/spksrc.cross-cc.mk

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -4,7 +4,7 @@ SPK_REV = 15
 SPK_ICON = src/tvheadend.png
 DSM_UI_DIR = app
 
-DEPENDS = cross/busybox cross/$(SPK_NAME)
+DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = m4tt075
 DESCRIPTION = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT IP and HDHomeRun as input sources. Tvheadend offers HTTP, HTSP and SAT IP streaming.
@@ -31,9 +31,6 @@ ADMIN_PORT = ${SERVICE_PORT}
 
 POST_STRIP_TARGET = tvheadend_extra_install
 
-BUSYBOX_CONFIG = usrmng
-ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
-
 include ../../mk/spksrc.common.mk
 
 # Reuse ffmpeg libraries
@@ -41,11 +38,8 @@ include ../../mk/spksrc.common.mk
 export FFMPEG_DIR = $(shell pwd)/../ffmpeg/work-$(ARCH)-$(TCVERSION)/install/var/packages/ffmpeg/target
 
 ifneq ($(wildcard $(FFMPEG_DIR)),)
-$(info Depend on ffmpeg package libraries)
 PRE_DEPEND_TARGET = tvheadend_pre_depend
 SPK_DEPENDS = "ffmpeg>4.1"
-else
-$(warning Build spk/ffmpeg first to depend on its libraries $(FFMPEG_DIR))
 endif
 
 include ../../mk/spksrc.spk.mk

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -1,9 +1,8 @@
 SPK_NAME = tvheadend
-SPK_VERS = 4.2.7
-SPK_REV = 14
+SPK_VERS = 4.2.8
+SPK_REV = 15
 SPK_ICON = src/tvheadend.png
 DSM_UI_DIR = app
-BETA = 1
 
 DEPENDS = cross/busybox cross/$(SPK_NAME)
 
@@ -12,7 +11,7 @@ DESCRIPTION = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD
 RELOAD_UI = yes
 DISPLAY_NAME = Tvheadend
 STARTABLE = yes
-CHANGELOG = "1. Update TVH to 4.2.7 (maintenance release), 2. Update libhdhomerun to 20180817, 3. Enable pcre2, 4. Remove dvb-apps (obsolete), 5. Remove default logging to allow NAS hibernation"
+CHANGELOG = "1. Update TVH to 4.2.8<br/>2. Fix software transcoding with x264<br/>3. Fix ppc build<br/>4. Remove beta flag"
 HOMEPAGE = https://www.lonelycoder.com/tvheadend/
 LICENSE = GPL v3
 
@@ -35,9 +34,30 @@ POST_STRIP_TARGET = tvheadend_extra_install
 BUSYBOX_CONFIG = usrmng
 ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
 
+include ../../mk/spksrc.common.mk
+
+# Reuse ffmpeg libraries
+# Requires to invoke: make [package|publish] ARCH= TCVERSION=
+export FFMPEG_DIR = $(shell pwd)/../ffmpeg/work-$(ARCH)-$(TCVERSION)/install/var/packages/ffmpeg/target
+
+ifneq ($(wildcard $(FFMPEG_DIR)),)
+$(info Depend on ffmpeg package libraries)
+PRE_DEPEND_TARGET = tvheadend_pre_depend
+SPK_DEPENDS = "ffmpeg>4.1"
+else
+$(warning Build spk/ffmpeg first to depend on its libraries $(FFMPEG_DIR))
+endif
+
 include ../../mk/spksrc.spk.mk
 
-.PHONY: tvheadend_extra_install
+.PHONY: tvheadend_pre_depend tvheadend_extra_install
+
+FFMPEG_LIBS = libavfilter.pc libpostproc.pc libswresample.pc libavresample.pc libswscale.pc libavutil.pc libavformat.pc libavcodec.pc
+
+tvheadend_pre_depend:
+	mkdir -p $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/
+	$(foreach lib,$(FFMPEG_LIBS),ln -s $(FFMPEG_DIR)/lib/pkgconfig/$(lib) $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/ ;)
+
 tvheadend_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/var/accesscontrol

--- a/spk/tvheadend/src/service-setup.sh
+++ b/spk/tvheadend/src/service-setup.sh
@@ -35,12 +35,6 @@ service_postinst ()
         FONT_NAME=`basename "${FONT_FILE}"`
         $LN "${FONTS_DIR}/${FONT_NAME}" "${CONFD_DIR}/${FONT_NAME}" >> ${INST_LOG}
     done
-
-    # Discard legacy obsolete busybox user account
-    BIN=${SYNOPKG_PKGDEST}/bin
-    $BIN/busybox --install $BIN
-    $BIN/delgroup "${USER}" "users" >> ${INST_LOG}
-    $BIN/deluser "${USER}" >> ${INST_LOG}
 }
 
 service_preupgrade ()


### PR DESCRIPTION
### Motivation
- Update Tvheadend to 4.2.8 (latest maintenance release)
- Fixes software transcoding with h264 (broken in 4.2.7 maintenance release)
- Fixes upstream regression for `ppc` platforms
- Enables HDR10+ support for `ffmpeg` spawn profile for NASs with `x64` architecture 
- Remove beta flag of TVH package 

### Linked issues
- https://tvheadend.org/boards/5/topics/27780?r=35267#message-35267
- PR #3530 

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
