### PR TITLE
Compile and distribute immutables along with Python3

### DIFF
--- a/cross/immutables/Makefile
+++ b/cross/immutables/Makefile
@@ -9,4 +9,4 @@ HOMEPAGE = https://github.com/MagicStack/immutables
 COMMENT  = A high-performance immutable mapping type for Python.
 LICENSE  = Apache-2.0
 
-include ../../mk/spksrc.python-module.mk
+include ../../mk/spksrc.python-wheel.mk

--- a/cross/immutables/Makefile
+++ b/cross/immutables/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME = immutables
+PKG_VERS = 0.11
+PKG_EXT = tar.gz
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/i/$(PKG_NAME)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+HOMEPAGE = https://github.com/MagicStack/immutables
+COMMENT  = A high-performance immutable mapping type for Python.
+LICENSE  = Apache-2.0
+
+include ../../mk/spksrc.python-module.mk

--- a/cross/immutables/PLIST
+++ b/cross/immutables/PLIST
@@ -1,0 +1,1 @@
+lib:@PYTHON_SITE_PACKAGES@/immutables/_map*.so

--- a/cross/immutables/PLIST
+++ b/cross/immutables/PLIST
@@ -1,1 +1,0 @@
-lib:@PYTHON_SITE_PACKAGES@/immutables/_map*.so

--- a/cross/immutables/digests
+++ b/cross/immutables/digests
@@ -1,0 +1,2 @@
+immutables-0.11.tar.gz SHA1 070277bbe664474ff4e0eae4aad7e8f1d37c08f8
+immutables-0.11.tar.gz SHA256 d6850578a0dc6530ac19113cfe4ddc13903df635212d498f176fe601a8a5a4a3

--- a/cross/immutables/digests
+++ b/cross/immutables/digests
@@ -1,2 +1,3 @@
 immutables-0.11.tar.gz SHA1 070277bbe664474ff4e0eae4aad7e8f1d37c08f8
 immutables-0.11.tar.gz SHA256 d6850578a0dc6530ac19113cfe4ddc13903df635212d498f176fe601a8a5a4a3
+immutables-0.11.tar.gz MD5 2478a4009ed371232fc9e4d00fac1159

--- a/spk/python3/Makefile
+++ b/spk/python3/Makefile
@@ -5,7 +5,6 @@ SPK_REV = 11
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
-#Build-time dependencies
 DEPENDS += cross/setuptools cross/pip cross/wheel
 DEPENDS += cross/cffi cross/bcrypt cross/sqlite
 # Cross-compiled wheels
@@ -21,7 +20,7 @@ DESCRIPTION_SPN = Lenguaje de programación Python.
 RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python3
-CHANGELOG = "1. Update to Python 3.6.10<br/>2. Update of dependencies and wheels"
+CHANGELOG = "1. Update to Python 3.6.10<br/>2. Add immutables<br/>3. Update of dependencies and wheels"
 
 HOMEPAGE = http://www.python.org
 LICENSE  = PSF

--- a/spk/python3/Makefile
+++ b/spk/python3/Makefile
@@ -10,7 +10,7 @@ DEPENDS += cross/setuptools cross/pip cross/wheel
 DEPENDS += cross/cffi cross/bcrypt cross/sqlite
 # Cross-compiled wheels
 DEPENDS += cross/lxml cross/pycrypto cross/pycurl cross/pyyaml
-DEPENDS += cross/msgpack-python cross/ruamel.yaml
+DEPENDS += cross/msgpack-python cross/ruamel.yaml cross/immutables
 
 WHEELS = src/requirements.txt
 

--- a/spk/python3/src/requirements.txt
+++ b/spk/python3/src/requirements.txt
@@ -5,6 +5,7 @@
 #Pillow==5.3.0
 #pycurl==7.43.0.2
 pyyaml==5.3
+immutables==0.11
 
 ## Cross-compiled via spksrc.wheel.mk
 markupsafe==1.1.1

--- a/spk/python3/src/requirements.txt
+++ b/spk/python3/src/requirements.txt
@@ -4,8 +4,8 @@
 #pycrypto==2.6.1
 #Pillow==5.3.0
 #pycurl==7.43.0.2
-pyyaml==5.3
-immutables==0.11
+#pyyaml==5.3
+#immutables==0.11
 
 ## Cross-compiled via spksrc.wheel.mk
 markupsafe==1.1.1


### PR DESCRIPTION
Hi,

Not sure I'll be able to convince you that this is a good idea but it's worth a shot. Here I go.

I install [Flexget ](https://flexget.com/) on my Synology using a Python virtual environment. Unfortunately for me, recent versions of Flexget require [`immutables`](https://github.com/MagicStack/immutables) (via `contextvars`) which has C extensions. As I don't have any toolchain installed on the Synology and there are no precompiled wheels for `aaarch64` when it's time to install this dependency via `pip install` everything fails for obvious reasons.

Having this library distributed by Python3 would make my life much easier. Creating a symlink from the Python virtual environment to `@appstore/python3/lib/python3.6/site-packages/immutables` is enough to make `pip` happy and get the latest Flexget installed. Also, this might be useful is somebody gives a push to the Synocommunity Flexget package in the future.

I'd totally understand if you didn't want this here but please don't delete the PR, just close it. It might be useful for my future me as a recipe for whenever I have to build Python3 again. I guess it's the price I have to pay for not having bought an Intel Synology where I could just run my stuff in Docker containers and forget about all this 😁.

The patch has been tested with a build for `arch-rtd1296`.

https://cern.ch/nacho/srcpkg/python3/

Thanks for your time 🤞 