### PR TITLE
fix zlib-so-linking with meson-build (#4478)

### DIFF
--- a/cross/zlib/Makefile
+++ b/cross/zlib/Makefile
@@ -11,6 +11,4 @@ HOMEPAGE = https://zlib.net/
 COMMENT  = A Massively Spiffy Yet Delicately Unobtrusive Compression Library.
 LICENSE  = zlib-license
 
-CONFIGURE_ARGS = --shared --prefix=$(INSTALL_PREFIX)
-
 include ../../mk/spksrc.cross-cc.mk


### PR DESCRIPTION
_Motivation:_  packages with meson-build cannot link to libz.so
_Linked issues:_  closes #4478

### Checklist
fixed packages: rmlint, zstd
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

A lot of packages depend on cross/zlib and/or cross/glib. To ensure those are no affected, I checked some:
- [x] imagemagick
- [x] mc
- [x] sshfs

