### PR TITLE
mono: replace relative references in applications

### DIFF
--- a/spk/jackett/src/service-setup.sh
+++ b/spk/jackett/src/service-setup.sh
@@ -5,7 +5,7 @@
 service_prestart ()
 {
     # Replace generic service startup
-    MONO_PATH="${SYNOPKG_PKGDEST}/../mono/bin"
+    MONO_PATH="/var/packages/mono/target/bin"
     PATH="${SYNOPKG_PKGDEST}/bin:${MONO_PATH}:${PATH}"
     MONO="${MONO_PATH}/mono"
     JACKETT="${SYNOPKG_PKGDEST}/share/${SYNOPKG_PKGNAME}/JackettConsole.exe"

--- a/spk/lidarr/src/service-setup.sh
+++ b/spk/lidarr/src/service-setup.sh
@@ -1,5 +1,5 @@
 PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
-MONO_PATH="${SYNOPKG_PKGDEST}/../mono/bin"
+MONO_PATH="/var/packages/mono/target/bin"
 MONO="${MONO_PATH}/mono"
 
 # Check versions during upgrade

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -1,5 +1,5 @@
 PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
-MONO_PATH="${SYNOPKG_PKGDEST}/../mono/bin"
+MONO_PATH="/var/packages/mono/target/bin"
 MONO="${MONO_PATH}/mono"
 
 # Check versions during upgrade

--- a/spk/sonarr/src/service-setup.sh
+++ b/spk/sonarr/src/service-setup.sh
@@ -1,5 +1,5 @@
 PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
-MONO_PATH="${SYNOPKG_PKGDEST}/../mono/bin"
+MONO_PATH="/var/packages/mono/target/bin"
 MONO="${MONO_PATH}/mono"
 
 # Sonarr uses the home directory to store it's ".config"


### PR DESCRIPTION
Invalid relative references if application package is not installed
on same DSM volume than mono package.

Closes #3947
