### PR TITLE
framework: add ninja-build and fix Debian 10 manual installation doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		lzip \
 		mercurial \
 		ncurses-dev \
+		ninja-build \
 		php \
 		pkg-config \
 		python3 \

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,12 @@ A virtual machine based on an 64-bit version of Debian 10 stable OS is recommend
 * Install the requirements (in sync with Dockerfile)::
 
     sudo dpkg --add-architecture i386 && sudo apt-get update
-    sudo apt install autogen automake bc bison build-essential check cmake curl cython debootstrap ed expect flex g++-multilib gawk gettext git gperf imagemagick intltool jq libbz2-dev libc6-i386 libcppunit-dev libffi-dev libgc-dev libgmp3-dev libltdl-dev libmount-dev libncurses-dev libpcre3-dev libssl-dev libtool libunistring-dev lzip mercurial ncurses-dev php pkg-config python3 python3-distutils rename scons subversion swig texinfo unzip xmlto zlib1g-dev
-    sudo pip install -U setuptools pip wheel httpie
+    sudo apt udpate
+    sudo apt install autogen automake bc bison build-essential check cmake curl cython debootstrap ed expect flex g++-multilib gawk gettext git gperf imagemagick intltool jq libbz2-dev libc6-i386 libcppunit-dev libffi-dev libgc-dev libgmp3-dev libltdl-dev libmount-dev libncurses-dev libpcre3-dev libssl-dev libtool libunistring-dev lzip mercurial ncurses-dev ninja-build php pkg-config python3 python3-distutils rename scons subversion swig texinfo unzip xmlto zlib1g-dev
+    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python2
+    sudo pip2 install wheel httpie
+    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python3
+    sudo pip3 install meson==0.56.0
 
 * You may need to install some packages from testing like autoconf. Read about Apt-Pinning to know how to do that.
 * Some older toolchains may require 32-bit development versions of packages, e.g. `zlib1g-dev:i386`


### PR DESCRIPTION
_Motivation:_  Default Debian 10 `ninja` version is suitable for compiling environment requirement `mesa+ninja`
_Linked issues:_  #4307 

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
