### PR TITLE
fix line 8: [: : integer expression expected

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -75,6 +75,10 @@ SERVICE_FILES =
 $(DSM_SCRIPTS_DIR)/service-setup:
 	$(create_target_dir)
 	@echo "### Package specific variables and functions" > $@
+	@echo 'if [ -z "$${SYNOPKG_PKGNAME}" ] || [ -z "$${SYNOPKG_PKGDEST}" ] || [ -z "$${SYNOPKG_DSM_VERSION_MAJOR}" ]; then' >> $@
+	@echo '  echo "Error: Environment variables are not set." 1>&2;' >> $@
+	@echo '  echo "Please run me using \"synopkg start [packagename]\" instead." 1>&2;' >> $@
+	@echo 'exit 1; fi' >> $@
 ifneq ($(strip $(SPK_USER)),)
 	@echo "# Base service USER to run background process prefixed according to DSM" >> $@
 	@echo USER=\"$(SPK_USER)\" >> $@

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -80,7 +80,7 @@ ifneq ($(strip $(SPK_USER)),)
 	@echo USER=\"$(SPK_USER)\" >> $@
 	@echo "PRIV_PREFIX=sc-" >> $@
 	@echo "SYNOUSER_PREFIX=svc-" >> $@
-	@echo 'if [ -n "$${SYNOPKG_DSM_VERSION_MAJOR}" -a "$${SYNOPKG_DSM_VERSION_MAJOR}" -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
+	@echo 'if [ -n "$${SYNOPKG_DSM_VERSION_MAJOR}" ] && [ "$${SYNOPKG_DSM_VERSION_MAJOR}" -lt 6 ]; then EFF_USER="$${SYNOUSER_PREFIX}$${USER}"; else EFF_USER="$${PRIV_PREFIX}$${USER}"; fi' >> $@
 endif
 ifneq ($(strip $(SERVICE_WIZARD_GROUP)),)
 	@echo "# Group name from UI if provided" >> $@

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -77,7 +77,7 @@ $(DSM_SCRIPTS_DIR)/service-setup:
 	@echo "### Package specific variables and functions" > $@
 	@echo 'if [ -z "$${SYNOPKG_PKGNAME}" ] || [ -z "$${SYNOPKG_DSM_VERSION_MAJOR}" ]; then' >> $@
 	@echo '  echo "Error: Environment variables are not set." 1>&2;' >> $@
-	@echo '  echo "Please run me using \"synopkg start [packagename]\" instead." 1>&2;' >> $@
+	@echo '  echo "Please run me using synopkg instead. Example: \"synopkg start [packagename]\"" 1>&2;' >> $@
 	@echo 'exit 1; fi' >> $@
 ifneq ($(strip $(SPK_USER)),)
 	@echo "# Base service USER to run background process prefixed according to DSM" >> $@

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -75,7 +75,7 @@ SERVICE_FILES =
 $(DSM_SCRIPTS_DIR)/service-setup:
 	$(create_target_dir)
 	@echo "### Package specific variables and functions" > $@
-	@echo 'if [ -z "$${SYNOPKG_PKGNAME}" ] || [ -z "$${SYNOPKG_PKGDEST}" ] || [ -z "$${SYNOPKG_DSM_VERSION_MAJOR}" ]; then' >> $@
+	@echo 'if [ -z "$${SYNOPKG_PKGNAME}" ] || [ -z "$${SYNOPKG_DSM_VERSION_MAJOR}" ]; then' >> $@
 	@echo '  echo "Error: Environment variables are not set." 1>&2;' >> $@
 	@echo '  echo "Please run me using \"synopkg start [packagename]\" instead." 1>&2;' >> $@
 	@echo 'exit 1; fi' >> $@


### PR DESCRIPTION
-a executes both left and right hand expressions.
When $SYNOPKG_DSM_VERSION_MAJOR is empty it shows a warning since "" is not an integer and evaluates to false.

Test case (as root):

```
root@dsm6 ~# /bin/sh /var/packages/transmission/scripts/service-setup log
/var/packages/transmission/scripts/service-setup: line 7: [: : integer expression expected
# vs
root@dsm6 ~# synopkg log transmission
The log file is /volume1/@appstore/transmission/var/transmission_temp.log
```