### PR TITLE
Update Lidarr to v0.8.0.2042

### DIFF
--- a/cross/lidarr/Makefile
+++ b/cross/lidarr/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = Lidarr
-PKG_VERS = 0.8.0.2041
+PKG_VERS = 0.8.0.2042
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME).develop.$(PKG_VERS).linux.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Lidarr/Lidarr/releases/download/v$(PKG_VERS)

--- a/cross/lidarr/Makefile
+++ b/cross/lidarr/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = Lidarr
-PKG_VERS = 0.7.1.1381
+PKG_VERS = 0.8.0.2041
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME).master.$(PKG_VERS).linux.$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME).develop.$(PKG_VERS).linux.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Lidarr/Lidarr/releases/download/v$(PKG_VERS)
 PKG_DIR = Lidarr
 

--- a/cross/lidarr/digests
+++ b/cross/lidarr/digests
@@ -1,3 +1,3 @@
-Lidarr.master.0.7.1.1381.linux.tar.gz SHA1 34abc7d86e58f641fd99d8d5f5227f6b738a15be
-Lidarr.master.0.7.1.1381.linux.tar.gz SHA256 f97a4ee981f69330476d4434e5089bc7bfb281c6420541086b9321b234cd61ee
-Lidarr.master.0.7.1.1381.linux.tar.gz MD5 85f85cd0790384595b7106496ecd6809
+Lidarr.develop.0.8.0.2041.linux.tar.gz SHA1 d48d042f90fa9fd20701cd8c7963b89e96dd1727
+Lidarr.develop.0.8.0.2041.linux.tar.gz SHA256 f08df77e224becd8486b2741e502307946aa7ced62b8c1338b0976432919381e
+Lidarr.develop.0.8.0.2041.linux.tar.gz MD5 063e9ed489aa8c0dbde1c7d99854aedd

--- a/cross/lidarr/digests
+++ b/cross/lidarr/digests
@@ -1,3 +1,3 @@
-Lidarr.develop.0.8.0.2041.linux.tar.gz SHA1 d48d042f90fa9fd20701cd8c7963b89e96dd1727
-Lidarr.develop.0.8.0.2041.linux.tar.gz SHA256 f08df77e224becd8486b2741e502307946aa7ced62b8c1338b0976432919381e
-Lidarr.develop.0.8.0.2041.linux.tar.gz MD5 063e9ed489aa8c0dbde1c7d99854aedd
+Lidarr.develop.0.8.0.2042.linux.tar.gz SHA1 8b3a0ac3977cbdefda02559869b86524fe01fac7
+Lidarr.develop.0.8.0.2042.linux.tar.gz SHA256 8fc14cbd7d8e94dcc32be9a1f6022ee580011e965d03d166363b24f4fa295679
+Lidarr.develop.0.8.0.2042.linux.tar.gz MD5 3646007e1dbbc14ee00d8323dcfdb32c

--- a/spk/lidarr/Makefile
+++ b/spk/lidarr/Makefile
@@ -16,7 +16,7 @@ DESCRIPTION  = Lidarr is a music collection manager for Usenet and BitTorrent us
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Lidarr
-CHANGELOG = "Update Lidarr to v0.8.0.2041"
+CHANGELOG = "Update Lidarr to v0.8.0.2042"
 
 HOMEPAGE = https://lidarr.audio/
 LICENSE  = GPLv3

--- a/spk/lidarr/Makefile
+++ b/spk/lidarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = lidarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 5
+SPK_REV = 6
 SPK_ICON = src/lidarr.png
 
 REQUIRED_DSM = 5.0
@@ -16,7 +16,7 @@ DESCRIPTION  = Lidarr is a music collection manager for Usenet and BitTorrent us
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = Lidarr
-CHANGELOG = "Update openssl to 1.1."
+CHANGELOG = "Update Lidarr to v0.8.0.2041"
 
 HOMEPAGE = https://lidarr.audio/
 LICENSE  = GPLv3

--- a/spk/lidarr/src/service-setup.sh
+++ b/spk/lidarr/src/service-setup.sh
@@ -55,8 +55,8 @@ service_postupgrade ()
     . ${CONFIG_DIR}/KEEP_VAR
     if [ "$KEEP_CUR" == "yes" ]; then
         echo "Restoring Lidarr version from before upgrade" >> ${INST_LOG}
-        rm -fr ${SYNOPKG_PKGDEST}/share >> $INST_LOG 2>&1
-        mv ${INST_VAR}/share ${SYNOPKG_PKGDEST}/ >> $INST_LOG 2>&1
+        rm -fr ${SYNOPKG_PKGDEST}/share >> ${INST_LOG} 2>&1
+        mv ${INST_VAR}/share ${SYNOPKG_PKGDEST}/ >> ${INST_LOG} 2>&1
         set_unix_permissions "${SYNOPKG_PKGDEST}/share"
     fi
     set_unix_permissions "${CONFIG_DIR}"


### PR DESCRIPTION
_Motivation:_  The in-app update to v0.8.0.2041 caused a startup issue. This amended PR is to move to v0.8.0.2042 which addresses this critical issue and re-base the package at the new version
_Linked issues:_  Resolves issue https://github.com/SynoCommunity/spksrc/issues/4409

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
