### PR TITLE
Add initial purley TC 6.2.2

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -36,7 +36,7 @@ SRM_ARCHS = northstarplus ipq806x dakota
 ARCHS_NO_KRNLSUPP = $(filter-out x64%, $(SUPPORTED_ARCHS))
 
 # remove archs for generic x64 build
-ARCHS_DUPES := $(filter-out apollolake% avoton% braswell% broadwell% bromolow% cedarview% grantley% x86% broadwellnk% denverton% dockerx64% grantley% purley% kvmx64% x86_64%, $(SUPPORTED_ARCHS))
+ARCHS_DUPES := $(filter-out apollolake% avoton% braswell% broadwell% broadwellnk% bromolow% cedarview% denverton% dockerx64% grantley% purley% kvmx64% x86% x86_64%, $(SUPPORTED_ARCHS))
 # remove archs for generic aarch64 build
 ARCHS_DUPES := $(filter-out rtd1296% armada37xx%, $(ARCHS_DUPES))
 # optional remove archs for generic armv7 build

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -138,6 +138,7 @@ else ifneq ($(strip $(TC_FIRMWARE)),)
 	@echo firmware=\"$(TC_FIRMWARE)\" >> $@
 	@echo os_min_ver=\"$(TC_FIRMWARE)\" >> $@
 else ifneq ($(strip $(TC_OS_MIN_VER)),)
+	@echo firmware=\"$(TC_OS_MIN_VER)\" >> $@
 	@echo os_min_ver=\"$(TC_OS_MIN_VER)\" >> $@
 else
 	@echo firmware=\"3.1-1594\" >> $@

--- a/toolchains/syno-purley-6.2.2/Makefile
+++ b/toolchains/syno-purley-6.2.2/Makefile
@@ -1,0 +1,22 @@
+TC_NAME = syno-$(TC_ARCH)
+
+TC_ARCH = purley
+TC_VERS = 6.2.2
+TC_OS_MIN_VER = 6.2-25023
+
+TC_DIST = purley-gcc493_glibc220_linaro_x86_64-GPL
+TC_EXT = txz
+TC_DIST_NAME = $(TC_DIST).$(TC_EXT)
+TC_DIST_SITE = https://sourceforge.net/projects/dsgpl/files/DSM%206.2.2%20Tool%20Chains/Intel%20x86%20Linux%204.4.59%20%28Purley%29
+
+TC_BASE_DIR = x86_64-pc-linux-gnu
+TC_PREFIX = x86_64-pc-linux-gnu
+TC_TARGET = x86_64-pc-linux-gnu
+
+TC_CFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CPPFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_CXXFLAGS = -I$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_BASE_DIR)/sys-root/usr/include
+TC_LIBDIR = $(TC_BASE_DIR)/sys-root/lib
+TC_LDFLAGS = -L$(WORK_DIR)/$(TC_BASE_DIR)/$(TC_LIBDIR)
+
+include ../../mk/spksrc.tc.mk

--- a/toolchains/syno-purley-6.2.2/digests
+++ b/toolchains/syno-purley-6.2.2/digests
@@ -1,0 +1,3 @@
+purley-gcc493_glibc220_linaro_x86_64-GPL.txz SHA1 7ca406bf6ac604706b99afdd0e9682985aa995a4
+purley-gcc493_glibc220_linaro_x86_64-GPL.txz SHA256 cc551c4de0b030df3717e2d216263a14ef17015e999716c336bc6c41ab6e1bb8
+purley-gcc493_glibc220_linaro_x86_64-GPL.txz MD5 374b11b1133c161e1f7bb99318bbd347

--- a/toolchains/syno-x64-6.1/Makefile
+++ b/toolchains/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley kvmx64 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley purley kvmx64 x86 x86_64
 TC_VERS = 6.1
 TC_OS_MIN_VER = 6.1-15047
 


### PR DESCRIPTION
_Motivation:_  The intel purley arch is not supported yet (introduced by model FS6400)
_Linked issues:_  #3949

### Remarks
- add purley to generic x64 archs
- reorder ARCHS_DUPES similar to x64 TC_ARCH
- add firmware to INFO too, when TC_OS_MIN_VER is specified
