### PR TITLE
beets: python3 upgrade followups

### DIFF
--- a/spk/beets/Makefile
+++ b/spk/beets/Makefile
@@ -1,17 +1,19 @@
 SPK_NAME = beets
 SPK_VERS = 1.4.9
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/beets.png
 
-PIP = pip3
+PIP = $(WORK_DIR)/../../../native/python3/work-native/install/usr/local/bin/pip
+BUILD_DEPENDS = native/python3
+
 WHEELS = src/requirements.txt
-SPK_DEPENDS = "python3>=3.5.6-8"
+SPK_DEPENDS = "python3>=3.7.7"
 
 MAINTAINER = ymartin59
 DESCRIPTION = "Beets is the media library management system for obsessive-compulsive music geeks. The purpose of beets is to get your music collection right once and for all. It catalogs your collection, automatically improving its metadata as it goes. It then provides a bouquet of tools for manipulating and accessing your music. Plugins not available due to lacking dependencies: AcousticBrainz Submit, Gmusic, ReplayGain."
 DISPLAY_NAME = beets
 
-CHANGELOG = "1. Upgrade to beets 1.4.9<br/>2. Update to python 3."
+CHANGELOG = "1. Upgraded minimum version of python 3."
 
 HOMEPAGE   = http://beets.io/
 LICENSE    = GPL


### PR DESCRIPTION
_Motivation:_  Following python3 update an intermediate version would need to be published for beets package
_Linked issues:_  Fixes partially #3944 

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
