### PR TITLE
Update SABnzbd 2.3.8 and unrar to 5.7

### DIFF
--- a/cross/sabnzbd/Makefile
+++ b/cross/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = SABnzbd
-PKG_VERS = 2.3.7
+PKG_VERS = 2.3.8
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-src.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/sabnzbd/sabnzbd/releases/download/$(PKG_VERS)

--- a/cross/sabnzbd/digests
+++ b/cross/sabnzbd/digests
@@ -1,3 +1,3 @@
-SABnzbd-2.3.7-src.tar.gz SHA1 1ee99b2f3f8853a6246ad59983884863e03c721e
-SABnzbd-2.3.7-src.tar.gz SHA256 e175ffd315728813fb1e117f40b22f848385b19b672a8fbe776050def4764e0d
-SABnzbd-2.3.7-src.tar.gz MD5 f183027b605137a2e04859dcf6b1c785
+SABnzbd-2.3.8-src.tar.gz SHA1 27a9fd42682ea5669a2dbee5b9298ddb5ef62f3d
+SABnzbd-2.3.8-src.tar.gz SHA256 0685e867250106c0cab6cc9ffb5241caa9b1e2cdd43faec67ea41021d4997b72
+SABnzbd-2.3.8-src.tar.gz MD5 b2ef15a5291a01b373c663ccacb31b0e

--- a/cross/unrar/Makefile
+++ b/cross/unrar/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = unrar
-PKG_VERS = 5.5.8
+PKG_VERS = 5.7.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)src-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.rarlab.com/rar

--- a/cross/unrar/digests
+++ b/cross/unrar/digests
@@ -1,3 +1,3 @@
-unrarsrc-5.5.8.tar.gz SHA1 f4fa1c4142b497356a3df505e1459c188f646fad
-unrarsrc-5.5.8.tar.gz SHA256 9b66e4353a9944bc140eb2a919ff99482dd548f858f5e296d809e8f7cdb2fcf4
-unrarsrc-5.5.8.tar.gz MD5 8d74b4d16b1317c4b1081e5f44025180
+unrarsrc-5.7.4.tar.gz SHA1 71ef4c898cd777f1c244c455826c5cdaeb85dfd0
+unrarsrc-5.7.4.tar.gz SHA256 582dd038fd4632f32493928cae5b37dbb436752813da08a1ee5df2ab1ee7e7b4
+unrarsrc-5.7.4.tar.gz MD5 7b6a2bebe2a0c096f353008c40644be7

--- a/cross/unrar/patches/001-remove-defaul-env-flags.patch
+++ b/cross/unrar/patches/001-remove-defaul-env-flags.patch
@@ -1,12 +1,12 @@
---- makefile.orig	2014-03-12 16:54:39.486673701 +0100
-+++ makefile	2014-03-12 16:54:25.254852618 +0100
+--- makefile.orig	2019-04-21 10:35:11.486673701 +0100
++++ makefile	2019-04-21 10:35:11.254852618 +0100
 @@ -2,12 +2,12 @@
  # Makefile for UNIX - unrar
 
  # Linux using GCC
 -CXX=c++
 +#CXX=c++
--CXXFLAGS=-O2
+-CXXFLAGS=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
 +CXXFLAGS=-O3
  LIBFLAGS=-fPIC
  DEFINES=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sabnzbd
-SPK_VERS = 2.3.7
-SPK_REV = 38
+SPK_VERS = 2.3.8
+SPK_REV = 39
 SPK_ICON = src/sabnzbd.png
 
 BUILD_DEPENDS = cross/python cross/setuptools cross/pip cross/wheel
@@ -15,7 +15,7 @@ DESCRIPTION_SPN = SABnzbd hace que Usenet sea lo más simple posible, automatiza
 RELOAD_UI = yes
 DISPLAY_NAME = SABnzbd
 STARTABLE = yes
-CHANGELOG = "1) Update SABnzbd to 2.3.7"
+CHANGELOG = "1) Update SABnzbd to 2.3.8. 2) Update included unrar to 5.70."
 
 HOMEPAGE   = http://sabnzbd.org
 LICENSE    = GPL


### PR DESCRIPTION
Closes #3667
Also updated `unrar`, other packages that depend on `cross/unrar` can benefit from that in the next update of those packages. Update of `unrar` doesn't seem to be essential enough to warrant re-release just for it.

### Checklist
- [x] Build rule `all-supported` completed [successfully](https://travis-ci.org/Safihre/spksrc/builds/522675703)
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
