### PR TITLE
DSM6: Keep previous behaviour and assume no file by default

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -278,7 +278,7 @@ ifneq ($(strip $(SPK_GROUP)),)
 endif
 endif
 
-ifneq ("$(wildcard $(DSM_CONF_DIR)/privilege)","")
+ifneq ("$(wildcard $(DSM_CONF_DIR))","")
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf
 endif

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -257,6 +257,8 @@ endif
 ifneq ($(strip $(SPK_GROUP)),)
 	@jq '."groupname" = "$(SPK_GROUP)"' $@ 1<>$@
 endif
+
+# Less then DSM 7
 else
 ifneq ($(strip $(SYSTEM_GROUP)),)
 # options: http, system

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -226,17 +226,23 @@ ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 $(DSM_CONF_DIR)/privilege:
 	$(create_target_dir)
 	@jq -n '."defaults" = {"run-as": "package"}' > $@
+	@$(MSG) "Creating $@"
+	@$(MSG) '(privilege) run-as: package'
 # DSM <= 6 and SERVICE_USER defined
 else ifneq ($(strip $(SPK_USER)),)
 ifeq ($(strip $(SERVICE_EXE)),)
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-installasroot
-	@$(MSG) "spksrc.service.privilege-installasroot"
 	@$(dsm_script_copy)
+	@$(MSG) "(privilege) spksrc.service.privilege-installasroot"
 else
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-startasroot
-	@$(MSG) "spksrc.service.privilege-startasroot"
 	@$(dsm_script_copy)
+	@$(MSG) "(privilege) spksrc.service.privilege-startasroot"
 endif
+else
+$(DSM_CONF_DIR)/privilege:
+	@$(MSG) "Creating $@"
+	@$(MSG) "(privilege) DSM <= 6 and SERVICE_USER undefined"
 endif
 # Apply variables to privilege file
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)


### PR DESCRIPTION
_Motivation:_  On DSM6 with latest update for DSM7 it creates, by default, a `conf/privilege` file while previous behavior did not.  Proposed patch revert back to this behavior on DSM <= 7.
_Linked issues:_  #4533 4533

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
