### PR TITLE
cross/libjpeg: archive contents were fixed

### DIFF
--- a/cross/libjpeg/digests
+++ b/cross/libjpeg/digests
@@ -1,3 +1,3 @@
-jpegsrc.v9c.tar.gz SHA1 2ce111c8c0ac828a44b13ad28c265e954a342d07
-jpegsrc.v9c.tar.gz SHA256 650250979303a649e21f87b5ccd02672af1ea6954b911342ea491f351ceb7122
-jpegsrc.v9c.tar.gz MD5 93c62597eeef81a84d988bccbda1e990
+jpegsrc.v9c.tar.gz SHA1 bc4ac17d1cc1162a034fa7708cda8d70aebff702
+jpegsrc.v9c.tar.gz SHA256 1e9793e1c6ba66e7e0b6e5fe7fd0f9e935cc697854d5737adec54d93e5b3f730
+jpegsrc.v9c.tar.gz MD5 cbc68018646e09b3fd8091e3de5ea451


### PR DESCRIPTION
_Motivation:_  Build of spks depending on cross/libjpeg would no longer be passing

Basically the archives have changed.

Manually checked the difference between the two archived contents and it's XML resources which have been changed (fixed, really) inside.
[jpegsrc.v9c.tar.gz (old one)](https://github.com/SynoCommunity/spksrc/files/5789596/jpegsrc.v9c.tar.gz) vs 
[jpegsrc.v9c.tar.gz (new one)](https://github.com/SynoCommunity/spksrc/files/5789599/jpegsrc.v9c.tar.gz)

To be fair, another option could have been to ask was this file changed. But I must confess I don't know any of the contributors nor any of the owners so...

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
