### PR TITLE
Allow arch-specific level patch to mk build

### DIFF
--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -17,17 +17,17 @@ endif
 
 ifeq ($(strip $(PATCHES)),)
 ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM][vV]?5/*.patch))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]5/*.patch patches/[aA][rR][mM][vV]5/*.patch))
 else ifeq ($(findstring $(ARCH),$(ARM7_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM][vV]?7/*.patch))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/[aA][rR][mM][vV]7/*.patch))
 else ifeq ($(findstring $(ARCH),$(ARM8_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM][vV]?8/*.patch))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]8/*.patch patches/[aA][rR][mM][vV]8/*.patch))
 else ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
 PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch))
 else ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
 PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]86/*.patch))
 else ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]8?6?_?64/*.patch))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]64/*.patch patches/[xX]86_64/*.patch))
 else
 PATCHES = $(sort $(wildcard patches/*.patch))
 endif

--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -17,15 +17,72 @@ endif
 
 ifeq ($(strip $(PATCHES)),)
 ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]5/*.patch patches/[aA][rR][mM][vV]5/*.patch))
+ifeq ($(findstring $(ARCH),'88f6281'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]5/*.patch patches/88f6281/*.patch))
+else
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]5/*.patch))
+endif
+
 else ifeq ($(findstring $(ARCH),$(ARM7_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/[aA][rR][mM][vV]7/*.patch))
+ifeq ($(findstring $(ARCH),'alpine'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/alpine/*.patch))
+else ifeq ($(findstring $(ARCH),'armada370'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada370/*.patch))
+else ifeq ($(findstring $(ARCH),'armada375'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada375/*.patch))
+else ifeq ($(findstring $(ARCH),'armada38x'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada38x/*.patch))
+else ifeq ($(findstring $(ARCH),'armadaxp'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armadaxp/*.patch))
+else ifeq ($(findstring $(ARCH),'comcerto2k'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/comcerto2k/*.patch))
+else ifeq ($(findstring $(ARCH),'monaco'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/monaco/*.patch))
+else ifeq ($(findstring $(ARCH),'hi3535'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/hi3535/*.patch))
+else ifeq ($(findstring $(ARCH),'ipq806x'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/ipq806x/*.patch))
+else ifeq ($(findstring $(ARCH),'northstarplus'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/northstarplus/*.patch))
+else ifeq ($(findstring $(ARCH),'dakota'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/dakota/*.patch))
+else
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch))
+endif
+
 else ifeq ($(findstring $(ARCH),$(ARM8_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]8/*.patch patches/[aA][rR][mM][vV]8/*.patch))
+ifeq ($(findstring $(ARCH),'rtd1296'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/rtd1296/*.patch))
+else ifeq ($(findstring $(ARCH),'armada37xx'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada37xx/*.patch))
+else ifeq ($(findstring $(ARCH),'aarch64'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/aarch64/*.patch))
+else
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch))
+endif
+
 else ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
+ifeq ($(findstring $(ARCH),'powerpc'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/powerpc/*.patch))
+else ifeq ($(findstring $(ARCH),'ppc824x'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/ppc824x/*.patch))
+else ifeq ($(findstring $(ARCH),'ppc853x'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/ppc853x/*.patch))
+else ifeq ($(findstring $(ARCH),'ppc854x'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/ppc854x/*.patch))
+else ifeq ($(findstring $(ARCH),'qoriq'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/qoriq/*.patch))
+else
 PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch))
+endif
+
 else ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
+ifeq ($(findstring $(ARCH),'evansport'),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]86/*.patch patches/evansport/*.patch))
+else
 PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]86/*.patch))
+endif
+
 else ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
 PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]64/*.patch patches/[xX]86_64/*.patch))
 else

--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -14,8 +14,23 @@
 ifeq ($(strip $(PATCHES_LEVEL)),)
 PATCHES_LEVEL = 0
 endif
+
 ifeq ($(strip $(PATCHES)),)
+ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM][vV]?5/*.patch))
+else ifeq ($(findstring $(ARCH),$(ARM7_ARCHES)),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM][vV]?7/*.patch))
+else ifeq ($(findstring $(ARCH),$(ARM8_ARCHES)),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM][vV]?8/*.patch))
+else ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch))
+else ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]86/*.patch))
+else ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
+PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]8?6?_?64/*.patch))
+else
 PATCHES = $(sort $(wildcard patches/*.patch))
+endif
 endif
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done

--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -17,8 +17,8 @@ endif
 
 ifeq ($(strip $(PATCHES)),)
 PATCHES = $(foreach arch,ARM5_ARCHES ARM7_ARCHES ARM8_ARCHES PPC_ARCHES x86_ARCHES x64_ARCHES, \
-          $(foreach subarch,$($(arch)), \
-          $(if $(findstring $(ARCH),$(subarch)),$(sort $(wildcard patches/*.patch patches/$(shell echo ${arch} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch patches/$(subarch)/*.patch)),)))
+	$(foreach subarch,$($(arch)), \
+	$(if $(filter $(ARCH),$(subarch)),$(sort $(wildcard patches/*.patch patches/$(shell echo ${arch} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch patches/$(subarch)/*.patch)),)))
 endif
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done

--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -16,78 +16,9 @@ PATCHES_LEVEL = 0
 endif
 
 ifeq ($(strip $(PATCHES)),)
-ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
-ifeq ($(findstring $(ARCH),'88f6281'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]5/*.patch patches/88f6281/*.patch))
-else
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]5/*.patch))
-endif
-
-else ifeq ($(findstring $(ARCH),$(ARM7_ARCHES)),$(ARCH))
-ifeq ($(findstring $(ARCH),'alpine'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/alpine/*.patch))
-else ifeq ($(findstring $(ARCH),'armada370'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada370/*.patch))
-else ifeq ($(findstring $(ARCH),'armada375'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada375/*.patch))
-else ifeq ($(findstring $(ARCH),'armada38x'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada38x/*.patch))
-else ifeq ($(findstring $(ARCH),'armadaxp'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armadaxp/*.patch))
-else ifeq ($(findstring $(ARCH),'comcerto2k'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/comcerto2k/*.patch))
-else ifeq ($(findstring $(ARCH),'monaco'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/monaco/*.patch))
-else ifeq ($(findstring $(ARCH),'hi3535'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/hi3535/*.patch))
-else ifeq ($(findstring $(ARCH),'ipq806x'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/ipq806x/*.patch))
-else ifeq ($(findstring $(ARCH),'northstarplus'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/northstarplus/*.patch))
-else ifeq ($(findstring $(ARCH),'dakota'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/dakota/*.patch))
-else
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch))
-endif
-
-else ifeq ($(findstring $(ARCH),$(ARM8_ARCHES)),$(ARCH))
-ifeq ($(findstring $(ARCH),'rtd1296'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/rtd1296/*.patch))
-else ifeq ($(findstring $(ARCH),'armada37xx'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/armada37xx/*.patch))
-else ifeq ($(findstring $(ARCH),'aarch64'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch patches/aarch64/*.patch))
-else
-PATCHES = $(sort $(wildcard patches/*.patch patches/[aA][rR][mM]7/*.patch))
-endif
-
-else ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
-ifeq ($(findstring $(ARCH),'powerpc'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/powerpc/*.patch))
-else ifeq ($(findstring $(ARCH),'ppc824x'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/ppc824x/*.patch))
-else ifeq ($(findstring $(ARCH),'ppc853x'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/ppc853x/*.patch))
-else ifeq ($(findstring $(ARCH),'ppc854x'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/ppc854x/*.patch))
-else ifeq ($(findstring $(ARCH),'qoriq'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch patches/qoriq/*.patch))
-else
-PATCHES = $(sort $(wildcard patches/*.patch patches/[pP][pP][cC]/*.patch))
-endif
-
-else ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
-ifeq ($(findstring $(ARCH),'evansport'),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]86/*.patch patches/evansport/*.patch))
-else
-PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]86/*.patch))
-endif
-
-else ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
-PATCHES = $(sort $(wildcard patches/*.patch patches/[xX]64/*.patch patches/[xX]86_64/*.patch))
-else
-PATCHES = $(sort $(wildcard patches/*.patch))
-endif
+PATCHES = $(foreach arch,ARM5_ARCHES ARM7_ARCHES ARM8_ARCHES PPC_ARCHES x86_ARCHES x64_ARCHES, \
+          $(foreach subarch,$($(arch)), \
+          $(if $(findstring $(ARCH),$(subarch)),$(sort $(wildcard patches/*.patch patches/$(shell echo ${arch} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch patches/$(subarch)/*.patch)),)))
 endif
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done


### PR DESCRIPTION
_Motivation:_  Allow arch specific patches to be applied automatically.
_Linked issues:_  Relates to multi-patches on ffmpeg where some of them are arch specific

### Checklist
@hgy59 : To be sure about existing packages I propose to test the following:
- [x] Buildrule make all-supported completed successfully for `mono` (has patch in native module)
- [x] Buildrule make all-supported completed successfully for `redis` (regular patches)
- [x] Buildrule make all-supported completed successfully for `minio` (without any patch file)
- [x] Buildrule make all-supported completed successfully for `ffmpeg` #3873 (regular + subarch patches)
- [x] Buildrule make all-supported completed successfully for `tvheadend` on top of #3873 