### PR TITLE
Use installer resources for DSM6, update TCL package

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -60,6 +60,12 @@ else ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 SPK_USER = $(SPK_NAME)
 endif
 
+ifeq ($(strip $(STARTABLE)),yes)
+# we only evaluate for STARTABLE=no
+# STARTABLE=yes is default (same as STARTABLE not defined)
+STARTABLE=
+endif
+
 # Recommend explicit STARTABLE=no
 ifeq ($(strip $(SSS_SCRIPT) $(SERVICE_COMMAND) $(SERVICE_EXE) $(STARTABLE)),)
 ifeq ($(strip $(SPK_COMMANDS) $(SPK_USR_LOCAL_LINKS)),)

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -177,6 +177,8 @@ ifneq ($(strip $(SERVICE_WIZARD_SHARE)),)
 		'."data-share" = {"shares": [{"name": $$share, "permission":{"rw":[$$user]}} ] }' $@ 1<>$@
 endif
 SERVICE_FILES += $(DSM_CONF_DIR)/resource
+
+# Less than DSM 6.0
 else
 ifneq ($(strip $(SPK_COMMANDS) $(SPK_USR_LOCAL_LINKS)),)
 	@echo "# List of commands to create links for" >> $@

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -60,12 +60,6 @@ else ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 SPK_USER = $(SPK_NAME)
 endif
 
-ifeq ($(strip $(STARTABLE)),yes)
-# we only evaluate for STARTABLE=no
-# STARTABLE=yes is default (same as STARTABLE not defined)
-STARTABLE=
-endif
-
 # Recommend explicit STARTABLE=no
 ifeq ($(strip $(SSS_SCRIPT) $(SERVICE_COMMAND) $(SERVICE_EXE) $(STARTABLE)),)
 ifeq ($(strip $(SPK_COMMANDS) $(SPK_USR_LOCAL_LINKS)),)
@@ -183,8 +177,15 @@ ifneq ($(strip $(SERVICE_WIZARD_SHARE)),)
 		'."data-share" = {"shares": [{"name": $$share, "permission":{"rw":[$$user]}} ] }' $@ 1<>$@
 endif
 SERVICE_FILES += $(DSM_CONF_DIR)/resource
+else
+ifneq ($(strip $(SPK_COMMANDS) $(SPK_USR_LOCAL_LINKS)),)
+	@echo "# List of commands to create links for" >> $@
+	@echo "SPK_COMMANDS=\"${SPK_COMMANDS}\"" >> $@
+	@echo "SPK_USR_LOCAL_LINKS=\"${SPK_USR_LOCAL_LINKS}\"" >> $@
+	@cat $(SPKSRC_MK)spksrc.service.create_links >> $@
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf
+endif
 endif
 
 # Less than DSM 6.0

--- a/spk/transmission/Makefile
+++ b/spk/transmission/Makefile
@@ -3,7 +3,7 @@ SPK_VERS = 3.00
 SPK_REV = 19
 SPK_ICON = src/transmission.png
 
-DEPENDS = cross/busybox cross/$(SPK_NAME)
+DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Transmission is an easy and fast BitTorrent client. You can control it remotely with its web interface or dedicated applications.
@@ -30,12 +30,7 @@ ADMIN_PORT = $(SERVICE_PORT)
 
 POST_STRIP_TARGET = transmission_extra_install
 
-BUSYBOX_CONFIG = usrmng
-ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
-
-
 include ../../mk/spksrc.spk.mk
-
 
 .PHONY: transmission_extra_install
 transmission_extra_install:

--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -2,12 +2,12 @@
 # This gives tranmission the power to execute python scripts on completion (like TorrentToMedia).
 PYTHON_DIR="/usr/local/python"
 PATH="${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}/bin:${PATH}"
-CFG_FILE="${SYNOPKG_PKGDEST}/var/settings.json"
+CFG_FILE="${SYNOPKG_PKGVAR}/settings.json"
 TRANSMISSION="${SYNOPKG_PKGDEST}/bin/transmission-daemon"
 
 GROUP="sc-download"
 
-SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGDEST}/var/ -x ${PID_FILE} -e ${LOG_FILE}"
+SERVICE_COMMAND="${TRANSMISSION} -g ${SYNOPKG_PKGVAR} -x ${PID_FILE} -e ${LOG_FILE}"
 
 service_preinst ()
 {
@@ -30,7 +30,7 @@ service_postinst ()
 {
     if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
         # Edit the configuration according to the wizard
-        sed -i -e "s|@download_dir@|${wizard_download_dir:=/volume1/downloads}|g" ${CFG_FILE}
+        sed -i -e "s|@download_dir@|${wizard_volume}/${wizard_download_dir:=downloads}|g" ${CFG_FILE}
         sed -i -e "s|@username@|${wizard_username:=admin}|g" ${CFG_FILE}
         sed -i -e "s|@password@|${wizard_password:=admin}|g" ${CFG_FILE}
         if [ -d "${wizard_watch_dir}" ]; then

--- a/spk/transmission/src/service-setup.sh
+++ b/spk/transmission/src/service-setup.sh
@@ -56,12 +56,6 @@ service_postinst ()
             set_syno_permissions "${wizard_incomplete_dir}" "${GROUP}"
         fi
     fi
-
-    # Discard legacy obsolete busybox user account
-    BIN=${SYNOPKG_PKGDEST}/bin
-    $BIN/busybox --install $BIN >> ${INST_LOG}
-    $BIN/delgroup "${USER}" "users" >> ${INST_LOG}
-    $BIN/deluser "${USER}" >> ${INST_LOG}
 }
 
 

--- a/spk/transmission/src/wizard/install_uifile
+++ b/spk/transmission/src/wizard/install_uifile
@@ -1,69 +1,125 @@
-[{
-    "step_title": "Basic configuration",
-    "items": [{
-        "type": "textfield",
-        "desc": "Download directory",
-        "subitems": [{
-            "key": "wizard_download_dir",
-            "desc": "Download directory",
-            "defaultValue": "/volume1/downloads",
-            "validator": {
-                "allowBlank": false,
-                "regex": {
-                    "expr": "/^\\\/volume\\w*[0-9]{1,2}\\\/[^<>: */?\"]*/",
-                    "errorText": "Path should begin with /volumename?/ where volumename can be 'volume' or also 'volumeUSB' and ? is the volume number (1-99)."
-                }
+[
+    {
+        "step_title": "Basic configuration",
+        "items": [
+            {
+                "type": "combobox",
+                "desc": "Please select a volume to use for the download folder",
+                "subitems": [
+                    {
+                        "key": "wizard_volume",
+                        "desc": "volume name",
+                        "displayField": "display_name",
+                        "valueField": "volume_path",
+                        "editable": false,
+                        "mode": "remote",
+                        "api_store": {
+                            "api": "SYNO.Core.Storage.Volume",
+                            "method": "list",
+                            "version": 1,
+                            "baseParams": {
+                                "limit": -1,
+                                "offset": 0,
+                                "location": "internal"
+                            },
+                            "root": "volumes",
+                            "idProperty": "volume_path",
+                            "fields": [
+                                "display_name",
+                                "volume_path"
+                            ]
+                        },
+                        "validator": {
+                            "fn": "{console.log(arguments);return true;}"
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "textfield",
+                "desc": "Download shared folder (using the volume chosen above)",
+                "subitems": [
+                    {
+                        "key": "wizard_download_dir",
+                        "desc": "Download shared folder",
+                        "defaultValue": "downloads",
+                        "validator": {
+                            "allowBlank": false,
+                            "regex": {
+                                "expr": "/^[\\w _-]+$/",
+                                "errorText": "Subdirectories are not supported."
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "textfield",
+                "desc": "Watch a directory for torrent files and add them to transmission. Leave empty to disable",
+                "subitems": [
+                    {
+                        "key": "wizard_watch_dir",
+                        "desc": "Watch directory",
+                        "validator": {
+                            "allowBlank": true,
+                            "regex": {
+                                "expr": "/^\\\/volume\\w*[0-9]{1,2}\\\/[^<>: */?\"]*/",
+                                "errorText": "Path should begin with /volumename?/ where volumename can be 'volume' or also 'volumeUSB' and ? is the volume number (1-99)."
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "textfield",
+                "desc": "Directory to keep files in until torrent is complete. Leave empty to disable",
+                "subitems": [
+                    {
+                        "key": "wizard_incomplete_dir",
+                        "desc": "Incomplete directory",
+                        "validator": {
+                            "allowBlank": true,
+                            "regex": {
+                                "expr": "/^\\\/volume\\w*[0-9]{1,2}\\\/[^<>: */?\"]*/",
+                                "errorText": "Path should begin with /volumename?/ where volumename can be 'volume' or also 'volumeUSB' and ? is the volume number (1-99)."
+                            }
+                        }
+                    }
+                ]
             }
-        }]
-    }, {
-        "type": "textfield",
-        "desc": "Watch a directory for torrent files and add them to transmission. Leave empty to disable",
-        "subitems": [{
-            "key": "wizard_watch_dir",
-            "desc": "Watch directory",
-            "validator": {
-                "allowBlank": true,
-                "regex": {
-                    "expr": "/^\\\/volume\\w*[0-9]{1,2}\\\/[^<>: */?\"]*/",
-                    "errorText": "Path should begin with /volumename?/ where volumename can be 'volume' or also 'volumeUSB' and ? is the volume number (1-99)."
-                }
+        ]
+    },
+    {
+        "step_title": "Basic configuration",
+        "items": [
+            {
+                "type": "textfield",
+                "desc": "Web interface username. Defaults to admin",
+                "subitems": [
+                    {
+                        "key": "wizard_username",
+                        "desc": "Username"
+                    }
+                ]
+            },
+            {
+                "type": "password",
+                "desc": "Web interface password. Defaults to admin",
+                "subitems": [
+                    {
+                        "key": "wizard_password",
+                        "desc": "Password"
+                    }
+                ]
             }
-        }]
-    }, {
-        "type": "textfield",
-        "desc": "Directory to keep files in until torrent is complete. Leave empty to disable",
-        "subitems": [{
-            "key": "wizard_incomplete_dir",
-            "desc": "Incomplete directory",
-            "validator": {
-                "allowBlank": true,
-                "regex": {
-                    "expr": "/^\\\/volume\\w*[0-9]{1,2}\\\/[^<>: */?\"]*/",
-                    "errorText": "Path should begin with /volumename?/ where volumename can be 'volume' or also 'volumeUSB' and ? is the volume number (1-99)."
-                }
+        ]
+    },
+    {
+        "step_title": "DSM Permissions",
+        "items": [
+            {
+                "desc": "Permissions for all download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
             }
-        }]
-    }]
-}, {
-    "step_title": "Basic configuration",
-    "items": [{
-        "type": "textfield",
-        "desc": "Web interface username. Defaults to admin",
-        "subitems": [{
-            "key": "wizard_username",
-            "desc": "Username"
-        }]
-    }, {
-        "type": "password",
-        "desc": "Web interface password. Defaults to admin",
-        "subitems": [{
-            "key": "wizard_password",
-            "desc": "Password"
-        }]
-    }]
-}, {
-    "step_title": "DSM Permissions",
-    "items": [{
-        "desc": "Permissions for all download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
-    }]
-}]
+        ]
+    }
+]

--- a/spk/transmission/src/wizard/install_uifile
+++ b/spk/transmission/src/wizard/install_uifile
@@ -118,7 +118,7 @@
         "step_title": "DSM Permissions",
         "items": [
             {
-                "desc": "Permissions for all download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+                "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
             }
         ]
     }

--- a/spk/transmission/src/wizard/install_uifile_fre
+++ b/spk/transmission/src/wizard/install_uifile_fre
@@ -64,6 +64,6 @@
 }, {
      "step_title": "Permissions DSM",
      "items": [{
-         "desc": "Les permissions de toutes les applications de SynoCommunity liés au téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+         "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
      }]
 }]

--- a/spk/transmission/src/wizard/upgrade_uifile
+++ b/spk/transmission/src/wizard/upgrade_uifile
@@ -5,5 +5,56 @@
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Transmission, manually set Read/Write permissions on the reported folders using File Station."
+    },
+    {
+        "type": "combobox",
+        "desc": "Please select a volume to use for the download folder",
+        "subitems": [
+            {
+                "key": "wizard_volume",
+                "desc": "volume name",
+                "displayField": "display_name",
+                "valueField": "volume_path",
+                "editable": false,
+                "mode": "remote",
+                "api_store": {
+                    "api": "SYNO.Core.Storage.Volume",
+                    "method": "list",
+                    "version": 1,
+                    "baseParams": {
+                        "limit": -1,
+                        "offset": 0,
+                        "location": "internal"
+                    },
+                    "root": "volumes",
+                    "idProperty": "volume_path",
+                    "fields": [
+                        "display_name",
+                        "volume_path"
+                    ]
+                },
+                "validator": {
+                    "fn": "{console.log(arguments);return true;}"
+                }
+            }
+        ]
+    },
+    {
+        "type": "textfield",
+        "desc": "Download shared folder (using the volume chosen above)",
+        "subitems": [
+            {
+                "key": "wizard_download_dir",
+                "desc": "Download shared folder",
+                "defaultValue": "downloads",
+                "validator": {
+                    "allowBlank": false,
+                    "regex": {
+                        "expr": "/^[\\w _-]+$/",
+                        "errorText": "Subdirectories are not supported."
+                    }
+                }
+            }
+        ]
     }]
 }]

--- a/spk/transmission/src/wizard/upgrade_uifile
+++ b/spk/transmission/src/wizard/upgrade_uifile
@@ -1,9 +1,9 @@
 [{
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
     },
     {
-        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Transmission, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."
+        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Transmission, manually set Read/Write permissions on the reported folders using File Station."
     }]
 }]

--- a/spk/transmission/src/wizard/upgrade_uifile_fre
+++ b/spk/transmission/src/wizard/upgrade_uifile_fre
@@ -4,6 +4,6 @@
         "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
     },
     {
-        "desc": "En cas d'erreur de permission dans Transmission, donner les droits de Lecture/Ecriture sur les repertoires mentionnès depuis File Station."
+        "desc": "En cas d'erreur de permission dans Transmission, donner les droits de Lecture/Ecriture sur les repertoires mentionnés depuis File Station."
     }]
 }]

--- a/spk/transmission/src/wizard/upgrade_uifile_fre
+++ b/spk/transmission/src/wizard/upgrade_uifile_fre
@@ -1,9 +1,9 @@
 [{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de SynoCommunity liés au téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
     },
     {
-        "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans Transmission, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."
+        "desc": "En cas d'erreur de permission dans Transmission, donner les droits de Lecture/Ecriture sur les repertoires mentionnès depuis File Station."
     }]
 }]


### PR DESCRIPTION
_Motivation:_  Another Framework cleanup and a package update for TCL
_Linked issues:_  #4524, #4539

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

### Remarks
1. Revert `SPK_LINKS` Makefile variable and use `SPK_USR_LOCAL_LINKS` for DSM6 and DSM5.
2. Update TCL and make use of SPK_LINKS obsolete, and add 64-bit support for amd64 archs
3. Adjust remaining packages to use `SPK_USR_LOCAL_LINKS`  instead of `SPK_LINKS`
4. Redesign DSM6 installer to use resource definitions for Links, FwPorts, SHARES similar to DSM7
5. Only keep creation of `/usr/local/{package}` link to avoid breaking already installed packages that lean on this

### References
- usr-local-linker for DSM6: https://github.com/SynoCommunity/spksrc/pull/4539#discussion_r611113503


