### PR TITLE
fix build dependencies

### DIFF
--- a/cross/autossh/Makefile
+++ b/cross/autossh/Makefile
@@ -5,7 +5,7 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.harding.motd.ca/autossh
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-BUILD_DEPENDS = cross/openssh
+DEPENDS = cross/openssh
 
 HOMEPAGE = https://www.harding.motd.ca/autossh/
 COMMENT  = Automatically restart SSH sessions and tunnels.

--- a/cross/he853/Makefile
+++ b/cross/he853/Makefile
@@ -5,13 +5,13 @@ PKG_DIST_NAME = $(PKG_NAME)-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/hphde/$(PKG_NAME)/archive
 PKG_DIR = $(PKG_NAME)-$(PKG_NAME)-v$(PKG_VERS)
 
-BUILD_DEPENDS = cross/libusb
+DEPENDS = cross/libusb
 
 HOMEPAGE = https://github.com/hphde/$(PKG_NAME)
 COMMENT  = HomeEasy HE853 USB device executable
 LICENSE  = GPLv2
 
-CONFIGURE_TARGET = none
+CONFIGURE_TARGET = nop
 
 INSTALL_TARGET = he853_install
 

--- a/cross/openssh/Makefile
+++ b/cross/openssh/Makefile
@@ -1,18 +1,31 @@
 PKG_NAME = openssh
-PKG_VERS = 7.9p1
+PKG_VERS = 8.4p1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable
+PKG_DIST_SITE = https://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib cross/openssl
 
-HOMEPAGE = http://www.openssh.com/
+HOMEPAGE = https://www.openssh.com/
 COMMENT  = Open source version of SSH connectivity tools
 LICENSE  = BSD-style
 
-CONFIGURE_ARGS += cross_compiling=yes --disable-lastlog --disable-utmp --disable-utmpx --disable-wtmp --disable-wtmpx
-CONFIGURE_ARGS += --disable-strip LD=$$CC
-ADDITIONAL_CFLAGS = -O1
+GNU_CONFIGURE = 1
+INSTALL_TARGET = openssh_install
+POST_INSTALL_TARGET = openssh_post_install
+
+CONFIGURE_ARGS = --with-privsep-path=$(INSTALL_PREFIX)/var/empty
+CONFIGURE_ARGS += --disable-lastlog --disable-strip
+CONFIGURE_ARGS += --disable-utmp --disable-utmpx
+CONFIGURE_ARGS += --disable-wtmp --disable-wtmpx
 
 include ../../mk/spksrc.cross-cc.mk
+
+.PHONY: openssh_install
+openssh_install:
+	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) install-nosysconf prefix=$(INSTALL_PREFIX)
+
+.PHONY: openssh_post_install
+openssh_post_install:
+	ln -sf $(STAGING_INSTALL_PREFIX)/bin/ssh $(STAGING_INSTALL_PREFIX)/bin/slogin

--- a/cross/openssh/PLIST
+++ b/cross/openssh/PLIST
@@ -1,15 +1,13 @@
 bin:bin/scp
 bin:bin/sftp
-bin:bin/slogin
+lnk:bin/slogin
 bin:bin/ssh
 bin:bin/ssh-add
 bin:bin/ssh-agent
 bin:bin/ssh-keygen
 bin:bin/ssh-keyscan
-rsc:etc/moduli
-bin:etc/ssh_config
-bin:etc/sshd_config
 bin:libexec/sftp-server
 bin:libexec/ssh-keysign
 bin:libexec/ssh-pkcs11-helper
+bin:libexec/ssh-sk-helper
 bin:sbin/sshd

--- a/cross/openssh/digests
+++ b/cross/openssh/digests
@@ -1,3 +1,3 @@
-openssh-7.9p1.tar.gz SHA1 993aceedea8ecabb1d0dd7293508a361891c4eaa
-openssh-7.9p1.tar.gz SHA256 6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad
-openssh-7.9p1.tar.gz MD5 c6af50b7a474d04726a5aa747a5dce8f
+openssh-8.4p1.tar.gz SHA1 69305059e10a60693ebe6f17731f962c9577535c
+openssh-8.4p1.tar.gz SHA256 5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24
+openssh-8.4p1.tar.gz MD5 8f897870404c088e4aa7d1c1c58b526b

--- a/cross/tcl/Makefile
+++ b/cross/tcl/Makefile
@@ -7,7 +7,6 @@ PKG_DIST_SITE = https://prdownloads.sourceforge.net/tcl/
 PKG_DIR = $(PKG_NAME)$(PKG_VERS)/unix
 
 DEPENDS =
-BUILD_DEPENDS = cross/zlib
 
 HOMEPAGE = https://www.tcl.tk/
 COMMENT  = Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more. Open source and business-friendly, Tcl is a mature yet evolving language that is truly cross platform, easily deployed and highly extensible.

--- a/cross/tcl/Makefile
+++ b/cross/tcl/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME = tcl
-PKG_MAIN_VERS = 8.6
-PKG_VERS = $(PKG_MAIN_VERS).10
+PKG_VERS = 8.6.10
+PKG_MAIN_VERS=$(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS)-src.$(PKG_EXT)
 PKG_DIST_SITE = https://prdownloads.sourceforge.net/tcl/
@@ -14,17 +14,20 @@ LICENSE  = https://tcl.tk/software/tcltk/license.html
 
 GNU_CONFIGURE = 1
 
-# Enable 64-bit support in Tcl for 64-bit architectures
-ifeq ($(findstring $(ARCH), $(x64_ARCHES) $(ARM8_ARCHES)),$(ARCH))
+include ../../mk/spksrc.common.mk
+
+# Enable 64-bit support in Tcl for x64 architectures
+# aarch64 does not support 64-bit (don't know magic for this platform)
+ifeq ($(findstring $(ARCH), $(x64_ARCHES)),$(ARCH))
   CONFIGURE_ARGS = --enable-64bit
 endif
 
-POST_INSTALL_TARGET = tcl_custom_post_install
+POST_INSTALL_TARGET = tcl_post_install
 
 include ../../mk/spksrc.cross-cc.mk
 
 # Create a symlink libtcl so that any other packages which are compiled by
-# spksrc will link to a library without a version number in the filename
-.PHONY: tcl_custom_post_install
-tcl_custom_post_install:
+# spksrc may link to a library without a version number in the filename
+.PHONY: tcl_post_install
+tcl_post_install:
 	$(RUN) ln -s -r $(STAGING_INSTALL_PREFIX)/lib/libtcl$(PKG_MAIN_VERS).so $(STAGING_INSTALL_PREFIX)/lib/libtcl.so

--- a/diyspk/autossh/Makefile
+++ b/diyspk/autossh/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = autossh
 SPK_VERS = 1.4g
-SPK_REV = 1
-CHANGELOG = "initial package version"
+SPK_REV = 2
+CHANGELOG = "1. Update OpenSSL to v1.1.<br/>2. Update OpenSSH to v8.4."
 
 DEPENDS = cross/$(SPK_NAME)
 
@@ -13,5 +13,8 @@ STARTABLE = no
 HOMEPAGE = https://www.harding.motd.ca/autossh/
 
 SPK_COMMANDS = bin/autossh
+SPK_COMMANDS += bin/scp bin/sftp bin/slogin bin/ssh bin/ssh-add bin/ssh-agent bin/ssh-keygen bin/ssh-keyscan
+SPK_COMMANDS += libexec/sftp-server libexec/ssh-keysign libexec/ssh-pkcs11-helper libexec/ssh-sk-helper
+SPK_COMMANDS += sbin/sshd
 
 include ../../mk/spksrc.spk.mk

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-net
 SPK_VERS = 1.5
-SPK_REV = 5
+SPK_REV = 6
 SPK_ICON = src/synocli-net.png
 
 DEPENDS = cross/screen cross/tmux cross/nmap cross/links cross/sshfs cross/socat
@@ -26,7 +26,7 @@ MAINTAINER = ymartin59
 DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilities: screen, tmux, socat, nmap, arp-scan, links, sshfs, rsync, autossh$(OPTIONAL_DESC). Credits to Sebastian Schmidt \(publicarray\) for icons"
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
-CHANGELOG = "1. update openssl to 1.1 for dependent packages \(tmux, nmap, socat, autossh, ser2net\).<br/>2. Add autossh<br/>3. Add arp-scan v1.9.7<br/>4. Add links v2.21<br/>5. Update nmap to version 7.80<br/>6. Update screen to version 4.8.0<br/>7. Update socat to version 1.7.3.4<br/>8. Remove mosh and remove dependency of Perl \(mosh is provided as dedicated package now\)"
+CHANGELOG = "1. update openssl to 1.1 for dependent packages (tmux, nmap, socat, autossh, ser2net).<br/>2. Add autossh (incl. openssh)<br/>3. Add arp-scan v1.9.7<br/>4. Add links v2.21<br/>5. Update nmap to version 7.80<br/>6. Update screen to version 4.8.0<br/>7. Update socat to version 1.7.3.4<br/>8. Remove mosh and remove dependency of Perl (mosh is provided as dedicated package now)"
 
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliNet
 LICENSE  = Each tool is licensed under it\'s respective license.
@@ -42,6 +42,9 @@ SPK_COMMANDS += bin/socat bin/procan bin/filan
 SPK_COMMANDS += bin/fritzctl
 SPK_COMMANDS += bin/rsync
 SPK_COMMANDS += bin/autossh
+SPK_COMMANDS += bin/scp bin/sftp bin/slogin bin/ssh bin/ssh-add bin/ssh-agent bin/ssh-keygen bin/ssh-keyscan
+SPK_COMMANDS += libexec/sftp-server libexec/ssh-keysign libexec/ssh-pkcs11-helper libexec/ssh-sk-helper
+SPK_COMMANDS += sbin/sshd
 SPK_COMMANDS += sbin/ser2net
 
 include ../../mk/spksrc.spk.mk

--- a/spk/tcl/Makefile
+++ b/spk/tcl/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = tcl
-SPK_MAIN_VERS = 8.6
-SPK_VERS = $(SPK_MAIN_VERS).10
-SPK_REV = 4
+SPK_VERS = 8.6.10
+SPK_MAIN_VERS=$(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
+SPK_REV = 5
 SPK_ICON = src/tcl.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -12,11 +12,11 @@ DISTRIBUTOR     = SynoCommunity
 DISTRIBUTOR_URL = https://synocommunity.com/
 HELPURL         = https://www.tcl.tk/doc/
 
-DESCRIPTION = Tcl \(Tool Command Language\) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more. Open source and business-friendly, Tcl is a mature yet evolving language that is truly cross platform, easily deployed and highly extensible.
+DESCRIPTION = "Tcl \(Tool Command Language\) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more. Open source and business-friendly, Tcl is a mature yet evolving language that is truly cross platform, easily deployed and highly extensible."
 RELOAD_UI = no
 DISPLAY_NAME = Tcl
 STARTABLE = no
-CHANGELOG = "1. Update to 8.6.10<br/>2. Fix symlinks."
+CHANGELOG = "1. 64-bit support for x64 archs added.<br/>2. zlib compression fixed."
 
 HOMEPAGE = https://www.tcl.tk
 LICENSE = Tcl/Tk License


### PR DESCRIPTION
_Motivation:_  Fix dependency issues reported in #4221
_Linked issues:_  #4250, closes #4221

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Remarks
- replace BUILD_DEPENDS by DEPENDS to fix shared library dependency errors that are mostly detected at runtime only.
- related packages: `synocli-net, tcl, he853 (HomeEasy)`
