### PR TITLE
Remove dependency of sqlite on speex (an audio codec)

### DIFF
--- a/cross/sqlite/Makefile
+++ b/cross/sqlite/Makefile
@@ -5,7 +5,7 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.sqlite.org/2018
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-DEPENDS = cross/zlib cross/speex
+DEPENDS = cross/zlib
 
 HOMEPAGE = https://www.sqlite.org/
 COMMENT  = Self-contained, serverless, zero-configuration, transactional SQL database engine.


### PR DESCRIPTION
_Motivation:_  Pretty sure sqlite shouldn't depend on speex.  Speeds up build of packages depending on sqlite a little.
_Linked issues:_  

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
