### PR TITLE
Update Radarr to v3

### DIFF
--- a/cross/radarr/Makefile
+++ b/cross/radarr/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = Radarr
-PKG_VERS = 0.2.0.1504
+PKG_VERS = 3.0.0.4204
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME).develop.$(PKG_VERS).linux.$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME).master.$(PKG_VERS).linux.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Radarr/Radarr/releases/download/v$(PKG_VERS)
 PKG_DIR = Radarr
 

--- a/cross/radarr/digests
+++ b/cross/radarr/digests
@@ -1,3 +1,3 @@
-Radarr.develop.0.2.0.1504.linux.tar.gz SHA1 0d858723f05fef73bf595e3180f9404ea472aba1
-Radarr.develop.0.2.0.1504.linux.tar.gz SHA256 6b2fb3cc175ed1fbf607106990d92710eeb2fb75db66ee42dea0f59d86c5f7c0
-Radarr.develop.0.2.0.1504.linux.tar.gz MD5 7c566942030f412012b83531642ea21d
+Radarr.master.3.0.0.4204.linux.tar.gz SHA1 0818bd0dcbcde55292b31588144c32e934857392
+Radarr.master.3.0.0.4204.linux.tar.gz SHA256 470ca22a0a561ada5ff8a7cbf15a09322a771b8edf9c8724d3cc7236342681c3
+Radarr.master.3.0.0.4204.linux.tar.gz MD5 b08276e2ffa805dd8c222309adc37555

--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -16,7 +16,7 @@ DESCRIPTION  = Radarr is a movie manager like Couchpotato, but based on the Sona
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Radarr
-CHANGELOG = "Add workaround for v3 PID file change"
+CHANGELOG = "Update Radarr to v3.0.0.4204"
 
 HOMEPAGE = https://radarr.video/
 LICENSE  = GPLv3

--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -16,7 +16,7 @@ DESCRIPTION  = Radarr is a movie manager like Couchpotato, but based on the Sona
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Radarr
-CHANGELOG = "Add workaround for mono bug with armv5/88f6281"
+CHANGELOG = "Add workaround for v3 PID file change"
 
 HOMEPAGE = https://radarr.video/
 LICENSE  = GPLv3

--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = radarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 12
+SPK_REV = 13
 SPK_ICON = src/radarr.png
 
 REQUIRED_DSM = 5.0

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -9,7 +9,7 @@ SPK_RADARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/Radarr/Radarr.exe"
 # Radarr uses custom Config and PID directories
 HOME_DIR="${SYNOPKG_PKGDEST}/var"
 CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
-PID_FILE="${CONFIG_DIR}/Radarr/nzbdrone.pid"
+PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
 
 # Some have it stored in the root of package
 LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/.config"

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -9,13 +9,7 @@ SPK_RADARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/Radarr/Radarr.exe"
 # Radarr uses custom Config and PID directories
 HOME_DIR="${SYNOPKG_PKGDEST}/var"
 CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
-# Workaround for v3 PID file
-CUR_VER=$(${MONO_PATH}/monodis --assembly ${RADARR} | grep "Version:" | awk '{print $2}')
-if [ "${CUR_VER:0:1}" -lt 3 ]; then
-    PID_FILE="${CONFIG_DIR}/Radarr/nzbdrone.pid"
-else
-    PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
-fi
+PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
 
 # Some have it stored in the root of package
 LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/.config"
@@ -56,10 +50,10 @@ service_preupgrade ()
     # The /var/ folder gets automatically copied by service-installer after this
     if [ -d "${LEGACY_CONFIG_DIR}" ]; then
         echo "Moving ${LEGACY_CONFIG_DIR} to ${INST_VAR}" >> ${INST_LOG}
-        mv ${LEGACY_CONFIG_DIR} ${CONFIG_DIR} >> ${LOG_FILE} 2>&1
+        mv ${LEGACY_CONFIG_DIR} ${CONFIG_DIR} >> ${INST_LOG} 2>&1
     else
         # Create, in case it's missing for some reason
-        mkdir ${CONFIG_DIR} >> ${LOG_FILE} 2>&1
+        mkdir ${CONFIG_DIR} >> ${INST_LOG} 2>&1
     fi
 
     # Is Installed Radarr Binary Ver. >= SPK Radarr Binary Ver.?
@@ -83,8 +77,8 @@ service_postupgrade ()
     . ${CONFIG_DIR}/KEEP_VAR
     if [ "$KEEP_CUR" == "yes" ]; then
         echo "Restoring Radarr version from before upgrade" >> ${INST_LOG}
-        rm -fr ${SYNOPKG_PKGDEST}/share >> $INST_LOG 2>&1
-        mv ${INST_VAR}/share ${SYNOPKG_PKGDEST}/ >> $INST_LOG 2>&1
+        rm -fr ${SYNOPKG_PKGDEST}/share >> ${INST_LOG} 2>&1
+        mv ${INST_VAR}/share ${SYNOPKG_PKGDEST}/ >> ${INST_LOG} 2>&1
         set_unix_permissions "${SYNOPKG_PKGDEST}/share"
     fi
     set_unix_permissions "${CONFIG_DIR}"

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -9,7 +9,13 @@ SPK_RADARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/Radarr/Radarr.exe"
 # Radarr uses custom Config and PID directories
 HOME_DIR="${SYNOPKG_PKGDEST}/var"
 CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
-PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
+# Workaround for v3 PID file
+CUR_VER=$(${MONO_PATH}/monodis --assembly ${RADARR} | grep "Version:" | awk '{print $2}')
+if [ "${CUR_VER:0:1}" -lt 3 ]; then
+    PID_FILE="${CONFIG_DIR}/Radarr/nzbdrone.pid"
+else
+    PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
+fi
 
 # Some have it stored in the root of package
 LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/.config"


### PR DESCRIPTION
With the in app update to version 3.0.0.4204 of Radarr the Synology service startup reports the package launch as failed if updated. This PR corrects the PID file reference allowing the startup to report correctly in the Package Center as well as updates the build to the stable v3.0.0.4204

_Motivation:_  To update Radarr to v3 release and correct service startup on Synology
_Linked issues:_  Fixes issue https://github.com/SynoCommunity/spksrc/issues/3987 and issue https://github.com/SynoCommunity/spksrc/issues/4285, previously identified via https://github.com/SynoCommunity/spksrc/issues/3987#issuecomment-700010196

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
