### PR TITLE
ppc853x: libbluray fix and tvheadend marked as unsupported

### DIFF
--- a/cross/libbluray/Makefile
+++ b/cross/libbluray/Makefile
@@ -15,5 +15,9 @@ GNU_CONFIGURE = 1
 
 CONFIGURE_ARGS = --disable-examples --disable-doxygen-doc --disable-doxygen-dot --disable-bdjava-jar
 
-include ../../mk/spksrc.cross-cc.mk
+# For ppc853x-5.2, define GNU_SOURCE
+ifeq ($(ARCH)-$(TCVERSION), ppc853x-5.2)
+ADDITIONAL_CFLAGS = -D_GNU_SOURCE
+endif
 
+include ../../mk/spksrc.cross-cc.mk

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -24,6 +24,10 @@ CHANGELOG = "1. Update to latest git version 51a4c5b as of June 10th 2020<br/>2.
 HOMEPAGE = https://tvheadend.org/
 LICENSE = GPL v3
 
+# PPC_ARCHES except qoriq are not supported
+# https://tvheadend.org/issues/5060
+UNSUPPORTED_ARCHS = powerpc ppc824x ppc853x ppc854x
+
 WIZARDS_DIR = src/wizard/
 CONF_DIR = src/conf/
 


### PR DESCRIPTION
_Motivations:_  
Thnx to github action I was able to notice:
1. `ppc853x-5.2` build failure since latest `libbluray` version 1.2.0 update.  To fix requires `-D_GNU_SOURCE` C flag.
2. Also `tvheadend` never built against `ppc853x`.  Now marked as unsupported to limit false-positives on github-actions.

_Linked issues:_  #3965, #3998

### Checklist
- [x] Build rule `arch-ppc853x-5.2` completed successfully
