### PR TITLE
tvheadend 4.3: ARMv5 arch 88f6281 build fix

### DIFF
--- a/cross/tvheadend/Makefile
+++ b/cross/tvheadend/Makefile
@@ -29,6 +29,10 @@ endif
 
 include ../../mk/spksrc.cross-cc.mk
 
+ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
+CONFIGURE_ARGS += --nowerror
+endif
+
 .PHONY: post_patch_target_tvheadend
 
 post_patch_target_tvheadend:

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -62,11 +62,7 @@ FFMPEG_LIBS = libavfilter.pc libpostproc.pc libswresample.pc libavresample.pc li
 
 tvheadend_pre_depend:
 	mkdir -p $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/
-	$(foreach lib,$(FFMPEG_LIBS),ln -s $(FFMPEG_DIR)/lib/pkgconfig/$(lib) $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/ ;)
-# Fix for review:
-# Fails when re-build against existing directories
-# in conjunction with pre-built spk/ffmpeg work dirs
-#	$(foreach lib,$(FFMPEG_LIBS),test -h $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/$(lib) || ln -s $(FFMPEG_DIR)/lib/pkgconfig/$(lib) $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/ ;)
+	$(foreach lib,$(FFMPEG_LIBS),ln -sfT $(FFMPEG_DIR)/lib/pkgconfig/$(lib) $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/$(lib) ;)
 
 tvheadend_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -63,6 +63,10 @@ FFMPEG_LIBS = libavfilter.pc libpostproc.pc libswresample.pc libavresample.pc li
 tvheadend_pre_depend:
 	mkdir -p $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/
 	$(foreach lib,$(FFMPEG_LIBS),ln -s $(FFMPEG_DIR)/lib/pkgconfig/$(lib) $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/ ;)
+# Fix for review:
+# Fails when re-build against existing directories
+# in conjunction with pre-built spk/ffmpeg work dirs
+#	$(foreach lib,$(FFMPEG_LIBS),test -h $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/$(lib) || ln -s $(FFMPEG_DIR)/lib/pkgconfig/$(lib) $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/ ;)
 
 tvheadend_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var


### PR DESCRIPTION
_Motivation:_  Fix for ARMv5 arch `88f6281` build failure as found by @ymartin59 while investigating issue #3863.
_Linked issues:_  None

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
