### PR TITLE
Make nv12 the default filter. This fixes hvec->h264 VAAPI transcoding.

### DIFF
--- a/cross/ffmpeg/patches/040-nv12-default-format.patch
+++ b/cross/ffmpeg/patches/040-nv12-default-format.patch
@@ -1,0 +1,11 @@
+--- a/libavfilter/vf_scale_vaapi.c
++++ ./libavfilter/vf_scale_vaapi.c
+@@ -206,7 +206,7 @@ static const AVOption scale_vaapi_options[] = {
+     { "h", "Output video height",
+       OFFSET(h_expr), AV_OPT_TYPE_STRING, {.str = "ih"}, .flags = FLAGS },
+     { "format", "Output video format (software format of hardware frames)",
+-      OFFSET(output_format_string), AV_OPT_TYPE_STRING, .flags = FLAGS },
++      OFFSET(output_format_string), AV_OPT_TYPE_STRING, {.str = "nv12"}, .flags = FLAGS },
+     { "mode", "Scaling mode",
+       OFFSET(mode), AV_OPT_TYPE_INT, { .i64 = VA_FILTER_SCALING_HQ },
+       0, VA_FILTER_SCALING_NL_ANAMORPHIC, FLAGS, "mode" },


### PR DESCRIPTION
_Motivation:_  VideoStation fails to play hevc videos.

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully

VideoStation's default ffmpeg args include:
`-vcodec h264_vaapi -vf format=nv12|vaapi,hwupload,setsar=sar=1,scale_vaapi=w=1920:h=1072`

which doesn't work in ffmpeg 4.1+ without adding `format=nv12` to the scaling specs:
`-vcodec h264_vaapi -vf format=nv12|vaapi,hwupload,setsar=sar=1,scale_vaapi=w=1920:h=1072:format=nv12`

VideoStation would have to change the way it constructs the ffmpeg args for transcoding, but we can't fix the code in VideoStation. Instead I set nv12 to be the default scaling format.

Disclaimer: I only tested it on DS918+ (apollo lake, x86_64)

Example of the error in ffmpeg 4.2.4:
[...]
Stream mapping:
  Stream #0:0 -> #0:0 (hevc (native) -> h264 (h264_vaapi))
  Stream #0:1 -> #0:1 (eac3 (native) -> mp3 (libmp3lame))
Press [q] to stop, [?] for help
Incompatible pixel format 'yuv420p' for codec 'h264_vaapi', auto-selecting format 'vaapi_vld'
[h264_vaapi @ 0xabf340] No usable encoding profile found.
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
[libmp3lame @ 0xac1580] 4 frames left in the queue on closing
Conversion failed!
