### PR TITLE
libicu: fix build on hi3535 architecture

### DIFF
--- a/cross/libicu/Makefile
+++ b/cross/libicu/Makefile
@@ -35,5 +35,7 @@ CONFIGURE_ARGS = --host=x86_64-pc-linux-gnu
 endif
 NATIVE_BUILD_DIR = $(WORK_DIR)/../../../native/$(PKG_NAME)/work-native/$(PKG_DIR)
 CONFIGURE_ARGS += --with-cross-build=$(NATIVE_BUILD_DIR) --prefix=$(INSTALL_PREFIX)
+ADDITIONAL_CPPFLAGS = -std=c++11
+ADDITIONAL_CXXFLAGS = -std=c++11
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/libicu/patches/armv7l/001-max_align_t.patch
+++ b/cross/libicu/patches/armv7l/001-max_align_t.patch
@@ -1,0 +1,62 @@
+# In armv7l architecture (namely hi3535) the gcc version is 4.8.3 which contains
+# non standard C++11 definition of max_align_t (meaning it's not in std namespace)
+--- common/uarrsort.cpp	2021-01-05 20:29:56.000000000 +0100
++++ common/uarrsort.cpp	2021-01-05 20:30:17.000000000 +0100
+@@ -37,7 +37,7 @@
+ };
+ 
+ static constexpr int32_t sizeInMaxAlignTs(int32_t sizeInBytes) {
+-    return (sizeInBytes + sizeof(std::max_align_t) - 1) / sizeof(std::max_align_t);
++    return (sizeInBytes + sizeof(max_align_t) - 1) / sizeof(max_align_t);
+ }
+ 
+ /* UComparator convenience implementations ---------------------------------- */
+@@ -141,7 +141,7 @@
+ insertionSort(char *array, int32_t length, int32_t itemSize,
+               UComparator *cmp, const void *context, UErrorCode *pErrorCode) {
+ 
+-    icu::MaybeStackArray<std::max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE)> v;
++    icu::MaybeStackArray<max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE)> v;
+     if (sizeInMaxAlignTs(itemSize) > v.getCapacity() &&
+             v.resize(sizeInMaxAlignTs(itemSize)) == nullptr) {
+         *pErrorCode = U_MEMORY_ALLOCATION_ERROR;
+@@ -235,7 +235,7 @@
+ quickSort(char *array, int32_t length, int32_t itemSize,
+             UComparator *cmp, const void *context, UErrorCode *pErrorCode) {
+     /* allocate two intermediate item variables (x and w) */
+-    icu::MaybeStackArray<std::max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE) * 2> xw;
++    icu::MaybeStackArray<max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE) * 2> xw;
+     if(sizeInMaxAlignTs(itemSize)*2 > xw.getCapacity() &&
+             xw.resize(sizeInMaxAlignTs(itemSize) * 2) == nullptr) {
+         *pErrorCode=U_MEMORY_ALLOCATION_ERROR;
+--- common/utext.cpp	2021-01-05 20:32:33.000000000 +0100
++++ common/utext.cpp	2021-01-05 20:33:01.000000000 +0100
+@@ -569,7 +569,7 @@
+ 
+ struct ExtendedUText {
+     UText               ut;
+-    std::max_align_t    extension;
++    max_align_t    extension;
+ };
+ 
+ static const UText emptyText = UTEXT_INITIALIZER;
+@@ -584,7 +584,7 @@
+         // We need to heap-allocate storage for the new UText
+         int32_t spaceRequired = sizeof(UText);
+         if (extraSpace > 0) {
+-            spaceRequired = sizeof(ExtendedUText) + extraSpace - sizeof(std::max_align_t);
++            spaceRequired = sizeof(ExtendedUText) + extraSpace - sizeof(max_align_t);
+         }
+         ut = (UText *)uprv_malloc(spaceRequired);
+         if (ut == NULL) {
+--- tools/toolutil/toolutil.cpp	2021-01-05 20:34:22.000000000 +0100
++++ tools/toolutil/toolutil.cpp	2021-01-05 20:34:27.000000000 +0100
+@@ -245,7 +245,7 @@
+     char name[64];
+     int32_t capacity, maxCapacity, size, idx;
+     void *array;
+-    alignas(std::max_align_t) char staticArray[1];
++    alignas(max_align_t) char staticArray[1];
+ };
+ 
+ U_CAPI UToolMemory * U_EXPORT2

--- a/native/libicu/Makefile
+++ b/native/libicu/Makefile
@@ -12,5 +12,7 @@ COMMENT  = International Components for Unicode
 LICENSE  = http://www.unicode.org/copyright.html#License
 
 GNU_CONFIGURE = 1
+ADDITIONAL_CPPFLAGS = -std=c++11
+ADDITIONAL_CXXFLAGS = -std=c++11
 
 include ../../mk/spksrc.native-cc.mk

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = znc
 SPK_VERS = 1.8.1
-SPK_REV = 15
+SPK_REV = 16
 SPK_ICON = src/znc.png
 DSM_UI_DIR = app
 
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Bouncer IRC avancé. Un bouncer IRC n\’est en fait qu\’un 
 DESCRIPTION_SPN = IRC bouncer avanzado. Un IRC bouncer no es más que un proxy para IRC. ZNC estará siempre conectado a tus canales, y hará de puerta de enlace entre tus clientes y tus servidores IRC. Puedes, por ejemplo, consultar mensajes mientras estuviste desconectado o esconder tu identidad.
 RELOAD_UI = yes
 DISPLAY_NAME = ZNC
-CHANGELOG = "Update to ZNC 1.8.1 - now built with libicu+python support."
+CHANGELOG = "Added hi3535 architecture support."
 
 STARTABLE = yes
 HOMEPAGE = https://wiki.znc.in/


### PR DESCRIPTION
_Motivation:_  `znc` spk package (depending on Python) wasn't building on "standard" architecture `hi3535`

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully (-15 -> -16 on evansport)
- [x] New installation of package completed successfully (evansport)
