### PR TITLE
Fix gh actions

### DIFF
--- a/.github/actions/build-push-pr.sh
+++ b/.github/actions/build-push-pr.sh
@@ -54,8 +54,8 @@ echo "===> PACKAGES to Build: $packages"
 for package in $packages
 do
     # make sure that the package exists
-    if [ -d "spk/$package" ]; then
-        cd spk/"$package" && make "$GH_ARCH"
+    if [ -d "/github/workspace/spk/$package" ]; then
+        cd /github/workspace/spk/"$package" && make "$GH_ARCH"
     else
         echo "$package is not found"
     fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 2
+            persist-credentials: false
 
       - name: Get changed files
         if: startsWith(github.ref, 'refs/tags/') == false


### PR DESCRIPTION
By default actions/checkout only retrieves the latest commit. To calculate the diff we need the previous commit. I failed to catch this problem earlier.

_Linked issues:_  #3982

Here is a run with ffmpeg: https://github.com/publicarray/spksrc/actions/runs/119815811