### PR TITLE
fix: python3 virtualenv dependencies

### DIFF
--- a/spk/python3/src/requirements.txt
+++ b/spk/python3/src/requirements.txt
@@ -16,6 +16,13 @@ zope.interface==4.7.1
 pyopenssl==19.1.0
 six==1.14.0
 virtualenv==20.0.5
+# virtualenv dependencies
+appdirs==1.4.3
+filelock==3.0.12
+importlib-resources==1.4.0
+importlib-metadata==1.5.0
+zipp==3.1.0
+distlib==0.3.0
 
 # cryptography dependencies
 #enum34==1.1.6  # incompatible with python>3.4


### PR DESCRIPTION
_Motivation:_  `virtualenv` in `python3` is not working due to missing dependencies
_Linked issues:_
* Needed for #3916, probably other python3 packages too such as `borgbackup`

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [ ] New installation of package completed successfully
