### PR TITLE
VSCode: Exclude folders from file watch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.watcherExclude": {
+        "**/distrib/**": true,
+        "**/packages/**": true,
+        "**/work-*/**": true,
+        "**/work/**": true
+    }
+}


### PR DESCRIPTION
_Motivation:_  I've switched to [VSCode](https://code.visualstudio.com/) and excluding these files fixes a performance warning.