### PR TITLE
Accelerate build: ensure upstream pip/wheel downloads are cached

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -15,7 +15,9 @@ RUN = cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV)
 
 # Pip command
 PIP ?= pip
-PIP_WHEEL = $(PIP) wheel --no-binary :all: --no-deps --requirement $(WORK_DIR)/wheelhouse/requirements.txt --wheel-dir $(WORK_DIR)/wheelhouse --build-dir $(WORK_DIR)/wheelbuild
+# Why ask for the same thing twice?  Always cache downloads
+PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR)
+PIP_WHEEL = $(PIP) wheel --no-binary :all: $(PIP_CACHE_OPT) --no-deps --requirement $(WORK_DIR)/wheelhouse/requirements.txt --wheel-dir $(WORK_DIR)/wheelhouse --build-dir $(WORK_DIR)/wheelbuild
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -12,9 +12,9 @@
 PWD := $(shell pwd)
 
 DISTRIB_DIR  = $(PWD)/../../distrib
-PIP_DIR = $(PWD)/../../distrib/pip
-TOOLCHAINS_DIR = $(PWD)/../../distrib/toolchains
-KERNELS_DIR = $(PWD)/../../distrib/kernels
+PIP_DIR = $(DISTRIB_DIR)/pip
+TOOLCHAINS_DIR = $(DISTRIB_DIR)/toolchains
+KERNELS_DIR = $(DISTRIB_DIR)/kernels
 PACKAGES_DIR = $(PWD)/../../packages
 
 ifndef WORK_DIR

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -351,6 +351,9 @@ publish-all-archs: $(addprefix publish-arch-,$(AVAILABLE_ARCHS))
 ####
 
 all-supported:
+ifneq ($(PIP_CACHE_OPT),)
+	@mkdir -p $(PIP_DIR)  # to ensure caching
+endif
 	@$(MSG) Build supported archs
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  for arch in $(sort $(basename $(subst -,.,$(basename $(subst .,,$(ARCHS_DUPES)))))) ; \
@@ -365,6 +368,9 @@ all-supported:
 	fi
 
 publish-all-supported:
+ifneq ($(PIP_CACHE_OPT),)
+	@mkdir -p $(PIP_DIR)  # to ensure caching
+endif
 	@$(MSG) Publish supported archs
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  for arch in $(sort $(basename $(subst -,.,$(basename $(subst .,,$(ARCHS_DUPES)))))) ; \
@@ -389,6 +395,9 @@ publish-all-legacy: $(addprefix publish-arch-,$(LEGACY_ARCHS))
 ####
 
 all-archs-latest:
+ifneq ($(PIP_CACHE_OPT),)
+	@mkdir -p $(PIP_DIR)  # to ensure caching
+endif
 	@$(MSG) Build all archs with latest DSM per FIRMWARE
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  $(MSG) Skipping duplicate arches; \
@@ -405,6 +414,9 @@ all-archs-latest:
 	fi
 
 publish-all-archs-latest:
+ifneq ($(PIP_CACHE_OPT),)
+	@mkdir -p $(PIP_DIR)  # to ensure caching
+endif
 	@$(MSG) Publish all archs with latest DSM per FIRMWARE
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  $(MSG) Skipping duplicate arches; \
@@ -433,6 +445,9 @@ publish-latest-arch-%:
 ####
 
 all-toolchain-%:
+ifneq ($(PIP_CACHE_OPT),)
+	@mkdir -p $(PIP_DIR)  # to ensure caching
+endif
 	@$(MSG) Built packages for toolchain $*
 	@for arch in $(sort $(basename $(subst -,.,$(basename $(subst .,,$(filter %$*, $(AVAILABLE_ARCHS))))))) ; \
 	do \

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -351,9 +351,6 @@ publish-all-archs: $(addprefix publish-arch-,$(AVAILABLE_ARCHS))
 ####
 
 all-supported:
-ifneq ($(PIP_CACHE_OPT),)
-	@mkdir -p $(PIP_DIR)  # to ensure caching
-endif
 	@$(MSG) Build supported archs
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  for arch in $(sort $(basename $(subst -,.,$(basename $(subst .,,$(ARCHS_DUPES)))))) ; \
@@ -368,9 +365,6 @@ endif
 	fi
 
 publish-all-supported:
-ifneq ($(PIP_CACHE_OPT),)
-	@mkdir -p $(PIP_DIR)  # to ensure caching
-endif
 	@$(MSG) Publish supported archs
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  for arch in $(sort $(basename $(subst -,.,$(basename $(subst .,,$(ARCHS_DUPES)))))) ; \
@@ -395,9 +389,6 @@ publish-all-legacy: $(addprefix publish-arch-,$(LEGACY_ARCHS))
 ####
 
 all-archs-latest:
-ifneq ($(PIP_CACHE_OPT),)
-	@mkdir -p $(PIP_DIR)  # to ensure caching
-endif
 	@$(MSG) Build all archs with latest DSM per FIRMWARE
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  $(MSG) Skipping duplicate arches; \
@@ -414,9 +405,6 @@ endif
 	fi
 
 publish-all-archs-latest:
-ifneq ($(PIP_CACHE_OPT),)
-	@mkdir -p $(PIP_DIR)  # to ensure caching
-endif
 	@$(MSG) Publish all archs with latest DSM per FIRMWARE
 	@if $(MAKE) kernel-required >/dev/null 2>&1 ; then \
 	  $(MSG) Skipping duplicate arches; \
@@ -445,9 +433,6 @@ publish-latest-arch-%:
 ####
 
 all-toolchain-%:
-ifneq ($(PIP_CACHE_OPT),)
-	@mkdir -p $(PIP_DIR)  # to ensure caching
-endif
 	@$(MSG) Built packages for toolchain $*
 	@for arch in $(sort $(basename $(subst -,.,$(basename $(subst .,,$(filter %$*, $(AVAILABLE_ARCHS))))))) ; \
 	do \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -34,8 +34,15 @@ endif
 wheel_msg_target:
 	@$(MSG) "Processing wheels of $(NAME)"
 
+# PIP distributions caching requires that the user running it owns the cache directory.
+# PIP_CACHE_OPT is default "--cache-dir $(PIP_DIR)", PIP_DIR defaults to $(DISTRIB_DIR)/pip, so
+# will move if the user chooses a custom persistent distribution dir for caching downloads between
+# containers and builds.
 pre_wheel_target: wheel_msg_target
 	@if [ ! -z "$(WHEELS)" ] ; then \
+		if [ ! -z "$(PIP_CACHE_OPT)" ] ; then \
+			mkdir -p $(PIP_DIR) ; \
+		fi; \
 		mkdir -p $(WORK_DIR)/wheelhouse ; \
 		if [ -f "$(WHEELS)" ] ; then \
 			$(MSG) "Using existing requirements file" ; \


### PR DESCRIPTION
_Motivation:_ 

Building large targets such as `all-supported` takes a long long time.  One thing that bugs me is when things are unnecessarily done: like re-downloading the same wheel via PIP for each and every build.  That doesn't seem like the right thing.

Now, this won't cleave the build time in half (unless you're building is slow shared wifi like coffee shops), but avoiding some downloads will speed things up, reduce unexpected download costs, and let us do builds in coffee shops.

_Linked issues:_ none

### Checklist
- [x] Build rule `all-supported` completed successfully  (doesn't apply)
- [x] Package upgrade completed successfully  (doesn't apply)
- [x] New installation of package completed successfully   (doesn't apply)

Checklist does not apply, but I've checked them off to ensure a "3 of 3" marker on the PR.  There's no specific package to build; rather, success is recognizing that cache is populated when clean and used on subsequent builds of similar content.

Tested with a `make -C spk/python arch-avoton-6.1` to ensure that the cache is created, owned by the builder, and populated; second build leverages the cache and downloads no new wheels.

-- boilerplate -- (sorry)

I've been granted permission by my employer to contribute to spksrc without risk of IP confusion. I am required to explicitly write that my contribution to this project is solely in my personal capacity, and I am not conveying any rights to any intellectual property of any third parties.