### PR TITLE
chromaprint: Fix building on DSM7

### DIFF
--- a/cross/chromaprint/Makefile
+++ b/cross/chromaprint/Makefile
@@ -27,3 +27,4 @@ include ../../mk/spksrc.cross-cmake.mk
 
 CMAKE_ARGS += -DBUILD_TOOLS=ON
 CMAKE_ARGS += -DCMAKE_INSTALL_RPATH=$(CMAKE_RPATH)
+CMAKE_ARGS += -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations"

--- a/cross/chromaprint/patches/001-disable-HAVE_AV_FRAME.patch
+++ b/cross/chromaprint/patches/001-disable-HAVE_AV_FRAME.patch
@@ -1,0 +1,17 @@
+--- src/audio/ffmpeg_audio_reader.h.orig	2020-04-15 04:08:10.000000000 +0000
++++ src/audio/ffmpeg_audio_reader.h	2021-04-12 23:31:30.658596475 +0000
+@@ -27,14 +27,6 @@ extern "C" {
+ #define av_packet_unref av_free_packet
+ #endif
+ 
+-#ifndef HAVE_AV_FRAME_ALLOC
+-#define av_frame_alloc avcodec_alloc_frame
+-#endif
+-
+-#ifndef HAVE_AV_FRAME_FREE
+-#define av_frame_free avcodec_free_frame
+-#endif
+-
+ #ifndef AV_ERROR_MAX_STRING_SIZE
+ #define AV_ERROR_MAX_STRING_SIZE 128
+ #endif

--- a/spk/chromaprint/Makefile
+++ b/spk/chromaprint/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = chromaprint
 SPK_VERS = 1.5.0
-SPK_REV = 13
+SPK_REV = 14
 SPK_ICON = src/chromaprint.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -19,6 +19,7 @@ LICENSE    = LGPL2.1+
 export FFMPEG_DIR = $(shell pwd)/../ffmpeg/work-$(ARCH)-$(TCVERSION)/install/var/packages/ffmpeg/target
 
 ifneq ($(wildcard $(FFMPEG_DIR)),)
+export ADDITIONAL_LDFLAGS = -Wl,--rpath-link,$(FFMPEG_DIR)/lib -Wl,--rpath,/var/packages/ffmpeg/target/lib
 PRE_DEPEND_TARGET = chromaprint_pre_depend
 SPK_DEPENDS = "ffmpeg>4.2"
 endif


### PR DESCRIPTION
_Motivation:_  `chromaprint` fails to build on DSM7, this is an attempt to fix it.  Tested over PR #4545
_Linked issues:_  

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
