### PR TITLE
ntopng: build fix when using non /spksrc root dir

### DIFF
--- a/cross/ntopng/Makefile
+++ b/cross/ntopng/Makefile
@@ -80,6 +80,6 @@ ntopng_pre_compile:
 	@$(MSG) "- patch generated Makefile to ignore third-party libs and use cross/* packages instead"
 	@$(RUN) sed -i 's|LIB_TARGETS = $$(LUA_LIB)|LIB_TARGETS =|g' ./Makefile
 	@$(RUN) sed -i 's|$$(LIBPCAP) $$(LUA_LIB) $$(LIBRRDTOOL_LIB)|$$(LIBPCAP) $$(LIBRRDTOOL_LIB)|g' ./Makefile
-	@$(RUN) sed -i 's| -L/spksrc/.*$(INSTALL_PREFIX)/lib -l   -L/spksrc/| -L/spksrc/|g' ./Makefile
+	@$(RUN) sed -i 's| -l   -L/| -L/|g' ./Makefile
 	@$(RUN) sed -i 's| -lssl -lssl | -lssl -lcurl -llua -lmysqlclient |g' ./Makefile
 	@$(RUN) sed -i 's|-L/usr/local/lib -lrt -lz -ldl -lcurl |-L/usr/local/lib -lrt -lz -ldl |g' ./Makefile

--- a/spk/ntopng/Makefile
+++ b/spk/ntopng/Makefile
@@ -19,6 +19,9 @@ DISPLAY_NAME = ntopng
 HELPURL = https://www.ntop.org/guides/ntopng/index.html
 LICENSE = GNU GPLv3
 
+# PPC_ARCHES except qoriq are not supported
+# https://tvheadend.org/issues/5060
+UNSUPPORTED_ARCHS = powerpc ppc824x ppc853x ppc854x
 
 # 'auto' (reserved value) grabs SPK_NAME
 SERVICE_USER   = auto


### PR DESCRIPTION
_Motivation:_  Building `ntopng` only works from `/spksrc` root dir.  This fix addresses this.
_Linked issues:_  #4028

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

### Notes
- Previous builds doesn't show support for PPC arches except `qoriq` - now forced as such.
- Makefile default `REQUIRED_DSM = 6.1` resulting in `armv7-1.2` to no be built