### PR TITLE
Bump imagemagick to stable version

### DIFF
--- a/cross/imagemagick/Makefile
+++ b/cross/imagemagick/Makefile
@@ -1,8 +1,9 @@
 PKG_NAME = ImageMagick
-PKG_VERS = 7.0.7-30
-PKG_EXT = tar.xz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://www.imagemagick.org/download/releases
+PKG_VERS = 7.0.8-53
+PKG_EXT = tar.gz
+PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/ImageMagick/ImageMagick/archive
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/freetype cross/libpng cross/libxml2 cross/libtiff cross/libjpeg
@@ -27,7 +28,7 @@ imagemagick_extra_install:
 	SHARE_PATH=$(STAGING_INSTALL_PREFIX)/share/ImageMagick-7/ \
 	DATA_DIR=$(STAGING_INSTALL_PREFIX)/share/ImageMagick-7/ \
 	CONFIGURE_PATH=$(STAGING_INSTALL_PREFIX)/etc/ImageMagick-6/ \
-	LIBRARY_PATH=$(STAGING_INSTALL_PREFIX)/lib/ImageMagick-7.0.7/ \
+	LIBRARY_PATH=$(STAGING_INSTALL_PREFIX)/lib/ImageMagick-7.0.8/ \
 	SHAREARCH_PATH=$(STAGING_INSTALL_PREFIX)/lib/ImageMagick-7.0.7/config-Q16 \
 	DOCUMENTATION_PATH=$(STAGING_INSTALL_PREFIX)/share/doc/ImageMagick-7 \
 	INCLUDE_PATH=$(STAGING_INSTALL_PREFIX)/include/ImageMagick-7 \

--- a/cross/imagemagick/digests
+++ b/cross/imagemagick/digests
@@ -1,3 +1,3 @@
-ImageMagick-7.0.7-30.tar.xz SHA1 bc147af6e63654cc4857f2b141dad279918920e8
-ImageMagick-7.0.7-30.tar.xz SHA256 f8f5cd7b4a3abb6b1a93b54ae8eb55a1a87cdba47f8efd187178a2d0eb9ba712
-ImageMagick-7.0.7-30.tar.xz MD5 678d25f58a4c4961fe7ba3b00d53388a
+ImageMagick-7.0.8-53.tar.gz SHA1 06e9e30024408ff8b09ab4f54bb474dfc72855dc
+ImageMagick-7.0.8-53.tar.gz SHA256 b8c35e03fc4bd2bf66bddfe232a34473e7df68c3716c831ba76dc30520e7b490
+ImageMagick-7.0.8-53.tar.gz MD5 990c8f23a2ca2d438d8f0a1c0c52c64b

--- a/spk/imagemagick/Makefile
+++ b/spk/imagemagick/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = imagemagick
-SPK_VERS = 7.0.7
-SPK_REV = 3
+SPK_VERS = 7.0.8
+SPK_REV = 4
 SPK_ICON = src/imagemagick.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -8,7 +8,7 @@ DEPENDS = cross/$(SPK_NAME)
 MAINTAINER = SynoCommunity
 DESCRIPTION = ImageMagick is a software suite to create, edit, compose, or convert bitmap images.
 DISPLAY_NAME = ImageMagick
-CHANGELOG = Updated to ImageMagick 7.0.7-30
+CHANGELOG = Update to ImageMagick 7.0.8-53
 
 STARTABLE = no
 


### PR DESCRIPTION
_Motivation:_ Imagemagick failed to build as the package is no longer available on http://www.imagemagick.org/download/releases/
The alternative is to fetch the source code from github: https://github.com/ImageMagick/ImageMagick/releases/tag/7.0.7-30
I know there's more recent builds but they don't keep the source of the recent builds on their release page.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
