### PR TITLE
Framework: Github Actions - fix Pull Request runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,19 +37,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-            fetch-depth: 2
+            fetch-depth: 3
             persist-credentials: false
 
-      - name: Get changed files
-        if: startsWith(github.ref, 'refs/tags/') == false
+      - name: Get changed files PR
+        if: github.event_name == 'pull_request'
+        id: getfile_pr
+        run: |
+          git diff-tree --no-commit-id --name-only -r ${{github.event.pull_request.head.sha}} | xargs
+          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{github.event.pull_request.head.sha}} | xargs)"
+
+      - name: Get changed files PUSH
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') == false
         id: getfile
         run: |
+          git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs
           echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)"
-
-      - name: Print changed files
-        if: startsWith(github.ref, 'refs/tags/') == false
-        run: |
-          echo ${{ steps.getfile.outputs.files }}
 
       - name: Build Package (file changes)
         if: startsWith(github.ref, 'refs/tags/') == false
@@ -57,7 +60,7 @@ jobs:
         with:
           entrypoint: ./.github/actions/build-push-pr.sh
         env:
-          GH_FILES: ${{ steps.getfile.outputs.files }}
+          GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
           GH_ARCH: arch-${{ matrix.arch }}
 
@@ -75,7 +78,13 @@ jobs:
       - name: List packages
         run: mkdir -p packages; ls packages
 
-      - name: Upload build artifacts
+      - name: Upload build artifacts per arch
+        uses: actions/upload-artifact@v2
+        with:
+          name: package-${{ matrix.arch }}
+          path: packages/*.spk
+
+      - name: Upload build all artifacts
         uses: actions/upload-artifact@v2
         with:
           name: packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-            fetch-depth: 3
+            fetch-depth: 0
             persist-credentials: false
 
       - name: Get changed files PR
         if: github.event_name == 'pull_request'
         id: getfile_pr
         run: |
-          git diff-tree --no-commit-id --name-only -r ${{github.event.pull_request.head.sha}} | xargs
+          git diff-tree --no-commit-id --name-only -r master ${{github.event.pull_request.head.sha}} | xargs
           echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{github.event.pull_request.head.sha}} | xargs)"
 
       - name: Get changed files PUSH


### PR DESCRIPTION
Pull Requests use a github.sha set in the future

This time I've run tests on github.com https://github.com/publicarray/spksrc/pull/13
https://github.com/publicarray/spksrc/actions/runs/127595298