### PR TITLE
Add sgmllib3k dependency for SABnzbd 3.1.0 feedparser

### DIFF
--- a/spk/sabnzbd/src/requirements.txt
+++ b/spk/sabnzbd/src/requirements.txt
@@ -3,7 +3,8 @@ cheetah3==3.2.6
 cheroot==8.4.2
 cherrypy==18.6.0
 configobj==5.0.6
-feedparser==6.0.1
+sgmllib3k==1.0.0
+feedparser==6.0.2
 jaraco.classes==3.1.0
 jaraco.collections==3.0.0
 jaraco.functools==3.0.1


### PR DESCRIPTION
@ymartin59 I fixed it. I used `feedparser==6.0.0` when testing, but turns out it broke in `6.0.1` which I added quickly before creating PR, assuming nothing major changed..

![image](https://user-images.githubusercontent.com/5703454/97791529-9d894300-1bd3-11eb-8108-f1a72743798a.png)

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
