### PR TITLE
synocli-file: remove rmlint for ppc853x

### DIFF
--- a/cross/rmlint/Makefile
+++ b/cross/rmlint/Makefile
@@ -12,6 +12,9 @@ HOMEPAGE = http://rmlint.rtfd.org/
 COMMENT = Extremely fast tool to remove duplicates and other lint from your filesystem.
 LICENSE = GPLv3
 
+# PPC_ARCHES except QorIQ are not supported
+UNSUPPORTED_ARCHS = powerpc ppc824x ppc853x ppc854x
+
 CONFIGURE_TARGET = none
 COMPILE_TARGET = rmlint_compile_target
 INSTALL_TARGET = rmlint_install_target

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -6,12 +6,18 @@ SPK_ICON = src/synocli-file.png
 include ../../mk/spksrc.common.mk
 
 DEPENDS = cross/less cross/tree cross/ncdu cross/jdupes cross/rhash cross/mc cross/nano cross/file
-DEPENDS += cross/detox cross/rmlint
+DEPENDS += cross/detox
 
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = SynoCli File Tools
 
 OPTIONAL_DESC =
+
+# PPC_ARCHES except QorIQ
+ifneq ($(findstring $(ARCH), powerpc ppc824x ppc853x ppc854x),$(ARCH))
+DEPENDS += cross/rmlint
+OPTIONAL_DESC += , rmlint
+endif
 
 ifneq ($(findstring $(ARCH), powerpc ppc824x ppc853x ppc854x $(ARM5_ARCHES)),$(ARCH))
 # to build rnm, GCC >= 4.8 is required, but not contained in older toolchains.
@@ -19,7 +25,7 @@ DEPENDS += cross/rnm
 OPTIONAL_DESC += , rnm
 endif
 
-DESCRIPTION = "SynoCli File Tools provides a set of small command-line utilities: less, tree, ncdu, jdupes, rhash, mc \(midnight commander\), nano, file, detox, rmlint$(OPTIONAL_DESC)."
+DESCRIPTION = "SynoCli File Tools provides a set of small command-line utilities: less, tree, ncdu, jdupes, rhash, mc \(midnight commander\), nano, file, detox$(OPTIONAL_DESC)."
 STARTABLE = no
 CHANGELOG = "Midnight-Commander: add sftp support;  Fix subshell; fix mouse handling; fix mcedit, mcview and mcdiff"
 


### PR DESCRIPTION
Fix the build of synocli-file for arch-ppc853x-5.2 that is built with `all-supported`

- avoid build and dependency of `cross/rmlint`  for ppc arches except qoirq.
