### PR TITLE
syno-magnet: Add support for DSM 7

### DIFF
--- a/spk/syno-magnet/Makefile
+++ b/spk/syno-magnet/Makefile
@@ -8,13 +8,13 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 SPK_NAME = $(PKG_NAME)
 SPK_VERS = $(PKG_VERS)
-SPK_REV = 2
+SPK_REV = 3
 SPK_ICON = src/magnet.png
 
 MAINTAINER = neykov
 DESCRIPTION = Download Station Magnet Handler. Register Download Station as the application to download magnet links from your browser. No plugins required.
 DISPLAY_NAME = Download Station Magnet
-CHANGELOG = "Initial Version"
+CHANGELOG = Re-packaged to add support for DSM 7
 
 HOMEPAGE   = https://github.com/neykov/syno-magnet
 LICENSE    = Apache 2.0


### PR DESCRIPTION
Make the package compatible with DSM7.

Build with "make noarch-6.1" & "make noarch-7.0" to get a compatible package.

~Hold off on merging before a package that's compatible with both DSM7 & DSM6 can be created. The changes here unblock manual install of the package for people that are already on DSM7.~

Fixes https://github.com/neykov/syno-magnet/issues/3.