### PR TITLE
WIP: (building) Bump openssl to 1.0.2q

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2n
+PKG_VERS = 1.0.2q
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2n.tar.gz SHA1 0ca2957869206de193603eca6d89f532f61680b1
-openssl-1.0.2n.tar.gz SHA256 370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
-openssl-1.0.2n.tar.gz MD5 13bdc1b1d1ff39b6fd42a255e74676a4
+openssl-1.0.2q.tar.gz SHA1 692f5f2f1b114f8adaadaa3e7be8cce1907f38c5
+openssl-1.0.2q.tar.gz SHA256 5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684
+openssl-1.0.2q.tar.gz MD5 7563e1ce046cb21948eeb6ba1a0eb71c


### PR DESCRIPTION
_Motivation:_ Security
_Linked issues:_ 

According to `all-affected-spks`, this will require an extensive build:

```
make -C spk/mutt all-supported
make -C spk/irssi all-supported
make -C spk/jackett all-supported
make -C spk/ejabberd all-supported
make -C spk/python all-supported
make -C spk/lidarr all-supported
make -C spk/radarr all-supported
make -C spk/museek-plus all-supported
make -C spk/python3 all-supported
make -C spk/homeassistant all-supported
make -C spk/octoprint all-supported
make -C spk/sonarr all-supported
make -C spk/synocli-net all-supported
make -C spk/itools all-supported
make -C spk/rdiff-backup all-supported
make -C spk/rutorrent all-supported
make -C spk/sabnzbd all-supported
make -C spk/ffsync all-supported
make -C spk/umurmur all-supported
make -C spk/boxbackup-client all-supported
make -C spk/mercurial all-supported
make -C spk/links all-supported
make -C spk/deluge all-supported
make -C spk/borgbackup all-supported
make -C spk/sabnzbd-testing all-supported
make -C spk/duplicity all-supported
```

... see you next week!  I honestly assume something in this list will fail to build but for unrelated reasons, so there might be a pre-PR with some version-bumps that are necessary to build this one.


### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [] New installation of package completed successfully
