### PR TITLE
Wrap tar calls using fakeroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		debootstrap \
 		ed \
 		expect \
+		fakeroot \
 		flex \
 		g++-multilib \
 		gawk \

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,9 @@ Docker
 * `Fork and clone`_ spksrc: ``git clone https://github.com/YOUR-USERNAME/spksrc ~/spksrc``
 * Install Docker on your host OS: `Docker installation`_. A wget-based alternative for linux: `Install Docker with wget`_.
 * Download the spksrc docker container: ``docker pull synocommunity/spksrc``
-* Run the container with ``docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash``
+* Run the container with ``docker run -it -v ~/spksrc:/spksrc synocommunity/spksrc /bin/bash``. 
+  On Mac hosts running OSX you might need to use fakeroot with tar to avoid permission errors while extracting the synology toolchain archives.
+  For that reason run the container with ``docker run -it -v~/spksrc:/spksrc -e TAR_CMD="fakeroot tar" synocommunity/spksrc /bin/bash``.
 
 
 Virtual machine

--- a/mk/spksrc.extract.mk
+++ b/mk/spksrc.extract.mk
@@ -8,7 +8,7 @@
 #  post_extract_target  (override with POST_EXTRACT_TARGET)
 EXTRACT_PATH ?= $(WORK_DIR)
 
-# Extract commands
+# Extract commands (optionally use TAR_CMD="fakeroot tar" as workaround on OSX)
 TAR_CMD ?= tar
 ifeq ($(strip $(EXTRACT_CMD.$(DIST_EXT))),)
 EXTRACT_CMD.tgz = $(TAR_CMD) -xzpf $(DIST_FILE) -C $(EXTRACT_PATH)

--- a/mk/spksrc.extract.mk
+++ b/mk/spksrc.extract.mk
@@ -7,16 +7,18 @@
 #  extract_target       (override with EXTRACT_TARGET)
 #  post_extract_target  (override with POST_EXTRACT_TARGET)
 EXTRACT_PATH ?= $(WORK_DIR)
+
 # Extract commands
+TAR_CMD = fakeroot tar
 ifeq ($(strip $(EXTRACT_CMD.$(DIST_EXT))),)
-EXTRACT_CMD.tgz = tar -xzpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.txz = tar -xpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.tar.gz = tar -xzpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.tar.bz2 = tar -xjpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.tbz = tar -xjpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.tar.xz = tar -xJpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.tar.lzma = tar --lzma -xpf $(DIST_FILE) -C $(EXTRACT_PATH)
-EXTRACT_CMD.tar.lz = tar --lzip -xpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tgz = $(TAR_CMD) -xzpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.txz = $(TAR_CMD) -xpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tar.gz = $(TAR_CMD) -xzpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tar.bz2 = $(TAR_CMD) -xjpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tbz = $(TAR_CMD) -xjpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tar.xz = $(TAR_CMD) -xJpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tar.lzma = $(TAR_CMD) --lzma -xpf $(DIST_FILE) -C $(EXTRACT_PATH)
+EXTRACT_CMD.tar.lz = $(TAR_CMD) --lzip -xpf $(DIST_FILE) -C $(EXTRACT_PATH)
 EXTRACT_CMD.zip = unzip $(DIST_FILE) -d $(EXTRACT_PATH)
 EXTRACT_CMD.deb = dpkg-deb -R $(DIST_FILE) $(EXTRACT_PATH)
 endif

--- a/mk/spksrc.extract.mk
+++ b/mk/spksrc.extract.mk
@@ -9,7 +9,7 @@
 EXTRACT_PATH ?= $(WORK_DIR)
 
 # Extract commands
-TAR_CMD = fakeroot tar
+TAR_CMD ?= tar
 ifeq ($(strip $(EXTRACT_CMD.$(DIST_EXT))),)
 EXTRACT_CMD.tgz = $(TAR_CMD) -xzpf $(DIST_FILE) -C $(EXTRACT_PATH)
 EXTRACT_CMD.txz = $(TAR_CMD) -xpf $(DIST_FILE) -C $(EXTRACT_PATH)


### PR DESCRIPTION
Some of the synology toolchain tarballs contain permissions that will make
extraction fail on MacOS Docker Host machines. Details are in #3570.

A simple fix for this issue is prepending the tar command with the
fakeroot command.

_Linked issues_: Fixes #3570, fixes #3523, closes #3524, #3428, fixes #3791
