### PR TITLE
spk.mk: Limit os_max_ver to point release updates for kernel spk

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -128,6 +128,10 @@ endif
 endif
 ifneq ($(strip $(OS_MAX_VER)),)
 	@echo os_max_ver=\"$(OS_MAX_VER)\" >> $@
+# If require kernel modules then limit
+# 'os_max_ver' to point releases only
+else ifeq ($(strip $(REQUIRE_KERNEL)),1)
+	@echo os_max_ver=\"$(word 1,$(subst ., ,$(TC_VERS))).$(word 2,$(subst ., ,$(TC_VERS)))-$$(expr $(TC_BUILD) + 10)\" >> $@
 endif
 ifneq ($(strip $(BETA)),)
 	@echo beta=\"yes\" >> $@


### PR DESCRIPTION
_Motivation:_  When providing kernel module packages we must not alow it to run on newer DSM versions.  Only acceptable point releases which equal to `<10` increase on build number such as:
* **COMPATIBLE**: Package built for DSM-6.2.3 = `6.2-25423` and point releases DSM-6.2.3 Update 3 = `6.2-25426`
* **INCOMPATIBLE:** Package built for DSM-6.2.3 = `6.2-25423` while DSM-6.2.4 = `6.2-25556`

_Linked issues:_  #4420, #4144

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
