### PR TITLE
Oscam added pcsc-lite support

### DIFF
--- a/cross/oscam/Makefile
+++ b/cross/oscam/Makefile
@@ -8,7 +8,7 @@ PKG_DIST_SITE = http://www.streamboard.tv/svn/oscam
 PKG_DIST_FILE = $(PKG_NAME)-r$(PKG_SVN_REV).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-r*
 
-DEPENDS = cross/openssl cross/libusb
+DEPENDS = cross/openssl cross/libusb cross/pcsc-lite
 
 HOMEPAGE = http://oscam.to/
 COMMENT  = OSCam is an Open Source Conditional Access Module software
@@ -27,7 +27,7 @@ myConfigure:
 
 .PHONY: myCompile
 myCompile:
-	$(RUN) $(MAKE) CROSS=$(shell echo $(ENV) | sed 's/ /\n/g' | sed -n -e 's/CC=\(.*-\)gcc/\1/p') CONF_DIR=$(INSTALL_PREFIX)/etc USE_LIBUSB=1
+	$(RUN) $(MAKE) CROSS=$(shell echo $(ENV) | sed 's/ /\n/g' | sed -n -e 's/CC=\(.*-\)gcc/\1/p') CONF_DIR=$(INSTALL_PREFIX)/etc USE_LIBUSB=1 USE_PCSC=1
 
 .PHONY: myInstall
 myInstall:

--- a/cross/pcsc-lite/Makefile
+++ b/cross/pcsc-lite/Makefile
@@ -1,0 +1,21 @@
+PKG_NAME = pcsc-lite
+PKG_VERS = 1.8.26
+PKG_EXT = tar.bz2
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://pcsclite.apdu.fr/files
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+DEPENDS =
+
+HOMEPAGE = https://pcsclite.apdu.fr
+COMMENT  = pcsc-lite
+LICENSE  =
+
+GNU_CONFIGURE = 1
+CONFIGURE_TARGET = myConfigure
+
+include ../../mk/spksrc.cross-cc.mk
+
+.PHONY: myConfigure
+myConfigure:
+	$(RUN) ./configure --disable-libsystemd --disable-libudev

--- a/cross/pcsc-lite/PLIST
+++ b/cross/pcsc-lite/PLIST
@@ -1,0 +1,3 @@
+lnk:lib/libpcsclite.so
+lnk:lib/libpcsclite.so.1
+lib:lib/libpcsclite.so.1.0.0

--- a/cross/pcsc-lite/digests
+++ b/cross/pcsc-lite/digests
@@ -1,0 +1,3 @@
+pcsc-lite-1.8.26.tar.bz2 MD5 9d36882998449daceec267c68a21ff0d
+pcsc-lite-1.8.26.tar.bz2 SHA1 7f0f54fc6d296634def123b8df7f5f17d36545a8
+pcsc-lite-1.8.26.tar.bz2 SHA256 3eb7be7d6ef618c0a444316cf5c1f2f9d7227aedba7a192f389fe3e7c0dfbbd9


### PR DESCRIPTION
_Motivation:_  if you want to use PCSC cardreader in Oscam, should be support pcsc-lite & libusb
_Linked issues:_  http://www.streamboard.tv/oscam/wiki/crosscompiling#Howtoinstallpcsc

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
