### PR TITLE
framework: drop ppc853x from supported arch

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -27,7 +27,7 @@ AVAILABLE_TCS = $(notdir $(wildcard ../../toolchains/syno-*))
 AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))
 
 # Toolchain filters
-SUPPORTED_ARCHS = $(sort $(filter-out powerpc% ppc824% ppc854x%, $(AVAILABLE_ARCHS)))
+SUPPORTED_ARCHS = $(sort $(filter-out powerpc% ppc824% ppc853x% ppc854x%, $(AVAILABLE_ARCHS)))
 LEGACY_ARCHS = $(sort $(filter-out $(SUPPORTED_ARCHS), $(AVAILABLE_ARCHS)))
 # SRM - Synology Router Manager
 SRM_ARCHS = northstarplus ipq806x dakota


### PR DESCRIPTION
_Motivation:_  `ppc853x` is not supported by DSM 6.x and should be dropped off from supported list.
_Linked issues:_  Getting harder to provide proper support or even functional packages for this specific arch & DSM version due to unsupported compiler.

### Checklist
- [x] Build rule `all-supported` completed successfully

This proposal is for discussion.