### PR TITLE
kernel.mk: Set COOKIE_PREFIX for kernel builds

### DIFF
--- a/mk/spksrc.kernel.mk
+++ b/mk/spksrc.kernel.mk
@@ -7,6 +7,7 @@ include ../../mk/spksrc.kernel-flags.mk
 
 # Configure the included makefiles
 NAME          = $(KERNEL_NAME)
+COOKIE_PREFIX = linux-
 URLS          = $(KERNEL_DIST_SITE)/$(KERNEL_DIST_NAME)
 PKG_DIR       = linux
 ifneq ($(KERNEL_DIST_FILE),)


### PR DESCRIPTION
_Motivation:_  As kernels are now built into the spk/* package tree it requires a COOKIE_PREFIX for various mk execution output.
_Linked issues:_  #4399

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
