### PR TITLE
update flexget to v3.1.117

### DIFF
--- a/spk/flexget/Makefile
+++ b/spk/flexget/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = flexget
-SPK_VERS = 3.1.110
+SPK_VERS = 3.1.117
 SPK_REV = 8
 SPK_ICON = src/${SPK_NAME}.png
 
@@ -10,7 +10,7 @@ SPK_DEPENDS = "python3>=3.7.7"
 MAINTAINER = manowark
 DESCRIPTION = FlexGet is a multipurpose automation tool for content like torrents, nzbs, podcasts, comics, series, movies, etc. It can use different kinds of sources like RSS-feeds, html pages, csv files, search engines and there are even plugins for sites that do not provide any kind of useful feeds.
 DISPLAY_NAME = FlexGet
-CHANGELOG = "Update FlexGet to version 3.1.110. Includes security update for CVE-2019-20477 and CVE-2020-28493."
+CHANGELOG = "Update FlexGet to version 3.1.117. Includes security updates for urllib3 and CVE-2019-20477, CVE-2020-28493."
 STARTABLE = yes
 
 HOMEPAGE = https://flexget.com/

--- a/spk/flexget/src/requirements.txt
+++ b/spk/flexget/src/requirements.txt
@@ -1,5 +1,5 @@
-# This file is a copy of the https://raw.githubusercontent.com/Flexget/Flexget/v3.1.110/requirements.txt file
-# including the https://raw.githubusercontent.com/Flexget/Flexget/v3.1.110/requirements.in
+# This file is a copy of the https://raw.githubusercontent.com/Flexget/Flexget/v3.1.116/requirements.txt file
+# including the https://raw.githubusercontent.com/Flexget/Flexget/v3.1.116/requirements.in
 # Additionally added the flexget and the transmissionrpc packages.
 # plumbum and rpyc packages are adjusted as the proposed versions are not accepted.
 aniso8601==9.0.1
@@ -20,15 +20,15 @@ flask-compress==1.9.0
 flask-cors==3.0.10
 flask-login==0.5.0
 flask-restful==0.3.8
-flask-restx==0.2.0
-flexget==3.1.110
+flask-restx==0.3.0
+flexget==3.1.117
 guessit==3.2.0
 html5lib==1.1
 idna==2.10
 itsdangerous==1.1.0
 jaraco.classes==3.2.1
-jaraco.collections==3.2.0
-jaraco.functools==3.2.1
+jaraco.collections==3.3.0
+jaraco.functools==3.3.0
 jaraco.text==3.5.0
 jinja2==2.11.3
 jsonschema==3.2.0
@@ -48,18 +48,19 @@ pytz==2021.1
 pyyaml==5.4.1
 rebulk==3.0.1
 requests==2.25.1
-#rpyc==4.1.5
+#rpyc==5.0.1
 rpyc==4.1.2
 sgmllib3k==1.0.0
 six==1.15.0
 soupsieve==2.2
-sqlalchemy==1.3.23
-tempora==4.0.1
+sqlalchemy==1.3.24
+tempora==4.0.2
 terminaltables==3.1.0
-transmissionrpc==0.11
+typing-extensions==3.7.4.3
 tzlocal==2.1
-urllib3==1.26.3
+urllib3==1.26.4
 webencodings==0.5.1
 werkzeug==1.0.1
 zc.lockfile==2.0
+zipp==3.4.1
 zxcvbn-python==4.4.24


### PR DESCRIPTION
_Motivation:_  Another flexget update to avoid security issue with urllib3
_Linked issues:_  

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
