### PR TITLE
chromaprint: Fix using shared libraries

### DIFF
--- a/cross/chromaprint/PLIST
+++ b/cross/chromaprint/PLIST
@@ -1,1 +1,4 @@
 bin:bin/fpcalc
+lnk:lib/libchromaprint.so
+lnk:lib/libchromaprint.so.1
+lib:lib/libchromaprint.so.1.5.0

--- a/spk/chromaprint/Makefile
+++ b/spk/chromaprint/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = chromaprint
 SPK_VERS = 1.5.0
-SPK_REV = 11
+SPK_REV = 12
 SPK_ICON = src/chromaprint.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -10,7 +10,7 @@ STARTABLE = no
 MAINTAINER = ymartin59
 DESCRIPTION = Chromaprint is the core component of the AcoustID project. It\'s a client-side library that implements a custom algorithm for extracting fingerprints from any audio source.
 DISPLAY_NAME = Chromaprint
-CHANGELOG = "1. Update version 1.5.0<br/>2. Update to ffmpeg 4.2.4"
+CHANGELOG = "1. Update version 1.5.0<br/>2. Update to ffmpeg 4.2.4<br/>3. Fix shared library build"
 
 HOMEPAGE   = http://acoustid.org/chromaprint
 LICENSE    = LGPL2.1+


### PR DESCRIPTION
_Motivation:_  Forgot to include the libraries into `PLIST` when switching to shared lib build.
_Linked issues:_  #4136

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
