### PR TITLE
framework: fix DISTRIB_DIR recursive definition

### DIFF
--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -11,11 +11,13 @@
 
 PWD := $(shell pwd)
 
-DISTRIB_DIR  = $(PWD)/../../distrib
-PIP_DIR = $(DISTRIB_DIR)/pip
-TOOLCHAINS_DIR = $(DISTRIB_DIR)/toolchains
-KERNELS_DIR = $(DISTRIB_DIR)/kernels
+BASE_DISTRIB_DIR  = $(PWD)/../../distrib
+PIP_DIR = $(BASE_DISTRIB_DIR)/pip
+TOOLCHAINS_DIR = $(BASE_DISTRIB_DIR)/toolchains
+KERNELS_DIR = $(BASE_DISTRIB_DIR)/kernels
 PACKAGES_DIR = $(PWD)/../../packages
+# Default download location, see spksrc.download.mk
+DISTRIB_DIR = $(BASE_DISTRIB_DIR)
 
 ifndef WORK_DIR
 WORK_DIR = $(PWD)/work$(ARCH_SUFFIX)

--- a/mk/spksrc.tc.mk
+++ b/mk/spksrc.tc.mk
@@ -51,8 +51,8 @@ CXXFLAGS += $(TC_CXXFLAGS)
 CXXFLAGS += -I$(INSTALL_DIR)/$(INSTALL_PREFIX)/include
 
 LDFLAGS += $(TC_LDFLAGS)
-LDFLAGS += -L$(INSTALL_DIR)/$(INSTALL_PREFIX)/lib 
-LDFLAGS += -Wl,--rpath-link,$(INSTALL_DIR)/$(INSTALL_PREFIX)/lib 
+LDFLAGS += -L$(INSTALL_DIR)/$(INSTALL_PREFIX)/lib
+LDFLAGS += -Wl,--rpath-link,$(INSTALL_DIR)/$(INSTALL_PREFIX)/lib
 LDFLAGS += -Wl,--rpath,$(INSTALL_PREFIX)/lib
 
 
@@ -95,5 +95,5 @@ $(DIGESTS_FILE): download
 	    SHA256)   tool=sha256sum ;; \
 	    MD5)      tool=md5sum ;; \
 	  esac ; \
-	  echo "$(LOCAL_FILE) $$type `$$tool $(DISTRIB_DIR)/$(TC_DIST_NAME) | cut -d\" \" -f1`" >> $@ ; \
+	  echo "$(LOCAL_FILE) $$type `$$tool $(DIST_FILE) | cut -d\" \" -f1`" >> $@ ; \
 	done


### PR DESCRIPTION
DISTRIB_DIR and DISTRIB_FILE are input parameters for spksrc.download.mk
To avoid mistake, "distrib" folder is now identified as BASE_DISTRIB_DIR

_Motivation:_ Fix toolchain operations (download, digests, extract, patch)
