### PR TITLE
Bump libewf version to experimental-20201230 fixing synocli-disk build

### DIFF
--- a/cross/libewf/Makefile
+++ b/cross/libewf/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libewf
-PKG_VERS = 20171104
+PKG_VERS = 20201230
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-experimental-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/libyal/libewf/releases/download/$(PKG_VERS)

--- a/cross/libewf/digests
+++ b/cross/libewf/digests
@@ -1,3 +1,3 @@
-libewf-experimental-20171104.tar.gz SHA1 9abad7a914402dd9a91a1c329941caaa2df45f7b
-libewf-experimental-20171104.tar.gz SHA256 cf36d3baf3a96dbe566fde55ae7d79fc2e7b998806ab13e0f69915799f19e040
-libewf-experimental-20171104.tar.gz MD5 1d64ca734b4dd07d0b793a855db5c31f
+libewf-experimental-20201230.tar.gz SHA1 b97acf4abdd470178027807d7b97b8d0e71b5b98
+libewf-experimental-20201230.tar.gz SHA256 d74af88cfcec037d271d0ce3760fd59304c6d4fc0eb24c2ff01adadf864f3207
+libewf-experimental-20201230.tar.gz MD5 5a170c2aae3a060233a2b25bfcb5b231


### PR DESCRIPTION
_Motivation:_  While working on https://github.com/SynoCommunity/spksrc/pull/4369 I noticed that the synocli-disk build was failing even without changes so I investigated and noticed that the libewf devs had removed their old releases (which were also all marked experimental). They did however provide new releases so I picked the most up to date release (no stable releases exist at all, so I had to take another experimental release) and bumped the libewf version to experimental-20201230 in order to fix the synocli-disk build
_Linked issues:_  Follow-up to (https://github.com/SynoCommunity/spksrc/pull/4364)

### Checklist
- [x] Build rule `all-supported` completed successfully