### PR TITLE
plist.mk: Cheap fix for PLIST madness found with Issue #4211

### DIFF
--- a/mk/spksrc.plist.mk
+++ b/mk/spksrc.plist.mk
@@ -9,14 +9,13 @@ endif
 
 .PHONY: cat_PLIST
 cat_PLIST:
-	@for depend in $(DEPENDS) ; \
+	@echo Processing PLIST dependencies 1>&2
+	@for depend in `$(MAKE) dependency-list` ; \
 	do                          \
-	  $(MAKE) WORK_DIR=$(WORK_DIR) --no-print-directory -C ../../$$depend cat_PLIST ; \
-	done
-	@if [ -f PLIST ] ; \
-	then \
-	  $(PLIST_TRANSFORM) PLIST ; \
-	else \
-	  $(MSG) "No PLIST for $(NAME)" >&2; \
-	fi
-
+	  if [ "$${depend%/*}" = "cross" ] && [ -s ../../$${depend}/PLIST ]; then \
+	    echo "$${depend}" 1>&2 ; \
+	    cat ../../$${depend}/PLIST 1>&2 ; \
+	    $(PLIST_TRANSFORM) ../../$${depend}/PLIST ; \
+	  fi ; \
+	done ; \
+	$(PLIST_TRANSFORM) $(WORK_DIR)/../PLIST


### PR DESCRIPTION
_Motivation:_  Fix `PLIST` black-magic issue found
_Linked issues:_  #4211

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
