### PR TITLE
Add clientbuffer module to znc

### DIFF
--- a/cross/znc/Makefile
+++ b/cross/znc/Makefile
@@ -8,6 +8,9 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 BUILD_DEPENDS = cross/python3
 DEPENDS = cross/openssl cross/libicu
 
+# due to libicu:
+UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
+
 HOMEPAGE = https://wiki.znc.in/
 COMMENT  = Advanced IRC bouncer
 LICENSE  = Apache 2.0
@@ -20,6 +23,19 @@ POST_INSTALL_TARGET = znc_post_install
 endif
 
 include ../../mk/spksrc.cross-cc.mk
+
+EXTRA_MODULES  = colloquy.cpp
+EXTRA_MODULES += identd.cpp
+EXTRA_MODULES += palaver.cpp
+EXTRA_MODULES += playback.cpp
+EXTRA_MODULES += privmsg.cpp
+ifneq ($(findstring $(ARCH), $(ARMv7L_ARCHS)),$(ARCH))
+EXTRA_MODULES += push.cpp
+else
+PLIST_TRANSFORM = sed -e '/:lib\/znc\/push.so/d'
+endif
+EXTRA_MODULES += clientbuffer.cpp
+
 
 # The following extra modules are stored in cross/znc/modules and are built via the znc-buildmod command.
 # Adapt as needed (-O is used to overwrite existing files, and to rename to *.cpp where needed).
@@ -40,5 +56,5 @@ znc_post_install:
 	@chmod +x $(WORK_DIR)/$(PKG_DIR)/znc-buildmod
 	@rm -fr $(WORK_DIR)/modules
 	@cp -R modules $(WORK_DIR)/
-	@cd $(WORK_DIR)/modules && PATH=$(WORK_DIR)/$(PKG_DIR) INCLUDES=-I$(STAGING_INSTALL_PREFIX)/include/znc prefix=$(STAGING_INSTALL_PREFIX) znc-buildmod $(WORK_DIR)/modules/*.cpp
+	@cd $(WORK_DIR)/modules && PATH=$(WORK_DIR)/$(PKG_DIR) INCLUDES=-I$(STAGING_INSTALL_PREFIX)/include/znc prefix=$(STAGING_INSTALL_PREFIX) znc-buildmod $(EXTRA_MODULES)
 	@install -m 644 $(WORK_DIR)/modules/*.so $(STAGING_INSTALL_PREFIX)/lib/znc/

--- a/cross/znc/Makefile
+++ b/cross/znc/Makefile
@@ -12,9 +12,8 @@ HOMEPAGE = https://wiki.znc.in/
 COMMENT  = Advanced IRC bouncer
 LICENSE  = Apache 2.0
 
-CONFIGURE_ARGS = --enable-python
-
 GNU_CONFIGURE = 1
+CONFIGURE_ARGS = --enable-python
 
 ifneq ($(wildcard modules/*),)
 POST_INSTALL_TARGET = znc_post_install
@@ -22,15 +21,21 @@ endif
 
 include ../../mk/spksrc.cross-cc.mk
 
+# The following extra modules are stored in cross/znc/modules and are built via the znc-buildmod command.
+# Adapt as needed (-O is used to overwrite existing files, and to rename to *.cpp where needed).
+# call "make znc_update_modules" in cross/znc folder to get the latest versions.
+.PHONY: znc_update_modules
+znc_update_modules:
+	wget -O modules/colloquy.cpp      https://raw.githubusercontent.com/colloquy/colloquypush/master/znc/colloquy.cpp
+	wget -O modules/identd.cpp        https://raw.githubusercontent.com/cynix/znc-identd/master/identd.cc
+	wget -O modules/palaver.cpp       https://raw.githubusercontent.com/cocodelabs/znc-palaver/master/palaver.cpp
+	wget -O modules/playback.cpp      https://raw.githubusercontent.com/jpnurmi/znc-playback/master/playback.cpp
+	wget -O modules/privmsg.cpp       https://raw.githubusercontent.com/kylef/znc-contrib/master/privmsg.cpp
+	wget -O modules/push.cpp          https://raw.githubusercontent.com/jreese/znc-push/master/push.cpp
+	wget -O modules/clientbuffer.cpp  https://raw.githubusercontent.com/CyberShadow/znc-clientbuffer/master/clientbuffer.cpp
+
 .PHONY: znc_post_install
 znc_post_install:
-	# The following extra modules are stored in cross/znc/modules and are built via the znc-buildmod command. Adapt as needed.
-	# wget https://raw.githubusercontent.com/colloquy/colloquypush/master/znc/colloquy.cpp
-	# wget -O identd.cpp https://raw.githubusercontent.com/cynix/znc-identd/master/identd.cc
-	# wget https://raw.githubusercontent.com/cocodelabs/znc-palaver/master/palaver.cpp
-	# wget https://raw.githubusercontent.com/jpnurmi/znc-playback/master/playback.cpp
-	# wget https://raw.githubusercontent.com/kylef/znc-contrib/master/privmsg.cpp
-	# wget https://raw.githubusercontent.com/jreese/znc-push/master/push.cpp
 	@$(MSG) "Building extra modules"
 	@chmod +x $(WORK_DIR)/$(PKG_DIR)/znc-buildmod
 	@rm -fr $(WORK_DIR)/modules

--- a/cross/znc/Makefile
+++ b/cross/znc/Makefile
@@ -5,7 +5,7 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://znc.in/releases/archive
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-BUILD_DEPENDS = cross/python3
+BUILD_DEPENDS = cross/python38
 DEPENDS = cross/openssl cross/libicu
 
 # due to libicu:

--- a/cross/znc/PLIST
+++ b/cross/znc/PLIST
@@ -17,6 +17,7 @@ lib:lib/znc/cert.so
 lib:lib/znc/certauth.so
 lib:lib/znc/chansaver.so
 lib:lib/znc/clearbufferonmsg.so
+lib:lib/znc/clientbuffer.so
 lib:lib/znc/clientnotify.so
 lib:lib/znc/colloquy.so
 lib:lib/znc/controlpanel.so

--- a/cross/znc/PLIST
+++ b/cross/znc/PLIST
@@ -38,8 +38,8 @@ lib:lib/znc/log.so
 lib:lib/znc/missingmotd.so
 lib:lib/znc/modpython.so
 lib:lib/znc/modpython/_znc_core.so
-lib:lib/znc/modpython/znc.py
-lib:lib/znc/modpython/znc_core.py
+rsc:lib/znc/modpython/znc.py
+rsc:lib/znc/modpython/znc_core.py
 lib:lib/znc/modules_online.so
 lib:lib/znc/nickserv.so
 lib:lib/znc/notes.so
@@ -49,7 +49,7 @@ lib:lib/znc/perform.so
 lib:lib/znc/playback.so
 lib:lib/znc/privmsg.so
 lib:lib/znc/push.so
-lib:lib/znc/pyeval.py
+rsc:lib/znc/pyeval.py
 lib:lib/znc/raw.so
 lib:lib/znc/route_replies.so
 lib:lib/znc/sample.so

--- a/cross/znc/modules/clientbuffer.cpp
+++ b/cross/znc/modules/clientbuffer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2015 J-P Nurmi
- * Copyright (C) 2017-2018 Vladimir Panteleev and contributors
+ * Copyright (C) 2017-2018, 2021 Vladimir Panteleev and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Information about this module can be found here: https://wiki.znc.in/Clientbuffer
- * Source code of this module can be found here: https://github.com/CyberShadow/znc-clientbuffer
  */
 
 #include <znc/Modules.h>
@@ -226,6 +223,10 @@ void CClientBufferMod::OnClientLogin()
     const CString& current = GetClient()->GetIdentifier();
 
     if (!HasClient(current) && m_bAutoAdd) {
+        if (current.length() == 0) {
+            PutModule("Not auto-adding a client with an empty identifier.");
+            return;
+        }
         AddClient(current);
     }
 }

--- a/cross/znc/modules/clientbuffer.cpp
+++ b/cross/znc/modules/clientbuffer.cpp
@@ -1,0 +1,626 @@
+/*
+ * Copyright (C) 2014-2015 J-P Nurmi
+ * Copyright (C) 2017-2018 Vladimir Panteleev and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <znc/Modules.h>
+#include <znc/IRCNetwork.h>
+#include <znc/Client.h>
+#include <znc/Utils.h>
+#include <znc/User.h>
+#include <znc/Chan.h>
+#include <znc/znc.h>
+#include <znc/version.h>
+#include <sys/time.h>
+
+#if (VERSION_MAJOR < 1) || (VERSION_MAJOR == 1 && VERSION_MINOR < 6)
+#error The clientbuffer module requires ZNC version 1.6.0 or later.
+#endif
+
+#if (VERSION_MAJOR > 1) || (VERSION_MAJOR == 1 && VERSION_MINOR >= 7)
+#define ZNC17 1
+#else
+#define ZNC17 0
+#endif
+
+class CClientBufferCacheJob : public CTimer
+{
+public:
+    CClientBufferCacheJob(CModule* pModule, unsigned int uInterval, unsigned int uCycles, const CString& sLabel, const CString& sDescription)
+        : CTimer(pModule, uInterval, uCycles, sLabel, sDescription) {}
+    virtual ~CClientBufferCacheJob() {}
+
+protected:
+    virtual void RunJob();
+};
+
+class CClientBufferMod : public CModule
+{
+public:
+    MODCONSTRUCTOR(CClientBufferMod)
+    {
+        AddHelpCommand();
+        AddCommand("AddClient", static_cast<CModCommand::ModCmdFunc>(&CClientBufferMod::OnAddClientCommand), "<identifier>", "Add a client.");
+        AddCommand("DelClient", static_cast<CModCommand::ModCmdFunc>(&CClientBufferMod::OnDelClientCommand), "<identifier>", "Delete a client.");
+        AddCommand("ListClients", static_cast<CModCommand::ModCmdFunc>(&CClientBufferMod::OnListClientsCommand), "", "List known clients.");
+        AddCommand("SetClientTimeLimit", static_cast<CModCommand::ModCmdFunc>(&CClientBufferMod::OnSetClientTimeLimit), "<identifier> [timelimit]", "Change a client's time limit.");
+        AddTimer(new CClientBufferCacheJob(this, 1 /* sec */, 0, "ClientBufferCache", "Periodically save ClientBuffer registry to disk"));
+    }
+
+    bool OnLoad(const CString& sArgs, CString& sErrorMsg) override {
+        VCString Args;
+        sArgs.Split(" ", Args);
+        for (size_t n=0; n<Args.size(); n++)
+        {
+            if (Args[n].Equals("autoadd", CString::CaseInsensitive))
+                m_bAutoAdd = true;
+            else if (Args[n].StartsWith("timelimit=", CString::CaseInsensitive))
+                m_iTimeLimit = Args[n].Token(1, false, "=").ToInt();
+            else
+	            fprintf(stderr, "ClientBuffer: Unrecognized option: %s\n", Args[n].c_str());
+        }
+        return true;
+    }
+
+    void OnAddClientCommand(const CString& line);
+    void OnDelClientCommand(const CString& line);
+    void OnSetClientTimeLimit(const CString& line);
+    void OnListClientsCommand(const CString& line);
+
+    virtual void OnClientLogin() override;
+
+#if ZNC17
+    virtual EModRet OnUserRawMessage(CMessage& Message) override;
+    virtual EModRet OnUserTextMessage(CTextMessage& Message) override;
+    virtual EModRet OnSendToClientMessage(CMessage& Message) override;
+#else
+    virtual EModRet OnUserRaw(CString& line) override;
+    virtual EModRet OnSendToClient(CString& line, CClient& client) override;
+#endif
+
+    virtual EModRet OnChanBufferStarting(CChan& chan, CClient& client) override;
+    virtual EModRet OnChanBufferEnding(CChan& chan, CClient& client) override;
+
+#if ZNC17
+    virtual EModRet OnChanBufferPlayMessage(CMessage& message) override;
+    virtual EModRet OnPrivBufferPlayMessage(CMessage& message) override;
+#else
+    virtual EModRet OnChanBufferPlayLine2(CChan& chan, CClient& client, CString& line, const timeval& tv) override;
+    virtual EModRet OnPrivBufferPlayLine2(CClient& client, CString& line, const timeval& tv) override;
+#endif
+
+private:
+    bool m_bAutoAdd = false;
+    bool m_bDirty = false;
+    int m_iTimeLimit = 0;
+
+    bool AddClient(const CString& identifier);
+    bool DelClient(const CString& identifier);
+    bool SetClientTimeLimit(const CString& identifier, const int timeLimit);
+    bool HasClient(const CString& identifier);
+
+#if ZNC17
+    CString GetTarget(const CMessage& msg);
+#else
+    bool ParseMessage(const CString& line, CNick& nick, CString& cmd, CString& target) const;
+#endif
+
+    timeval GetTimestamp(const CString& identifier, const CString& target);
+    timeval GetTimestamp(const CBuffer& buffer) const;
+    bool SetTimestamp(const CString& identifier, const CString& target, const timeval& tv);
+    bool HasSeenTimestamp(const CString& identifier, const CString& target, const timeval& tv);
+    bool UpdateTimestamp(const CString& identifier, const CString& target, const timeval& tv);
+
+#if !ZNC17
+    void UpdateTimestamp(const CClient* client, const CString& target);
+#endif
+
+	bool WithinTimeLimit(const timeval& tv, const CString& identifier);
+
+    void FlushRegistry();
+    friend class CClientBufferCacheJob;
+};
+
+/// Callback for the AddClient module command.
+void CClientBufferMod::OnAddClientCommand(const CString& line)
+{
+    const CString identifier = line.Token(1);
+
+    if (identifier.empty()) {
+        PutModule("Usage: AddClient <identifier>");
+        return;
+    }
+    if (HasClient(identifier)) {
+        PutModule("Client already exists: " + identifier);
+        return;
+    }
+
+    AddClient(identifier);
+    PutModule("Client added: " + identifier);
+}
+
+/// Callback for the DelClient module command.
+void CClientBufferMod::OnDelClientCommand(const CString& line)
+{
+    const CString identifier = line.Token(1);
+    if (identifier.empty()) {
+        PutModule("Usage: DelClient <identifier>");
+        return;
+    }
+    if (!HasClient(identifier)) {
+        PutModule("Unknown client: " + identifier);
+        return;
+    }
+    DelClient(identifier);
+    PutModule("Client removed: " + identifier);
+}
+
+/// Callback for the SetClientTimeLimit module command.
+void CClientBufferMod::OnSetClientTimeLimit(const CString& line)
+{
+    const CString identifier = line.Token(1);
+    const int timeLimit = line.Token(2).ToInt();
+
+    if (identifier.empty()) {
+        PutModule("Usage: SetClientTimeLimit <identifier> [timelimit]");
+        return;
+    }
+    if (!HasClient(identifier)) {
+        PutModule("Client doesn't exist: " + identifier);
+        return;
+    }
+    SetClientTimeLimit(identifier, timeLimit);
+    if (timeLimit)
+        PutModule("Client's " + identifier +  " changed time limit: " + CString(timeLimit) );
+    else
+        PutModule("Client's " + identifier +  " cleared time limit.");
+}
+
+/// Callback for the ListClients module command.
+void CClientBufferMod::OnListClientsCommand(const CString& line)
+{
+    const CString& current = GetClient()->GetIdentifier();
+
+    CTable table;
+    table.AddColumn("Client");
+    table.AddColumn("TimeLimit");
+    table.AddColumn("Connected");
+
+    for (MCString::iterator it = BeginNV(); it != EndNV(); ++it) {
+        if (it->first.Find("/") == CString::npos) {
+            table.AddRow();
+            if (it->first == current)
+                table.SetCell("Client",  "*" + it->first);
+            else
+                table.SetCell("Client",  it->first);
+            table.SetCell("TimeLimit", GetNV(it->first + "/timelimit"));
+            table.SetCell("Connected", CString(!GetNetwork()->FindClients(it->first).empty()));
+        }
+    }
+
+    if (table.empty())
+        PutModule("No identified clients");
+    else
+        PutModule(table);
+}
+
+/// ZNC callback (called when a client successfully logged in to ZNC).
+/// Implements the "autoadd" option.
+void CClientBufferMod::OnClientLogin()
+{
+    const CString& current = GetClient()->GetIdentifier();
+
+    if (!HasClient(current) && m_bAutoAdd) {
+        AddClient(current);
+    }
+}
+
+/// Filter which message kinds cause us to consider the buffer updated.
+#if ZNC17
+static bool WantMessageType(CMessage::Type MessageType)
+{
+    return MessageType == CMessage::Type::Text
+        || MessageType == CMessage::Type::Notice
+        || MessageType == CMessage::Type::Action
+        || MessageType == CMessage::Type::CTCP;
+}
+#else
+static bool WantMessageCmd(CString cmd)
+{
+    return cmd == "PRIVMSG" || cmd == "NOTICE";
+}
+#endif
+
+/// ZNC callback (called when a client sends any message to ZNC).
+/// Updates the client "last seen" timestamp.
+#if ZNC17
+CModule::EModRet CClientBufferMod::OnUserRawMessage(CMessage& Message)
+{
+    CClient* client = Message.GetClient();
+    if (!client)
+        return CONTINUE;
+
+    if (WantMessageType(Message.GetType()))
+        UpdateTimestamp(client->GetIdentifier(), GetTarget(Message), Message.GetTime());
+
+    return CONTINUE;
+}
+#else
+CModule::EModRet CClientBufferMod::OnUserRaw(CString& line)
+{
+    CClient* client = GetClient();
+    if (client) {
+        CNick nick; CString cmd, target;
+        if (ParseMessage(line, nick, cmd, target) && WantMessageCmd(cmd))
+            UpdateTimestamp(client, target);
+    }
+    return CONTINUE;
+}
+#endif
+
+/// ZNC callback for messages sent from clients.
+/// Used in addition to OnUserRawMessage as this one will contain the parsed target.
+#if ZNC17
+CModule::EModRet CClientBufferMod::OnUserTextMessage(CTextMessage& Message)
+{
+    CClient* client = Message.GetClient();
+    if (client)
+        UpdateTimestamp(client->GetIdentifier(), GetTarget(Message), Message.GetTime());
+
+    return CONTINUE;
+}
+#endif
+
+/// ZNC callback (called when ZNC sends a raw traffic line to a client).
+/// Updates the client "last seen" timestamp.
+#if ZNC17
+CModule::EModRet CClientBufferMod::OnSendToClientMessage(CMessage& Message)
+{
+    // make sure not to update the timestamp for a channel when joining it
+    if (!WantMessageType(Message.GetType()))
+        return CONTINUE;
+
+    // make sure not to update the timestamp for a channel when attaching it
+    CChan* chan = Message.GetChan();
+    if (!chan || !chan->IsDetached())
+        UpdateTimestamp(Message.GetClient()->GetIdentifier(), GetTarget(Message), Message.GetTime());
+    return CONTINUE;
+}
+#else
+CModule::EModRet CClientBufferMod::OnSendToClient(CString& line, CClient& client)
+{
+    CIRCNetwork* network = GetNetwork();
+    if (network) {
+        CNick nick; CString cmd, target;
+        // make sure not to update the timestamp for a channel when attaching it
+        if (ParseMessage(line, nick, cmd, target)) {
+            CChan* chan = network->FindChan(target);
+            if (!chan || !chan->IsDetached())
+                UpdateTimestamp(&client, target);
+        }
+    }
+    return CONTINUE;
+}
+#endif
+
+/// ZNC callback (called before a channel buffer is played back to a client).
+/// Filters out the "Buffer Playback..." message as necessary.
+CModule::EModRet CClientBufferMod::OnChanBufferStarting(CChan& chan, CClient& client)
+{
+    if (client.HasServerTime())
+        return HALTCORE;
+
+    const CString& identifier = client.GetIdentifier();
+    if (!HasClient(identifier))
+        return HALTCORE;
+
+    // let "Buffer Playback..." message through?
+    const CBuffer& buffer = chan.GetBuffer();
+    if (!WithinTimeLimit(GetTimestamp(buffer), identifier))
+	    return HALTCORE;
+
+    if (!buffer.IsEmpty() && HasSeenTimestamp(identifier, chan.GetName(), GetTimestamp(buffer)))
+        return HALTCORE;
+
+    return CONTINUE;
+}
+
+/// ZNC callback (called after a channel buffer was played back to a client).
+/// Filters out the "Buffer Complete" message as necessary.
+CModule::EModRet CClientBufferMod::OnChanBufferEnding(CChan& chan, CClient& client)
+{
+    if (client.HasServerTime())
+        return HALTCORE;
+
+    const CString& identifier = client.GetIdentifier();
+    if (!HasClient(identifier))
+        return HALTCORE;
+
+    // let "Buffer Complete" message through?
+    const CBuffer& buffer = chan.GetBuffer();
+    if (!WithinTimeLimit(GetTimestamp(buffer), identifier))
+	    return HALTCORE;
+
+    if (!buffer.IsEmpty() && !UpdateTimestamp(identifier, chan.GetName(), GetTimestamp(buffer)))
+        return HALTCORE;
+
+    return CONTINUE;
+}
+
+/// ZNC callback (called for each message during a channel's buffer play back).
+/// Filters out the messages as necessary.
+#if ZNC17
+CModule::EModRet CClientBufferMod::OnChanBufferPlayMessage(CMessage& Message)
+{
+    CClient* client = Message.GetClient();
+    if (!client)
+        return CONTINUE;
+
+    const CString& identifier = client->GetIdentifier();
+    if (!HasClient(identifier))
+        return HALTCORE;
+
+    if (!WithinTimeLimit(Message.GetTime(), identifier))
+	    return HALTCORE;
+
+    if (HasSeenTimestamp(identifier, GetTarget(Message), Message.GetTime()))
+        return HALTCORE;
+
+    return CONTINUE;
+}
+#else
+CModule::EModRet CClientBufferMod::OnChanBufferPlayLine2(CChan& chan, CClient& client, CString& line, const timeval& tv)
+{
+    const CString& identifier = client.GetIdentifier();
+    if (!HasClient(identifier))
+        return HALTCORE;
+
+    if (!WithinTimeLimit(tv, identifier))
+	    return HALTCORE;
+
+    if (HasSeenTimestamp(identifier, chan.GetName(), tv))
+        return HALTCORE;
+
+    return CONTINUE;
+}
+#endif
+
+/// ZNC callback (called for each message during a query's buffer play back).
+/// Filters out the messages as necessary.
+#if ZNC17
+CModule::EModRet CClientBufferMod::OnPrivBufferPlayMessage(CMessage& Message)
+{
+    CClient* client = Message.GetClient();
+    if (!client)
+        return CONTINUE;
+
+    const CString& identifier = client->GetIdentifier();
+    if (!HasClient(identifier))
+        return HALTCORE;
+
+    if (!WithinTimeLimit(Message.GetTime(), identifier))
+	    return HALTCORE;
+
+    if (HasSeenTimestamp(identifier, GetTarget(Message), Message.GetTime()))
+        return HALTCORE;
+
+    return CONTINUE;
+}
+#else
+CModule::EModRet CClientBufferMod::OnPrivBufferPlayLine2(CClient& client, CString& line, const timeval& tv)
+{
+    const CString& identifier = client.GetIdentifier();
+    if (!HasClient(identifier))
+        return HALTCORE;
+
+    if (!WithinTimeLimit(tv, identifier))
+	    return HALTCORE;
+
+    CNick nick; CString cmd, target;
+    if (ParseMessage(line, nick, cmd, target) && !UpdateTimestamp(identifier, target, tv))
+        return HALTCORE;
+
+    return CONTINUE;
+}
+#endif
+
+/// Add a client identifier.
+/// Returns true upon success.
+bool CClientBufferMod::AddClient(const CString& identifier)
+{
+    m_bDirty = true;
+    return SetNV(identifier, "", false);
+}
+
+/// Remove a client identifier.
+/// Returns true upon success.
+bool CClientBufferMod::DelClient(const CString& identifier)
+{
+    SCString keys;
+    for (MCString::iterator it = BeginNV(); it != EndNV(); ++it) {
+        const CString client = it->first.Token(0, false, "/");
+        if (client.Equals(identifier))
+            keys.insert(it->first);
+    }
+    bool success = true;
+    for (const CString& key : keys)
+        success &= DelNV(key, false);
+    m_bDirty = true;
+    return success;
+}
+
+/// Check whether a client identifier is known.
+bool CClientBufferMod::HasClient(const CString& identifier)
+{
+    return !identifier.empty() && FindNV(identifier) != EndNV();
+}
+
+/// Set a client's timelimit.
+/// Returns true upon success.
+bool CClientBufferMod::SetClientTimeLimit(const CString& identifier, const int timeLimit)
+{
+    m_bDirty = true;
+    if (timeLimit)
+        return SetNV(identifier + "/timelimit", CString(timeLimit), false);
+    else
+        return DelNV(identifier + "/timelimit", false);
+}
+
+#if ZNC17
+CString CClientBufferMod::GetTarget(const CMessage& msg)
+{
+    if (msg.GetChan())
+        return msg.GetChan()->GetName();
+    else {
+        CString Nick = msg.GetNick().GetNick();
+        CIRCNetwork* Network = msg.GetNetwork();
+        // Detect self-messages
+        if (Network && Nick == Network->GetNick() && msg.GetParams().size() >= 1)
+            return msg.GetParam(0);
+        return Nick;
+    }
+}
+#else
+/// Split an IRC message line into parts.
+/// Populates nick, cmd and target.
+/// Returns true upon success.
+bool CClientBufferMod::ParseMessage(const CString& line, CNick& nick, CString& cmd, CString& target) const
+{
+    // discard message tags
+    CString msg = line;
+    if (msg.StartsWith("@"))
+        msg = msg.Token(1, true);
+
+    CString rest;
+    if (msg.StartsWith(":")) {
+        nick = CNick(msg.Token(0).TrimPrefix_n());
+        cmd = msg.Token(1);
+        rest = msg.Token(2, true);
+    } else {
+        cmd = msg.Token(0);
+        rest = msg.Token(1, true);
+    }
+
+    if (cmd.length() == 3 && isdigit(cmd[0]) && isdigit(cmd[1]) && isdigit(cmd[2])) {
+        // must block the following numeric replies that are automatically sent on attach:
+        // RPL_NAMREPLY, RPL_ENDOFNAMES, RPL_TOPIC, RPL_TOPICWHOTIME...
+        unsigned int num = cmd.ToUInt();
+        if (num == 353) // RPL_NAMREPLY
+            target = rest.Token(2);
+        else
+            target = rest.Token(1);
+    } else if (cmd.Equals("PRIVMSG") || cmd.Equals("NOTICE") || cmd.Equals("JOIN") || cmd.Equals("PART") || cmd.Equals("MODE") || cmd.Equals("KICK") || cmd.Equals("TOPIC")) {
+        target = rest.Token(0).TrimPrefix_n(":");
+    }
+
+    return !target.empty() && !cmd.empty();
+}
+#endif
+
+/// Get the "last seen" timestamp for a given client identifier and target.
+timeval CClientBufferMod::GetTimestamp(const CString& identifier, const CString& target)
+{
+    CString timestamp = GetNV(identifier + "/" + target);
+
+    long long sec = 0;
+    long usec = 0;
+    std::sscanf(timestamp.c_str(), "%lld.%06ld", &sec, &usec);
+
+    timeval tv;
+    tv.tv_sec = (time_t)sec;
+    tv.tv_usec = (suseconds_t)usec;
+    return tv;
+}
+
+/// Get the timestamp of the last message in a given ZNC playback buffer.
+timeval CClientBufferMod::GetTimestamp(const CBuffer& buffer) const
+{
+    return buffer.GetBufLine(buffer.Size() - 1).GetTime();
+}
+
+/// Set the "last seen" timestamp for a given client identifier and target.
+bool CClientBufferMod::SetTimestamp(const CString& identifier, const CString& target, const timeval& tv)
+{
+    char timestamp[32];
+    std::snprintf(timestamp, 32, "%lld.%06ld", (long long)tv.tv_sec, (long)tv.tv_usec);
+    m_bDirty = true;
+    return SetNV(identifier + "/" + target, timestamp, false);
+}
+
+/// Returns true if the given timestamp is not greater than the "last
+/// seen" timestamp for the given client identifier and target.
+bool CClientBufferMod::HasSeenTimestamp(const CString& identifier, const CString& target, const timeval& tv)
+{
+    const timeval seen = GetTimestamp(identifier, target);
+    return !timercmp(&seen, &tv, <);
+}
+
+/// Checks whether the given client should receive a message with the
+/// given timestamp and target.
+/// If the timestamp is greater than the client's "last seen"
+/// timestamp, updates the client's "last seen" timestamp accordingly
+/// and returns true. Otherwise, returns false.
+bool CClientBufferMod::UpdateTimestamp(const CString& identifier, const CString& target, const timeval& tv)
+{
+    if (!HasSeenTimestamp(identifier, target, tv))
+        return SetTimestamp(identifier, target, tv);
+    return false;
+}
+
+#if !ZNC17
+/// Update the "last seen" timestamp of the given client and target to
+/// the current time.
+void CClientBufferMod::UpdateTimestamp(const CClient* client, const CString& target)
+{
+    if (client && !client->IsPlaybackActive()) {
+        const CString& identifier = client->GetIdentifier();
+        if (HasClient(identifier)) {
+            timeval tv;
+            gettimeofday(&tv, NULL);
+            UpdateTimestamp(identifier, target, tv);
+        }
+    }
+}
+#endif
+
+bool CClientBufferMod::WithinTimeLimit(const timeval& tv, const CString& identifier)
+{
+    int timeLimit = GetNV(identifier + "/timelimit").ToInt();
+	if (!timeLimit && !m_iTimeLimit)
+		return true;
+	timeval now;
+	gettimeofday(&now, NULL);
+	return now.tv_sec - tv.tv_sec < timeLimit ? timeLimit : m_iTimeLimit;
+}
+
+template<> void TModInfo<CClientBufferMod>(CModInfo& info) {
+	info.SetWikiPage("Clientbuffer");
+	info.SetHasArgs(true);
+}
+
+void CClientBufferCacheJob::RunJob() {
+    CClientBufferMod* mod = (CClientBufferMod*)GetModule();
+    mod->FlushRegistry();
+}
+
+void CClientBufferMod::FlushRegistry()
+{
+    if (m_bDirty) {
+        SaveRegistry();
+        m_bDirty = false;
+    }
+}
+
+NETWORKMODULEDEFS(CClientBufferMod, "Client specific buffer playback")

--- a/cross/znc/modules/clientbuffer.cpp
+++ b/cross/znc/modules/clientbuffer.cpp
@@ -13,6 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Information about this module can be found here: https://wiki.znc.in/Clientbuffer
+ * Source code of this module can be found here: https://github.com/CyberShadow/znc-clientbuffer
  */
 
 #include <znc/Modules.h>

--- a/cross/znc/modules/palaver.cpp
+++ b/cross/znc/modules/palaver.cpp
@@ -7,7 +7,7 @@
 
 #define REQUIRESSL
 
-#define PALAVER_VERSION "1.1.2"
+#define ZNC_PALAVER_VERSION "1.2.1"
 
 #include <znc/Modules.h>
 #include <znc/User.h>
@@ -28,8 +28,15 @@
 #endif
 
 
+#if defined VERSION_MAJOR && defined VERSION_MINOR && VERSION_MAJOR >= 1 && VERSION_MINOR >= 7
+#define HAS_CAP_NOTIFY
+#endif
+
+
+
 const char *kPLVCapability = "palaverapp.com";
 const char *kPLVCommand = "PALAVER";
+const char *kPLVPushTokenKey = "PUSH-TOKEN";
 const char *kPLVPushEndpointKey = "PUSH-ENDPOINT";
 const char *kPLVMentionKeywordKey = "MENTION-KEYWORD";
 const char *kPLVMentionChannelKey = "MENTION-CHANNEL";
@@ -96,7 +103,8 @@ public:
 		}
 
 		mcsHeaders["Connection"] = "close";
-		mcsHeaders["User-Agent"] = "ZNC";
+		// as per https://tools.ietf.org/html/rfc7231#section-5.5.3
+		mcsHeaders["User-Agent"] = "znc-palaver/" + CString(ZNC_PALAVER_VERSION) + " znc/" + CZNC::GetVersion();
 
 		if (sMethod.Equals("GET") == false || sContent.length() > 0) {
 			mcsHeaders["Content-Length"] = CString(sContent.length());
@@ -197,20 +205,20 @@ private:
 
 class PLVHTTPNotificationSocket : public PLVHTTPSocket {
 public:
-	PLVHTTPNotificationSocket(CModule *pModule, const CString &sToken, const CString &sMethod, const CString &sURL, MCString &mcsHeaders, const CString &sContent) : PLVHTTPSocket(pModule, sMethod, sURL, mcsHeaders, sContent) {
-		m_sToken = sToken;
+	PLVHTTPNotificationSocket(CModule *pModule, const CString &sIdentifier, const CString &sMethod, const CString &sURL, MCString &mcsHeaders, const CString &sContent) : PLVHTTPSocket(pModule, sMethod, sURL, mcsHeaders, sContent) {
+		m_sIdentifier = sIdentifier;
 	}
 
 	virtual void HandleStatusCode(unsigned int status);
 
 private:
-	CString m_sToken;
+	CString m_sIdentifier;
 };
 
 class CDevice {
 public:
-	CDevice(const CString &sToken) {
-		m_sToken = sToken;
+	CDevice(const CString &sIdentifier) {
+		m_sIdentifier = sIdentifier;
 		m_bInNegotiation = false;
 		m_uiBadge = 0;
 	}
@@ -231,8 +239,16 @@ public:
 		m_sVersion = sVersion;
 	}
 
-	CString GetToken() const {
-		return m_sToken;
+	CString GetIdentifier() const {
+		return m_sIdentifier;
+	}
+
+	void SetPushToken(const CString &sToken) {
+		m_sPushToken = sToken;
+	}
+
+	CString GetPushToken() const {
+		return m_sPushToken;
 	}
 
 	void SetPushEndpoint(const CString &sEndpoint) {
@@ -410,6 +426,7 @@ public:
 	void ResetDevice() {
 		m_bInNegotiation = false;
 		m_sVersion = "";
+		m_sPushToken = "";
 		m_sPushEndpoint = "";
 		m_bShowMessagePreview = true;
 
@@ -590,6 +607,8 @@ public:
 				SetVersion(sValue);
 			} else if (sKey.Equals(kPLVPushEndpointKey)) {
 				SetPushEndpoint(sValue);
+			} else if (sKey.Equals(kPLVPushTokenKey)) {
+				SetPushToken(sValue);
 			} else if (sKey.Equals(kPLVShowMessagePreviewKey)) {
 				SetShowMessagePreview(sValue.Equals("true"));
 			}
@@ -623,7 +642,7 @@ public:
 	}
 
 	void Write(CFile& File) const {
-		File.Write("BEGIN " + GetToken() + "\n");
+		File.Write("BEGIN " + GetIdentifier() + "\n");
 
 		if (GetVersion().empty() == false) {
 			File.Write("SET VERSION " + GetVersion() + "\n");
@@ -637,6 +656,10 @@ public:
 
 		if (GetPushEndpoint().empty() == false) {
 			File.Write("SET " + CString(kPLVPushEndpointKey) + " " + GetPushEndpoint() + "\n");
+		}
+
+		if (GetPushToken().empty() == false) {
+			File.Write("SET " + CString(kPLVPushTokenKey) + " " + GetPushToken() + "\n");
 		}
 
 		for (VCString::const_iterator it = m_vMentionKeywords.begin();
@@ -704,7 +727,12 @@ public:
 
 		MCString mcsHeaders;
 
-		mcsHeaders["Authorization"] = CString("Bearer " + GetToken());
+		CString token = GetPushToken();
+		if (token.empty()) {
+			token = GetIdentifier();
+		}
+
+		mcsHeaders["Authorization"] = CString("Bearer " + token);
 		mcsHeaders["Content-Type"] = "application/json";
 
 		CString sJSON = "{";
@@ -729,21 +757,27 @@ public:
 		}
 		sJSON += "}";
 
-		PLVHTTPSocket *pSocket = new PLVHTTPNotificationSocket(&module, GetToken(), "POST", GetPushEndpoint(), mcsHeaders, sJSON);
+		PLVHTTPSocket *pSocket = new PLVHTTPNotificationSocket(&module, token, "POST", GetPushEndpoint(), mcsHeaders, sJSON);
 		module.AddSocket(pSocket);
 	}
 
-	void ClearBadges(CModule& module) {
+	void ClearBadges(CModule& module, bool bInformAPI) {
 		if (m_uiBadge != 0) {
-			MCString mcsHeaders;
+			if (bInformAPI) {
+				MCString mcsHeaders;
 
-			mcsHeaders["Authorization"] = CString("Bearer " + GetToken());
-			mcsHeaders["Content-Type"] = "application/json";
+				CString token = GetPushToken();
+				if (token.empty()) {
+					token = GetIdentifier();
+				}
+				mcsHeaders["Authorization"] = CString("Bearer " + token);
+				mcsHeaders["Content-Type"] = "application/json";
 
-			CString sJSON = "{\"badge\": 0}";
+				CString sJSON = "{\"badge\": 0}";
 
-			PLVHTTPSocket *pSocket = new PLVHTTPNotificationSocket(&module, GetToken(), "POST", GetPushEndpoint(), mcsHeaders, sJSON);
-			module.AddSocket(pSocket);
+				PLVHTTPSocket *pSocket = new PLVHTTPNotificationSocket(&module, token, "POST", GetPushEndpoint(), mcsHeaders, sJSON);
+				module.AddSocket(pSocket);
+			}
 
 			m_uiBadge = 0;
 		}
@@ -754,9 +788,10 @@ public:
 	}
 
 private:
-	CString m_sToken;
+	CString m_sIdentifier;
 	CString m_sVersion;
 	CString m_sPushEndpoint;
+	CString m_sPushToken;
 
 	std::map<CString, MCString> m_msmsNetworks;
 
@@ -791,8 +826,36 @@ public:
 	virtual bool OnLoad(const CString& sArgs, CString& sMessage) {
 		Load();
 
+#ifdef HAS_CAP_NOTIFY
+		const std::map<CString, CUser*>& msUsers = CZNC::Get().GetUserMap();
+
+		for (std::map<CString, CUser*>::const_iterator it = msUsers.begin(); it != msUsers.end(); ++it) {
+			CUser* pUser = it->second;
+			for (CClient* pClient : pUser->GetAllClients()) {
+				if (pClient->HasCapNotify()) {
+					pClient->PutClient(":irc.znc.in CAP " + pClient->GetNick() + " NEW :" + kPLVCapability);
+				}
+			}
+		}
+#endif
+
 		return true;
 	}
+
+#ifdef HAS_CAP_NOTIFY
+	~CPalaverMod() {
+		const std::map<CString, CUser*>& msUsers = CZNC::Get().GetUserMap();
+
+		for (std::map<CString, CUser*>::const_iterator it = msUsers.begin(); it != msUsers.end(); ++it) {
+			CUser* pUser = it->second;
+			for (CClient* pClient : pUser->GetAllClients()) {
+				if (pClient->HasCapNotify()) {
+					pClient->PutClient(":irc.znc.in CAP " + pClient->GetNick() + " DEL :" + kPLVCapability);
+				}
+			}
+		}
+	}
+#endif
 
 #pragma mark - Cap
 
@@ -828,11 +891,11 @@ public:
 					pDevice->RemoveClient(*pClient);
 				}
 
-				CString sToken = sLine.Token(2);
+				CString sClientIdentifier = sLine.Token(2);
 				CString sVersion = sLine.Token(3);
 				CString sNetworkID = sLine.Token(4);
 
-				CDevice& device = DeviceWithToken(sToken);
+				CDevice& device = DeviceWithIdentifier(sClientIdentifier);
 
 				if (device.InNegotiation() == false && device.GetVersion().Equals(sVersion) == false) {
 					pClient->PutClient("PALAVER REQ *");
@@ -854,10 +917,10 @@ public:
 					return HALT;
 				}
 
-				CString sToken = sLine.Token(2);
+				CString sClientIdentifier = sLine.Token(2);
 				CString sVersion = sLine.Token(3);
 
-				if (!pDevice->GetToken().Equals(sToken)) {
+				if (!pDevice->GetIdentifier().Equals(sClientIdentifier)) {
 					// Setting was for a different device than the one the user registered with
 					return HALT;
 				}
@@ -904,8 +967,8 @@ public:
 					it != m_vDevices.end(); ++it) {
 				CDevice& device = **it;
 
-				if (device.HasClient(*m_pClient) == false && device.HasNetwork(*pNetwork)) {
-					device.ClearBadges(*this);
+				if (device.HasNetwork(*pNetwork)) {
+					device.ClearBadges(*this, !device.HasClient(*m_pClient));
 				}
 			}
 		}
@@ -921,21 +984,21 @@ public:
 
 #pragma mark -
 
-	CDevice& DeviceWithToken(const CString& sToken) {
+	CDevice& DeviceWithIdentifier(const CString& sIdentifier) {
 		CDevice *pDevice = NULL;
 
 		for (std::vector<CDevice*>::const_iterator it = m_vDevices.begin();
 				it != m_vDevices.end(); ++it) {
 			CDevice& device = **it;
 
-			if (device.GetToken().Equals(sToken)) {
+			if (device.GetIdentifier().Equals(sIdentifier)) {
 				pDevice = &device;
 				break;
 			}
 		}
 
 		if (pDevice == NULL) {
-			pDevice = new CDevice(sToken);
+			pDevice = new CDevice(sIdentifier);
 			m_vDevices.push_back(pDevice);
 		}
 
@@ -958,12 +1021,12 @@ public:
 		return pDevice;
 	}
 
-	bool RemoveDeviceWithToken(const CString& sToken) {
+	bool RemoveDeviceWithIdentifier(const CString& sIdentifier) {
 		for (std::vector<CDevice*>::iterator it = m_vDevices.begin();
 				it != m_vDevices.end(); ++it) {
 			CDevice& device = **it;
 
-			if (device.GetToken().Equals(sToken)) {
+			if (device.GetIdentifier().Equals(sIdentifier)) {
 				m_vDevices.erase(it);
 				Save();
 				return true;
@@ -1178,7 +1241,7 @@ public:
 					const CString sNetwork = it3->first;
 
 					Table.AddRow();
-					Table.SetCell("Device", device.GetToken());
+					Table.SetCell("Device", device.GetIdentifier());
 					Table.SetCell("User", sUsername);
 					Table.SetCell("Network", sNetwork);
 					Table.SetCell("Negotiating", CString(device.InNegotiation()));
@@ -1186,7 +1249,7 @@ public:
 
 				if (networks.size() == 0) {
 					Table.AddRow();
-					Table.SetCell("Device", device.GetToken());
+					Table.SetCell("Device", device.GetIdentifier());
 					Table.SetCell("User", sUsername);
 					Table.SetCell("Network", "");
 					Table.SetCell("Negotiating", CString(device.InNegotiation()));
@@ -1195,7 +1258,7 @@ public:
 
 			if (msmsNetworks.size() == 0) {
 				Table.AddRow();
-				Table.SetCell("Device", device.GetToken());
+				Table.SetCell("Device", device.GetIdentifier());
 				Table.SetCell("User", "");
 				Table.SetCell("Network", "");
 				Table.SetCell("Negotiating", CString(device.InNegotiation()));
@@ -1208,7 +1271,7 @@ public:
 
 		CDevice *pDevice = DeviceForClient(*m_pClient);
 		if (pDevice) {
-			PutModule("You are connected from Palaver. (" + pDevice->GetToken() + ")");
+			PutModule("You are connected from Palaver. (" + pDevice->GetIdentifier() + ")");
 		} else {
 			PutModule("You are not connected from a Palaver client.");
 		}
@@ -1219,10 +1282,10 @@ public:
 		PutModule("Be sure to include all information from this command so we can try and debug any issues.");
 		PutModule("--");
 
-		PutModule("Palaver ZNC: " + CString(PALAVER_VERSION) + " -- http://palaverapp.com/");
+		PutModule("Palaver ZNC: " + CString(ZNC_PALAVER_VERSION) + " -- http://palaverapp.com/");
 		CDevice *pDevice = DeviceForClient(*m_pClient);
 		if (pDevice) {
-			PutModule("Current device: (" + pDevice->GetToken() + ")");
+			PutModule("Current device: (" + pDevice->GetIdentifier() + ")");
 		}
 		PutModule(CString(m_vDevices.size()) + " registered devices");
 
@@ -1238,7 +1301,7 @@ void PLVHTTPNotificationSocket::HandleStatusCode(unsigned int status) {
 	if (status == 401) {
 		if (CPalaverMod *pModule = dynamic_cast<CPalaverMod *>(m_pModule)) {
 			DEBUG("palaver: Removing device");
-			pModule->RemoveDeviceWithToken(m_sToken);
+			pModule->RemoveDeviceWithIdentifier(m_sIdentifier);
 		}
 	}
 }

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/znc.png
 DSM_UI_DIR = app
 
 DEPENDS = cross/$(SPK_NAME)
-SPK_DEPENDS = "python3>=3.7.7-15"
+SPK_DEPENDS = "python38"
 
 MAINTAINER = worstje
 DESCRIPTION = Advanced IRC bouncer. An IRC bouncer is nothing more than an IRC proxy. ZNC will always be connected in your chat rooms, and will be the gateway between your clients, and your IRC servers. You can, for instance, consult messages while you were offline or hide your identity.
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Bouncer IRC avancé. Un bouncer IRC n\’est en fait qu\’un 
 DESCRIPTION_SPN = IRC bouncer avanzado. Un IRC bouncer no es más que un proxy para IRC. ZNC estará siempre conectado a tus canales, y hará de puerta de enlace entre tus clientes y tus servidores IRC. Puedes, por ejemplo, consultar mensajes mientras estuviste desconectado o esconder tu identidad.
 RELOAD_UI = yes
 DISPLAY_NAME = ZNC
-CHANGELOG = "1. Add clientbuffer module.<br/>2. Update palaver module to v1.2.1.<br/>3. Update push module."
+CHANGELOG = "1. Update python to Python 3.8.<br/>2. Add clientbuffer module.<br/>3. Update palaver module to v1.2.1.<br/>4. Update push module."
 
 STARTABLE = yes
 HOMEPAGE = https://wiki.znc.in/
@@ -22,9 +22,8 @@ LICENSE  = Apache License 2.0
 # Ensure C++11 compatibility
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PCC_ARCHS)
 
-
-WIZARDS_DIR = src/wizard/
-CONF_DIR = src/conf/
+WIZARDS_DIR = src/wizard
+CONF_DIR = src/conf
 
 # 'auto' reserved value grabs SPK_NAME
 SERVICE_USER = auto
@@ -43,8 +42,7 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: znc_extra_install
 znc_extra_install:
-	install -m 755 -d $(STAGING_DIR)/var/modules
-	install -m 755 -d $(STAGING_DIR)/var/configs
+	install -m 755 -d $(STAGING_DIR)/var/modules $(STAGING_DIR)/var/configs
 	install -m 644 src/znc.conf $(STAGING_DIR)/var/configs/znc.conf
 	install -m 644 src/oidentd.conf ${STAGING_DIR}/var/configs/oidentd.conf
 	ln -sf /etc/ssl/certs $(STAGING_DIR)/certs

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = znc
 SPK_VERS = 1.8.2
-SPK_REV = 17
+SPK_REV = 18
 SPK_ICON = src/znc.png
 DSM_UI_DIR = app
 
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Bouncer IRC avancé. Un bouncer IRC n\’est en fait qu\’un 
 DESCRIPTION_SPN = IRC bouncer avanzado. Un IRC bouncer no es más que un proxy para IRC. ZNC estará siempre conectado a tus canales, y hará de puerta de enlace entre tus clientes y tus servidores IRC. Puedes, por ejemplo, consultar mensajes mientras estuviste desconectado o esconder tu identidad.
 RELOAD_UI = yes
 DISPLAY_NAME = ZNC
-CHANGELOG = "Update znc to v1.8.2."
+CHANGELOG = "1. Add clientbuffer module.<br/>2. Update palaver module to v1.2.1.<br/>3. Update push module."
 
 STARTABLE = yes
 HOMEPAGE = https://wiki.znc.in/
@@ -43,7 +43,6 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: znc_extra_install
 znc_extra_install:
-	install -m 755 -d $(STAGING_DIR)/var
 	install -m 755 -d $(STAGING_DIR)/var/modules
 	install -m 755 -d $(STAGING_DIR)/var/configs
 	install -m 644 src/znc.conf $(STAGING_DIR)/var/configs/znc.conf

--- a/spk/znc/src/service-setup.sh
+++ b/spk/znc/src/service-setup.sh
@@ -1,33 +1,36 @@
-# Package specific behaviors
-# Sourced script by generic installer and start-stop-status scripts
 
-# Replace generic service startup, run service in background
+# znc service setup
+# Sourced by generic installer and start-stop-status scripts
+
+# Set generic service startup, run service in background
 PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
 ZNC="${SYNOPKG_PKGDEST}/bin/znc"
-CERT_FILE="${SYNOPKG_PKGDEST}/var/znc.pem"
-PYTHON3_LIB_PATH="/var/packages/python3/target/lib"
-SERVICE_COMMAND="env LD_LIBRARY_PATH=${PYTHON3_LIB_PATH} ${ZNC} -d ${SYNOPKG_PKGDEST}/var"
+CERT_FILE="${SYNOPKG_PKGVAR}/znc.pem"
+PYTHON3_LIB_PATH="/var/packages/python38/target/lib"
+SERVICE_COMMAND="env LD_LIBRARY_PATH=${PYTHON3_LIB_PATH} ${ZNC} -d ${SYNOPKG_PKGVAR}"
 SVC_BACKGROUND=yes
+CONF_FILE=${SYNOPKG_PKGVAR}/configs/znc.conf
+OID_FILE=${SYNOPKG_PKGVAR}/configs/oidentd.conf
 
 service_postinst ()
 {
     # Edit the configuration according to the wizard
-    sed -i -e "s,@pidfile@,${PID_FILE},g" ${SYNOPKG_PKGDEST}/var/configs/znc.conf
-    sed -i -e "s,@certfile@,${CERT_FILE},g" ${SYNOPKG_PKGDEST}/var/configs/znc.conf
-    sed -i -e "s,@username@,${wizard_username:=admin},g" ${SYNOPKG_PKGDEST}/var/configs/znc.conf
-    sed -i -e "s,@password@,${wizard_password:=admin},g" ${SYNOPKG_PKGDEST}/var/configs/znc.conf
-    sed -i -e "s,@zncuser@,${EFF_USER},g" ${SYNOPKG_PKGDEST}/var/configs/oidentd.conf
+    sed -i -e "s,@pidfile@,${PID_FILE},g" ${CONF_FILE}
+    sed -i -e "s,@certfile@,${CERT_FILE},g" ${CONF_FILE}
+    sed -i -e "s,@username@,${wizard_username:=admin},g" ${CONF_FILE}
+    sed -i -e "s,@password@,${wizard_password:=admin},g" ${CONF_FILE}
+    sed -i -e "s,@zncuser@,${EFF_USER},g" ${OID_FILE}
 }
 
 service_prestart ()
 {
     # Generate certificate if it does not exist (on first run)
     if [ -e "${CERT_FILE}" ]; then
-        echo "Certificate file exists. Starting..." >> ${LOG_FILE}
+        echo "Certificate file exists. Starting..."     >> ${LOG_FILE}
     else
-        echo "Generating initial certificate file" >> ${LOG_FILE}
-        ${ZNC} -d ${SYNOPKG_PKGDEST}/var -p >> ${LOG_FILE}
-        echo "Certificate file created. Starting..." >> ${LOG_FILE}
+        echo "Generating initial certificate file"      >> ${LOG_FILE}
+        ${ZNC} -d ${SYNOPKG_PKGVAR} -p                  >> ${LOG_FILE}
+        echo "Certificate file created. Starting..."    >> ${LOG_FILE}
     fi
 }
 


### PR DESCRIPTION
_Motivation:_  A very usefull module who is still absent in the actual version of ZNC
_Linked issues:_  closes #4279

I saw that the makefile for ZNC compile all the cpp files who are present in module dir so I just have to add the .cpp file for client buffer in /modules dir and add clientbuffer.so in the PLIST file. All compilation are done and .spk packages can be found here: https://github.com/jaloji/spksrc/releases/tag/1.8.2-17

For each new updates of ZNC all the module must be recompiled with the new version.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
