### PR TITLE
borgbackup: downgraded ruamel.yaml to 0.15.78

### DIFF
--- a/spk/borgbackup/src/requirements.txt
+++ b/spk/borgbackup/src/requirements.txt
@@ -1,7 +1,7 @@
 # Cross compiled packages dependencies
 #borgbackup==1.1.9
 #msgpack-python==0.5.6
-#ruamel.yaml==0.15.78
+ruamel.yaml==0.15.78
 
 # Downloaded dependencies
 borgmatic==1.2.15


### PR DESCRIPTION
_Motivation:_  ruamel.yaml version shipped with python3 is now "too recent"
_Linked issues:_  Fixes partially #3944 

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [x] New installation of package completed successfully
