### PR TITLE
fix download url for pip of python 2.7

### DIFF
--- a/native/python2/Makefile
+++ b/native/python2/Makefile
@@ -25,7 +25,7 @@ PIP = $(WORK_DIR)/install/usr/local/bin/pip
 # install latest pip that supports python2
 python_native_post_install: $(WORK_DIR)/python-native.mk
 	@$(MSG) Installing setuptools, pip and cffi
-	@$(RUN) wget https://bootstrap.pypa.io/2.7/get-pip.py -O - | $(PYTHON)
+	@$(RUN) wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O - | $(PYTHON)
 	@$(PIP) install "setuptools==44.1.0"
 	@$(PIP) install "cffi==1.14.1"
 


### PR DESCRIPTION
_Motivation:_  make python2 compile again
_Linked issues:_  #4488

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
