### PR TITLE
[github actions] Update build_status.sh to print out the proper error output file contents

### DIFF
--- a/.github/actions/build_status.sh
+++ b/.github/actions/build_status.sh
@@ -9,7 +9,7 @@
 
 if [ -f "${BUILD_ERROR_FILE}" ]; then
     if [ $(cat "${BUILD_ERROR_FILE}" | wc -l) -gt 0 ]; then
-        cat "${GH_BUILD_ERROR_FILE}"
+        cat "${BUILD_ERROR_FILE}"
         echo ""
         echo "Please analyze the log file of the build job."
         exit 1


### PR DESCRIPTION
_Motivation:_  When errors are being spotted the contents of the error file is not printed out
