### PR TITLE
patch.mk: Add ARM_ARCHS group allowing patches/arm generic patches

### DIFF
--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -23,11 +23,11 @@ endif
 #    patches/$(group)-$(TCVERSION)/*.patch
 #    patches/$(arch)/*.patch
 #    patches/$(arch)-$(TCVERSION)/*.patch
-# supported groups: armv5, armv7, armv7l, armv8, ppc, i686, x64
+# supported groups: arm, armv5, armv7, armv7l, armv8, ppc, i686, x64
 ifeq ($(strip $(PATCHES)),)
-PATCHES = $(foreach group,ARMv5_ARCHS ARMv7_ARCHS ARMv7L_ARCHS ARMv8_ARCHS PPC_ARCHS i686_ARCHS x64_ARCHS, \
+PATCHES = $(sort $(foreach group,ARM_ARCHS ARMv5_ARCHS ARMv7_ARCHS ARMv7L_ARCHS ARMv8_ARCHS PPC_ARCHS i686_ARCHS x64_ARCHS, \
 	$(foreach arch,$($(group)), \
-	$(if $(filter $(ARCH),$(arch)),$(sort $(wildcard patches/*.patch patches/kernel-$(subst +,,$(TC_KERNEL))/*.patch patches/DSM-$(TCVERSION)/*.patch patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch  patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')-$(TCVERSION)/*.patch patches/$(arch)/*.patch patches/$(arch)-$(TCVERSION)/*.patch)),)))
+	$(if $(filter $(ARCH),$(arch)),$(sort $(wildcard patches/*.patch patches/kernel-$(subst +,,$(TC_KERNEL))/*.patch patches/DSM-$(TCVERSION)/*.patch patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch  patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')-$(TCVERSION)/*.patch patches/$(arch)/*.patch patches/$(arch)-$(TCVERSION)/*.patch)),))))
 endif
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done


### PR DESCRIPTION
_Motivation:_  While helping on Fishell PR #4494 a patch for all `arm` arches would have been useful.  This PR aims to allow this.  Note that there is now a sort to remove any duplicate entries as looping over `ARM_ARCHS` creates duplicate entries from other `ARMvX_ARCHS` afterwards.
_Linked issues:_  

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
