### PR TITLE
ffmpeg: Fix a build issue with libshine caused by endif

### DIFF
--- a/cross/ffmpeg/Makefile
+++ b/cross/ffmpeg/Makefile
@@ -137,6 +137,7 @@ ifeq ($(findstring $(ARCH),$(PPC_ARCHES)),$(ARCH))
 DEPENDS += native/nasm
 ENV += PATH=$(NASM_PATH):$$PATH
 CONFIGURE_ARGS += --arch=ppc
+endif
 
 ifeq ($(findstring $(ARCH),qoriq),$(ARCH))
 CONFIGURE_ARGS += --disable-asm --cpu=e500v2
@@ -146,7 +147,6 @@ endif
 ifneq ($(findstring $(ARCH),ppc853x),$(ARCH))
 DEPENDS += cross/shine
 CONFIGURE_ARGS += --enable-libshine
-endif
 endif
 
 .PHONY: ffmpeg_post_install

--- a/cross/libbluray/Makefile
+++ b/cross/libbluray/Makefile
@@ -16,7 +16,7 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --disable-examples --disable-doxygen-doc --disable-doxygen-dot --disable-bdjava-jar
 
 # For ppc853x-5.2, define GNU_SOURCE
-ifeq ($(ARCH)-$(TCVERSION), ppc853x-5.2)
+ifeq ($(findstring $(ARCH)-$(TCVERSION), ppc853x-5.2 qoriq-5.2),$(ARCH)-$(TCVERSION))
 ADDITIONAL_CFLAGS = -D_GNU_SOURCE
 endif
 

--- a/spk/ffmpeg/Makefile
+++ b/spk/ffmpeg/Makefile
@@ -2,7 +2,7 @@ SPK_NAME = ffmpeg
 SPK_VERS = 4.3.1
 SPK_REV = 34
 SPK_ICON = src/ffmpeg.png
-CHANGELOG = "1. Update ffmpeg to 4.3.1<br/>2. Update Intel libva to version 2.8 and media drivers 2020Q2<br/>3. Enable ZeroMQ support<br/>4. Update svt-hevc to 1.5.0<br/>5. Update x264 to July 2nd git hash and use github mirror<br/>6. Update libaom to version 2.0.0<br/>7. Update SVT-AV1 to version 0.8.4<br/>8. Update x265 to version 3.4<br/>Enable libzmq support with version 4.3.2"
+CHANGELOG = "1. Update ffmpeg to 4.3.1<br/>2. Update Intel libva to version 2.8 and media drivers 2020Q2<br/>3. Enable ZeroMQ support<br/>4. Update svt-hevc to 1.5.0<br/>5. Update x264 to July 2nd git hash and use github mirror<br/>6. Update libaom to version 2.0.0<br/>7. Update SVT-AV1 to version 0.8.4<br/>8. Update x265 to version 3.4<br/>9. Enable libzmq support with version 4.3.2<br/>10. Fix a build issue with libshine"
 
 DEPENDS = cross/$(SPK_NAME)
 


### PR DESCRIPTION
_Motivation:_  Due to a misplaced `endif` it caused a few librairies to not be built as expected causing a `ffmpeg` failure.  This should really be a trivial fix.
_Linked issues:_  #4125

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
