### PR TITLE
GitHub Action: Added the ability to publish to synocommunity

### DIFF
--- a/.github/actions/build-tag.sh
+++ b/.github/actions/build-tag.sh
@@ -14,6 +14,6 @@ echo "$GH_PACKAGE"
 make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C spk/${GH_PACKAGE}
 
 # publish to synocommunity.com when the API key is set
-if [-n $API_KEY ]; then
+if [ -n "${API_KEY}" ]; then
     make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} publish -C spk/${GH_PACKAGE}
 fi

--- a/.github/actions/build-tag.sh
+++ b/.github/actions/build-tag.sh
@@ -12,3 +12,8 @@ echo "$GH_PACKAGE"
 
 # use TCVERSION and ARCH parameters to get real exit code.
 make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C spk/${GH_PACKAGE}
+
+# publish to synocommunity.com when the API key is set
+if [-n $API_KEY ]; then
+    make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} publish -C spk/${GH_PACKAGE}
+fi

--- a/.github/actions/build-tag.sh
+++ b/.github/actions/build-tag.sh
@@ -2,7 +2,7 @@
 
 make setup-synocommunity
 sed -i -e "s|#PARALLEL_MAKE=.*|PARALLEL_MAKE=4|" \
-    -e "s|PUBLISH_API_KEY=.*|PUBLISH_API_KEY=$API_KEY|" \
+    -e "s|PUBLISH_API_KEY =.*|PUBLISH_API_KEY = $API_KEY|" \
     local.mk
 
 # PACKAGE=$(echo "refs/tags/dnscrypt-proxy-2.0.42" | grep -oE "([0-9a-zA-Z]*-)*")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
           GH_ARCH: ${{ matrix.arch }}
-          #   API_KEY: ${{ secrets.PUBLISH_API_KEY }}
+          API_KEY: ${{ secrets.PUBLISH_API_KEY }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
@@ -109,7 +109,9 @@ jobs:
   release:
     needs: build
     name: Release
-    if: startsWith(github.ref, 'refs/tags/')
+    ## Build a github release on a git tag with the format 'packagename-version'
+    ## But don't make a github release when the PUBLISH_API_KEY is set.
+    if: startsWith(github.ref, 'refs/tags/') && secrets.PUBLISH_API_KEY == ''
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,9 +109,7 @@ jobs:
   release:
     needs: build
     name: Release
-    ## Build a github release on a git tag with the format 'packagename-version'
-    ## But don't make a github release when the PUBLISH_API_KEY is set.
-    if: startsWith(github.ref, 'refs/tags/') && secrets.PUBLISH_API_KEY == ''
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -354,7 +354,7 @@ endif
 ifeq ($(PUBLISH_API_KEY),)
 	$(error Set PUBLISH_API_KEY in local.mk)
 endif
-	http --verify=no --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME)
+	http --verify=no --ignore-stdin --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME)
 
 
 ### Clean rules


### PR DESCRIPTION
_Motivation:_  Open the conversation again to enable the packages to be published via GitHub actions
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4459#issuecomment-797304855. There was another discussion somewhere, but I can't find it.

This would only apply on a GitHub tag like `git tag -a -s -m jackett-0.17.668 jackett-0.17.668` feel free to come up with a better way to initiate a publish action.

~~I disabled the GitHub release when the API key is set because I think it's unnecessary, but I don't feel indifferent about it if there is a use case for having them hosted on GitHub also.~~
