### PR TITLE
python3: update to use ncursesw instead of ncurses

### DIFF
--- a/cross/python3/Makefile
+++ b/cross/python3/Makefile
@@ -8,7 +8,7 @@ PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.python.org/ftp/python/$(PKG_VERS)
 PKG_DIR = Python-$(PKG_VERS)
 
-DEPENDS  = cross/zlib cross/openssl cross/sqlite cross/readline cross/ncurses cross/bzip2 cross/xz
+DEPENDS  = cross/zlib cross/openssl cross/sqlite cross/readline cross/ncursesw cross/bzip2 cross/xz
 # required for uuid module to be available
 DEPENDS += cross/libuuid
 # required because libffi is no longer bundled with python

--- a/spk/python3/Makefile
+++ b/spk/python3/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python3
 SPK_SHORT_VERS = 3.7
 SPK_VERS = $(SPK_SHORT_VERS).7
-SPK_REV = 12
+SPK_REV = 13
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/busybox cross/$(SPK_NAME)
@@ -21,7 +21,7 @@ DESCRIPTION_SPN = Lenguaje de programación Python.
 RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python3
-CHANGELOG = "1. Update to Python 3.7.7"
+CHANGELOG = "1. Fixed curses native module"
 
 HOMEPAGE = http://www.python.org
 LICENSE  = PSF


### PR DESCRIPTION
_Motivation:_  `curses` module was no longer shipped within Python 3's spk.
_Linked issues:_  Fixes #4152 

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [ ] New installation of package completed successfully

### Rationale

Algorithm used by python3's build process is to first look for `ncursesw` library which is, unfortunately, installed in build environment (at least on Docker). The issue, here, was that we were actually using the cross compiled version of `ncurses` which didn't include the expected functions. Hence the extension build failure.
