### PR TITLE
[security] update libvorbis to v1.3.7

### DIFF
--- a/cross/libvorbis/Makefile
+++ b/cross/libvorbis/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libvorbis
-PKG_VERS = 1.3.6
+PKG_VERS = 1.3.7
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://ftp.osuosl.org/pub/xiph/releases/vorbis

--- a/cross/libvorbis/PLIST
+++ b/cross/libvorbis/PLIST
@@ -1,9 +1,9 @@
-lnk:lib/libvorbisenc.so
-lnk:lib/libvorbisenc.so.2
-lib:lib/libvorbisenc.so.2.0.11
-lnk:lib/libvorbisfile.so
-lnk:lib/libvorbisfile.so.3
-lib:lib/libvorbisfile.so.3.3.7
 lnk:lib/libvorbis.so
 lnk:lib/libvorbis.so.0
-lib:lib/libvorbis.so.0.4.8
+lib:lib/libvorbis.so.0.4.9
+lnk:lib/libvorbisenc.so
+lnk:lib/libvorbisenc.so.2
+lib:lib/libvorbisenc.so.2.0.12
+lnk:lib/libvorbisfile.so
+lnk:lib/libvorbisfile.so.3
+lib:lib/libvorbisfile.so.3.3.8

--- a/cross/libvorbis/digests
+++ b/cross/libvorbis/digests
@@ -1,3 +1,3 @@
-libvorbis-1.3.6.tar.xz SHA1 237e3d1c66452734fd9b32f494f44238b4f0185e
-libvorbis-1.3.6.tar.xz SHA256 af00bb5a784e7c9e69f56823de4637c350643deedaf333d0fa86ecdba6fcb415
-libvorbis-1.3.6.tar.xz MD5 b7d1692f275c73e7833ed1cc2697cd65
+libvorbis-1.3.7.tar.xz SHA1 0a2dd71a999656b8091506839e8007a61a8fda1f
+libvorbis-1.3.7.tar.xz SHA256 b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b
+libvorbis-1.3.7.tar.xz MD5 50902641d358135f06a8392e61c9ac77


### PR DESCRIPTION
_Motivation:_  security update to fix CVE-2018-10393, CVE-2017-14160, CVE-2018-10392
_Linked issues:_  

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
