### PR TITLE
go: updated to 1.15.2 (security update)

### DIFF
--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.14.6
+PKG_VERS = 1.15.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).src.$(PKG_EXT)
 PKG_DIST_SITE = https://storage.googleapis.com/golang

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.14.6.src.tar.gz SHA1 7cdd6edb158e41d7be2c93c2fc3bd89f73bc3bf2
-go1.14.6.src.tar.gz SHA256 73fc9d781815d411928eccb92bf20d5b4264797be69410eac854babe44c94c09
-go1.14.6.src.tar.gz MD5 bf555f5aaaf51eadfeb48e6faf42e8e5
+go1.15.2.src.tar.gz SHA1 9cd6e84fd6d7b61bd5152f4b4d356b2d6d8bf08f
+go1.15.2.src.tar.gz SHA256 28bf9d0bcde251011caae230a4a05d917b172ea203f2a62f2c2f9533589d4b4d
+go1.15.2.src.tar.gz MD5 4420f969ba483c1cf4def71da62bfe0f


### PR DESCRIPTION
_Motivation:_  Update go toolchain to latest release.

Includes a security bugfix in go1.14.8 and go1.15.1: security fixes for CVE-2020-24553 to the net/http/cgi and net/http/fcgi packages.

See https://github.com/golang/go/issues/41165 for details

### Checklist
- [x] Build rule `all-supported` completed successfully
