### PR TITLE
deluge: update libtorrent requirement to 1.1.14

### DIFF
--- a/cross/libtorrent/Makefile
+++ b/cross/libtorrent/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libtorrent
-PKG_VERS = 1.0.11
+PKG_VERS = 1.1.14
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-rasterbar-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/arvidn/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(subst .,_,$(PKG_VERS))
@@ -26,6 +26,7 @@ GNU_CONFIGURE = 1
 -include $(WORK_DIR)/python-cc.mk
 CONFIGURE_ARGS  = --enable-python-binding --with-libiconv
 CONFIGURE_ARGS += --with-boost-system=boost_system --with-boost-python=boost_python
+CONFIGURE_ARGS += --with-boost-chrono=boost_chrono --with-boost-random=boost_random
 CONFIGURE_ARGS += PYTHON=$(WORK_DIR)/../../../native/python/work-native/install/usr/local/bin/python
 CONFIGURE_ARGS += LIB=-L/$(STAGING_INSTALL_PREFIX)/$(PYTHON_LIB_DIR)
 CONFIGURE_ARGS += PYTHON_CPPFLAGS=-I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR)
@@ -33,7 +34,7 @@ ADDITIONAL_CFLAGS = -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR)
 ADDITIONAL_CXXFLAGS = -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR)
 ADDITIONAL_LDFLAGS = "-Wl,-Bsymbolic"
 
-BOOST_LIBRARIES += system python
+BOOST_LIBRARIES += system python chrono random
 ENV += BOOST_LIBRARIES="$(BOOST_LIBRARIES)"
 
 include ../../mk/spksrc.python-wheel.mk

--- a/cross/libtorrent/PLIST
+++ b/cross/libtorrent/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libtorrent-rasterbar.so
-lnk:lib/libtorrent-rasterbar.so.8
-lib:lib/libtorrent-rasterbar.so.8.0.0
+lnk:lib/libtorrent-rasterbar.so.9
+lib:lib/libtorrent-rasterbar.so.9.0.0

--- a/cross/libtorrent/digests
+++ b/cross/libtorrent/digests
@@ -1,3 +1,3 @@
-libtorrent-rasterbar-1.0.11.tar.gz SHA1 8ddf7f7c614986acdbdd4cc293b01844e4dc8fd5
-libtorrent-rasterbar-1.0.11.tar.gz SHA256 828d686770346f6da2c143c5a2844c5f5e407eb4a37982e90022763508abd62f
-libtorrent-rasterbar-1.0.11.tar.gz MD5 f49e43286a64e8bbdef9ea59baa78b55
+libtorrent-rasterbar-1.1.14.tar.gz SHA1 7c54e1c06bed36f64bf705f533b449de3cddd3bc
+libtorrent-rasterbar-1.1.14.tar.gz SHA256 4c1fe55da9361c9d98e725ece7d88f183c09797b2e2667ca4d9386599f8dc36a
+libtorrent-rasterbar-1.1.14.tar.gz MD5 2955bfc076bad6dfacc62bdd7d9a4cdb

--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = deluge
 SPK_VERS = 2.0.3
-SPK_REV = 11
+SPK_REV = 12
 SPK_ICON = src/deluge.png
 
 BUILD_DEPENDS = cross/python cross/setuptools cross/pip cross/wheel


### PR DESCRIPTION
libtorrent now requires Boost chrono and random libraries

_Motivation:_  Requirement for deluge 2.03 deamon startup
_Linked issues:_  Fixes #4106

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
