### PR TITLE
Mark znc as unsupported on hi3535

### DIFF
--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -20,8 +20,7 @@ HOMEPAGE = https://wiki.znc.in/
 LICENSE  = Apache License 2.0
 
 # Ensure C++11 compatibility
-UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PCC_ARCHS)
-
+UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PCC_ARCHS) $(ARMv7L_ARCHS)
 
 WIZARDS_DIR = src/wizard/
 CONF_DIR = src/conf/


### PR DESCRIPTION
_Motivation:_   znc fails to build on hi3535 which is why I'm marking it unsupported for now (builds fine on other archs).
_Linked issues:_   See e.g. build log here https://github.com/SynoCommunity/spksrc/pull/4369/checks?check_run_id=1694292733