### PR TITLE
Fix homeassistant integrations

### DIFF
--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -29,7 +29,7 @@ WHEELS = src/requirements.txt
 MAINTAINER = ymartin59
 DESCRIPTION = Home Assistant is an open-source home automation platform running on Python 3. Track and control all devices at home and automate control.
 DISPLAY_NAME = Home Assistant Core
-CHANGELOG = "Fix xiaomi device integrations"
+CHANGELOG = "Fix integrations: Xiaomi Gateway (Aqara), Xiaomi Miio, Sony PlayStation 4, IKEA TRÅDFRI, Apple iCloud, Minut Point"
 RELOAD_UI = yes
 STARTABLE = yes
 

--- a/spk/homeassistant/src/requirements.txt
+++ b/spk/homeassistant/src/requirements.txt
@@ -786,6 +786,7 @@ gTTS-token==1.1.3
 
 # homeassistant.components.nest
 #google-nest-sdm==0.1.14
+#grpcio==1.34.0   # fails to cross-compile wheel
 
 # homeassistant.components.google_travel_time
 #googlemaps==2.5.1
@@ -945,10 +946,10 @@ ua_parser==0.10.0
 #keba-kecontact==1.1.0
 
 # homeassistant.scripts.keyring
-#keyring==21.2.0
+keyring==21.2.0
 
 # homeassistant.scripts.keyring
-#keyrings.alt==3.4.0
+keyrings.alt==3.4.0
 
 # homeassistant.components.kiwi
 #kiwiki-client==0.1.1
@@ -1540,6 +1541,7 @@ pygatt[GATTTOOL]==4.0.5
 
 # homeassistant.components.icloud
 pyicloud==0.9.7
+future==0.18.2
 
 # homeassistant.components.insteon
 #pyinsteon==1.0.8
@@ -1711,7 +1713,11 @@ pyotp==2.3.0
 #pypjlink2==1.2.1
 
 # homeassistant.components.point
-#pypoint==2.0.0
+pypoint==2.0.0
+Authlib==0.15.2
+httpcore==0.12.2
+sniffio==1.2.0
+rfc3986==1.4.0
 
 # homeassistant.components.profiler
 #pyprof2calltree==1.4.5
@@ -1966,6 +1972,7 @@ python-wink==1.10.5
 
 # homeassistant.components.tradfri
 pytradfri[async]==7.0.4
+aiocoap==0.4b3
 
 # homeassistant.components.trafikverket_train
 # homeassistant.components.trafikverket_weatherstation


### PR DESCRIPTION
_Motivation:_  Unfortunately some integrations fail with recent package update
_Linked issues:_ #4341, closes #4343

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Remarks
Fixed integrations:
- [x] IKEA TRÅDFRI
- [x] Apple iCloud
- [x] Minut Point

The google Nest integration does not work anymore due to cross compilation error (but works with v0.114.2-9) .
