### PR TITLE
Update beets to v1.4.9 and migrate to Python3

### DIFF
--- a/mk/spksrc.service.call_func
+++ b/mk/spksrc.service.call_func
@@ -3,7 +3,7 @@
 call_func ()
 {
     FUNC=$1
-    if type -t "$FUNC" | grep -q 'function' 2>/dev/null; then
+    if type "$FUNC" 2>/dev/null | grep -q 'function' 2>/dev/null; then
         if [ -n "${INST_LOG}" ]; then
             echo "Invoke $FUNC" >> ${INST_LOG}
         fi

--- a/spk/beets/Makefile
+++ b/spk/beets/Makefile
@@ -8,7 +8,7 @@ WHEELS = src/requirements.txt
 SPK_DEPENDS = "python3>=3.5.6-8"
 
 MAINTAINER = ymartin59
-DESCRIPTION = "Beets is the media library management system for obsessive-compulsive music geeks. The purpose of beets is to get your music collection right once and for all. It catalogs your collection, automatically improving its metadata as it goes. It then provides a bouquet of tools for manipulating and accessing your music. Plugins not available due lacking dependencies: AcousticBrainz Submit, Gmusic, ReplayGain."
+DESCRIPTION = "Beets is the media library management system for obsessive-compulsive music geeks. The purpose of beets is to get your music collection right once and for all. It catalogs your collection, automatically improving its metadata as it goes. It then provides a bouquet of tools for manipulating and accessing your music. Plugins not available due to lacking dependencies: AcousticBrainz Submit, Gmusic, ReplayGain."
 DISPLAY_NAME = beets
 
 CHANGELOG = "1. Upgrade to beets 1.4.9<br/>2. Update to python 3."

--- a/spk/beets/Makefile
+++ b/spk/beets/Makefile
@@ -3,14 +3,15 @@ SPK_VERS = 1.4.9
 SPK_REV = 4
 SPK_ICON = src/beets.png
 
+PIP = pip3
 WHEELS = src/requirements.txt
-SPK_DEPENDS = "python>=2.7.8-17"
+SPK_DEPENDS = "python3>=3.5.6-8"
 
 MAINTAINER = ymartin59
-DESCRIPTION = "Beets is the media library management system for obsessive-compulsive music geeks. The purpose of beets is to get your music collection right once and for all. It catalogs your collection, automatically improving its metadata as it goes. It then provides a bouquet of tools for manipulating and accessing your music. ReplayGain plugin is not available because of lacking dependencies."
+DESCRIPTION = "Beets is the media library management system for obsessive-compulsive music geeks. The purpose of beets is to get your music collection right once and for all. It catalogs your collection, automatically improving its metadata as it goes. It then provides a bouquet of tools for manipulating and accessing your music. Plugins not available due lacking dependencies: AcousticBrainz Submit, Gmusic, ReplayGain."
 DISPLAY_NAME = beets
 
-CHANGELOG = "1. Upgrade to beets 1.4.9<br/>2. Include Chromaprint/Acoustid plugin, corresponding SynoCommunity package has to be installed if enabled."
+CHANGELOG = "1. Upgrade to beets 1.4.9<br/>2. Update to python 3."
 
 HOMEPAGE   = http://beets.io/
 LICENSE    = GPL

--- a/spk/beets/src/requirements.txt
+++ b/spk/beets/src/requirements.txt
@@ -1,19 +1,46 @@
 beets==1.4.9
-Click==7.0
-discogs-client==2.2.2
-Flask==1.1.1
-Flask-Cors==3.0.8
-itsdangerous==1.1.0
-jellyfish==0.6.1
-Jinja2==2.11.1
-munkres==1.0.11
+
+# Direct dependencies
+# six>=1.10.0          ==> included in python3 package installation
+mutagen==1.44.0
+Unidecode==1.1.1
 musicbrainzngs==0.7.1
-mutagen==1.43.0
+#PyYAML>=3.12          ==> included in python3 package installation
+#MarkupSafe>=0.23      ==> included in python3 package installation
+munkres==1.1.2
+
+# Plugin dependencies
+beautifulsoup4==4.8.2
+certifi==2019.11.28
+chardet==3.0.4
+discogs-client==2.2.2
+langdetect==1.0.7
+# Pillow==7.0.0  # arch dependent, would need cross compilation
 oauthlib==3.1.0
-pylast==2.4.0
+pyacoustid==1.1.7
+pylast==3.2.0
 python-mpd2==1.0.0
+pyxdg==0.26
+rarfile==3.1
 requests==2.23.0
 requests-oauthlib==1.3.0
-Unidecode==1.1.1
+soupsieve==2.0
+soco==0.18.1
+urllib3==1.25.8
+xmltodict==0.12.0
+
+# For web plugin
+Flask==1.1.1
+Flask-Cors==3.0.8
+Click==7.0
+itsdangerous==1.1.0
+jellyfish==0.7.2
+Jinja2==2.11.1
 Werkzeug==1.0.0
-pyacoustid==1.1.7
+
+# For gmusic plugin 
+# Despite installing following wheels 'google' is not found at runtime
+#future==0.18.2
+#gmusicapi==12.1.1
+#decorator==4.4.2
+#google==2.0.3

--- a/spk/beets/src/service-setup.sh
+++ b/spk/beets/src/service-setup.sh
@@ -6,15 +6,15 @@ PIP=${SYNOPKG_PKGDEST}/env/bin/pip3
 service_postinst ()
 {
     # Create a Python virtualenv
-    ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env 2>&1 >> ${INST_LOG}
+    ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env >> ${INST_LOG} 2>&1
 
     # Install the wheels
-    ${PIP} install --no-deps --no-index --upgrade --force-reinstall --find-links ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl 2>&1 >> ${INST_LOG}
+    ${PIP} install --no-deps --no-index --upgrade --force-reinstall --find-links ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl >> ${INST_LOG} 2>&1
 
     # Log installation information
     echo -e "\nInstalled version:" >> ${INST_LOG}
-    ${SYNOPKG_PKGDEST}/env/bin/beet version 2>&1 >> ${INST_LOG}
+    ${SYNOPKG_PKGDEST}/env/bin/beet version >> ${INST_LOG} 2>&1
     echo -e "\nInstalled python modules:" >> ${INST_LOG}
-    ${PIP} freeze 2>&1 >> ${INST_LOG}
+    ${PIP} freeze >> ${INST_LOG} 2>&1
     echo "" >> ${INST_LOG}
 }

--- a/spk/beets/src/service-setup.sh
+++ b/spk/beets/src/service-setup.sh
@@ -1,19 +1,20 @@
 PYTHON_DIR="/usr/local/python3"
 PATH="${INSTALL_DIR}/bin:${INSTALL_DIR}/env/bin:${PYTHON_DIR}/bin:${PATH}"
 VIRTUALENV="${PYTHON_DIR}/bin/python3 -m venv"
+PIP=${SYNOPKG_PKGDEST}/env/bin/pip3
 
 service_postinst ()
 {
     # Create a Python virtualenv
-    ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env &>> ${INST_LOG}
+    ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env 2>&1 >> ${INST_LOG}
 
     # Install the wheels
-    ${SYNOPKG_PKGDEST}/env/bin/pip3 install --no-deps --no-index --upgrade --force-reinstall --find-links ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl &>> ${INST_LOG}
+    ${PIP} install --no-deps --no-index --upgrade --force-reinstall --find-links ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl 2>&1 >> ${INST_LOG}
 
     # Log installation information
     echo -e "\nInstalled version:" >> ${INST_LOG}
-    ${SYNOPKG_PKGDEST}/env/bin/beet version &>> ${INST_LOG}
+    ${SYNOPKG_PKGDEST}/env/bin/beet version 2>&1 >> ${INST_LOG}
     echo -e "\nInstalled python modules:" >> ${INST_LOG}
-    ${SYNOPKG_PKGDEST}/env/bin/pip3 freeze >> ${INST_LOG}
+    ${PIP} freeze 2>&1 >> ${INST_LOG}
     echo "" >> ${INST_LOG}
 }

--- a/spk/beets/src/service-setup.sh
+++ b/spk/beets/src/service-setup.sh
@@ -1,18 +1,19 @@
-PYTHON_DIR="/usr/local/python"
+PYTHON_DIR="/usr/local/python3"
 PATH="${INSTALL_DIR}/bin:${INSTALL_DIR}/env/bin:${PYTHON_DIR}/bin:${PATH}"
-VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
+VIRTUALENV="${PYTHON_DIR}/bin/python3 -m venv"
 
 service_postinst ()
 {
     # Create a Python virtualenv
-    ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env > /dev/null
+    ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env &>> ${INST_LOG}
 
     # Install the wheels
-    ${SYNOPKG_PKGDEST}/env/bin/pip install --no-deps --no-index -U --force-reinstall -f ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl >> ${INST_LOG} 2>&1
+    ${SYNOPKG_PKGDEST}/env/bin/pip3 install --no-deps --no-index --upgrade --force-reinstall --find-links ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl &>> ${INST_LOG}
 
-    # Extended diagnostic information
-    ${SYNOPKG_PKGDEST}/env/bin/beet version >> ${INST_LOG}
-    ${SYNOPKG_PKGDEST}/env/bin/beet --version --help >> ${INST_LOG}
-    echo -e "\nModules:" >> ${INST_LOG}
-    ${SYNOPKG_PKGDEST}/env/bin/pip freeze >> ${INST_LOG}
+    # Log installation information
+    echo -e "\nInstalled version:" >> ${INST_LOG}
+    ${SYNOPKG_PKGDEST}/env/bin/beet version &>> ${INST_LOG}
+    echo -e "\nInstalled python modules:" >> ${INST_LOG}
+    ${SYNOPKG_PKGDEST}/env/bin/pip3 freeze >> ${INST_LOG}
+    echo "" >> ${INST_LOG}
 }


### PR DESCRIPTION
_Motivation:_  Beets is a pure python package that supports python3
_Linked issues:_  #3743, bypass #3897, #3901, #2572

### Checklist
- [x] Build rule `all-supported` completed successfully (package is `noarch`)
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Remarks
- Unfortunatly #3897 was pushed from a `master` branch, so I created my own.
- As discussed in #2572 this is still a command line tool. So there is no service `beet web` nor user created.
- The output of `beet help` is no longer added to the installation log, expecting there is no configuration for the `root` user.
- We should migrate all _pure python_ packages to python3 where supported (#3633)
