### PR TITLE
ruby: declare old_ppc_archs as unsupported

### DIFF
--- a/cross/ruby/Makefile
+++ b/cross/ruby/Makefile
@@ -8,6 +8,9 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS  = cross/openssl cross/readline cross/gdbm cross/berkeleydb native/$(PKG_NAME)
 
+# even it compiles with older cross/gdbm, ruby crashes at runtime
+UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+
 HOMEPAGE = http://www.ruby-lang.org/
 COMMENT  = Ruby Programming Language.
 LICENSE  = 2-clause BSDL

--- a/spk/ruby/Makefile
+++ b/spk/ruby/Makefile
@@ -5,6 +5,9 @@ SPK_ICON = src/ruby.png
 
 DEPENDS = cross/$(SPK_NAME)
 
+# even it compiles with older cross/gdbm, ruby crashes at runtime
+UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+
 CHANGELOG = "Restore package and update to v3.3.0, due to the fact that Synology retired Ruby v2.4.3-0067."
 
 MAINTAINER = SynoCommunity


### PR DESCRIPTION
_Motivation:_  Ruby package does not support OLD_PPC_ARCHS 
_Linked issues:_ #4352

### Remarks
Ruby compiles for OLD_PPC_ARCHS with older cross/gdbm, but crashes at runtime. 
