### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,2 @@
-distrib
-packages
-native/*/work*
-cross/*/work*
-kernel/*/work*
-spk/*/work*
-toolchains/*/work*
-local.mk
-*.DS_Store
-*~
+# exclude all files in the repository
+*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,54 +6,58 @@ ENV LANG C.UTF-8
 # Manage i386 arch
 RUN dpkg --add-architecture i386
 
-# Install required packages (in sync with README.rst instructions
+# Install required packages (in sync with README.rst instructions)
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        autogen \
-        automake \
-        bc \
-        bison \
-        build-essential \
-        check \
-        cmake \
-        curl \
-        cython \
-        debootstrap \
-        expect \
-        flex \
-        g++-multilib \
-        gettext \
-        git \
-        gperf \
-        imagemagick \
-        intltool \
-        libbz2-dev \
-        libc6-i386 \
-        libcppunit-dev \
-        libffi-dev \
-        libgc-dev \
-        libgmp3-dev \
-        libltdl-dev \
-        libmount-dev \
-        libncurses-dev \
-        libpcre3-dev \
-        libssl-dev \
-        libtool \
-        libunistring-dev \
-        lzip \
-        mercurial \
-        ncurses-dev \
-        php \
-        pkg-config \
-        python3 \
-        python3-distutils \
-        scons \
-        subversion \
-        swig \
-        unzip \
-        xmlto \
-        zlib1g-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+		autogen \
+		automake \
+		bc \
+		bison \
+		build-essential \
+		check \
+		cmake \
+		curl \
+		cython \
+		debootstrap \
+		ed \
+		expect \
+		flex \
+		g++-multilib \
+		gawk \
+		gettext \
+		git \
+		gperf \
+		imagemagick \
+		intltool \
+		libbz2-dev \
+		libc6-i386 \
+		libcppunit-dev \
+		libffi-dev \
+		libgc-dev \
+		libgmp3-dev \
+		libltdl-dev \
+		libmount-dev \
+		libncurses-dev \
+		libpcre3-dev \
+		libssl-dev \
+		libtool \
+		libunistring-dev \
+		lzip \
+		mercurial \
+		ncurses-dev \
+		php \
+		pkg-config \
+		pngquant \
+		python3 python3-distutils \
+		rename \
+		scons \
+		subversion \
+		swig \
+		texinfo \
+		unzip \
+		xmlto \
+		zlib1g-dev && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install setuptools, wheel and pip for Python3
 RUN wget https://bootstrap.pypa.io/get-pip.py -O - | python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		ncurses-dev \
 		php \
 		pkg-config \
-		pngquant \
-		python3 python3-distutils \
+		python3 \
+		python3-distutils \
 		rename \
 		scons \
 		subversion \

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ A virtual machine based on an 64-bit version of Debian 10 stable OS is recommend
 * Install the requirements (in sync with Dockerfile)::
 
     sudo dpkg --add-architecture i386 && sudo apt-get update
-    sudo apt install autogen automake bc bison build-essential check cmake curl cython debootstrap expect flex g++-multilib gettext git gperf imagemagick intltool libbz2-dev libc6-i386 libcppunit-dev libffi-dev libgc-dev libgmp3-dev libltdl-dev libmount-dev libncurses-dev libpcre3-dev libssl-dev libtool libunistring-dev lzip mercurial ncurses-dev php pkg-config python3 python3-distutils scons subversion swig unzip xmlto zlib1g-dev
+    sudo apt install autogen automake bc bison build-essential check cmake curl cython debootstrap ed expect flex g++-multilib gawk gettext git gperf imagemagick intltool libbz2-dev libc6-i386 libcppunit-dev libffi-dev libgc-dev libgmp3-dev libltdl-dev libmount-dev libncurses-dev libpcre3-dev libssl-dev libtool libunistring-dev lzip mercurial ncurses-dev php pkg-config python3 python3-distutils rename scons subversion swig texinfo unzip xmlto zlib1g-dev
     sudo pip install -U setuptools pip wheel httpie
 
 * You may need to install some packages from testing like autoconf. Read about Apt-Pinning to know how to do that.


### PR DESCRIPTION
_Motivation:_  The builds of some packages are missing some tools in the build environment
_Linked issues:_  Closes #4043, add tools for #3253

- add rename for gevent (#4043)
- add ed, gawk and texinfo for gnu packages
- exclude all repository files from docker image

### Remarks
- as updates of the master branch trigger the update of the synocommunity/spksrc image on docker hub, the merge of this PR will fix github build actions for related packages.
- to get the current image, a developer may manually update with `docker pull synocommunity/spksrc`. (github-action uses the latest image anyway).
- the tools for gnu packages are required for my WIP on synocli-dev #3253 (not pushed so far)
