### PR TITLE
add jq to dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		gperf \
 		imagemagick \
 		intltool \
+		jq \
 		libbz2-dev \
 		libc6-i386 \
 		libcppunit-dev \


### PR DESCRIPTION
_Motivation:_  I am almost sure we will need `jq`  for DSM7 framework


- add jq for json with bash scripts