### PR TITLE
Arch geminilake

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -36,7 +36,7 @@ SRM_ARCHS = northstarplus ipq806x dakota
 ARCHS_NO_KRNLSUPP = $(filter-out x64%, $(SUPPORTED_ARCHS))
 
 # remove archs for generic x64 build
-ARCHS_DUPES := $(filter-out apollolake% avoton% braswell% broadwell% broadwellnk% bromolow% cedarview% denverton% dockerx64% grantley% purley% kvmx64% x86% x86_64%, $(SUPPORTED_ARCHS))
+ARCHS_DUPES := $(filter-out apollolake% avoton% braswell% broadwell% broadwellnk% bromolow% cedarview% denverton% dockerx64% geminilake% grantley% purley% kvmx64% x86% x86_64%, $(SUPPORTED_ARCHS))
 # remove archs for generic aarch64 build
 ARCHS_DUPES := $(filter-out rtd1296% armada37xx%, $(ARCHS_DUPES))
 # optional remove archs for generic armv7 build
@@ -53,7 +53,7 @@ ARM8_ARCHES = aarch64 rtd1296 armada37xx
 ARM_ARCHES = $(ARM5_ARCHES) $(ARM7_ARCHES) $(ARM8_ARCHES)
 PPC_ARCHES = powerpc ppc824x ppc853x ppc854x qoriq
 x86_ARCHES = evansport
-x64_ARCHES = x64 apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley purley kvmx64 x86 x86_64
+x64_ARCHES = x64 apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 x86 x86_64
 
 # Load local configuration
 LOCAL_CONFIG_MK = ../../local.mk

--- a/toolchains/syno-x64-6.1/Makefile
+++ b/toolchains/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 grantley purley kvmx64 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 x86 x86_64
 TC_VERS = 6.1
 TC_OS_MIN_VER = 6.1-15047
 


### PR DESCRIPTION
_Motivation:_  Add generic x64 support for intel geminilake arch
_Linked issues:_  #3999

- only generic x64 packages are supported until Synology provides the toolchains for geminilake archs.