### PR TITLE
Determine and build affected spks

### DIFF
--- a/mk/build-target-determinator.bash
+++ b/mk/build-target-determinator.bash
@@ -1,0 +1,51 @@
+#!bash
+#
+# A fairly-reliable method of determining the SPKs that need to be rebuild based on the files that
+# changed in the last commit.  Only looks at cross/* native/* and spk/* because, well, mk/* might
+# be a bit harder, and toolchains/* would require a rebuild of the world.
+#
+# I did this as a script rather than inside a mk/spksrc.spk.mk target to ensure I'm not evaluating
+# this on every run, only when needed.
+
+# test via:  git diff --stat HEAD^^^ | bash mk/build-target-determinator.bash
+# expected output is a list of subdirs of spk dir
+awk '
+func getdeps(depdir) {
+	checked[depdir]++
+
+	# somewhat reliable shell-exec grep for Makefiles referring to what we have
+	command = "grep -l \"DEPENDS .*"depdir"\" {cross,native,spk}/*/Makefile"
+	while ((command | getline line) > 0) {
+		split(line,path,"/");
+		dep[path[1]"/"path[2]]++;
+	}
+	close(command)
+}
+
+BEGIN {
+    # This is effectively a typedef, avoids errors when check has no elements
+	checked[2]="bogus"; delete checked[2];
+}
+
+/^ (cross|native|spk)\// {
+	split($1,path,"/");
+	dep[path[1]"/"path[2]]++;
+}
+
+END {
+	max_cycles = 30  # avoid infinite loop
+	while ((length(checked) < length(dep)) && (max_cycles--)) {
+		# easier with re-entrant code :)
+		# but instead we loop until the checked == depends
+		for (d in dep) {
+			# simplified "if (d not in checked) { getdeps(d)}"
+			found=0;
+			for (c in checked) if (c == d) found++;
+			if (1 > found) {
+			   getdeps(d)
+			}
+		}
+	}
+	# print the collected dependents, spk subdirs only
+	for (d in dep) if (d ~ "^spk/") { gsub("^spk/","",d); printf "%s ",d; } printf "\n";
+}'


### PR DESCRIPTION
_Motivation:_  It's difficult sometimes to know what SPKs to build to verify a change to a dependent `cross`.  This script is a way to determine the changes in the current PR, and for each affected `cross`, `native`, or `spk`, determine the dependencies.  Recurse up to 30 times to find all dependent SPKs.

Built in awk because awk is everywhere.  Like vi.

Originally started as #3459
_Linked issues:_  This is a tool I use, as follows:

### Setup
1. forked `SynoCommunity/spksrc` into my own space `chickenandpork/spksrc`
2. `git clone chickenandpork/spksrc`
3. `git add remote upstream https://github.com/SynoCommunity/spksrc.git`

You should now have something like the following, except with your own fork:
```
bash-4.3$ git remote -v
origin	git@github.com:chickenandpork/spksrc.git (fetch)
origin	git@github.com:chickenandpork/spksrc.git (push)
upstream	https://github.com/SynoCommunity/spksrc.git (fetch)
upstream	https://github.com/SynoCommunity/spksrc.git (push)
```

After you've made your change on your own development branch, run this:
```
    git diff --stat upstream/master...HEAD | \
        bash mk/build-target-determinator.bash | \
        sort
```

The results will show the SPKs to build; in my own work, I pipe this into a script to build each, and it takes a very long time, but for now, this will tell you what to build.  For example:

### Test: #3833
```
    bash-4.3$ git remote add smaarn https://github.com/smaarn/spksrc.git
    bash-4.3$ git fetch smaarn build/python3/fix-cross-compilation-issue
    bash-4.3$ git checkout build/python3/fix-cross-compilation-issue
    bash-4.3$ git diff --stat upstream/master...HEAD | bash mk/build-target-determinator.bash
    python3 borgbackup homeassistant 
```
This shows that @smaarn might need to test `borgbackup`, `homeassistant` might just be specific to my workspace.

### Test: #3648 (python-2.7.16)
```
bash-4.3$ git remote add hgy59 https://github.com/hgy59/spksrc.git
bash-4.3$ git fetch hgy59 python_2.7.16
remote: Enumerating objects: 42, done.
remote: Counting objects: 100% (42/42), done.
remote: Total 70 (delta 42), reused 42 (delta 42), pack-reused 28
Unpacking objects: 100% (70/70), done.
From https://github.com/hgy59/spksrc
 * branch              python_2.7.16 -> FETCH_HEAD
 * [new branch]        python_2.7.16 -> hgy59/python_2.7.16
bash-4.3$ git checkout python_2.7.16
Branch 'python_2.7.16' set up to track remote branch 'python_2.7.16' from 'hgy59'.
Switched to a new branch 'python_2.7.16'
bash-4.3$ git diff --stat upstream/master...HEAD | bash mk/build-target-determinator.bash
python3 sabnzbd rdiff-backup duplicity borgbackup python mercurial flexget pyload octoprint homeassistant ffsync deluge rutorrent 
```
I think this list is similar to what @hgy59 has been testing.

The longer-term intent is to enable a consistent logic for Developers to use to build-test, plus enable automating the architecture-specific build of updated packages in a TC or CI/CD

### Checklist
- [n/a] Build rule `all-supported` completed successfully
- [n/a] Package upgrade completed successfully
- [n/a] New installation of package completed successfully
