### PR TITLE
syncthing: Incorporate upstream release v1.2.2.

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.1.0
+PKG_VERS = 1.2.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-source-v1.1.0.tar.gz SHA1 8750e88c541a3a345e413c9a4e78a33f569ab733
-syncthing-source-v1.1.0.tar.gz SHA256 6565fd30d704f7039d350c522875925acc287c8e45e18a7d42f22512860a7ac6
-syncthing-source-v1.1.0.tar.gz MD5 92492ce461a5737eef5f95ca6d35175a
+syncthing-source-v1.2.2.tar.gz SHA1 2fb3525a8589878239917e4134dae5aa623a04d7
+syncthing-source-v1.2.2.tar.gz SHA256 7a6c6a427a84f33268f1e23ebf6e230abf140c01bb2476a7b34127c03b82b2f1
+syncthing-source-v1.2.2.tar.gz MD5 250c90695ddf0bdf1eefffc3048df630

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.1.0
-SPK_REV = 16
+SPK_VERS = 1.2.2
+SPK_REV = 17
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -13,7 +13,7 @@ DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 RELOAD_UI = yes
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update to 1.1.0<br />2. built with go 1.12"
+CHANGELOG = "Update to upstream version 1.2.2.  Fix support for custom command line options set in by options.conf."
 HOMEPAGE = http://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes


### PR DESCRIPTION
_Motivation:_  Upstream has some partly backwards-incompatible changes, so it's better when users see an up-to-date version for the SPK as well. It auto-updates anyway right after installation, but publishing a recent version would save on migrations being done.
_Linked issues:_  fixes #3761

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [ ] New installation of package completed successfully
