### PR TITLE
spksrc.download.mk: Don't break, continue

### DIFF
--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -62,7 +62,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	    git) \
 	      localFolder=$(NAME)-git$(PKG_GIT_HASH) ; \
 	      localFile=$${localFolder}.tar.gz ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFolder}.part ] && sleep 10 || break; done ; \
+	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFolder}.part ] && sleep 10 || continue ; done ; \
 	      if [ ! -f $${localFile} ]; then \
 	        rm -fr $${localFolder}.part /tmp/git.$${localFolder}.lock ; \
 	        echo "git clone $${url}" ; \
@@ -83,7 +83,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      localFolder=$(NAME)-r$${rev} ; \
 	      localFile=$${localFolder}.tar.gz ; \
 	      localHead=$(NAME)-rHEAD.tar.gz ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFolder}.part ] && sleep 10 || break; done ; \
+	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFolder}.part ] && sleep 10 || continue ; done ; \
 	      if [ ! -f $${localFile} ]; then \
 	        rm -fr $${localFolder}.part /tmp/svn.$${localFolder}.lock ; \
 	        echo "svn co -r $${rev} $${url}" ; \
@@ -108,7 +108,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      localFolder=$(NAME)-r$${rev} ; \
 	      localFile=$${localFolder}.tar.gz ; \
 	      localTip=$(NAME)-rtip.tar.gz ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFolder}.part ] && sleep 10 || break; done ; \
+	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFolder}.part ] && sleep 10 || continue ; done ; \
 	      if [ ! -f $${localFile} ]; then \
 	        rm -fr $${localFolder}.part /tmp/hg.$${localFolder}.lock ; \
 	        echo "hg clone -r $${rev} $${url}" ; \
@@ -129,7 +129,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      if [ -z "$${localFile}" ]; then \
 	        localFile=`basename $${url}` ; \
 	      fi ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFile}.part ] && sleep 10 || break; done ; \
+	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFile}.part ] && sleep 10 || continue ; done ; \
 	      if [ ! -f $${localFile} ]; then \
 	        rm -f $${localFile}.part /tmp/wget.$${localFile}.lock ; \
 	        url=`echo $${url} | sed -e '#^\(http://sourceforge\.net/.*\)$#\1?use_mirror=autoselect#'` ; \


### PR DESCRIPTION
_Motivation:_  One-liner fix to `spksrc.download.mk` for parallel build through `make -jX all-supported`
_Linked issues:_  N/A
_Details:_ 
Using break stops the for loop but sends signal 1 which gets
interpreted by the Makefile as an error and stops.  Signal
needs to be 0 thus either using `echo > /dev/null` or better
using `continue` which simply complete the for loop with no
sleep.

### Checklist
- [ ] N/A
