### PR TITLE
generic solution for multifile digests (followup of #4566)

### DIFF
--- a/cross/libstdc++/Makefile
+++ b/cross/libstdc++/Makefile
@@ -19,7 +19,7 @@ INSTALL_TARGET = libstdc++6_install
 include ../../mk/spksrc.archs.mk
 
 # use digests with multiple files
-PKG_DIST_ARCHS = amd64 armhf arm64 armel i386
+PKG_DIST_ARCH_LIST = amd64 armhf arm64 armel i386
 
 PKG_DIST_ARCH = amd64
 LIB_DIR = x86_64-linux-gnu

--- a/cross/libstdc++/Makefile
+++ b/cross/libstdc++/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = libstdc++6
 PKG_VERS = 6.3.0-18+deb9u1
 PKG_EXT = deb
-PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS)_$(PKG_ARCH).$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME)_$(PKG_VERS)_$(PKG_DIST_ARCH).$(PKG_EXT)
 PKG_DIST_SITE = http://http.us.debian.org/debian/pool/main/g/gcc-6/
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 EXTRACT_PATH = $(WORK_DIR)/$(PKG_DIR)
@@ -14,60 +14,33 @@ HOMEPAGE = https://gcc.gnu.org/
 COMMENT  = The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, Go, and D, as well as libraries for these languages (libstdc++,...). GCC was originally written as the compiler for the GNU operating system. The GNU system was developed to be 100% free software, free in the sense that it respects the user\'s freedom.
 LICENSE  = GPLv3
 
-CONFIGURE_TARGET = nop
-COMPILE_TARGET = nop
 INSTALL_TARGET = libstdc++6_install
 
 include ../../mk/spksrc.archs.mk
 
-PKG_ARCH = amd64
+# use digests with multiple files
+PKG_DIST_ARCHS = amd64 armhf arm64 armel i386
+
+PKG_DIST_ARCH = amd64
 LIB_DIR = x86_64-linux-gnu
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS) $(ARMv5_ARCHS)),$(ARCH))
-PKG_ARCH = armhf
+PKG_DIST_ARCH = armhf
 LIB_DIR = arm-linux-gnueabihf
 else ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
-PKG_ARCH = arm64
+PKG_DIST_ARCH = arm64
 LIB_DIR = aarch64-linux-gnu
 else ifeq ($(findstring $(ARCH),$(ARMv7L_ARCHS)),$(ARCH))
-PKG_ARCH = armel
+PKG_DIST_ARCH = armel
 LIB_DIR = arm-linux-gnueabi
 else ifeq ($(findstring $(ARCH),$(i686_ARCHS)),$(ARCH))
-PKG_ARCH = i386
+PKG_DIST_ARCH = i386
 LIB_DIR = i386-linux-gnu
 endif
 
-include ../../mk/spksrc.cross-cc.mk
+include ../../mk/spksrc.install-resources.mk
 
 .PHONY: libstdc++6_install
 libstdc++6_install:
 	install -m 755 -d $(STAGING_INSTALL_PREFIX)/lib
 	install -m 644 $(WORK_DIR)/$(PKG_DIR)/usr/lib/$(LIB_DIR)/libstdc++.so.6.0.22 $(STAGING_INSTALL_PREFIX)/lib
 	ln -s libstdc++.so.6.0.22 $(STAGING_INSTALL_PREFIX)/lib/libstdc++.so.6
-
-
-# digests file contains check sums for all PKG_ARCH specific source files.
-# Use 'make update-digests' to update digests file once for new PKG_VERS
-# This will download the sources and create the cumulated digests file.
-# ARCH mappings: 
-# - amd64: GENERIC_x64_ARCH
-# - armhf: GENERIC_ARMv7_ARCH
-# - arm64: GENERIC_ARMv8_ARCH
-# - armel: hi3535
-# - i386:  evansport
-.PHONY: update-digests
-update-digests:
-	@echo "=== Create digests file ==="; \
-	export TCVERSION=6.1 ; \
-	tmp_digests=digests.tmp ; \
-	>$$tmp_digests ; \
-	for _arch in $(GENERIC_x64_ARCH) $(GENERIC_ARMv7_ARCH) $(GENERIC_ARMv8_ARCH) hi3535 evansport ; do \
-	  echo "add digests for $$_arch" ; \
-	  $(MAKE) -C . digests ARCH=$$_arch > /dev/null ; \
-	  cat digests >> $$tmp_digests ; \
-	done ; \
-	rm -f digests ; \
-	mv $$tmp_digests digests ; \
-	echo ""=== Please verify checksums with original sources. "===" ; \
-	cat digests ; \
-	exit 0
-

--- a/cross/lidarr/Makefile
+++ b/cross/lidarr/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = Lidarr
 PKG_VERS = 0.8.0.2042
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME).develop.$(PKG_VERS).linux-core-$(PKG_ARCH).$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME).develop.$(PKG_VERS).linux-core-$(PKG_DIST_ARCH).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/lidarr/$(PKG_NAME)/releases/download/v$(PKG_VERS)
 PKG_DIR = Lidarr
 
@@ -13,48 +13,23 @@ HOMEPAGE = https://lidarr.audio/
 COMMENT  = Lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
 LICENSE  = GPLv3
 
-CONFIGURE_TARGET = nop
-COMPILE_TARGET = nop
 INSTALL_TARGET = lidarr_install
 
+# use digests with multiple files
+PKG_DIST_ARCHS = x64 arm arm64
+
 include ../../mk/spksrc.archs.mk
-PKG_ARCH = x64
+PKG_DIST_ARCH = x64
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS)),$(ARCH))
-PKG_ARCH = arm
+PKG_DIST_ARCH = arm
 else ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
-PKG_ARCH = arm64
+PKG_DIST_ARCH = arm64
 endif
 
-include ../../mk/spksrc.cross-cc.mk
+include ../../mk/spksrc.install-resources.mk
 
 .PHONY: lidarr_install
 lidarr_install:
 	rm -rf $(WORK_DIR)/$(PKG_DIR)/Lidarr.Update
 	mkdir -p $(STAGING_INSTALL_PREFIX)/share/$(PKG_DIR)/bin
 	tar -cf - -C $(WORK_DIR)/$(PKG_DIR) . | tar -xf - -C $(STAGING_INSTALL_PREFIX)/share/$(PKG_DIR)/bin
-
-
-# digests file contains check sums for all PKG_ARCH specific source files.
-# Use 'make update-digests' to update digests file once for new PKG_VERS
-# This will download the sources and create the cumulated digests file.
-# ARCH mappings: 
-# - x64:   GENERIC_x64_ARCH
-# - arm:   GENERIC_ARMv7_ARCH
-# - arm64: GENERIC_ARMv8_ARCH
-.PHONY: update-digests
-update-digests:
-	@echo "=== Create digests file ==="; \
-	export TCVERSION=6.1 ; \
-	tmp_digests=digests.tmp ; \
-	>$$tmp_digests ; \
-	for _arch in $(GENERIC_x64_ARCH) $(GENERIC_ARMv7_ARCH) $(GENERIC_ARMv8_ARCH); do \
-	  echo "add digests for $$_arch" ; \
-	  $(MAKE) -C . digests ARCH=$$_arch > /dev/null ; \
-	  cat digests >> $$tmp_digests ; \
-	done ; \
-	rm -f digests ; \
-	mv $$tmp_digests digests ; \
-	echo ""=== Please verify checksums with original sources. "===" ; \
-	cat digests ; \
-	exit 0
-

--- a/cross/lidarr/Makefile
+++ b/cross/lidarr/Makefile
@@ -16,7 +16,7 @@ LICENSE  = GPLv3
 INSTALL_TARGET = lidarr_install
 
 # use digests with multiple files
-PKG_DIST_ARCHS = x64 arm arm64
+PKG_DIST_ARCH_LIST = x64 arm arm64
 
 include ../../mk/spksrc.archs.mk
 PKG_DIST_ARCH = x64

--- a/cross/radarr/Makefile
+++ b/cross/radarr/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = Radarr
 PKG_VERS = 3.0.2.4552
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME).master.$(PKG_VERS).linux-core-$(PKG_ARCH).$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME).master.$(PKG_VERS).linux-core-$(PKG_DIST_ARCH).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Radarr/Radarr/releases/download/v$(PKG_VERS)
 PKG_DIR = Radarr
 
@@ -13,48 +13,23 @@ HOMEPAGE = https://radarr.video/
 COMMENT  = Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
 LICENSE  = GPLv3
 
-CONFIGURE_TARGET = nop
-COMPILE_TARGET = nop
 INSTALL_TARGET = radarr_install
 
+# use digests with multiple files
+PKG_DIST_ARCHS = x64 arm arm64
+
 include ../../mk/spksrc.archs.mk
-PKG_ARCH = x64
+PKG_DIST_ARCH = x64
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS)),$(ARCH))
-PKG_ARCH = arm
+PKG_DIST_ARCH = arm
 else ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
-PKG_ARCH = arm64
+PKG_DIST_ARCH = arm64
 endif
 
-include ../../mk/spksrc.cross-cc.mk
+include ../../mk/spksrc.install-resources.mk
 
 .PHONY: radarr_install
 radarr_install:
 	rm -rf $(WORK_DIR)/$(PKG_DIR)/Radarr.Update
 	mkdir -p $(STAGING_INSTALL_PREFIX)/share/$(PKG_DIR)/bin
 	tar -cf - -C $(WORK_DIR)/$(PKG_DIR) . | tar -xf - -C $(STAGING_INSTALL_PREFIX)/share/$(PKG_DIR)/bin
-
-
-# digests file contains check sums for all PKG_ARCH specific source files.
-# Use 'make update-digests' to update digests file once for new PKG_VERS
-# This will download the sources and create the cumulated digests file.
-# ARCH mappings: 
-# - x64:   GENERIC_x64_ARCH
-# - arm:   GENERIC_ARMv7_ARCH
-# - arm64: GENERIC_ARMv8_ARCH
-.PHONY: update-digests
-update-digests:
-	@echo "=== Create digests file ==="; \
-	export TCVERSION=6.1 ; \
-	tmp_digests=digests.tmp ; \
-	>$$tmp_digests ; \
-	for _arch in $(GENERIC_x64_ARCH) $(GENERIC_ARMv7_ARCH) $(GENERIC_ARMv8_ARCH); do \
-	  echo "add digests for $$_arch" ; \
-	  $(MAKE) -C . digests ARCH=$$_arch > /dev/null ; \
-	  cat digests >> $$tmp_digests ; \
-	done ; \
-	rm -f digests ; \
-	mv $$tmp_digests digests ; \
-	echo ""=== Please verify checksums with original sources. "===" ; \
-	cat digests ; \
-	exit 0
-

--- a/cross/radarr/Makefile
+++ b/cross/radarr/Makefile
@@ -16,7 +16,7 @@ LICENSE  = GPLv3
 INSTALL_TARGET = radarr_install
 
 # use digests with multiple files
-PKG_DIST_ARCHS = x64 arm arm64
+PKG_DIST_ARCH_LIST = x64 arm arm64
 
 include ../../mk/spksrc.archs.mk
 PKG_DIST_ARCH = x64

--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -38,7 +38,11 @@ endif
 .PHONY: $(PRE_DOWNLOAD_TARGET) $(DOWNLOAD_TARGET) $(POST_DOWNLOAD_TARGET)
 
 download_msg:
+ifeq ($(strip $(PKG_DIST_ARCH)),)
 	@$(MSG) "Downloading files for $(NAME)"
+else
+	@$(MSG) "Downloading files for $(NAME), PKG_DIST_ARCH = $(PKG_DIST_ARCH)"
+endif
 
 manual_dl_target:
 	@manual_dl=$(PKG_DIST_FILE) ; \

--- a/mk/spksrc.generate-digests.mk
+++ b/mk/spksrc.generate-digests.mk
@@ -3,7 +3,7 @@
 # include this file after the rule "all:"
 #
 
-ifeq ($(strip $(PKG_DIST_ARCHS)),)
+ifeq ($(strip $(PKG_DIST_ARCH_LIST)),)
 
 $(DIGESTS_FILE): download
 	@$(MSG) "Generate digests for $(NAME) - PKG_DIST_ARCH=$(PKG_DIST_ARCH)"
@@ -19,7 +19,7 @@ $(DIGESTS_FILE): download
 
 else
 
-# download different files for multiple PKG_DIST_ARCHS and add digests for all of them
+# download different files for multiple PKG_DIST_ARCH and add digests for all of them
 
 digests-%:
 	$(MSG) "Add digests for PKG_DIST_ARCH = $*"
@@ -33,12 +33,12 @@ digests-%:
 	done
 
 $(DIGESTS_FILE): download
-	@for pkg_arch in $(PKG_DIST_ARCHS); do \
+	@for pkg_arch in $(PKG_DIST_ARCH_LIST); do \
 	  rm $(DOWNLOAD_COOKIE) ; \
 	  $(MAKE) -s PKG_DIST_ARCH=$${pkg_arch} download ; \
 	done ; \
 	rm -f $(DIGESTS_FILE) && touch -f $(DIGESTS_FILE) ; \
-	for pkg_arch in $(PKG_DIST_ARCHS); do \
+	for pkg_arch in $(PKG_DIST_ARCH_LIST); do \
 	  $(MAKE) -s PKG_DIST_ARCH=$${pkg_arch} digests-$${pkg_arch} ; \
 	done ; \
 

--- a/mk/spksrc.generate-digests.mk
+++ b/mk/spksrc.generate-digests.mk
@@ -3,8 +3,10 @@
 # include this file after the rule "all:"
 #
 
+ifeq ($(strip $(PKG_DIST_ARCHS)),)
+
 $(DIGESTS_FILE): download
-	@$(MSG) "Generating digests for $(NAME)"
+	@$(MSG) "Generate digests for $(NAME) - PKG_DIST_ARCH=$(PKG_DIST_ARCH)"
 	@rm -f $@ && touch -f $@
 	@for type in SHA1 SHA256 MD5; do \
 	  case $$type in \
@@ -14,3 +16,30 @@ $(DIGESTS_FILE): download
 	  esac ; \
 	  echo "$(LOCAL_FILE) $$type `$$tool $(DIST_FILE) | cut -d\" \" -f1`" >> $@ ; \
 	done
+
+else
+
+# download different files for multiple PKG_DIST_ARCHS and add digests for all of them
+
+digests-%:
+	$(MSG) "Add digests for PKG_DIST_ARCH = $*"
+	@for type in SHA1 SHA256 MD5; do \
+	  case $$type in \
+	    SHA1)     tool=sha1sum ;; \
+	    SHA256)   tool=sha256sum ;; \
+	    MD5)      tool=md5sum ;; \
+	  esac ; \
+	  echo "$(LOCAL_FILE) $$type `$$tool $(DIST_FILE) | cut -d\" \" -f1`" >> $(DIGESTS_FILE) ; \
+	done
+
+$(DIGESTS_FILE): download
+	@for pkg_arch in $(PKG_DIST_ARCHS); do \
+	  rm $(DOWNLOAD_COOKIE) ; \
+	  $(MAKE) -s PKG_DIST_ARCH=$${pkg_arch} download ; \
+	done ; \
+	rm -f $(DIGESTS_FILE) && touch -f $(DIGESTS_FILE) ; \
+	for pkg_arch in $(PKG_DIST_ARCHS); do \
+	  $(MAKE) -s PKG_DIST_ARCH=$${pkg_arch} digests-$${pkg_arch} ; \
+	done ; \
+
+endif

--- a/mk/spksrc.install-resources.mk
+++ b/mk/spksrc.install-resources.mk
@@ -21,6 +21,12 @@ endif
 DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
+ifneq ($(ARCH),)
+ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+TC = syno$(ARCH_SUFFIX)
+endif
+
+
 #####
 
 ifneq ($(REQUIRE_KERNEL),)

--- a/mk/spksrc.install-resources.mk
+++ b/mk/spksrc.install-resources.mk
@@ -75,22 +75,8 @@ clean:
 
 all: install
 
-sha1sum := $(shell which sha1sum 2>/dev/null || which gsha1sum 2>/dev/null)
-sha256sum := $(shell which sha256sum 2>/dev/null || which gsha256sum 2>/dev/null)
-md5sum := $(shell which md5sum 2>/dev/null || which gmd5sum 2>/dev/null || which md5 2>/dev/null)
-
-.PHONY: $(DIGESTS_FILE)
-$(DIGESTS_FILE): download
-	@$(MSG) "Generating digests for $(PKG_NAME)"
-	@rm -f $@ && touch -f $@
-	@for type in SHA1 SHA256 MD5; do \
-	  case $$type in \
-	    SHA1)     tool=${sha1sum} ;; \
-	    SHA256)	  tool=${sha256sum} ;; \
-	    MD5)      tool=${md5sum} ;; \
-	  esac ; \
-	  echo "$(LOCAL_FILE) $$type `$$tool $(DIST_FILE) | cut -d\" \" -f1`" >> $@ ; \
-	done
+### For make digests
+include ../../mk/spksrc.generate-digests.mk
 
 ### For make dependency-tree
 include ../../mk/spksrc.dependency-tree.mk


### PR DESCRIPTION
_Motivation:_  The previous solution was not handy and has duplicated code.
_Linked issues:_  #4566

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

###Remarks

Now a single `make digests` call works for packages with and without multiple source files to create the `digests` file.

