### PR TITLE
Revert "framework: accelerate build, cache upstream pip/wheel downloa…

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -15,9 +15,7 @@ RUN = cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV)
 
 # Pip command
 PIP ?= pip
-# Why ask for the same thing twice?  Always cache downloads
-PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR)
-PIP_WHEEL = $(PIP) wheel --no-binary :all: $(PIP_CACHE_OPT) --no-deps --requirement $(WORK_DIR)/wheelhouse/requirements.txt --wheel-dir $(WORK_DIR)/wheelhouse --build-dir $(WORK_DIR)/wheelbuild
+PIP_WHEEL = $(PIP) wheel --no-binary :all: --no-deps --requirement $(WORK_DIR)/wheelhouse/requirements.txt --wheel-dir $(WORK_DIR)/wheelhouse --build-dir $(WORK_DIR)/wheelbuild
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -12,9 +12,9 @@
 PWD := $(shell pwd)
 
 DISTRIB_DIR  = $(PWD)/../../distrib
-PIP_DIR = $(DISTRIB_DIR)/pip
-TOOLCHAINS_DIR = $(DISTRIB_DIR)/toolchains
-KERNELS_DIR = $(DISTRIB_DIR)/kernels
+PIP_DIR = $(PWD)/../../distrib/pip
+TOOLCHAINS_DIR = $(PWD)/../../distrib/toolchains
+KERNELS_DIR = $(PWD)/../../distrib/kernels
 PACKAGES_DIR = $(PWD)/../../packages
 
 ifndef WORK_DIR

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -34,15 +34,8 @@ endif
 wheel_msg_target:
 	@$(MSG) "Processing wheels of $(NAME)"
 
-# PIP distributions caching requires that the user running it owns the cache directory.
-# PIP_CACHE_OPT is default "--cache-dir $(PIP_DIR)", PIP_DIR defaults to $(DISTRIB_DIR)/pip, so
-# will move if the user chooses a custom persistent distribution dir for caching downloads between
-# containers and builds.
 pre_wheel_target: wheel_msg_target
 	@if [ ! -z "$(WHEELS)" ] ; then \
-		if [ ! -z "$(PIP_CACHE_OPT)" ] ; then \
-			mkdir -p $(PIP_DIR) ; \
-		fi; \
 		mkdir -p $(WORK_DIR)/wheelhouse ; \
 		if [ -f "$(WHEELS)" ] ; then \
 			$(MSG) "Using existing requirements file" ; \


### PR DESCRIPTION
…ds (#3620)"

This reverts commit 416f001e72902577074ff9259fd9c610f2156d6c.

Sorry, but the changes brought with this merge in the file `mk/spksrc.directories.mk` breaks the toolchain build (at least for apollolake-6.1 targets).

I get a lot of errors telling:
`recursive variable DISTRIB_DIR references itself (eventually) - mk/spksrc.tc.mk (16)`

please test pull requests with build of `all-supported` on a clean environment before merging - and don't ignore this on the checklist!
