### PR TITLE
Framework: .net add armada370 to unsupported architectures

### DIFF
--- a/mk/spksrc.cross-dotnet-env.mk
+++ b/mk/spksrc.cross-dotnet-env.mk
@@ -4,7 +4,8 @@
 # NOTE: 32bit (x86) is not supported:
 # https://github.com/dotnet/core/issues/5403
 # https://github.com/dotnet/core/issues/4595
-UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
+# https://github.com/SynoCommunity/spksrc/pull/4464#issuecomment-808184517
+UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS) armada370
 
 DOTNET_OS = linux
 DOTNET_DEFAULT_VERSION = 3.1


### PR DESCRIPTION
_Motivation:_  From a user report ds213j returns `Illegal instruction (core dumped)` https://github.com/SynoCommunity/spksrc/pull/4464#issuecomment-807198028. Other armada architectures might also be affected. Thanks @ta264 for the report and analysis
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4464#issuecomment-808126327

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
