### PR TITLE
dnscrypt-proxy hotfix for dsm and package update

### DIFF
--- a/cross/dnscrypt-proxy/Makefile
+++ b/cross/dnscrypt-proxy/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = dnscrypt-proxy
-PKG_VERS = 2.0.33
+PKG_VERS = 2.0.42
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jedisct1/$(PKG_NAME)/archive

--- a/cross/dnscrypt-proxy/digests
+++ b/cross/dnscrypt-proxy/digests
@@ -1,3 +1,3 @@
-dnscrypt-proxy-2.0.33.tar.gz SHA1 25fbb825269124f4cbdb0c17cdf7047c7d51a985
-dnscrypt-proxy-2.0.33.tar.gz SHA256 9e62dd3dff59c283a0b8214d99925c1ca8855876992be1755b3eb6b3489194fd
-dnscrypt-proxy-2.0.33.tar.gz MD5 5fac77325c076a6985aa0344022514ba
+dnscrypt-proxy-2.0.42.tar.gz SHA1 2d7d5cd09b05779ed55d676ff73064440513bbf8
+dnscrypt-proxy-2.0.42.tar.gz SHA256 c000ca4e159c6606cb3476ea9e34ed64b5c46c710d70cc5651f14f1125c8d352
+dnscrypt-proxy-2.0.42.tar.gz MD5 9892c5d281b57c5f315d2f95cd6c33d8

--- a/spk/dnscrypt-proxy/Makefile
+++ b/spk/dnscrypt-proxy/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = dnscrypt-proxy
-SPK_VERS = 2.0.33
+SPK_VERS = 2.0.42
 SPK_REV = 4
 SPK_ICON = src/dnscrypt-proxy.png
 

--- a/spk/dnscrypt-proxy/src/service-setup.sh
+++ b/spk/dnscrypt-proxy/src/service-setup.sh
@@ -35,7 +35,7 @@ blocklist_setup () {
 
 blocklist_cron_uninstall () {
     # remove cron job
-    if [ "$OS" == 'dsm' ]; then
+    if [ "$OS" = "dsm" ]; then
         rm -f /etc/cron.d/dnscrypt-proxy-update-blocklist
     else
         sed -i '/.*update-blocklist.sh/d' /etc/crontab
@@ -44,7 +44,7 @@ blocklist_cron_uninstall () {
 }
 
 pgrep () {
-    if [ "$OS" == 'dsm' ]; then
+    if [ "$OS" = 'dsm' ]; then
         # shellcheck disable=SC2009,SC2153
         ps aux | grep "$1" >> "${LOG_FILE}" 2>&1
     else
@@ -59,16 +59,16 @@ restart_dhcpd () {
 
 forward_dns_dhcpd () {
     echo "dns forwarding - $1" >> "${LOG_FILE}"
-    if [ "$1" == "no" ] && [ -f /etc/dhcpd/dhcpd-dnscrypt-dnscrypt.conf ]; then
-        if [ "$OS" == 'dsm' ]; then
+    if [ "$1" = "no" ] && [ -f /etc/dhcpd/dhcpd-dnscrypt-dnscrypt.conf ]; then
+        if [ "$OS" = "dsm" ]; then
             echo "enable=no" > /etc/dhcpd/dhcpd-dns-dns.info
         else
             echo "enable=no" > /etc/dhcpd/dhcpd-dnscrypt-dnscrypt.info
         fi
         restart_dhcpd
-    elif [ "$1" == "yes" ]; then
+    elif [ "$1" = "yes" ]; then
         if pgrep "dhcpd.conf"; then  # if dhcpd (dnsmasq) is enabled and running
-            if [ "$OS" == 'dsm ' ]; then
+            if [ "$OS" = "dsm" ]; then
                 echo "server=127.0.0.1#${BACKUP_PORT}" > /etc/dhcpd/dhcpd-dns-dns.conf
                 echo "enable=yes" > /etc/dhcpd/dhcpd-dns-dns.info
                 # /etc/dhcpd/dhcpd-vendor.conf
@@ -88,7 +88,7 @@ service_prestart () {
     echo "service_preinst ${SYNOPKG_PKG_STATUS}" >> "${INST_LOG}"
 
     # Install daily cron job (3 minutes past midnight), to update the block list
-    if [ "$OS" == 'dsm' ]; then
+    if [ "$OS" = 'dsm' ]; then
         mkdir -p /etc/cron.d
         echo "3       0       *       *       *       root    /var/packages/dnscrypt-proxy/target/var/update-blocklist.sh" >> /etc/cron.d/dnscrypt-proxy-update-blocklist
     else # RSM
@@ -164,7 +164,7 @@ service_postinst () {
             "${CFG_FILE}" >> "${INST_LOG}" 2>&1
     fi
 
-    echo "Fixing permissions for cgi GUI... on SRM" >> "${INST_LOG}"
+    echo "Fixing permissions for cgi GUI... " >> "${INST_LOG}"
     # Fixes https://github.com/publicarray/spksrc/issues/3
     # https://originhelp.synology.com/developer-guide/privilege/privilege_specification.html
     chmod 0777 "${SYNOPKG_PKGDEST}/var/" >> "${INST_LOG}" 2>&1
@@ -187,7 +187,7 @@ service_postuninst () {
     pkgindexer_del "${SYNOPKG_PKGDEST}/ui/helptoc.conf" >> "${INST_LOG}" 2>&1
     pkgindexer_del "${SYNOPKG_PKGDEST}/ui/index.conf" >> "${INST_LOG}" 2>&1
     disable_dhcpd_dns_port "no"
-    if [ "$OS" == 'dsm ' ]; then
+    if [ "$OS" = "dsm" ]; then
         rm -f /etc/dhcpd/dhcpd-dns-dns.conf
         rm -f /etc/dhcpd/dhcpd-dns-dns.info
     else


### PR DESCRIPTION
_Motivation:_  I had someone on twitter contact me that the package did not work as intended on DSM and the DHCP setup as described in the wiki.

There was a unwanted space character in the string comparison and therefore did not execute  the correct instructions for the DSM.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
