### PR TITLE
add autoconf-archive to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN dpkg --add-architecture i386
 
 # Install required packages (in sync with README.rst instructions)
 RUN apt-get update && apt-get install --no-install-recommends -y \
+		autoconf-archive \
 		autogen \
 		automake \
 		bc \


### PR DESCRIPTION
autoconf-archive is required to build python >= 3.8.9
