### PR TITLE
borgbackup: update to 1.1.9 for python 3.6

### DIFF
--- a/cross/borgbackup/Makefile
+++ b/cross/borgbackup/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = borgbackup
-PKG_VERS = 1.1.7
+PKG_VERS = 1.1.9
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/b/$(PKG_NAME)

--- a/cross/borgbackup/digests
+++ b/cross/borgbackup/digests
@@ -1,3 +1,3 @@
-borgbackup-1.1.7.tar.gz SHA1 d012b8fb55b01efe5840af86012ab7d5a6e346f5
-borgbackup-1.1.7.tar.gz SHA256 f7b51a132e9edfbe1cacb4f478b28caf3622d79fffcb369bdae9f92d8c8a7fdc
-borgbackup-1.1.7.tar.gz MD5 b45ac57fbf5566811e5a37e61d3a9d7c
+borgbackup-1.1.9.tar.gz SHA1 6028a5b867b0a7d87e1ca67b1e4f60a15e048bfd
+borgbackup-1.1.9.tar.gz SHA256 7d0ff84e64c4be35c43ae2c047bb521a94f15b278c2fe63b43950c4836b42575
+borgbackup-1.1.9.tar.gz MD5 0fda2c1f636754d0748569bff67a6836

--- a/spk/borgbackup/Makefile
+++ b/spk/borgbackup/Makefile
@@ -1,20 +1,20 @@
 SPK_NAME = borgbackup
-SPK_VERS = 1.1.7
-SPK_REV = 3
+SPK_VERS = 1.1.9
+SPK_REV = 4
 SPK_ICON = src/$(SPK_NAME).png
 
 BUILD_DEPENDS = cross/python3 cross/setuptools cross/pip cross/wheel
 BUILD_DEPENDS += cross/$(SPK_NAME)
 DEPENDS = cross/bash cross/acl cross/attr
 WHEELS = src/requirements.txt
-SPK_DEPENDS = "python3>=3.5.5-8"
+SPK_DEPENDS = "python3>=3.6.8-9"
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Deduplicating backup program with compression and authenticated encryption.
 RELOAD_UI = no
 DISPLAY_NAME = Borg
 STARTABLE = no
-CHANGELOG = Update to 1.1.7
+CHANGELOG = Update to 1.1.9
 
 HOMEPAGE = https://borgbackup.readthedocs.io
 LICENSE  = BSD-3-Clause

--- a/spk/borgbackup/src/requirements.txt
+++ b/spk/borgbackup/src/requirements.txt
@@ -1,10 +1,10 @@
 # Cross compiled packages dependencies
-#borgbackup==1.1.7
+#borgbackup==1.1.9
 #msgpack-python==0.5.6
-#ruamel.yaml==0.15.70
+#ruamel.yaml==0.15.78
 
 # Downloaded dependencies
-borgmatic==1.2.2
+borgmatic==1.2.15
 pykwalify==1.6.1
 docopt==0.6.2
-python-dateutil==2.4.2
+python-dateutil==2.8.0


### PR DESCRIPTION
borgmatic: update to 1.2.15

_Motivation:_ support for Python 3.6
_Linked issues:_ depends on #3562 

### Checklist
- [X] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully
