### PR TITLE
improve recognition of unsupported archs

### DIFF
--- a/mk/spksrc.cross-cmake-env.mk
+++ b/mk/spksrc.cross-cmake-env.mk
@@ -17,7 +17,6 @@ CMAKE_ARGS += -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE
 CMAKE_ARGS += -DBUILD_SHARED_LIBS=ON
 
 # set default ASM build environment
-$(warning now we reached ifeq CMAKE_USE_NASM=$(CMAKE_USE_NASM))
 ifeq ($(strip $(CMAKE_USE_NASM)),1)
 DEPENDS += native/nasm 
 NASM_PATH = $(WORK_DIR)/../../../native/nasm/work-native/install/usr/local/bin

--- a/mk/spksrc.cross-go-env.mk
+++ b/mk/spksrc.cross-go-env.mk
@@ -33,7 +33,8 @@ ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
   GO_ARCH = amd64
 endif
 ifeq ($(GO_ARCH),)
-  $(error Unsupported ARCH $(ARCH))
+  # don't report error to use regular UNSUPPORTED_ARCHS logging
+  $(warning Unsupported ARCH $(ARCH))
 endif
 
 ifeq ($(strip $(GO_STATIC_BINARIES)),1)

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -26,20 +26,27 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
 POST_STRIP_TARGET = debian-chroot_extra_install
 
+include ../../mk/spksrc.common.mk
+
+UNSUPPORTED_ARCHS = $(PPC_ARCHES) $(ARM8_ARCHES)
+
 DEBIAN_ARCH =
-ifeq ($(findstring $(ARCH),88f6281),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
 DEBIAN_ARCH = armel
 endif
-ifeq ($(findstring $(ARCH),alpine armada370 armada375 armada38x armadaxp monaco),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM7_ARCHES)),$(ARCH))
 DEBIAN_ARCH = armhf
 endif
-ifeq ($(findstring $(ARCH),evansport),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM8_ARCHES)),$(ARCH))
+DEBIAN_ARCH = arm64
+endif
+ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
 DEBIAN_ARCH = i386
 endif
-ifeq ($(findstring $(ARCH),braswell bromolow cedarview x86 avoton x64),$(ARCH))
+ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
 DEBIAN_ARCH = amd64
 endif
-ifeq ($(findstring $(ARCH),qoriq),$(ARCH))
+ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
 DEBIAN_ARCH = powerpc
 endif
 ifeq ($(strip $(DEBIAN_ARCH)),)

--- a/spk/gentoo-chroot/Makefile
+++ b/spk/gentoo-chroot/Makefile
@@ -26,20 +26,31 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
 POST_STRIP_TARGET = gentoo-chroot_extra_install
 
+include ../../mk/spksrc.common.mk
+
+UNSUPPORTED_ARCHS = $(ARM8_ARCHES)
+
 GENTOO_ARCH =
-ifeq ($(findstring $(ARCH),88f6281),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM5_ARCHES)),$(ARCH))
 GENTOO_CPU = arm
 GENTOO_ARCH = armv5tel
 endif
-ifeq ($(findstring $(ARCH),alpine armada370 armada375 armada38x armadaxp monaco),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM7_ARCHES)),$(ARCH))
 GENTOO_CPU = arm
 GENTOO_ARCH = armv7a_hardfp
 endif
-ifeq ($(findstring $(ARCH),braswell bromolow cedarview evansport x86 avoton x64),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARM8_ARCHES)),$(ARCH))
+GENTOO_ARCH = arm64
+endif
+ifeq ($(findstring $(ARCH),$(x86_ARCHES)),$(ARCH))
+GENTOO_CPU = x86
+GENTOO_ARCH = i386
+endif
+ifeq ($(findstring $(ARCH),$(x64_ARCHES)),$(ARCH))
 GENTOO_CPU = x86
 GENTOO_ARCH = i686
 endif
-ifeq ($(findstring $(ARCH),qoriq),$(ARCH))
+ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
 GENTOO_CPU = ppc
 GENTOO_ARCH = ppc
 endif

--- a/spk/lirc/Makefile
+++ b/spk/lirc/Makefile
@@ -7,9 +7,7 @@ FIRMWARE = 4.3-3776
 LIRC_SUPPORTED_DRIVERS =
 
 # Abort for ARCHs that won't compile LIRC cleanly
-ifneq ($(findstring $(ARCH),powerpc),)
-$(error Sorry, this package does not support the $(ARCH) architecture)
-endif
+UNSUPPORTED_ARCHS = powerpc
 
 # include definition of PPC_ARCHES...
 include ../../mk/spksrc.common.mk

--- a/spk/ntopng/Makefile
+++ b/spk/ntopng/Makefile
@@ -19,10 +19,6 @@ DISPLAY_NAME = ntopng
 HELPURL = https://www.ntop.org/guides/ntopng/index.html
 LICENSE = GNU GPLv3
 
-# PPC_ARCHES except qoriq are not supported
-# https://tvheadend.org/issues/5060
-UNSUPPORTED_ARCHS = powerpc ppc824x ppc853x ppc854x
-
 # 'auto' (reserved value) grabs SPK_NAME
 SERVICE_USER   = auto
 SSS_SCRIPT     = src/start-stop-status.sh


### PR DESCRIPTION
_Motivation:_  Avoid missing recognition of unsupported archs in github actions

- avoid make errors for unsupported archs
- remove make warning introduced with cmake rules #3998
