### PR TITLE
framework: store package options in variables

### DIFF
--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -71,6 +71,9 @@ save_wizard_variables ()
     if [ -n "${SHARE_PATH}" ]; then
         echo "SHARE_PATH=${SHARE_PATH}" >> ${INST_VARIABLES}
     fi
+    # Restriction permissions to protect sensitive options
+    chmod go-rwx ${INST_VARIABLES}
+    chown ${EFF_USER} ${INST_VARIABLES}
 }
 
 # Remove user from system and from groups it is member of

--- a/spk/demoservice/Makefile
+++ b/spk/demoservice/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = demoservice
-SPK_VERS = 1.2
-SPK_REV = 6
+SPK_VERS = 1.3
+SPK_REV = 10
 SPK_ICON = src/demoservice.png
 
 override ARCH=

--- a/spk/demoservice/PLIST
+++ b/spk/demoservice/PLIST
@@ -1,1 +1,1 @@
-bin:README
+rsc:README

--- a/spk/demoservice/src/service-setup.sh
+++ b/spk/demoservice/src/service-setup.sh
@@ -18,6 +18,7 @@ service_preinst ()
 service_postinst ()
 {
     echo "service_postinst ${SYNOPKG_PKG_STATUS}" >> $INST_LOG
+    echo "CUSTOM_OPTION=${wizard_custom_option}" >> ${INST_VARIABLES}
 }
 
 service_preuninst ()
@@ -25,7 +26,7 @@ service_preuninst ()
     echo "service_preuninst ${SYNOPKG_PKG_STATUS}" >> $INST_LOG
 }
 
-service_postinst ()
+service_postuninst ()
 {
     echo "service_postuninst ${SYNOPKG_PKG_STATUS}" >> $INST_LOG
 }

--- a/spk/demoservice/src/wizard/upgrade_uifile.sh
+++ b/spk/demoservice/src/wizard/upgrade_uifile.sh
@@ -1,3 +1,14 @@
+#!/bin/sh
+
+INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
+INST_VARIABLES="${INST_ETC}/installer-variables"
+
+# Reload wizard variables stored by postinst
+if [ -r "${INST_VARIABLES}" ]; then
+    . "${INST_VARIABLES}"
+fi
+
+cat <<EOF > $SYNOPKG_TEMP_LOGFILE
 [
   {
     "step_title": "Example configuration for demoservice",
@@ -9,7 +20,7 @@
           {
             "key": "wizard_download_dir",
             "desc": "Download location",
-            "defaultValue": "/volume1/downloads",
+            "defaultValue": "${SHARE_PATH}",
             "validator": {
               "allowBlank": false,
               "regex": {
@@ -21,7 +32,7 @@
           {
             "key": "wizard_group",
             "desc": "DSM group",
-            "defaultValue": "sc-download",
+            "defaultValue": "${GROUP}",
             "validator": {
               "allowBlank": false,
               "regex": {
@@ -33,6 +44,7 @@
           {
             "key": "wizard_custom_option",
             "desc": "Demoservice custom option",
+            "defaultValue": "${CUSTOM_OPTION}",
           }
         ]
       }
@@ -42,8 +54,10 @@
     "step_title": "Attention! DSM Permissions",
     "items": [
       {
-        "desc": "Permissions are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user (= demoservice) will not appear on most UI settings.<br>Including the following:<br>- Application privilege's permission viewer<br>- FPT's chroot user selector<br>- File Stations's<br>- Change owner<br>- Shared Links Manager -> Enable secure sharing<br><br>The only exceptions are:<br>- Control Panel > Shared Folder > Edit > Permission > System internal user<br>- ACL editor<br>"
+        "desc": "Permissions are managed with the group <b>'sc-download'</b> in DSM."
       }
     ]
   }
 ]
+EOF
+exit 0


### PR DESCRIPTION
Also restore so that values come to wizard at each upgrade

_Motivation:_  Provide a common way to store and retrieve package specific options
_Linked issues:_  Target package minio #3689 

### Checklist
- [X] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully
