### PR TITLE
OpenSSL version bump to 1.1.1k

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.1.1j
+PKG_VERS = 1.1.1k
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1j.tar.gz SHA1 04c340b086828eecff9df06dceff196790bb9268
-openssl-1.1.1j.tar.gz SHA256 aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
-openssl-1.1.1j.tar.gz MD5 cccaa064ed860a2b4d1303811bf5c682
+openssl-1.1.1k.tar.gz SHA1 bad9dc4ae6dcc1855085463099b5dacb0ec6130b
+openssl-1.1.1k.tar.gz SHA256 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
+openssl-1.1.1k.tar.gz MD5 c4e7d95f782b08116afa27b30393dd27


### PR DESCRIPTION
_Motivation:_  OpenSSL version bump to 1.1.1k
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4541#

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
