### PR TITLE
[python][wheels] Use crossenv to generate cross compiled wheels

### DIFF
--- a/cross/python3/Makefile
+++ b/cross/python3/Makefile
@@ -82,12 +82,14 @@ python3_custom_install:
 python3_post_install: $(WORK_DIR)/python-cc.mk
 	mkdir -p $(PYTHON_LIB_CROSS)
 	cp -R $(HOSTPYTHON_LIB_NATIVE) $(PYTHON_LIB_CROSS)/../
+	@$(RUN) $(PYTHON_NATIVE) -m crossenv $(STAGING_INSTALL_PREFIX)/bin/python$(PKG_VERS_MAJOR).$(PKG_VERS_MINOR) $(WORK_DIR)/crossenv/
 ifneq ($(PYTHON_LIB_NATIVE),$(PYTHON_LIB_CROSS))
 	cp $(PYTHON_LIB_CROSS)/_sysconfigdata_*.py $(PYTHON_LIB_NATIVE)/_sysconfigdata.py
 endif
 
 $(WORK_DIR)/python-cc.mk:
 	@echo HOSTPYTHON=$(HOSTPYTHON) > $@
+	@echo CROSSENV=$(WORK_DIR)/crossenv/bin/activate >> $@
 	@echo HOSTPYTHON_LIB_NATIVE=$(HOSTPYTHON_LIB_NATIVE) >> $@
 	@echo PYTHON_LIB_NATIVE=$(PYTHON_LIB_NATIVE) >> $@
 	@echo PYTHON_SITE_PACKAGES_NATIVE=$(PYTHON_SITE_PACKAGES_NATIVE) >> $@

--- a/mk/spksrc.python-wheel.mk
+++ b/mk/spksrc.python-wheel.mk
@@ -25,7 +25,13 @@ PYTHONPATH = $(PYTHON_LIB_NATIVE):$(INSTALL_DIR)$(INSTALL_PREFIX)/$(PYTHON_LIB_D
 
 ### Python wheel rules
 build_python_wheel:
+ifeq ($(strip $(CROSSENV)),)
+# Python 2 way
 	@$(RUN) PYTHONPATH=$(PYTHONPATH) $(HOSTPYTHON) -c "import setuptools;__file__='setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" $(BUILD_ARGS) bdist_wheel -b $(WORK_DIR)/wheelbuild -d $(WORK_DIR)/wheelhouse
+else
+# Python 3 case: using crossenv helper
+	@. $(CROSSENV) && $(RUN) PYTHONPATH=$(PYTHONPATH) python -c "import setuptools;__file__='setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" $(BUILD_ARGS) bdist_wheel -b $(WORK_DIR)/wheelbuild -d $(WORK_DIR)/wheelhouse
+endif
 
 install_python_wheel: $(WHEEL_TARGET)
 	@if [ -d "$(WORK_DIR)/wheelhouse" ] ; then \

--- a/native/python3/Makefile
+++ b/native/python3/Makefile
@@ -29,10 +29,11 @@ PIP_NATIVE = $(WORK_DIR)/../../../native/$(PKG_NAME)/work-native/install/usr/loc
 
 .PHONY: nativepython3_post_install
 nativepython3_post_install: $(WORK_DIR)/python-native.mk
-	@$(MSG) Installing setuptools, pip and cffi
+	@$(MSG) Installing setuptools, pip, cffi and cross env
 	@$(RUN) wget https://bootstrap.pypa.io/ez_setup.py -O - | $(PYTHON)
 	@$(RUN) wget https://bootstrap.pypa.io/get-pip.py -O - | $(PYTHON)
 	@$(PIP) install "cffi==1.14.0"
+	@$(PIP) install "crossenv==0.7"
 
 $(WORK_DIR)/python-native.mk:
 	@echo PIP=$(PIP_NATIVE) >> $@


### PR DESCRIPTION
_Motivation:_  Generated wheels ship libraries were generated using the native `EXT_SUFFIX` value for native libraries. 
_Linked issues:_  Fixes https://github.com/SynoCommunity/spksrc/issues/3944

### Checklist
- [x] Build rule `all-supported` completed successfully (validated by building Python 3.7.7 and checking generated wheel contents)
- [x] Package upgrade completed successfully (validated by using Python 3.7.7 spk compiled with this)
- [x] New installation of package completed successfully