### PR TITLE
Bump OpenSSL to 1.1.1k and Python to 3.8.9

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.1.1j
+PKG_VERS = 1.1.1k
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1j.tar.gz SHA1 04c340b086828eecff9df06dceff196790bb9268
-openssl-1.1.1j.tar.gz SHA256 aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
-openssl-1.1.1j.tar.gz MD5 cccaa064ed860a2b4d1303811bf5c682
+openssl-1.1.1k.tar.gz SHA1 bad9dc4ae6dcc1855085463099b5dacb0ec6130b
+openssl-1.1.1k.tar.gz SHA256 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
+openssl-1.1.1k.tar.gz MD5 c4e7d95f782b08116afa27b30393dd27

--- a/cross/python38/Makefile
+++ b/cross/python38/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = python38
-PKG_VERS = 3.8.8
+PKG_VERS = 3.8.9
 PKG_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
 PKG_EXT = tar.xz
 PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)

--- a/cross/python38/digests
+++ b/cross/python38/digests
@@ -1,3 +1,3 @@
-Python-3.8.8.tar.xz SHA1 d7dd8ef51ebe7ddd8ec41e39a607ac26d1834a8f
-Python-3.8.8.tar.xz SHA256 7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc
-Python-3.8.8.tar.xz MD5 23e6b769857233c1ac07b6be7442eff4
+Python-3.8.9.tar.xz SHA1 ea40651135adc4126a60a45093d100722610f4de
+Python-3.8.9.tar.xz SHA256 5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572
+Python-3.8.9.tar.xz MD5 51b5bbf2ab447e66d15af4883db1c133

--- a/native/python38/Makefile
+++ b/native/python38/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = python38
-PKG_VERS = 3.8.8
+PKG_VERS = 3.8.9
 PKG_EXT = tar.xz
 PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.python.org/ftp/python/$(PKG_VERS)
@@ -32,6 +32,6 @@ python38_native_post_install: $(WORK_DIR)/python-native.mk
 	@$(MSG) Installing pip, setuptools, cffi and cross env
 	@$(RUN) wget https://bootstrap.pypa.io/get-pip.py -O - | $(PYTHON)
 	@$(PIP) install "setuptools==44.1.0" "cffi==1.14.1" "crossenv==1.0"
-	
+
 $(WORK_DIR)/python-native.mk:
 	@echo PIP=$(PIP_NATIVE) >> $@

--- a/native/python38/digests
+++ b/native/python38/digests
@@ -1,3 +1,3 @@
-Python-3.8.8.tar.xz SHA1 d7dd8ef51ebe7ddd8ec41e39a607ac26d1834a8f
-Python-3.8.8.tar.xz SHA256 7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc
-Python-3.8.8.tar.xz MD5 23e6b769857233c1ac07b6be7442eff4
+Python-3.8.9.tar.xz SHA1 ea40651135adc4126a60a45093d100722610f4de
+Python-3.8.9.tar.xz SHA256 5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572
+Python-3.8.9.tar.xz MD5 51b5bbf2ab447e66d15af4883db1c133

--- a/spk/python38/Makefile
+++ b/spk/python38/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python38
-SPK_VERS = 3.8.8
+SPK_VERS = 3.8.9
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 2
+SPK_REV = 3
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/$(SPK_NAME)
@@ -21,7 +21,7 @@ DESCRIPTION_SPN = Lenguaje de programación Python.
 RELOAD_UI = yes
 STARTABLE = no
 DISPLAY_NAME = Python 3.8
-CHANGELOG = "Python 3.8.8 update"
+CHANGELOG = "Python 3.8.9 update, including OpenSSL 1.1.1k/"
 
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF


### PR DESCRIPTION
OpenSSL 1.1.1k fixes 2 high-severity problems for servers, so relevant for DMS users: CVE-2021-3449 and CVE-2021-3450.
I think the pipeline will try to build like 15 packages, so not sure if it fails if it has anything to do with the change.
