### PR TITLE
update openssl to v1.1.1j

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,7 +1,5 @@
 PKG_NAME = openssl
-VERSION = 1.1.1
-PATCH_VERS = i
-PKG_VERS = $(VERSION)$(PATCH_VERS)
+PKG_VERS = 1.1.1j
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1i.tar.gz SHA1 eb684ba4ed31fe2c48062aead75233ecd36882a6
-openssl-1.1.1i.tar.gz SHA256 e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
-openssl-1.1.1i.tar.gz MD5 08987c3cf125202e2b0840035efb392c
+openssl-1.1.1j.tar.gz SHA1 04c340b086828eecff9df06dceff196790bb9268
+openssl-1.1.1j.tar.gz SHA256 aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
+openssl-1.1.1j.tar.gz MD5 cccaa064ed860a2b4d1303811bf5c682


### PR DESCRIPTION
_Motivation:_  Update OpenSSL to 1.1.1j (Security Updates of 16 Feb 2021)
_Linked issues:_  

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
