### PR TITLE
salt-minion: declare arm5 ppc arch unsupported

### DIFF
--- a/spk/salt-minion/Makefile
+++ b/spk/salt-minion/Makefile
@@ -6,6 +6,7 @@ SPK_ICON = src/salt-minion.png
 PIP = $(WORK_DIR)/../../../native/python3/work-native/install/usr/local/bin/pip
 BUILD_DEPENDS = cross/python3
 SPK_DEPENDS = "python3>=3.7"
+UNSUPPORTED_ARCHS = $(PPC_ARCHES) $(ARM5_ARCHES)
 
 # Requirements file generation
 # /usr/local/python3/bin/python3 -mvirtualenv --python=python3  salt-env


### PR DESCRIPTION
_Motivation:_  salt-minion build on older arm5 and ppc arches is failing CI
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4153

### Checklist
- [X] Build rule `all-supported` completed successfully
- [X] Package upgrade completed successfully
- [X] New installation of package completed successfully
