### PR TITLE
framework: fix pkgconfig rpath and rpath-link

### DIFF
--- a/cross/bzip2/Makefile
+++ b/cross/bzip2/Makefile
@@ -12,21 +12,21 @@ COMMENT  = High-quality data compressor
 LICENSE  = BSD License
 
 CONFIGURE_TARGET = nop
-COMPILE_TARGET = myCompile
-INSTALL_TARGET = myInstall
+COMPILE_TARGET = bzip2_compile
+INSTALL_TARGET = bzip2_install
 
 ADDITIONAL_CFLAGS = -fpic -fPIC -O3 -D_FILE_OFFSET_BITS=64
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: myCompile
-myCompile:
-	$(RUN) $(MAKE) bzip2 bzip2recover PREFIX=$(STAGING_INSTALL_PREFIX)
-	$(RUN) $(MAKE) -f Makefile-libbz2_so PREFIX=$(STAGING_INSTALL_PREFIX)
+.PHONY: bzip2_compile
+bzip2_compile:
+	$(RUN) $(MAKE) bzip2 bzip2recover PREFIX=$(INSTALL_PREFIX)
+	$(RUN) $(MAKE) -f Makefile-libbz2_so PREFIX=$(INSTALL_PREFIX)
 
-.PHONY: myInstall
-myInstall:
-	@$(RUN) $(MAKE) PREFIX=$(STAGING_INSTALL_PREFIX) install
+.PHONY: bzip2_install
+bzip2_install:
+	@$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) PREFIX=$(INSTALL_PREFIX) install
 	ln -sf bzip2 $(STAGING_INSTALL_PREFIX)/bin/bunzip2
 	ln -sf bzip2 $(STAGING_INSTALL_PREFIX)/bin/bzcat
 	ln -sf bzdiff $(STAGING_INSTALL_PREFIX)/bin/bzcmp

--- a/cross/ddrescue/Makefile
+++ b/cross/ddrescue/Makefile
@@ -12,6 +12,4 @@ HOMEPAGE = http://www.gnu.org/software/ddrescue/
 COMMENT = GNU ddrescue is a data recovery tool. It copies data from one file or block device (hard disc, cdrom, etc) to another, trying hard to rescue data in case of read errors.
 LICENSE = GNU GPL
 
-CONFIGURE_ARGS = --prefix="$(STAGING_INSTALL_PREFIX)"
-
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/fdupes/Makefile
+++ b/cross/fdupes/Makefile
@@ -11,10 +11,4 @@ LICENSE  = MIT
 
 CONFIGURE_TARGET = none
 
-INSTALL_TARGET = myInstall
-
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: myInstall
-myInstall:
-	$(RUN) $(MAKE) install PREFIX=$(STAGING_INSTALL_PREFIX)

--- a/cross/fuse/Makefile
+++ b/cross/fuse/Makefile
@@ -12,7 +12,7 @@ COMMENT  = The reference implementation of the Linux FUSE (Filesystem in Userspa
 LICENSE  = GNU GPLv2
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS =  --exec-prefix=$(STAGING_INSTALL_PREFIX)
+#CONFIGURE_ARGS =  --exec-prefix=$(STAGING_INSTALL_PREFIX)
 
 include ../../mk/spksrc.cross-cc.mk
 

--- a/cross/gnupg/Makefile
+++ b/cross/gnupg/Makefile
@@ -13,7 +13,7 @@ COMMENT  = GnuPG allows to encrypt and sign your data and communication, feature
 LICENSE  = GNU General Public License
 
 PRE_CONFIGURE_TARGET = myPreConfigure
-CONFIGURE_ARGS = --with-gpg-error-prefix=$(STAGING_INSTALL_PREFIX) --with-libgcrypt-prefix=$(STAGING_INSTALL_PREFIX) --with-libassuan-prefix=$(STAGING_INSTALL_PREFIX) --with-ksba-prefix=$(STAGING_INSTALL_PREFIX) --with-npth-prefix=$(STAGING_INSTALL_PREFIX)
+# CONFIGURE_ARGS = --with-gpg-error-prefix=$(STAGING_INSTALL_PREFIX) --with-libgcrypt-prefix=$(STAGING_INSTALL_PREFIX) --with-libassuan-prefix=$(STAGING_INSTALL_PREFIX) --with-ksba-prefix=$(STAGING_INSTALL_PREFIX) --with-npth-prefix=$(STAGING_INSTALL_PREFIX)
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/gnupg/Makefile
+++ b/cross/gnupg/Makefile
@@ -13,7 +13,7 @@ COMMENT  = GnuPG allows to encrypt and sign your data and communication, feature
 LICENSE  = GNU General Public License
 
 PRE_CONFIGURE_TARGET = myPreConfigure
-# CONFIGURE_ARGS = --with-gpg-error-prefix=$(STAGING_INSTALL_PREFIX) --with-libgcrypt-prefix=$(STAGING_INSTALL_PREFIX) --with-libassuan-prefix=$(STAGING_INSTALL_PREFIX) --with-ksba-prefix=$(STAGING_INSTALL_PREFIX) --with-npth-prefix=$(STAGING_INSTALL_PREFIX)
+CONFIGURE_ARGS = --with-gpg-error-prefix=$(STAGING_INSTALL_PREFIX) --with-libgcrypt-prefix=$(STAGING_INSTALL_PREFIX) --with-libassuan-prefix=$(STAGING_INSTALL_PREFIX) --with-ksba-prefix=$(STAGING_INSTALL_PREFIX) --with-npth-prefix=$(STAGING_INSTALL_PREFIX)
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/he853/Makefile
+++ b/cross/he853/Makefile
@@ -13,11 +13,11 @@ LICENSE  = GPLv2
 
 CONFIGURE_TARGET = none
 
-INSTALL_TARGET = myInstall
+INSTALL_TARGET = he853_install
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: myInstall
-myInstall:
+.PHONY: he853_install
+he853_install:
 	mkdir -p $(STAGING_INSTALL_PREFIX)/lib/udev/rules.d
-	$(RUN) $(MAKE) install PREFIX=$(STAGING_INSTALL_PREFIX) MY_UDEV_RULES=$(STAGING_INSTALL_PREFIX)/lib/udev/rules.d
+	$(RUN) $(MAKE) install DESTDIR=$(INSTALL_DIR) PREFIX=$(INSTALL_PREFIX) MY_UDEV_RULES=$(STAGING_INSTALL_PREFIX)/lib/udev/rules.d

--- a/cross/libxml2/Makefile
+++ b/cross/libxml2/Makefile
@@ -11,13 +11,13 @@ HOMEPAGE = http://xmlsoft.org
 COMMENT  = Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform)
 LICENSE  = MIT
 
-CONFIGURE_ARGS = --without-python --with-zlib=$(STAGING_INSTALL_PREFIX)
+CONFIGURE_ARGS = --without-python
 GNU_CONFIGURE = 1
 ADDITIONAL_CFLAGS = -O3
-POST_INSTALL_TARGET = myPostInstall
+POST_INSTALL_TARGET = libxml2_post_install
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: myPostInstall
-myPostInstall:
+.PHONY: libxml2_post_install
+libxml2_post_install:
 	sed -i -e 's|^prefix=$(INSTALL_PREFIX)$$|prefix=$(STAGING_INSTALL_PREFIX)|' $(STAGING_INSTALL_PREFIX)/bin/xml2-config

--- a/cross/libxslt/Makefile
+++ b/cross/libxslt/Makefile
@@ -11,8 +11,7 @@ HOMEPAGE = http://xmlsoft.org/
 COMMENT  = Libxslt is the XSLT C library developed for the GNOME project
 LICENSE  = MIT
 
-CONFIGURE_ARGS  = --without-python --with-libxml-prefix=$(STAGING_INSTALL_PREFIX)
-CONFIGURE_ARGS += --with-libxml-include-prefix=$(STAGING_INSTALL_PREFIX)/include/libxml2
+CONFIGURE_ARGS  = --without-python
 GNU_CONFIGURE = 1
 
 # if for libgcrypt, replace the -config path with abspath

--- a/cross/libxslt/Makefile
+++ b/cross/libxslt/Makefile
@@ -11,7 +11,7 @@ HOMEPAGE = http://xmlsoft.org/
 COMMENT  = Libxslt is the XSLT C library developed for the GNOME project
 LICENSE  = MIT
 
-CONFIGURE_ARGS  = --without-python
+CONFIGURE_ARGS  = --without-python --with-libxml-prefix=$(STAGING_INSTALL_PREFIX)
 GNU_CONFIGURE = 1
 
 # if for libgcrypt, replace the -config path with abspath

--- a/cross/lirc-0.8.7/Makefile
+++ b/cross/lirc-0.8.7/Makefile
@@ -16,7 +16,6 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --with-transmitter --with-driver=all --with-moduledir=$(MOD_DIR) --enable-sandboxed  --with-kerneldir=$(KERNEL_DIR)
 
 POST_CONFIGURE_TARGET = lirc_kill_drivers
-INSTALL_TARGET = lirc_custom_install
 
 # These drivers would not make and are likely un-needed anyway
 KILL_DRIVERS = lirc_wpc8769l
@@ -28,9 +27,7 @@ endif
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: lirc_custom_install lirc_kill_drivers
-lirc_custom_install:
-	$(RUN) $(MAKE) install DESTDIR=$(STAGING_INSTALL_PREFIX) prefix=""
+.PHONY: lirc_kill_drivers
 lirc_kill_drivers:
 	@for DRIVER in $(KILL_DRIVERS); do \
 	    echo -e ".PHONY: all install\nall:\ninstall:\n" > $(WORK_DIR)/$(PKG_DIR)/drivers/$$DRIVER/Makefile; \

--- a/cross/lirc-0.9.0/Makefile
+++ b/cross/lirc-0.9.0/Makefile
@@ -16,12 +16,9 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --with-transmitter --with-driver=userspace --with-moduledir=$(MOD_DIR) --enable-sandboxed  --with-kerneldir=$(KERNEL_DIR)
 
 #POST_CONFIGURE_TARGET = lirc_kill_wpc8769l
-INSTALL_TARGET = lirc_custom_install
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: lirc_custom_install lirc_kill_wpc8769l
-lirc_custom_install:
-	$(RUN) $(MAKE) install DESTDIR=$(STAGING_INSTALL_PREFIX) prefix=""
+.PHONY: lirc_kill_wpc8769l
 lirc_kill_wpc8769l:
 	echo -e ".PHONY: all install\nall:\ninstall:\n" > $(WORK_DIR)/$(PKG_DIR)/drivers/lirc_wpc8769l/Makefile

--- a/cross/lz4/Makefile
+++ b/cross/lz4/Makefile
@@ -13,11 +13,5 @@ COMMENT  = LZ4 is lossless compression algorithm, providing compression speed at
 LICENSE  = BSD
 
 CONFIGURE_TARGET = nop
-INSTALL_TARGET = myInstall
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: myInstall
-myInstall:
-	$(RUN) $(MAKE) install PREFIX=$(STAGING_INSTALL_PREFIX)
-

--- a/cross/ncurses/Makefile
+++ b/cross/ncurses/Makefile
@@ -14,7 +14,6 @@ LICENSE  = http://www.gnu.org/licenses/gpl.html
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --with-shared --enable-rpath --without-manpages --without-tests --enable-overwrite --disable-widec
 CONFIGURE_ARGS += --disable-home-terminfo --with-default-terminfo-dir=$(INSTALL_DIR)/$(INSTALL_PREFIX)/share/terminfo
-CONFIGURE_ARGS += --disable-stripping --with-terminfo-dirs=$(INSTALL_PREFIX)/share/terminfo
+CONFIGURE_ARGS += --disable-stripping --with-terminfo-dirs=$(INSTALL_PREFIX)/share/terminfo --prefix=$(INSTALL_PREFIX)
 
 include ../../mk/spksrc.cross-cc.mk
-

--- a/cross/ncursesw/Makefile
+++ b/cross/ncursesw/Makefile
@@ -14,7 +14,7 @@ LICENSE  = http://www.gnu.org/licenses/gpl.html
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --with-shared --enable-rpath --without-manpages --without-tests --enable-overwrite --enable-widec
 CONFIGURE_ARGS += --disable-home-terminfo --with-default-terminfo-dir=$(INSTALL_DIR)/$(INSTALL_PREFIX)/share/terminfo
-CONFIGURE_ARGS += --disable-stripping --with-terminfo-dirs=$(INSTALL_PREFIX)/share/terminfo
+CONFIGURE_ARGS += --disable-stripping --with-terminfo-dirs=$(INSTALL_PREFIX)/share/terminfo --prefix=$(INSTALL_PREFIX)
 
 include ../../mk/spksrc.cross-cc.mk
 

--- a/cross/openssh/Makefile
+++ b/cross/openssh/Makefile
@@ -11,15 +11,7 @@ HOMEPAGE = http://www.openssh.com/
 COMMENT  = Open source version of SSH connectivity tools
 LICENSE  =
 
-DESTDIR = $(INSTALL_DIR)
-
-CONFIGURE_ARGS  = cross_compiling=yes --disable-lastlog --disable-utmp --disable-utmpx --disable-wtmp --disable-wtmpx
-CONFIGURE_ARGS += --disable-strip --with-zlib=$(STAGING_INSTALL_PREFIX) --with-ssl-dir=$(STAGING_INSTALL_PREFIX) LD=$$CC
-INSTALL_TARGET = myInstall
+CONFIGURE_ARGS += cross_compiling=yes --disable-lastlog --disable-utmp --disable-utmpx --disable-wtmp --disable-wtmpx
+CONFIGURE_ARGS += --disable-strip LD=$$CC
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: myInstall
-myInstall:
-	$(RUN) $(MAKE) install DESTDIR=$(INSTALL_DIR)
-

--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -11,9 +11,9 @@ HOMEPAGE = http://www.openssl.org
 COMMENT  = Compression Library
 LICENSE  = http://www.openssl.org/source/license.html
 
-CONFIGURE_TARGET = myConfigure
+CONFIGURE_TARGET = openssl_configure
 
-INSTALL_TARGET = myInstall
+INSTALL_TARGET = openssl_install
 
 STAGING_INSTALL_PREFIX := $(INSTALL_DIR)
 
@@ -48,10 +48,10 @@ $(error Arch $(ARCH) not expected yet)
 endif
 
 
-.PHONY: myConfigure
-myConfigure:
+.PHONY: openssl_configure
+openssl_configure:
 	$(RUN) ./Configure --openssldir=$(INSTALL_PREFIX) $(OPENSSL_ARCH) zlib-dynamic shared threads
 
-.PHONY: myInstall
-myInstall:
+.PHONY: openssl_install
+openssl_install:
 	$(RUN) $(MAKE) install_sw INSTALL_PREFIX=$(INSTALL_DIR)

--- a/cross/python3/Makefile
+++ b/cross/python3/Makefile
@@ -16,7 +16,7 @@ COMMENT  = Python Programming Language
 LICENSE  = PSF
 
 GNU_CONFIGURE = 1
-ADDITIONAL_CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -L $(WORK_DIR)/install/usr/local/python3/lib -I $(WORK_DIR)/install/usr/local/python3/include
+ADDITIONAL_CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -L $(STAGING_INSTALL_PREFIX)/lib -I $(STAGING_INSTALL_PREFIX)/include
 CONFIGURE_ARGS  = --enable-shared --enable-ipv6 --without-ensurepip --enable-loadable-sqlite-extensions PYTHON_FOR_BUILD=$(HOSTPYTHON) PGEN_FOR_BUILD=$(HOSTPGEN)
 CONFIGURE_ARGS += ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no ac_cv_have_long_long_format=yes
 
@@ -54,10 +54,10 @@ python3_pre_configure:
 	# create phantom header and library to succeed add_dir_to_list in setup.py
 	# so that future-promised libsqlite3.so and sqlite3.h will be used.  Yep,
 	# it's a bit hokey, but avoids editing upstream pristine source
-	mkdir -p $(WORK_DIR)/install/usr/local/python3/lib $(WORK_DIR)/install/usr/local/python3/include
+	mkdir -p $(STAGING_INSTALL_PREFIX)/lib $(STAGING_INSTALL_PREFIX)/include
 	mkdir -p $(WORK_DIR)/Python-$(PKG_VERS)/Include $(WORK_DIR)/Python-$(PKG_VERS)/lib
-	test -h $(WORK_DIR)/Python-$(PKG_VERS)/Include/sqlite3.h || ln -fs $(WORK_DIR)/install/usr/local/python3/include/sqlite3.h $(WORK_DIR)/Python-$(PKG_VERS)/Include/sqlite3.h
-	test -h $(WORK_DIR)/Python-$(PKG_VERS)/lib/libsqlite3.so || ln -fs $(WORK_DIR)/install/usr/local/python3/lib/libsqlite3.so $(WORK_DIR)/Python-$(PKG_VERS)/lib/
+	test -h $(WORK_DIR)/Python-$(PKG_VERS)/Include/sqlite3.h || ln -fs $(STAGING_INSTALL_PREFIX)/include/sqlite3.h $(WORK_DIR)/Python-$(PKG_VERS)/Include/sqlite3.h
+	test -h $(WORK_DIR)/Python-$(PKG_VERS)/lib/libsqlite3.so || ln -fs $(STAGING_INSTALL_PREFIX)/lib/libsqlite3.so $(WORK_DIR)/Python-$(PKG_VERS)/lib/
 
 .PHONY: python3_custom_compile
 python3_custom_compile:

--- a/cross/redis/Makefile
+++ b/cross/redis/Makefile
@@ -12,15 +12,10 @@ COMMENT  = Redis is an open source, advanced key-value store. It is often referr
 LICENSE  = BSD
 
 CONFIGURE_TARGET = nop
-COMPILE_TARGET = myCompile
-INSTALL_TARGET = myInstall
+COMPILE_TARGET = redis_custom_compile
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: myCompile
-myCompile:
+.PHONY: redis_custom_compile
+redis_custom_compile:
 	$(RUN) $(MAKE) MALLOC=libc DEBUG=
-
-.PHONY: myInstall
-myInstall:
-	$(RUN) $(MAKE) install PREFIX=$(STAGING_INSTALL_PREFIX)

--- a/cross/shairport-sync/Makefile
+++ b/cross/shairport-sync/Makefile
@@ -14,7 +14,7 @@ LICENSE  = https://raw.githubusercontent.com/mikebrady/shairport-sync/$(PKG_VERS
 
 GNU_CONFIGURE = 1
 
-CONFIGURE_ARGS = --prefix=$(STAGING_INSTALL_PREFIX) --with-alsa --with-ssl=openssl --with-tinysvcmdns --without-configfiles --with-piddir=$(INSTALL_DIR)/var
+CONFIGURE_ARGS += --with-alsa --with-ssl=openssl --with-tinysvcmdns --without-configfiles --with-piddir=$(INSTALL_DIR)/var
 CONFIGURE_ARGS += ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes
 
 PRE_CONFIGURE_TARGET = myPreConfigure

--- a/cross/umurmur/Makefile
+++ b/cross/umurmur/Makefile
@@ -13,9 +13,10 @@ COMMENT  = Minimalistic Murmur (Mumble server)
 LICENSE  = BSD 3-clause License
 
 CONFIGURE_TARGET = umurmur_configure
+INSTALL_TARGET = install_target
 
 CMAKE_ARGS = -DSSL=openssl -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX)
-CMAKE_ARGS += -DCMAKE_STAGING_PREFIX=$(INSTALL_DIR)
+CMAKE_ARGS += -DCMAKE_STAGING_PREFIX=$(STAGING_INSTALL_PREFIX)
 
 include ../../mk/spksrc.cross-cc.mk
 

--- a/cross/umurmur/Makefile
+++ b/cross/umurmur/Makefile
@@ -12,12 +12,13 @@ HOMEPAGE = https://github.com/umurmur/umurmur
 COMMENT  = Minimalistic Murmur (Mumble server)
 LICENSE  = BSD 3-clause License
 
-CONFIGURE_TARGET = myConfigure
+CONFIGURE_TARGET = umurmur_configure
 
-CMAKE_ARGS = -DSSL=openssl -DCMAKE_INSTALL_PREFIX=$(STAGING_INSTALL_PREFIX)
+CMAKE_ARGS = -DSSL=openssl -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX)
+CMAKE_ARGS += -DCMAKE_STAGING_PREFIX=$(INSTALL_DIR)
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: myConfigure
-myConfigure:
+.PHONY: umurmur_configure
+umurmur_configure:
 	$(RUN) cmake ${CMAKE_ARGS} .

--- a/cross/unrar/Makefile
+++ b/cross/unrar/Makefile
@@ -12,11 +12,5 @@ COMMENT  = Extract files from rar archives
 LICENSE  = freeware
 
 CONFIGURE_TARGET = nop
-INSTALL_TARGET = myInstall
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: myInstall
-myInstall:
-	$(RUN) $(MAKE) install DESTDIR=$(STAGING_INSTALL_PREFIX)
-

--- a/mk/spksrc.install.mk
+++ b/mk/spksrc.install.mk
@@ -6,7 +6,8 @@
 #  install_msg_target
 #  $(PRE_INSTALL_PLIST)
 #  pre_install_target              (override with PRE_INSTALL_TARGET)
-#  install_target                  (override with INSTALL_TARGET)
+#  install_destdir_target          (default override with INSTALL_TARGET)
+#  install_target                  (alternative for INSTALL_TARGET)
 #  post_install_target             (override with POST_INSTALL_TARGET)
 #  $(INSTALL_PLIST)
 #  install_correct_lib_files
@@ -30,7 +31,7 @@ else
 $(PRE_INSTALL_TARGET): $(PRE_INSTALL_PLIST)
 endif
 ifeq ($(strip $(INSTALL_TARGET)),)
-INSTALL_TARGET = install_target
+INSTALL_TARGET = install_destdir_target
 else
 $(INSTALL_TARGET): $(PRE_INSTALL_TARGET)
 endif
@@ -52,6 +53,9 @@ $(PRE_INSTALL_PLIST):
 pre_install_target: install_msg_target $(PRE_INSTALL_PLIST)
 
 install_target: $(PRE_INSTALL_TARGET)
+	$(RUN) $(MAKE) install prefix=$(INSTALL_PREFIX)
+
+install_destdir_target: $(PRE_INSTALL_TARGET)
 	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) install prefix=$(INSTALL_PREFIX)
 
 post_install_target: $(INSTALL_TARGET)

--- a/mk/spksrc.install.mk
+++ b/mk/spksrc.install.mk
@@ -13,7 +13,7 @@
 # Variables:
 #  INSTALL_PREFIX          Target directory where the software will be run.
 #  INSTALL_DIR             Where to install files. INSTALL_PREFIX will be added.
-#  STAGING_INSTALL_PREFIX  Where to instll files, in extenso. 
+#  STAGING_INSTALL_PREFIX  Where to install files, in extenso.
 # Files:
 #  $(WORK_DIR)/$(PKG_NAME).plist   List of files installed. Can be used to build the PLIST file
 #                                  of each software.
@@ -39,7 +39,7 @@ POST_INSTALL_TARGET = post_install_target
 else
 $(POST_INSTALL_TARGET): $(INSTALL_TARGET)
 endif
-$(INSTALL_PLIST): $(POST_INSTALL_TARGET) 
+$(INSTALL_PLIST): $(POST_INSTALL_TARGET)
 
 install_msg_target:
 	@$(MSG) "Installing for $(NAME)"
@@ -52,9 +52,9 @@ $(PRE_INSTALL_PLIST):
 pre_install_target: install_msg_target $(PRE_INSTALL_PLIST)
 
 install_target: $(PRE_INSTALL_TARGET)
-	$(RUN) $(MAKE) install prefix=$(STAGING_INSTALL_PREFIX)
+	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) install prefix=$(INSTALL_PREFIX)
 
-post_install_target: $(INSTALL_TARGET) 
+post_install_target: $(INSTALL_TARGET)
 
 $(INSTALL_PLIST):
 	find $(INSTALL_DIR)/$(INSTALL_PREFIX)/ \! -type d -printf '%P\n' | sort | \
@@ -64,7 +64,8 @@ install_correct_lib_files: $(INSTALL_PLIST)
 	@for pc_file in `grep -e "^lib/pkgconfig/.*\.pc$$" $(INSTALL_PLIST)` ; \
 	do \
 	  $(MSG) "Correcting pkg-config file $${pc_file}" ; \
-	  sed -i -e 's#\($(INSTALL_PREFIX)\)#$(INSTALL_DIR)\1#g' \
+	  sed -i -e 's#=\($(INSTALL_PREFIX)\)#=$(INSTALL_DIR)\1#g' \
+	         -e 's#-rpath,\([^ ,]*\)#-rpath,\1,-rpath-link,$(INSTALL_DIR)\1#g' \
 	         -e 's#$$(libdir)#$${libdir}#g' $(INSTALL_DIR)/$(INSTALL_PREFIX)/$${pc_file} ; \
 	done
 	@for la_file in `grep -e "^lib/.*\.la$$" $(INSTALL_PLIST)` ; \
@@ -82,4 +83,3 @@ $(INSTALL_COOKIE): install_correct_lib_files
 else
 install: ;
 endif
-


### PR DESCRIPTION
Following DESTDIR make install addition, most path are as expected.
Add rpath-link for compilation against dependant package binaries.

_Motivation:_ allow compilation and runtime linkage across different SPK packages
_Linked issues:_ #3587
