### PR TITLE
Add $SYNOPKG_PKGVAR backwards compatibility to start-stop-status

### DIFF
--- a/mk/spksrc.service.start-stop-daemon
+++ b/mk/spksrc.service.start-stop-daemon
@@ -4,7 +4,7 @@
 DNAME="${SYNOPKG_PKGNAME}"
 
 if [ "$SYNOPKG_DSM_VERSION_MAJOR" -lt 7 ]; then
-    # define SYNOPKG_PKGVAR for backwards compatibility
+    # define SYNOPKG_PKGVAR for forward compatibility
     SYNOPKG_PKGVAR="${SYNOPKG_PKGDEST}/var"
 fi
 

--- a/mk/spksrc.service.start-stop-daemon
+++ b/mk/spksrc.service.start-stop-daemon
@@ -3,6 +3,11 @@
 # Default display name
 DNAME="${SYNOPKG_PKGNAME}"
 
+if [ "$SYNOPKG_DSM_VERSION_MAJOR" -lt 7 ]; then
+    # define SYNOPKG_PKGVAR for backwards compatibility
+    SYNOPKG_PKGVAR="${SYNOPKG_PKGDEST}/var"
+fi
+
 # Source package specific variable and functions
 SVC_SETUP=`dirname $0`"/service-setup"
 if [ -r "${SVC_SETUP}" ]; then

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -4,7 +4,7 @@
 DNAME="${SYNOPKG_PKGNAME}"
 
 if [ "$SYNOPKG_DSM_VERSION_MAJOR" -lt 7 ]; then
-    # define SYNOPKG_PKGVAR for backwards compatibility
+    # define SYNOPKG_PKGVAR for forward compatibility
     SYNOPKG_PKGVAR="${SYNOPKG_PKGDEST}/var"
 fi
 

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -3,6 +3,11 @@
 # Default display name
 DNAME="${SYNOPKG_PKGNAME}"
 
+if [ "$SYNOPKG_DSM_VERSION_MAJOR" -lt 7 ]; then
+    # define SYNOPKG_PKGVAR for backwards compatibility
+    SYNOPKG_PKGVAR="${SYNOPKG_PKGDEST}/var"
+fi
+
 # Source package specific variable and functions
 SVC_SETUP=`dirname $0`"/service-setup"
 if [ -r "${SVC_SETUP}" ]; then


### PR DESCRIPTION
_Motivation:_  Patch SYNOPKG_PKGVAR so it's available in older DSM versions.
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4545#issuecomment-818832332

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
