### PR TITLE
service.mk: Fix integer comparison with null string

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -80,7 +80,7 @@ ifneq ($(strip $(SPK_USER)),)
 	@echo USER=\"$(SPK_USER)\" >> $@
 	@echo "PRIV_PREFIX=sc-" >> $@
 	@echo "SYNOUSER_PREFIX=svc-" >> $@
-	@echo 'if [ -n "$${SYNOPKG_DSM_VERSION_MAJOR}" -a "$${SYNOPKG_DSM_VERSION_MAJOR}" -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
+	@echo 'if [ -n "$${SYNOPKG_DSM_VERSION_MAJOR}" ] && [ "$${SYNOPKG_DSM_VERSION_MAJOR}" -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
 endif
 ifneq ($(strip $(SERVICE_WIZARD_GROUP)),)
 	@echo "# Group name from UI if provided" >> $@

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -80,7 +80,7 @@ ifneq ($(strip $(SPK_USER)),)
 	@echo USER=\"$(SPK_USER)\" >> $@
 	@echo "PRIV_PREFIX=sc-" >> $@
 	@echo "SYNOUSER_PREFIX=svc-" >> $@
-	@echo 'if [ -n "$${SYNOPKG_DSM_VERSION_MAJOR}" ] && [ "$${SYNOPKG_DSM_VERSION_MAJOR}" -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
+	@echo 'case $${SYNOPKG_DSM_VERSION_MAJOR} in [12345] ) EFF_USER="$${SYNOUSER_PREFIX}$${USER}" ;; * ) EFF_USER="$${PRIV_PREFIX}$${USER}" ;; esac' >> $@
 endif
 ifneq ($(strip $(SERVICE_WIZARD_GROUP)),)
 	@echo "# Group name from UI if provided" >> $@

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -26,7 +26,7 @@ start_daemon ()
         else
             OUT="${LOG_FILE}"
         fi
-        if [ -n "${USER}" -a -n "${SYNOPKG_DSM_VERSION_MAJOR}" -a "$SYNOPKG_DSM_VERSION_MAJOR" -lt 6 ]; then
+        if [ -n "${USER}" ] && [ -n "${SYNOPKG_DSM_VERSION_MAJOR}" ] && [ "$SYNOPKG_DSM_VERSION_MAJOR" -lt 6 ]; then
             if [ -z "${SERVICE_SHELL}" ]; then
                 SERVICE_SHELL=/bin/sh
             fi

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -26,7 +26,8 @@ start_daemon ()
         else
             OUT="${LOG_FILE}"
         fi
-        if [ -n "${USER}" ] && [ -n "${SYNOPKG_DSM_VERSION_MAJOR}" ] && [ "$SYNOPKG_DSM_VERSION_MAJOR" -lt 6 ]; then
+        case ${SYNOPKG_DSM_VERSION_MAJOR} in
+        [12345] )
             if [ -z "${SERVICE_SHELL}" ]; then
                 SERVICE_SHELL=/bin/sh
             fi
@@ -40,7 +41,8 @@ start_daemon ()
             else
                 su ${EFF_USER} -s ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1 &
             fi
-        else
+            ;;
+        * )
             # DSM 6 user is set by conf/privilege
             if [ -n "${SVC_CWD}" ]; then
                 cd "${SVC_CWD}"
@@ -50,7 +52,8 @@ start_daemon ()
             else
                 ${SERVICE_COMMAND} >> ${OUT} 2>&1 &
             fi
-        fi
+            ;;
+        esac
         if [ -n "${SVC_WRITE_PID}" -a -n "${SVC_BACKGROUND}" -a -n "${PID_FILE}" ]; then
             echo "$!" > "${PID_FILE}"
         else


### PR DESCRIPTION
_Motivation:_  Found a bug related to shell integer comparison in default startup scripts.
_Linked issues:_  N/A

### Checklist
- [ ] N/A
