### PR TITLE
go: update to 1.15.5 (includes security fixes)

### DIFF
--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.15.2
+PKG_VERS = 1.15.5
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).src.$(PKG_EXT)
 PKG_DIST_SITE = https://storage.googleapis.com/golang

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.15.2.src.tar.gz SHA1 9cd6e84fd6d7b61bd5152f4b4d356b2d6d8bf08f
-go1.15.2.src.tar.gz SHA256 28bf9d0bcde251011caae230a4a05d917b172ea203f2a62f2c2f9533589d4b4d
-go1.15.2.src.tar.gz MD5 4420f969ba483c1cf4def71da62bfe0f
+go1.15.5.src.tar.gz SHA1 696fee3f3efa184c5d9ad28b048bbd36d7c84ef3
+go1.15.5.src.tar.gz SHA256 c1076b90cf94b73ebed62a81d802cd84d43d02dea8c07abdc922c57a071c84f1
+go1.15.5.src.tar.gz MD5 12a60d319ff58c03c323e8dcc125ae81


### PR DESCRIPTION
_Motivation:_ Update golang compiler to 1.15.5

Fixes multiple security issues: CVE-2020-28366, CVE-2020-28367, CVE-2020-28362

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
