### PR TITLE
Correct OpenSSL download URL path

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,8 +1,10 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2n
+OLD_VERSION = 1.0.2
+PATCH_VERS = n
+PKG_VERS = $(OLD_VERSION)$(PATCH_VERS)
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://www.openssl.org/source/old/1.0.2/
+PKG_DIST_SITE = https://www.openssl.org/source/old/$(OLD_VERSION)/
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib

--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = openssl
 PKG_VERS = 1.0.2n
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://www.openssl.org/source
+PKG_DIST_SITE = https://www.openssl.org/source/old/1.0.2/
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib


### PR DESCRIPTION
Old OpenSSL versions have been moved to a separate download path.

This patch fixes the compilation of packages depending on OpenSSL (like Python3) that were failing to download the source due to a wrong download URL.

```
$ wget -O /dev/null https://www.openssl.org/source/openssl-1.0.2n.tar.gz
--2020-04-04 11:04:52--  https://www.openssl.org/source/openssl-1.0.2n.tar.gz
Resolving www.openssl.org (www.openssl.org)... 2a02:26f0:f3:585::c1e, 2a02:26f0:f3:598::c1e, 104.83.84.113
Connecting to www.openssl.org (www.openssl.org)|2a02:26f0:f3:585::c1e|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-04-04 11:04:52 ERROR 404: Not Found.

$ wget -O /dev/null https://www.openssl.org/source/old/1.0.2/openssl-1.0.2n.tar.gz
--2020-04-04 11:05:00--  https://www.openssl.org/source/old/1.0.2/openssl-1.0.2n.tar.gz
Resolving www.openssl.org (www.openssl.org)... 2a02:26f0:f3:585::c1e, 2a02:26f0:f3:598::c1e, 104.83.84.113
Connecting to www.openssl.org (www.openssl.org)|2a02:26f0:f3:585::c1e|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 5375802 (5.1M) [application/x-gzip]
Saving to: ‘/dev/null’

/dev/null                                   100%[=========================================================================================>]   5.13M  16.4MB/s    in 0.3s    

2020-04-04 11:05:00 (16.4 MB/s) - ‘/dev/null’ saved [5375802/5375802]

$ 
```