### PR TITLE
synocli-file: fix pcre2 tools and fdupes

### DIFF
--- a/cross/fdupes/Makefile
+++ b/cross/fdupes/Makefile
@@ -11,9 +11,6 @@ HOMEPAGE = https://github.com/adrianlopezroche/fdupes
 COMMENT  = FDUPES is a program for identifying or deleting duplicate files residing within specified directories.
 LICENSE  = MIT
 
-# fdupes needs pcre2-32
-ENV += PCRE2_CLI_FULL=1 
-
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/pcre2/Makefile
+++ b/cross/pcre2/Makefile
@@ -8,16 +8,15 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 DEPENDS =
 OPTIONAL_DEPENDS = cross/readline cross/zlib cross/bzip2
 
-ifeq ($(PCRE2_CLI_FULL),1)
+CONFIGURE_ARGS = --enable-pcre2-32
+
+ifeq ($(strip $(PCRE2_CLI_FULL)),1)
 # add additional features to pcre2grep and pcre2test
 DEPENDS += cross/readline cross/zlib cross/bzip2
 
 CONFIGURE_ARGS += --enable-jit
-CONFIGURE_ARGS += --enable-pcre2-16 --enable-pcre2-32
 CONFIGURE_ARGS += --enable-pcre2grep-libz --enable-pcre2grep-libbz2 --enable-pcre2grep-callout 
 CONFIGURE_ARGS += --enable-pcre2test-libreadline
-else
-PLIST_TRANSFORM = sed -e '/:lib\/libpcre2-16.so\|:lib\/libpcre2-32.so/d'
 endif
 
 HOMEPAGE = https://www.pcre.org

--- a/cross/pcre2/PLIST
+++ b/cross/pcre2/PLIST
@@ -1,9 +1,6 @@
 rsc:bin/pcre2-config
 bin:bin/pcre2grep
 bin:bin/pcre2test
-lnk:lib/libpcre2-16.so
-lnk:lib/libpcre2-16.so.0
-lib:lib/libpcre2-16.so.0.10.0
 lnk:lib/libpcre2-32.so
 lnk:lib/libpcre2-32.so.0
 lib:lib/libpcre2-32.so.0.10.0

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-file
 SPK_VERS = 2.1
-SPK_REV = 6
+SPK_REV = 7
 SPK_ICON = src/synocli-file.png
 
 DEPENDS = cross/less cross/tree cross/ncdu cross/jdupes cross/rhash cross/mc cross/nano cross/file
@@ -28,14 +28,13 @@ DEPENDS += cross/rnm
 OPTIONAL_DESC := $(OPTIONAL_DESC)", rnm"
 endif
 
-# activate additional features for 
-# - pcre2grep and pcre2test
-# - fdupes
-ENV += PCRE2_CLI_FULL=1
+# activate additional features for pcre2grep and pcre2test
+PCRE2_CLI_FULL=1
+export PCRE2_CLI_FULL
 
 DESCRIPTION = "SynoCli File Tools provides a set of small command-line utilities: less, tree, ncdu, jdupes, fdupes, rhash, mc \(midnight commander\), nano, file, detox, pcre2, zstd$(OPTIONAL_DESC)."
 STARTABLE = no
-CHANGELOG = "Add fdupes v2.1.2"
+CHANGELOG = "Fix fdupes and pcre2 tools"
 
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliFile
 LICENSE  = Each tool is licensed under it\'s respective license.


### PR DESCRIPTION
- fix fdupes dependencies in synocli-file
- always build libpcre2-32.so
- fix definition of PCRE2_CLI_FULL=1 (without export it was not available at copy-target)

_Motivation:_  fdupes and pcre2 tools have missing references
_Linked issues:_  closes #4353

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
