### PR TITLE
Docker: fix new pip url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O - | python3
 RUN pip3 install meson==0.56.0
 
 # Install setuptools, pip, virtualenv, wheel and httpie for Python2
-RUN wget https://bootstrap.pypa.io/2.7/get-pip.py -O - | python
+RUN wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O - | python
 RUN pip install virtualenv httpie
 
 # Volume pointing to spksrc sources


### PR DESCRIPTION
_Motivation:_  docker build fails due to pip changing the URL after a major version change
_Linked issues:_  #4422
