### PR TITLE
GH Action: fix build dependencies for python2

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -44,9 +44,12 @@ do
     SPK_TO_BUILD+=${packages}
 done
 
-# fix for packages with different name
+# fix for packages with different names
 if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
     SPK_TO_BUILD+=sonarr
+fi
+if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
+    SPK_TO_BUILD+=python2
 fi
 
 # remove duplicate packages


### PR DESCRIPTION
_Motivation:_  spk/python folder was renamed to spk/python2 but package name is still python, so this little extra handling is required
_Linked issues:_  followup of #4406

The dependency resolver in the github build action needs extra handling for all packages with a folder name that does not match the package name (sonarr->nzbget, python2->python).