### PR TITLE
fix wizard creation

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -312,10 +312,16 @@ ifneq ($(strip $(WIZARDS_DIR)),)
 	@mkdir -p $(DSM_WIZARDS_DIR)
 	@find $${SPKSRC_WIZARDS_DIR} -maxdepth 1 -type f -and \( -name "install_uifile" -or -name "install_uifile_???" -or -name "install_uifile.sh" -or -name "install_uifile_???.sh" -or -name "upgrade_uifile" -or -name "upgrade_uifile_???" -or -name "upgrade_uifile.sh" -or -name "upgrade_uifile_???.sh" -or -name "uninstall_uifile" -or -name "uninstall_uifile_???" -or -name "uninstall_uifile.sh" -or -name "uninstall_uifile_???.sh" \) -print -exec cp -f {} $(DSM_WIZARDS_DIR) \;
 endif
-ifneq ($(wildcard $(DSM_WIZARDS_DIR)/.*),)
+ifneq ($(strip $(WIZARDS_DIR)),)
 	@find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name "*.sh" -print -exec chmod 0644 {} \;
 	@find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -name "*.sh" -print -exec chmod 0755 {} \;
 	$(eval SPK_CONTENT += WIZARD_UIFILES)
+else
+ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+	@find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name "*.sh" -print -exec chmod 0644 {} \;
+	@find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -name "*.sh" -print -exec chmod 0755 {} \;
+	$(eval SPK_CONTENT += WIZARD_UIFILES)
+endif
 endif
 
 .PHONY: conf

--- a/spk/demoservice/PLIST
+++ b/spk/demoservice/PLIST
@@ -1,1 +1,1 @@
-bin:README
+rsc:README


### PR DESCRIPTION
_Motivation:_  Finally fix wizard creation broken by #4395
_Linked issues:_  fixes #4489

### Remarks
- Fix missing wizards in packages introduced with #4489
- This is a working solution for packages without wizards as expected by #4489
- The solution of #4489 did not work, as the copied files where not detected with `ifneq ($(wildcard $(DSM_WIZARDS_DIR)/.*),)` and therefore not included in the package. (but a second build without `make clean` created the package with the wizard files - so it was hard to detect the error).


The solution uses duplicated statements as there is no solution found for logical OR conditions.