### PR TITLE
kernel.mk: Missed cross-env kernel variable fix.

### DIFF
--- a/mk/spksrc.cross-env.mk
+++ b/mk/spksrc.cross-env.mk
@@ -5,8 +5,9 @@ ENV += WORK_DIR=$(WORK_DIR)
 ENV += INSTALL_PREFIX=$(INSTALL_PREFIX)
 
 ifeq ($(strip $(REQUIRE_KERNEL)),1)
-ENV += KERNEL_ROOT=$(WORK_DIR)/../../../kernel/syno-$(ARCH)-$(TCVERSION)/work/source/linux
-KERNEL_ROOT=$(WORK_DIR)/../../../kernel/syno-$(ARCH)-$(TCVERSION)/work/source/linux
+ENV += REQUIRE_KERNEL_MODULE="$(REQUIRE_KERNEL_MODULE)"
+ENV += KERNEL_ROOT=$(WORK_DIR)/linux
+KERNEL_ROOT=$(WORK_DIR)/linux
 endif
 
 ifeq ($(strip $(REQUIRE_TOOLKIT)),1)


### PR DESCRIPTION

_Motivation:_  Was missing from previous merged PR: 
- Export REQUIRE_KERNEL_MODULE to default ENV
- Fix KERNEL_ROOT to point to $(WORK_DIR)/linux

_Linked issues:_  #4526

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
