### PR TITLE
cross/sqlite: http is no longer available

### DIFF
--- a/cross/sqlite/Makefile
+++ b/cross/sqlite/Makefile
@@ -2,14 +2,14 @@ PKG_NAME = sqlite-autoconf
 PKG_VERS = 3250300
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://www.sqlite.org/2018
+PKG_DIST_SITE = https://www.sqlite.org/2018
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib cross/speex
 
-HOMEPAGE = http://www.sqlite.org/
+HOMEPAGE = https://www.sqlite.org/
 COMMENT  = Self-contained, serverless, zero-configuration, transactional SQL database engine.
-LICENSE  = http://www.sqlite.org/copyright.html
+LICENSE  = https://www.sqlite.org/copyright.html
 
 GNU_CONFIGURE = 1
 


### PR DESCRIPTION
_Motivation:_  Trying to access `www.sqlite.org` through http no longer works
_Linked issues:_  closes #4047

### Checklist
- ~~[ ] Build rule `all-supported` completed successfully~~
- ~~[ ] Package upgrade completed successfully~~
- ~~[ ] New installation of package completed successfully~~
