### PR TITLE
Remove busybox dependency for Redis

### DIFF
--- a/spk/redis/Makefile
+++ b/spk/redis/Makefile
@@ -4,9 +4,9 @@ SPK_REV = 6
 SPK_ICON = src/redis.png
 DSM_UI_DIR = app
 
-DEPENDS = cross/busybox cross/$(SPK_NAME)
+DEPENDS = cross/$(SPK_NAME)
 
-MAINTAINER = DigitalBox
+MAINTAINER = DigitalBox98
 DESCRIPTION = Redis is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 
 RELOAD_UI = yes
@@ -28,9 +28,6 @@ NO_SERVICE_SHORTCUT = yes
 INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
 POST_STRIP_TARGET = redis_extra_install
-
-BUSYBOX_CONFIG = usrmng daemon
-ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
 
 include ../../mk/spksrc.spk.mk
 


### PR DESCRIPTION
_Motivation:_  Clean busybox dependency for Redis server and fix maintainer name

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

Tested successfully on braswell architecture