### PR TITLE
Update expat to avoid vulnerable version

### DIFF
--- a/cross/expat/Makefile
+++ b/cross/expat/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = expat
-PKG_VERS = 2.2.7
+PKG_VERS = 2.3.0
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://downloads.sourceforge.net/project/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERS)
+PKG_DIST_SITE = https://github.com/libexpat/lib$(PKG_NAME)/releases/download/R_$(subst .,_,$(PKG_VERS))
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/expat/PLIST
+++ b/cross/expat/PLIST
@@ -1,4 +1,4 @@
 bin:bin/xmlwf
 lnk:lib/libexpat.so
 lnk:lib/libexpat.so.1
-lib:lib/libexpat.so.1.6.9
+lib:lib/libexpat.so.1.7.0

--- a/cross/expat/digests
+++ b/cross/expat/digests
@@ -1,3 +1,3 @@
-expat-2.2.7.tar.bz2 SHA1 9c8a268211e3f1ae31c4d550e5be7708973ec6a6
-expat-2.2.7.tar.bz2 SHA256 cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18
-expat-2.2.7.tar.bz2 MD5 72f36b87cdb478aba1e78473393766aa
+expat-2.3.0.tar.bz2 SHA1 e17fc843abc43be34ce85e53a4ca00b7a1e6d612
+expat-2.3.0.tar.bz2 SHA256 f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586
+expat-2.3.0.tar.bz2 MD5 54ea624caca3f9003cebcab4f0a75c8f


### PR DESCRIPTION
_Motivation:_  I noticed in another pull request that the GitHub Actions build was failing because a package could not download `expat` v2.2.7. On the project website (https://sourceforge.net/projects/expat/files/expat/2.2.7/) I found that version of `expat` had been taken down because it has a vulnerability. In this PR I upgrade the version to the recommended v2.3.0.

N.B. I do not know if upgrading `expat` will cause any other issues for packages that depend on it.
