### PR TITLE
fix dependency targets

### DIFF
--- a/mk/spksrc.cross-meson-env.mk
+++ b/mk/spksrc.cross-meson-env.mk
@@ -34,11 +34,14 @@ ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
   MESON_CFG_FILE = x86_64.cfg
 endif
 
-ifeq ($(strip $(MESON_CFG_FILE)),)
-  $(warning No meson config file defined for $(ARCH))
-else
-  ifeq ($(wildcard $(MESON_CFG_DIR)/$(MESON_CFG_FILE)),)
-    $(warning meson config file not found: $(MESON_CFG_DIR)/$(MESON_CFG_FILE))
+# disable error handling for target dependency-list
+ifneq ($(strip $(DEPENDENCY_WALK)),1)
+  ifeq ($(strip $(MESON_CFG_FILE)),)
+    $(error No meson config file defined for $(ARCH))
+  else
+    ifeq ($(wildcard $(MESON_CFG_DIR)/$(MESON_CFG_FILE)),)
+      $(error meson config file not found: $(MESON_CFG_DIR)/$(MESON_CFG_FILE))
+    endif
   endif
 endif
 

--- a/mk/spksrc.dependency-tree.mk
+++ b/mk/spksrc.dependency-tree.mk
@@ -8,14 +8,24 @@
 ###   the list is sorted and does not include duplicate dependencies.
 ###   sample:
 ###   minio: cross/busybox cross/minio native/go native/go-1.4
-
+### 
+### NOTES:
+### o Packages with conditional dependencies must define such dependencies 
+###   additionally with OPTIONAL_DEPENDS, otherwise not all dependencies are found.
+### 
+### o dependency-tree and dependency-list call make for all dependencies without 
+###   the definition of specific ARCH nor TCVERSION.
+###   Therefore every Makefile (including mk/*.mk) must not abort nor put 
+###   output with error, warning or info directive when the variable 
+###   DEPENDENCY_WALK is set to 1.
+### 
 
 .PHONY: dependency-tree
 dependency-tree:
 	@echo `perl -e 'print "\\\t" x $(MAKELEVEL),"\n"'`+ $(NAME) $(PKG_VERS)
 	@for depend in $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS) ; \
 	do \
-	  $(MAKE) -s -C ../../$$depend dependency-tree ; \
+	  DEPENDENCY_WALK=1 $(MAKE) -s -C ../../$$depend dependency-tree ; \
 	done
 
 
@@ -30,5 +40,5 @@ dependency-flat:
 	@echo "$(CURDIR)" | grep -Po "/\K(spk|cross|native|diyspk)/.*"
 	@for depend in $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS) ; \
 	do \
-	  $(MAKE) -s -C ../../$$depend dependency-flat ; \
+	  DEPENDENCY_WALK=1 $(MAKE) -s -C ../../$$depend dependency-flat ; \
 	done


### PR DESCRIPTION
_Motivation:_  Fix dependency-list target to allow error exit in Makefiles
_Linked issues:_  follow up of #4347, #4348 and #4349

Recover error handling for meson config file definition, that broke the github build action due to failures in `make dependency-list`
