### PR TITLE
Update SABnzbd to 3.3.1. Update Unrar to 6.0.1.

### DIFF
--- a/cross/sabnzbd/Makefile
+++ b/cross/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = SABnzbd
-PKG_VERS = 3.2.1
+PKG_VERS = 3.3.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-src.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/sabnzbd/sabnzbd/releases/download/$(PKG_VERS)

--- a/cross/sabnzbd/Makefile
+++ b/cross/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = SABnzbd
-PKG_VERS = 3.3.0
+PKG_VERS = 3.3.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-src.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/sabnzbd/sabnzbd/releases/download/$(PKG_VERS)

--- a/cross/sabnzbd/digests
+++ b/cross/sabnzbd/digests
@@ -1,3 +1,3 @@
-SABnzbd-3.3.0-src.tar.gz SHA1 9c3627fa2b4e7f84bef8f4208c1260fba77f04f6
-SABnzbd-3.3.0-src.tar.gz SHA256 bb5617f8e5d89720e69655275fc2a25023d8d7173dce2eae5ef45d9dd5df442e
-SABnzbd-3.3.0-src.tar.gz MD5 1a36f530cbf064eaf803af0e772aefd2
+SABnzbd-3.3.1-src.tar.gz SHA1 a3765df321f7109c32ff816380a4414312c309b2
+SABnzbd-3.3.1-src.tar.gz SHA256 4ca22408e2f4f88880c8d0fb480c231c0b51d144eb871d01870dcb9b14199ec3
+SABnzbd-3.3.1-src.tar.gz MD5 62483a336ea4a1241e4e122e67f2f217

--- a/cross/sabnzbd/digests
+++ b/cross/sabnzbd/digests
@@ -1,3 +1,3 @@
-SABnzbd-3.2.1-src.tar.gz SHA1 25918c13cc5486d5b6a7b479499e6bf3af15dd7b
-SABnzbd-3.2.1-src.tar.gz SHA256 79c2bb46e41f2316e4c2827b61598157fbc9467ecddaca6fc4f0b2f4e7b8f809
-SABnzbd-3.2.1-src.tar.gz MD5 832fe051d3a3761a014aac0d98472550
+SABnzbd-3.3.0-src.tar.gz SHA1 9c3627fa2b4e7f84bef8f4208c1260fba77f04f6
+SABnzbd-3.3.0-src.tar.gz SHA256 bb5617f8e5d89720e69655275fc2a25023d8d7173dce2eae5ef45d9dd5df442e
+SABnzbd-3.3.0-src.tar.gz MD5 1a36f530cbf064eaf803af0e772aefd2

--- a/cross/unrar/Makefile
+++ b/cross/unrar/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = unrar
-PKG_VERS = 5.7.4
+PKG_VERS = 6.0.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)src-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.rarlab.com/rar

--- a/cross/unrar/digests
+++ b/cross/unrar/digests
@@ -1,3 +1,3 @@
-unrarsrc-5.7.4.tar.gz SHA1 71ef4c898cd777f1c244c455826c5cdaeb85dfd0
-unrarsrc-5.7.4.tar.gz SHA256 582dd038fd4632f32493928cae5b37dbb436752813da08a1ee5df2ab1ee7e7b4
-unrarsrc-5.7.4.tar.gz MD5 7b6a2bebe2a0c096f353008c40644be7
+unrarsrc-6.0.1.tar.gz SHA1 47554030b1e90eb0f36cd442b5045299463abab0
+unrarsrc-6.0.1.tar.gz SHA256 43e4d3ac762e2f58bfa9e37693efa342c1363eb1029fab409dfdf69171201450
+unrarsrc-6.0.1.tar.gz MD5 0f5a438ebee5cf92184d0b039e6890af

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = sabnzbd
-SPK_VERS = 3.3.0
+SPK_VERS = 3.3.1
 SPK_REV = 49
 SPK_ICON = src/sabnzbd.png
 
@@ -17,7 +17,7 @@ DESCRIPTION_FRE = SABnzbd rend Usenet aussi simple et automatisé que possible. 
 DESCRIPTION_SPN = SABnzbd hace que Usenet sea lo más simple posible, automatizando todo lo que se puede. Todo lo que tienes que hacer es agregar un archivo .nzb. SABnzbd empieza desde ahí. Tus archivos serán automáticamente descargados, verificados, reparados, descomprimidos y archivados.
 DISPLAY_NAME = SABnzbd
 STARTABLE = yes
-CHANGELOG = "Update SABnzbd to 3.3.0. Update Unrar to 6.0.1."
+CHANGELOG = "Update SABnzbd to 3.3.1. Update Unrar to 6.0.1."
 
 HOMEPAGE  = https://sabnzbd.org
 LICENSE   = GPL

--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sabnzbd
-SPK_VERS = 3.2.1
-SPK_REV = 48
+SPK_VERS = 3.3.0
+SPK_REV = 49
 SPK_ICON = src/sabnzbd.png
 
 BUILD_DEPENDS = cross/python38 cross/setuptools cross/pip cross/wheel
@@ -17,7 +17,7 @@ DESCRIPTION_FRE = SABnzbd rend Usenet aussi simple et automatisé que possible. 
 DESCRIPTION_SPN = SABnzbd hace que Usenet sea lo más simple posible, automatizando todo lo que se puede. Todo lo que tienes que hacer es agregar un archivo .nzb. SABnzbd empieza desde ahí. Tus archivos serán automáticamente descargados, verificados, reparados, descomprimidos y archivados.
 DISPLAY_NAME = SABnzbd
 STARTABLE = yes
-CHANGELOG = "Update SABnzbd to 3.2.1 and restore ionice. Requires the Python 3.8 package."
+CHANGELOG = "Update SABnzbd to 3.3.0. Update Unrar to 6.0.1."
 
 HOMEPAGE  = https://sabnzbd.org
 LICENSE   = GPL

--- a/spk/sabnzbd/src/requirements.txt
+++ b/spk/sabnzbd/src/requirements.txt
@@ -4,7 +4,7 @@ cheroot==8.5.2
 cherrypy==18.6.0
 configobj==5.0.6
 sgmllib3k==1.0.0
-feedparser==6.0.2
+feedparser==6.0.6
 jaraco.classes==3.2.1
 jaraco.collections==3.3.0
 jaraco.functools==3.3.0

--- a/spk/sabnzbd/src/requirements.txt
+++ b/spk/sabnzbd/src/requirements.txt
@@ -9,9 +9,9 @@ jaraco.classes==3.2.1
 jaraco.collections==3.3.0
 jaraco.functools==3.3.0
 jaraco.text==3.5.0
-more-itertools==8.7.0
+more-itertools==8.8.0
 portend==2.7.1
 pytz==2021.1
 sabyenc3==4.0.2
-tempora==4.0.1
+tempora==4.0.2
 zc.lockfile==2.0


### PR DESCRIPTION
The build on GA fails due to `squidguard` being unable to fetch a dependency from Sourceforge.

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
