### PR TITLE
Deactivate python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN wget https://bootstrap.pypa.io/get-pip.py -O - | python3
 
 # Install setuptools, pip, virtualenv, wheel and httpie for Python2
-RUN wget https://bootstrap.pypa.io/get-pip.py -O - | python
+# Remarks: pip >= 21 has removed support for python2
+RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py "pip<21" && rm -f get-pip.py
 RUN pip install virtualenv httpie
 
 # Volume pointing to spksrc sources


### PR DESCRIPTION
_Motivation:_  Python 2 is EOL since 01.01.2020 and should be deactivated
_Linked issues:_  #3633 

Deactivate all automated builds for Python2 and related packages.

### Tasks
- [x] Develop environment: install pip < 21 as pip 21.0 will drop python2 support
- [ ] introduce cross/pip2 for python2
- [ ] Deactivate CI (github build action) for python2 and related packages

### Related Packages
Packages to deactivate or migrate to python3:
  - [ ] python2
  - [ ] deluge (#4153)
  - [x] duplicity (#3823)
  - [ ] ffsync (#3849 but still python2)
  - [x] mercurial (#4591)
  - [x] octoprint (#4096)
  - [x] tvheadend (#4394)



