### PR TITLE
Fix build of python module files

### DIFF
--- a/cross/setuptools/Makefile
+++ b/cross/setuptools/Makefile
@@ -1,9 +1,12 @@
 PKG_NAME = setuptools
-PKG_VERS = 45.2.0
+PKG_VERS = 44.0.0
 PKG_EXT = zip
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/s/$(PKG_NAME)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+# Version 44.x is the final version that is Python 2.7 compatible
+# Version >= 45.0.0 requires Python >= 3.5
 
 DEPENDS =
 

--- a/cross/setuptools/digests
+++ b/cross/setuptools/digests
@@ -1,3 +1,3 @@
-setuptools-45.2.0.zip SHA1 7cef5bf90ea21eed7cad3ca19f4786286ca35d0a
-setuptools-45.2.0.zip SHA256 89c6e6011ec2f6d57d43a3f9296c4ef022c2cbf49bab26b407fe67992ae3397f
-setuptools-45.2.0.zip MD5 0c956eea142af9c2b02d72e3c042af30
+setuptools-44.0.0.zip SHA1 d3b0c646c298a30d7446a43e5bcf367ed29d17d7
+setuptools-44.0.0.zip SHA256 e5baf7723e5bb8382fc146e33032b241efc63314211a3a120aaa55d62d2bb008
+setuptools-44.0.0.zip MD5 32b6cdce670ce462086d246bea181e9d

--- a/cross/wheel/Makefile
+++ b/cross/wheel/Makefile
@@ -7,8 +7,8 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/setuptools
 
-HOMEPAGE = https://bitbucket.org/pypa/wheel
-COMMENT  = A built-package format for Python
+HOMEPAGE = https://wheel.readthedocs.io/en/stable/
+COMMENT  = Reference implementation of the Python wheel packaging standard, as defined in PEP 427.
 LICENSE  = MIT
 
 include ../../mk/spksrc.python-module.mk

--- a/mk/spksrc.python-module.mk
+++ b/mk/spksrc.python-module.mk
@@ -31,14 +31,13 @@ install_python_module:
 	@$(RUN) PYTHONPATH=$(PYTHONPATH) $(HOSTPYTHON) setup.py install --root $(INSTALL_DIR) --prefix $(INSTALL_PREFIX) $(INSTALL_ARGS)
 
 fix_shebang_python_module:
-	@cat PLIST | sed 's/:/ /' | while read type file ; \
-	do \
-	  case $${type} in \
-	    bin) \
-	      echo -n "Fixing shebang for $${file}... " ; \
-	      sed -i -e 's|^#!.*$$|#!$(PYTHON_INTERPRETER)|g' $(INSTALL_DIR)$(INSTALL_PREFIX)/$${file} > /dev/null 2>&1 && echo "ok" || echo "failed!" \
-	      ;; \
-	  esac ; \
+	@cat PLIST | sed 's/:/ /' | while read type file ; do \
+	  for script in $(INSTALL_DIR)$(INSTALL_PREFIX)/$${file} ; do \
+	    if file $${script} | grep -iq "python script" ; then \
+	        echo -n "Fixing shebang for $${script} ... " ; \
+	        sed -i -e '1 s|^#!.*$$|#!$(PYTHON_INTERPRETER)|g' $${script} > /dev/null 2>&1 && echo "ok" || echo "failed!" ; \
+	    fi ; \
+	  done ; \
 	done
 
 all: install fix_shebang_python_module


### PR DESCRIPTION
_Motivation:_  current Python3 package does not run
_Linked issues:_  [Error reported here ](https://github.com/SynoCommunity/spksrc/pull/3906#issuecomment-593587061)

The error was introduced with commit 2d23bd2ed3dc5386fbc6bbd18d88f4003707577d 

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Remarks
- Unfortunalty the shebang adjustment in the installed python files depended on the file type in the PLIST file.
- The error was introduced by changing file types in PLIST from `bin` to `rsc` (to avoid logging of stripping errors, I suppose).
- This type is used to decide whether an installed file can be stripped. It was bad design to look only for `bin` types in PLIST to adjust the python shebang when package is a python-module.
- Now independent of PLIST, all installed files of type "Python script" get the shebang adjustment.
- Now every patched file gets logged when wildcards are used.
- And the patch is now limited on the first line in the python scripts
- Without the shebang adjustment errors appear like
```
/var/packages/python3/scripts/service-setup: /volume1/@appstore/python3/bin/pip: /spksrc/spk/python3/work-x64-6.1/Python-3.6.10/hostpython: bad interpreter: No such file or directory
```
- included in this PR is the downgrade of cross/setuptools to keep it compatible with python 2.7