### PR TITLE
ffmpeg: Forgot to bump spk package version - conflicting online

### DIFF
--- a/spk/ffmpeg/Makefile
+++ b/spk/ffmpeg/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ffmpeg
 SPK_VERS = 4.3.1
-SPK_REV = 34
+SPK_REV = 35
 SPK_ICON = src/ffmpeg.png
 CHANGELOG = "1. Update ffmpeg to 4.3.1<br/>2. Update Intel libva to version 2.8 and media drivers 2020Q2<br/>3. Enable ZeroMQ support<br/>4. Update svt-hevc to 1.5.0<br/>5. Update x264 to July 2nd git hash and use github mirror<br/>6. Update libaom to version 2.0.0<br/>7. Update SVT-AV1 to version 0.8.4<br/>8. Update x265 to version 3.4<br/>9. Enable libzmq support with version 4.3.2<br/>10. Fix a build issue with libshine"
 


### PR DESCRIPTION
_Motivation:_  Version online is 4.2.4-34 and forgot to bump to `-35` the 4.3.1 version.  This causes a conflict online and refuse to publish updated packages.  Bumping the version accordingly.
_Linked issues:_  N/A

### Checklist
- [x] Build rule `all-supported` completed successfully

