### PR TITLE
update meson build

### DIFF
--- a/mk/spksrc.cross-meson-env.mk
+++ b/mk/spksrc.cross-meson-env.mk
@@ -9,7 +9,7 @@ endif
 CONFIGURE_ARGS += -Dbuildtype=release
 
 # Use arch specific configuration file
-MESON_CFG_DIR=$(realpath $(WORK_DIR)/../../../mk/meson)
+MESON_CFG_DIR = $(realpath $(WORK_DIR)/../../../mk/meson)
 MESON_CFG_FILE =
 
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
@@ -35,10 +35,10 @@ ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
 endif
 
 ifeq ($(strip $(MESON_CFG_FILE)),)
-  $(error No meson config file defined for $(ARCH))
+  $(warning No meson config file defined for $(ARCH))
 else
   ifeq ($(wildcard $(MESON_CFG_DIR)/$(MESON_CFG_FILE)),)
-    $(error meson config file not found: $(MESON_CFG_DIR)/$(MESON_CFG_FILE))
+    $(warning meson config file not found: $(MESON_CFG_DIR)/$(MESON_CFG_FILE))
   endif
 endif
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -371,7 +371,7 @@ endif
 
 pre-build-native:
 	@$(MSG) Pre-build native dependencies for parallel build
-	@for depend in `$(MAKE) dependency-list` ; \
+	@for depend in $(sort $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS)) ; \
 	do \
 	  if [ "$${depend%/*}" = "native" ]; then \
 	    echo "Pre-processing $${depend}" ; \


### PR DESCRIPTION
_Motivation:_  Revert error output introduced by #4348 

Any error thrown by make $(errror ...) breaks the dependency-list target.
`make dependency-list` is required by github build action. 
As fix error output is replaced by warning.

The target `all-supported` failed too. The pre-build of native dependencies must not call `make dependency-list`.

### Changes
- use warning output instead of error to avoid failure with make dependency-list
- replace make dependency-list by depends variables to pre-build native dependencies
