### PR TITLE
cross/gevent: disable build of libev and cares (it's in the dependencies)

### DIFF
--- a/cross/gevent/Makefile
+++ b/cross/gevent/Makefile
@@ -14,9 +14,11 @@ LICENSE  = MIT
 
 INSTALL_TARGET = gevent_install
 
+ENV += EMBED=false LIBEV_EMBED=false CARES_EMBED=false 
+
 include ../../mk/spksrc.python-wheel.mk
 
 .PHONY: gevent_install
 gevent_install:
-	@$(RUN) LIBEV_EMBED=FALSE CARES_EMBED=FALSE PYTHONPATH=$(PYTHONPATH) $(HOSTPYTHON) -c "import setuptools;__file__='setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d $(WORK_DIR)/wheelhouse
+	@$(RUN) PYTHONPATH=$(PYTHONPATH) $(HOSTPYTHON) -c "import setuptools;__file__='setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d $(WORK_DIR)/wheelhouse
 	@rename -f 's/linux_i686/any/g' $(WORK_DIR)/wheelhouse/*.whl

--- a/cross/gevent/patches/0001-disable-libevent-configuring.patch
+++ b/cross/gevent/patches/0001-disable-libevent-configuring.patch
@@ -1,0 +1,22 @@
+Disabled libev configure command which would 
+1. would not work "as is" 
+2. is not required since libev is already present
+
+diff --git a/setup.py.old b/setup.py
+index 9c229add..02b3219b 100755
+--- setup.py
++++ setup.py
+@@ -117,13 +117,6 @@ if ((len(sys.argv) >= 2
+ 
+ def run_setup(ext_modules, run_make):
+     if run_make:
+-        if (not LIBEV_EMBED and not WIN and cffi_modules) or PYPY:
+-            # We're not embedding libev but we do want
+-            # to build the CFFI module. We need to configure libev
+-            # because the CORE Extension won't.
+-            # TODO: Generalize this.
+-            system(libev_configure_command)
+-
+         MakeSdist.make()
+ 
+     setup(

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ffsync
 SPK_VERS = 1.5.2
-SPK_REV = 3
+SPK_REV = 4
 SPK_ICON = src/ffsync.png
 BETA = 1
 
@@ -40,6 +40,7 @@ include ../../mk/spksrc.spk.mk
 ffsync_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
 	install -m 644 src/ffsync.ini $(STAGING_DIR)/var/
+	install -m 644 src/requirements.txt $(STAGING_DIR)/share/wheelhouse/requirements.txt
 	sed -i -e "s|https://github.com/mozilla-services/mozservices/archive/e00e1b68130423ad98d0f6185655bde650443da8.zip|mozsvc==0.8|g" \
 	       -e "s|https://github.com/mozilla-services/tokenserver/archive/d7e513e8a4f5c588b70d685a8df1d2e508c341c0.zip|tokenserver==1.2.7|g" \
 	       -e "s|https://github.com/mozilla-services/server-syncstorage/archive/1.5.5.zip|SyncStorage==1.5.5|g" \

--- a/spk/ffsync/src/requirements.txt
+++ b/spk/ffsync/src/requirements.txt
@@ -92,11 +92,11 @@ repoze.lru==0.6
 #requests==2.4.3
 simplejson==3.6.5
 six==1.8
-testfixtures==4.1.0
+#testfixtures==4.1.0
 tokenlib==0.3.1
 translationstring==1.1
 umemcache==1.6.3
-unittest2==0.6
+#unittest2==0.6
 venusian==1.0
 waitress==0.8.9
 wsgiref==0.1.2


### PR DESCRIPTION
_Motivation:_ Cross compilation was failing on depending packages.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
