### PR TITLE
Autossh fix ac_cv_path_ssh

### DIFF
--- a/cross/autossh/Makefile
+++ b/cross/autossh/Makefile
@@ -12,6 +12,6 @@ COMMENT  = Automatically restart SSH sessions and tunnels.
 
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS = ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes
-CONFIGURE_ARGS += ac_cv_path_ssh=$(STAGING_INSTALL_PREFIX)/bin
+CONFIGURE_ARGS += ac_cv_path_ssh=$(INSTALL_PREFIX)/bin
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/autossh/Makefile
+++ b/cross/autossh/Makefile
@@ -12,6 +12,6 @@ COMMENT  = Automatically restart SSH sessions and tunnels.
 
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS = ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes
-CONFIGURE_ARGS += ac_cv_path_ssh=$(INSTALL_PREFIX)/bin
+CONFIGURE_ARGS += ac_cv_path_ssh=$(INSTALL_PREFIX)/bin/ssh
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/openssh/Makefile
+++ b/cross/openssh/Makefile
@@ -28,4 +28,4 @@ openssh_install:
 
 .PHONY: openssh_post_install
 openssh_post_install:
-	ln -sf $(STAGING_INSTALL_PREFIX)/bin/ssh $(STAGING_INSTALL_PREFIX)/bin/slogin
+	cd $(STAGING_INSTALL_PREFIX)/bin && ln -sf ssh slogin

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -26,7 +26,7 @@ MAINTAINER = ymartin59
 DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilities: screen, tmux, socat, nmap, arp-scan, links, sshfs, rsync, autossh$(OPTIONAL_DESC). Credits to Sebastian Schmidt \(publicarray\) for icons"
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
-CHANGELOG = "1. update openssl to 1.1 for dependent packages (tmux, nmap, socat, autossh, ser2net).<br/>2. Add autossh (incl. openssh)<br/>3. Add arp-scan v1.9.7<br/>4. Add links v2.21<br/>5. Update nmap to version 7.80<br/>6. Update screen to version 4.8.0<br/>7. Update socat to version 1.7.3.4<br/>8. Remove mosh and remove dependency of Perl (mosh is provided as dedicated package now)<br/>9. Fix autossh fails siliently #4250"
+CHANGELOG = "1. update openssl to 1.1 for dependent packages (tmux, nmap, socat, autossh, ser2net).<br/>2. Add autossh (incl. openssh)<br/>3. Add arp-scan v1.9.7<br/>4. Add links v2.21<br/>5. Update nmap to version 7.80<br/>6. Update screen to version 4.8.0<br/>7. Update socat to version 1.7.3.4<br/>8. Remove mosh and remove dependency of Perl (mosh is provided as dedicated package now)<br/>9. Fix autossh fails siliently (issue 4250)"
 
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliNet
 LICENSE  = Each tool is licensed under it\'s respective license.

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-net
 SPK_VERS = 1.5
-SPK_REV = 6
+SPK_REV = 7
 SPK_ICON = src/synocli-net.png
 
 DEPENDS = cross/screen cross/tmux cross/nmap cross/links cross/sshfs cross/socat
@@ -26,7 +26,7 @@ MAINTAINER = ymartin59
 DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilities: screen, tmux, socat, nmap, arp-scan, links, sshfs, rsync, autossh$(OPTIONAL_DESC). Credits to Sebastian Schmidt \(publicarray\) for icons"
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
-CHANGELOG = "1. update openssl to 1.1 for dependent packages (tmux, nmap, socat, autossh, ser2net).<br/>2. Add autossh (incl. openssh)<br/>3. Add arp-scan v1.9.7<br/>4. Add links v2.21<br/>5. Update nmap to version 7.80<br/>6. Update screen to version 4.8.0<br/>7. Update socat to version 1.7.3.4<br/>8. Remove mosh and remove dependency of Perl (mosh is provided as dedicated package now)"
+CHANGELOG = "1. update openssl to 1.1 for dependent packages (tmux, nmap, socat, autossh, ser2net).<br/>2. Add autossh (incl. openssh)<br/>3. Add arp-scan v1.9.7<br/>4. Add links v2.21<br/>5. Update nmap to version 7.80<br/>6. Update screen to version 4.8.0<br/>7. Update socat to version 1.7.3.4<br/>8. Remove mosh and remove dependency of Perl (mosh is provided as dedicated package now)<br/>9. Fix autossh fails siliently #4250"
 
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliNet
 LICENSE  = Each tool is licensed under it\'s respective license.


### PR DESCRIPTION
_Motivation:_  Output binary uses the `$(STAGING_INSTALL_PREFIX)` instead of $(INSTALL_PREFIX) leading to an non-existing path once installed when setting the `ac_cv_path_ssh` build parameter.
_Linked issues:_  #4250

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
