### PR TITLE
transmission: fix ssl certification verification for version 3.00

### DIFF
--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -3,11 +3,12 @@
 PYTHON_DIR="/usr/local/python"
 PATH="${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}/bin:${PATH}"
 CFG_FILE="${SYNOPKG_PKGDEST}/var/settings.json"
+ENV="CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 TRANSMISSION="${SYNOPKG_PKGDEST}/bin/transmission-daemon"
 
 GROUP="sc-download"
 
-SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGDEST}/var/ -x ${PID_FILE} -e ${LOG_FILE}"
+SERVICE_COMMAND="env $(ENV) ${TRANSMISSION} -g ${SYNOPKG_PKGDEST}/var/ -x ${PID_FILE} -e ${LOG_FILE}"
 
 service_preinst ()
 {


### PR DESCRIPTION
Since transmission 3.00, SSL cert is verified by default. But no
default CA bundle set, which causes all SSL tracker to stop
working. Set the CA bundle to the default CA bundle in Synology.

_Motivation:_  Fix transmission SSL issue
_Linked issues:_  https://github.com/SynoCommunity/spksrc/issues/4088

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
