### PR TITLE
python3: fixed endianness detection for ppc853x architecture

### DIFF
--- a/cross/borgbackup/patches/001-remove-useless-endianness-logic.patch
+++ b/cross/borgbackup/patches/001-remove-useless-endianness-logic.patch
@@ -1,0 +1,25 @@
+Disables pseudo logic made to enforce setting of macros which are actually already defined in corresponding headers.
+
+--- setup.py
++++ setup.py
+@@ -804,20 +804,16 @@ if not on_rtd:
+                                                system_prefix=libb2_prefix, system=libb2_system,
+                                                **crypto_ext_kwargs)
+ 
+-    msgpack_endian = '__BIG_ENDIAN__' if (sys.byteorder == 'big') else '__LITTLE_ENDIAN__'
+-    msgpack_macros = [(msgpack_endian, '1')]
+     msgpack_packer_ext_kwargs = dict(
+         sources=[msgpack_packer_source],
+         include_dirs=include_dirs,
+         library_dirs=library_dirs,
+-        define_macros=msgpack_macros,
+         language='c++',
+     )
+     msgpack_unpacker_ext_kwargs = dict(
+         sources=[msgpack_unpacker_source],
+         include_dirs=include_dirs,
+         library_dirs=library_dirs,
+-        define_macros=msgpack_macros,
+         language='c++',
+     )
+ 


### PR DESCRIPTION
_Motivation:_  Fixing detection of endianness for cross compiled python in case of big endian architecture
_Linked issues:_  #3944 

This actually addresses two concerns:

* the `sys.byteorder` attribute seemed to be invalid (it turns out that this information is actually not valid, even when using `crossenv` since that attribute is actually hardcoded in the python executable itself)
* borgbackup was actually trying to do something clever depending on that attribute to pass flags which were actually already appropriately defined and provided by python headers

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
