### PR TITLE
tvheadend: Remove native/python dependency

### DIFF
--- a/cross/tvheadend/Makefile
+++ b/cross/tvheadend/Makefile
@@ -7,7 +7,7 @@ PKG_DIST_SITE = https://github.com/tvheadend/tvheadend.git
 PKG_DIST_FILE = $(PKG_NAME)-git$(PKG_GIT_HASH).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-git$(PKG_GIT_HASH)
 
-DEPENDS = cross/openssl cross/uriparser cross/pcre2 cross/libiconv native/python
+DEPENDS = cross/openssl cross/uriparser cross/pcre2 cross/libiconv
 DEPENDS += cross/libhdhomerun cross/libdvbcsa cross/dvb-apps cross/pngquant
 
 HOMEPAGE = https://tvheadend.org/


### PR DESCRIPTION
_Motivation:_  Trying to remove `native/python` dependency in order to free-up from python2
_Linked issues:_   #4303

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully (not applicable)
- [ ] New installation of package completed successfully (not applicable)
