### PR TITLE
native/libmysqlclient: Fix download URL to align against cross/*

### DIFF
--- a/native/libmysqlclient/Makefile
+++ b/native/libmysqlclient/Makefile
@@ -1,9 +1,10 @@
 PKG_NAME = libmysqlclient
+PKG_REAL_NAME = mysql-connector-c
 PKG_VERS = 6.1.11
 PKG_EXT = tar.gz
-DIST_NAME = mysql-connector-c-$(PKG_VERS)-src
+DIST_NAME = $(PKG_REAL_NAME)-$(PKG_VERS)-src
 PKG_DIST_NAME = $(DIST_NAME).$(PKG_EXT)
-PKG_DIST_SITE = https://cdn.mysql.com/archives/$(PKG_NAME)
+PKG_DIST_SITE = https://cdn.mysql.com/archives/$(PKG_REAL_NAME)
 PKG_DIR = $(DIST_NAME)
 
 DEPENDS =


### PR DESCRIPTION
_Motivation:_  `libmysqlclient` native fails to download the package.  Re-aligned the code against `cross/libmysqlclient` for file download and package naming.
_Linked issues:_  #4211 related to releasing `ntopng` updated package

### Checklist
- [x] Build rule `all-supported` completed successfully

