### PR TITLE
DSM7: revert var overwrite

### DIFF
--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -167,7 +167,7 @@ postinst ()
     # copy target/var data to permanent storage
     # and don't override old configurations
     if [ -d ${SYNOPKG_PKGDEST}/var ] && [ "$(find ${SYNOPKG_PKGVAR} -mindepth 1 -not -name '*.log' -print)" = "" ]; then
-        $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR}
+        $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
     fi    
 
     call_func "service_postinst" install_log

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -167,7 +167,7 @@ postinst ()
     # copy target/var data to permanent storage
     # and don't override old configurations
     if [ -d ${SYNOPKG_PKGDEST}/var ] && [ "$(find ${SYNOPKG_PKGVAR} -mindepth 1 -not -name '*.log' -print)" = "" ]; then
-        $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
+        $CP ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
     fi    
 
     call_func "service_postinst" install_log
@@ -218,7 +218,7 @@ preupgrade ()
     # Migrate data to permanent storage
     if [ ! "$(ls -A ${SYNOPKG_PKGVAR})" ]; then
         # only migrate when destination is empty
-        $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
+        $CP ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
     fi
 
     call_func "service_preupgrade" install_log

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -165,10 +165,10 @@ postinst ()
     save_wizard_variables 2>&1 | install_log
 
     # copy target/var data to permanent storage
-    # and overwrite with configurations found in old location
-    if [ -d ${SYNOPKG_PKGDEST}/var ] && [ "$(find ${SYNOPKG_PKGDEST}/var -mindepth 1 -not -name '*.log' -print)" = "" ]; then
-        $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
-    fi
+    # and don't override old configurations
+    if [ -d ${SYNOPKG_PKGDEST}/var ] && [ "$(find ${SYNOPKG_PKGVAR} -mindepth 1 -not -name '*.log' -print)" = "" ]; then
+        $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR}
+    fi    
 
     call_func "service_postinst" install_log
     


### PR DESCRIPTION
_Motivation:_  Revert a breaking change of #4539

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

### Remarks
- revert overwriting files in ${SYNOPKG_PKGVAR} folder from target/var (introduced with #4539)

_Reference:_ [comment on spksrc.service.installer.dsm7 in  #4539](https://github.com/SynoCommunity/spksrc/commit/0eaccc5f0a45bfa91b505f7ed9750c987128c235?branch=0eaccc5f0a45bfa91b505f7ed9750c987128c235&diff=split#r49449742)

As linking into the merged PR is not very good, here is the comment of @publicarray 
> Dang I missed it, why change it? This is a regression or please let me explain how it was supposed to work.
> 
> DSM7:
> 
> `${SYNOPKG_PKGDEST}/var` => /var/packages/{package}/target/var
> `${SYNOPKG_PKGVAR}` => /var/packages/{package}/var
> 
> DSM6:
> `${SYNOPKG_PKGDEST}/var` => /var/packages/{package}/target/var
> `${SYNOPKG_PKGVAR}` => /var/packages/{package}/target/var or undefined (need to double-check)
> 
> If `${SYNOPKG_PKGDEST}/var` exists we want its contents to be coped to `${SYNOPKG_PKGVAR}` unless there are already files there. (think new dsm7 installation or upgrading from dsm6 to dsm7)
> 
> And we don't want to override the on next install since there are updated database/user files in there.
> 
> So please don't publish any DSM7 packages yet.


