### PR TITLE
force tls 1.2 for downloads with wget

### DIFF
--- a/cross/libsodium/Makefile
+++ b/cross/libsodium/Makefile
@@ -12,7 +12,6 @@ COMMENT  = Sodium is a modern, easy-to-use software library for encryption, decr
 LICENSE  = ISC
 
 GNU_CONFIGURE = 1
-DOWNLOAD_ARGS = --no-check-certificate
 ADDITIONAL_CFLAGS = -O
 
 include ../../mk/spksrc.cross-cc.mk

--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -128,7 +128,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	        rm -f $${localFile}.part ; \
 	        url=`echo $${url} | sed -e '#^\(http://sourceforge\.net/.*\)$#\1?use_mirror=autoselect#'` ; \
 	        echo "wget $${url}" ; \
-	        wget $(DOWNLOAD_ARGS) -nv -O $${localFile}.part $${url} ; \
+	        wget --secure-protocol=TLSv1_2 -nv -O $${localFile}.part $${url} ; \
 	        mv $${localFile}.part $${localFile} ; \
 	      else \
 	        $(MSG) "  File $${localFile} already downloaded" ; \


### PR DESCRIPTION
_Motivation:_  github build actions fail often to download sources
_Linked Issues:_ fixes build of #4066 

### Remarks
1. As SSL protocols <= TLSv1.1 are not supported by most sites nowadays and wget defaults to TLSv1.0 we need to force the use of TLSv1.2 for source downloads ([see reference](https://www.gnu.org/software/wget/manual/html_node/HTTPS-_0028SSL_002fTLS_0029-Options.html)).
This option is ignored for downloads with http protocol. Anyway a lot of download sites support https and should be updated in cross and native Makefiles.


2. The option to define `DOWNLOAD_ARGS` is removed, as it was used only to disable certificate check in cross/libsodium/Makefile with `DOWNLOAD_ARGS = --no-check-certificate`, and this is fixed with TLS 1.2.
