### PR TITLE
cross/numpy: fixed auto detection of avx-512f intrinsics

### DIFF
--- a/cross/cffi/Makefile
+++ b/cross/cffi/Makefile
@@ -13,14 +13,15 @@ LICENSE  = MIT
 
 PLIST_TRANSFORM = sed -e 's%@PYTHON_SITE_PACKAGES@%$(PYTHON_LIB_DIR)/site-packages%' -e 's%@PYTHON_VERSION@%$(SPK_SHORT_VERS)%'
 
-POST_INSTALL_TARGET = install_into_cross_env
+PRE_INSTALL_TARGET = pre_install_into_cross_env
 
 include ../../mk/spksrc.python-module.mk
 
-.PHONY: install_into_cross_env
-install_into_cross_env:
-ifneq ($(CROSSENV),)
-	@. $(CROSSENV) && \
-		build-pip install "$(PKG_NAME)==$(PKG_VERS)" && \
-		pip install "$(PKG_NAME)==$(PKG_VERS)"
+.PHONY: pre_install_into_cross_env
+pre_install_into_cross_env: 
+ifeq ($(strip $(CROSSENV)),)
+	$(RUN) $(PIP) install "$(PKG_NAME)==$(PKG_VERS)"
+else
+	@. $(CROSSENV) && $(RUN) build-pip install "$(PKG_NAME)==$(PKG_VERS)"  --no-build-isolation
+	@. $(CROSSENV) && $(RUN) pip install "$(PKG_NAME)==$(PKG_VERS)"  --no-build-isolation
 endif

--- a/cross/numpy/Makefile
+++ b/cross/numpy/Makefile
@@ -19,3 +19,8 @@ ADDITIONAL_CFLAGS += -O0
 endif
 
 include ../../mk/spksrc.python-wheel.mk
+
+ifeq ($(PYTHON_LIB_NATIVE),$(PYTHON_LIB_CROSS))
+LD_LIBRARY_PATH := $(INSTALL_DIR)$(INSTALL_PREFIX)/lib:$(LD_LIBRARY_PATH)
+export LD_LIBRARY_PATH
+endif

--- a/cross/numpy/patches/x64/001-fix-auto-detection-of-avx-512f-intrinsics.patch
+++ b/cross/numpy/patches/x64/001-fix-auto-detection-of-avx-512f-intrinsics.patch
@@ -1,0 +1,30 @@
+#From 39c915c1236d61debb4b3e10dfadf910da6c9b30 Mon Sep 17 00:00:00 2001
+#From: Raghuveer Devulapalli <raghuveer.devulapalli@intel.com>
+#Date: Tue, 14 Jul 2020 13:34:55 -0700
+#Subject: [PATCH] BUG: Update compiler check for AVX-512F
+#
+#gcc-4.9 is missing a few AVX-512F intrisics, see
+#https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61878. We use some of these
+#missing intrinsics to check for compiler support of AVX-512F.
+#---diff --git numpy/core/setup_common.py numpy/core/setup_common.py
+#index 8c0149497bc..f15425c8763 100644
+--- numpy/core/setup_common.py
++++ numpy/core/setup_common.py
+@@ -171,6 +171,9 @@ def check_api_version(apiversion, codegen_dir):
+ # gcc 4.8.4 support attributes but not with intrisics
+ # tested via "#include<%s> int %s %s(void *){code; return 0;};" % (header, attribute, name, code)
+ # function name will be converted to HAVE_<upper-case-name> preprocessor macro
++# The _mm512_castps_si512 instruction is specific check for AVX-512F support
++# in gcc-4.9 which is missing a subset of intrinsics. See
++# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61878
+ OPTIONAL_FUNCTION_ATTRIBUTES_WITH_INTRINSICS = [('__attribute__((target("avx2,fma")))',
+                                 'attribute_target_avx2_with_intrinsics',
+                                 '__m256 temp = _mm256_set1_ps(1.0); temp = \
+@@ -178,6 +181,6 @@ def check_api_version(apiversion, codegen_dir):
+                                 'immintrin.h'),
+                                 ('__attribute__((target("avx512f")))',
+                                 'attribute_target_avx512f_with_intrinsics',
+-                                '__m512 temp = _mm512_set1_ps(1.0)',
++                                '__m512i temp = _mm512_castps_si512(_mm512_set1_ps(1.0))',
+                                 'immintrin.h'),
+                                 ]

--- a/cross/poetry/Makefile
+++ b/cross/poetry/Makefile
@@ -5,21 +5,17 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/p/$(PKG_NAME)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-BUILD_DEPENDS = cross/cffi
-DEPENDS =
+DEPENDS = cross/cffi
 
 HOMEPAGE = https://python-poetry.org/
 COMMENT  = Poetry helps you declare, manage and install dependencies of Python projects, ensuring you have the right stack everywhere.
 LICENSE  = MIT
 
-POST_INSTALL_TARGET = install_into_cross_env
+PRE_INSTALL_TARGET = pre_install_into_cross_env
 
 include ../../mk/spksrc.python-module.mk
 
-.PHONY: install_into_cross_env
-install_into_cross_env: 
-ifneq ($(strip $(CROSSENV)),)
-	@. $(CROSSENV) \
-		&& build-pip install "$(PKG_NAME)==$(PKG_VERS)" \
-		&& pip install "$(PKG_NAME)==$(PKG_VERS)"
-endif
+.PHONY: pre_install_into_cross_env
+pre_install_into_cross_env: 
+	@. $(CROSSENV) && $(RUN) build-pip install "$(PKG_NAME)==$(PKG_VERS)"  --no-build-isolation
+	@. $(CROSSENV) && $(RUN) pip install "$(PKG_NAME)==$(PKG_VERS)"  --no-build-isolation

--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -1,35 +1,29 @@
 SPK_NAME = homeassistant
 SPK_VERS = 0.118.5
-SPK_REV = 11
+SPK_REV = 12
 SPK_ICON = src/${SPK_NAME}.png
 
 SPK_DEPENDS = "python3>=3.7.7"
 
 BUILD_DEPENDS = cross/python3 cross/setuptools cross/pip cross/wheel
 BUILD_DEPENDS += cross/poetry
-OPTIONAL_DEPENDS += cross/numpy
 
 DEPENDS += cross/libyaml cross/bcrypt cross/cryptography
 DEPENDS += cross/pillow
+# for iqvia
+DEPENDS += cross/numpy
+
 # for python-libnmap
 DEPENDS += cross/nmap
 # for mobile_app
 DEPENDS += cross/PyNaCl
-
-include ../../mk/spksrc.archs.mk
-
-# unable to compile numpy 1.19.1 for x64 archs
-ifneq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
-# for iqvia
-DEPENDS += cross/numpy
-endif
 
 WHEELS = src/requirements.txt
 
 MAINTAINER = ymartin59
 DESCRIPTION = Home Assistant is an open-source home automation platform running on Python 3. Track and control all devices at home and automate control.
 DISPLAY_NAME = Home Assistant Core
-CHANGELOG = "Fix integrations: Xiaomi Gateway (Aqara), Xiaomi Miio, Sony PlayStation 4, IKEA TRÅDFRI, Apple iCloud, Minut Point"
+CHANGELOG = "Added x64 iqvia support."
 RELOAD_UI = yes
 STARTABLE = yes
 


### PR DESCRIPTION
_Motivation:_  I need numpy as a non optional dependency on another spk (namely bazarr).

This was fixed on the 20.x branch of numpy but hasn't been backported. I only picked it up manually (with minor adaptations).
Additionally some python wheel builds weren't working properly because of a lack of "build isolation" enforcement.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully (evansport: python, python3 and homeassitant)
- [x] New installation of package completed successfully (evansport: python, python3 and homeassistant)
