### PR TITLE
Update Radarr to v3.0.1.4259

### DIFF
--- a/cross/radarr/Makefile
+++ b/cross/radarr/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = Radarr
-PKG_VERS = 3.0.0.4204
+PKG_VERS = 3.0.1.4259
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME).master.$(PKG_VERS).linux.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Radarr/Radarr/releases/download/v$(PKG_VERS)

--- a/cross/radarr/digests
+++ b/cross/radarr/digests
@@ -1,3 +1,3 @@
-Radarr.master.3.0.0.4204.linux.tar.gz SHA1 0818bd0dcbcde55292b31588144c32e934857392
-Radarr.master.3.0.0.4204.linux.tar.gz SHA256 470ca22a0a561ada5ff8a7cbf15a09322a771b8edf9c8724d3cc7236342681c3
-Radarr.master.3.0.0.4204.linux.tar.gz MD5 b08276e2ffa805dd8c222309adc37555
+Radarr.master.3.0.1.4259.linux.tar.gz SHA1 4c527002b56bc2f636ae41bcb326397c23932a2f
+Radarr.master.3.0.1.4259.linux.tar.gz SHA256 e8af5a006b234c0646429040936ff4851aff7c05593a58019ecb2409a3cad653
+Radarr.master.3.0.1.4259.linux.tar.gz MD5 08c8418a9aacee4b5e0e3bad8a4ff6a8

--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = radarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 13
+SPK_REV = 14
 SPK_ICON = src/radarr.png
 
 REQUIRED_DSM = 5.0
@@ -16,7 +16,7 @@ DESCRIPTION  = Radarr is a movie manager like Couchpotato, but based on the Sona
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Radarr
-CHANGELOG = "Update Radarr to v3.0.0.4204"
+CHANGELOG = "Update Radarr to v3.0.1.4259"
 
 HOMEPAGE = https://radarr.video/
 LICENSE  = GPLv3


### PR DESCRIPTION
_Motivation:_  To incorporate latest Radarr release code. Includes a fix to backup v0.2 DB as part of upgrade if it exists.
_Linked issues:_  N/A

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
