### PR TITLE
spk.mk: Add a new spkclean option for package specific build files

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -319,6 +319,21 @@ endif
 clean:
 	rm -fr work work-*
 
+spkclean:
+	rm -fr work-*/.copy_done \
+	       work-*/.depend_done \
+	       work-*/.icon_done \
+	       work-*/.strip_done \
+	       work-*/.wheel_done \
+	       work-*/conf \
+	       work-*/scripts \
+	       work-*/staging \
+	       work-*/package.tgz \
+	       work-*/INFO \
+	       work-*/PLIST \
+	       work-*/PACKAGE_ICON* \
+	       work-*/WIZARD_UIFILES
+
 all: package
 
 ### For make dependency-tree


### PR DESCRIPTION
_Motivation:_  When debugging package compilation it is really useful to be able to only remove spk package creation files.
_Linked issues:_  None

### Checklist
- [x] N/A

