### PR TITLE
Remove busybox from transmission deps

### DIFF
--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -30,12 +30,7 @@ ADMIN_PORT = $(SERVICE_PORT)
 
 POST_STRIP_TARGET = transmission_extra_install
 
-BUSYBOX_CONFIG = usrmng
-ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
-
-
 include ../../mk/spksrc.spk.mk
-
 
 .PHONY: transmission_extra_install
 transmission_extra_install:

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = transmission
 SPK_VERS = 3.00
-SPK_REV = 20
+SPK_REV = 19
 SPK_ICON = src/transmission.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -12,7 +12,7 @@ DESCRIPTION_SPN = Transmission es un cliente BitTorrent simple y rápido. Puedes
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Transmission
-CHANGELOG = "Remove busybox dependency"
+CHANGELOG = "Update openssl to 1.1."
 
 HOMEPAGE = https://transmissionbt.com
 LICENSE  = GPLv2/GPLv3

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -1,9 +1,9 @@
 SPK_NAME = transmission
 SPK_VERS = 3.00
-SPK_REV = 19
+SPK_REV = 20
 SPK_ICON = src/transmission.png
 
-DEPENDS = cross/busybox cross/$(SPK_NAME)
+DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Transmission is an easy and fast BitTorrent client. You can control it remotely with its web interface or dedicated applications.
@@ -12,7 +12,7 @@ DESCRIPTION_SPN = Transmission es un cliente BitTorrent simple y rápido. Puedes
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Transmission
-CHANGELOG = "Update openssl to 1.1."
+CHANGELOG = "Remove busybox dependency"
 
 HOMEPAGE = https://transmissionbt.com
 LICENSE  = GPLv2/GPLv3

--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -5,8 +5,6 @@ PATH="${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}/bin:${PATH}"
 CFG_FILE="${SYNOPKG_PKGVAR}/settings.json"
 TRANSMISSION="${SYNOPKG_PKGDEST}/bin/transmission-daemon"
 
-GROUP="sc-transmission"
-
 SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGVAR} -x ${PID_FILE} -e ${LOG_FILE}"
 
 service_preinst ()

--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -5,6 +5,8 @@ PATH="${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}/bin:${PATH}"
 CFG_FILE="${SYNOPKG_PKGVAR}/settings.json"
 TRANSMISSION="${SYNOPKG_PKGDEST}/bin/transmission-daemon"
 
+GROUP="sc-download"
+
 SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGVAR} -x ${PID_FILE} -e ${LOG_FILE}"
 
 service_preinst ()

--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -5,7 +5,7 @@ PATH="${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}/bin:${PATH}"
 CFG_FILE="${SYNOPKG_PKGVAR}/settings.json"
 TRANSMISSION="${SYNOPKG_PKGDEST}/bin/transmission-daemon"
 
-GROUP="sc-download"
+GROUP="sc-transmission"
 
 SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGVAR} -x ${PID_FILE} -e ${LOG_FILE}"
 
@@ -56,12 +56,6 @@ service_postinst ()
             set_syno_permissions "${wizard_incomplete_dir}" "${GROUP}"
         fi
     fi
-
-    # Discard legacy obsolete busybox user account
-    BIN=${SYNOPKG_PKGDEST}/bin
-    $BIN/busybox --install $BIN >> ${INST_LOG}
-    $BIN/delgroup "${USER}" "users" >> ${INST_LOG}
-    $BIN/deluser "${USER}" >> ${INST_LOG}
 }
 
 

--- a/spk/transmission/src/wizard/install_uifile
+++ b/spk/transmission/src/wizard/install_uifile
@@ -118,7 +118,7 @@
         "step_title": "DSM Permissions",
         "items": [
             {
-                "desc": "Permissions for all download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+                "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
             }
         ]
     }

--- a/spk/transmission/src/wizard/install_uifile_fre
+++ b/spk/transmission/src/wizard/install_uifile_fre
@@ -64,6 +64,6 @@
 }, {
      "step_title": "Permissions DSM",
      "items": [{
-         "desc": "Les permissions de toutes les applications de SynoCommunity liés au téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+         "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
      }]
 }]

--- a/spk/transmission/src/wizard/upgrade_uifile
+++ b/spk/transmission/src/wizard/upgrade_uifile
@@ -1,9 +1,9 @@
 [{
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
     },
     {
-        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Transmission, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."
+        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Transmission, manually set Read/Write permissions on the reported folders using File Station."
     }]
 }]

--- a/spk/transmission/src/wizard/upgrade_uifile_fre
+++ b/spk/transmission/src/wizard/upgrade_uifile_fre
@@ -1,9 +1,9 @@
 [{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de SynoCommunity liés au téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
     },
     {
-        "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans Transmission, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."
+        "desc": "En cas d'erreur de permission dans Transmission, donner les droits de Lecture/Ecriture sur les repertoires mentionnès depuis File Station."
     }]
 }]


### PR DESCRIPTION
_Motivation:_  busybox shouldn't be required by transmission anymore as it was only used in dsm6 to get rid of legacy accounts and groups.
_Linked issues:_  Follow-up to (https://github.com/SynoCommunity/spksrc/pull/4364)

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
