### PR TITLE
Update nzbget to support new archs

### DIFF
--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -1,18 +1,17 @@
 SPK_NAME = nzbget
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 26
+SPK_REV = 27
 SPK_ICON = src/nzbget.png
 
-DEPENDS = cross/busybox cross/p7zip cross/unrar
+DEPENDS = cross/p7zip cross/unrar
 
 MAINTAINER = Safihre
 DESCRIPTION = NZBGet is a command-line based binary newsgrabber for nzb files, written in C++. It supports client/server mode, automatic par-check/-repair, unpack and web-interface. NZBGet requires low system resources.
 DESCRIPTION_FRE = NZBGet est un récupérateur de news en ligne de commande écrit en C++ pour les fichiers nzb. Il intègre un mode client/serveur, la vérification, réparation et décompression automatique ainsi qu\'une interface web. NZBGet requiert peu de ressources système.
 DESCRIPTION_SPN = NZBGet es una aplicación de linea de comandos escrita en C++ para descargar binarios, desde servidores de noticias, utilizando archivos nzb. Soporta modo cliente y servidor, verificación y descompresión automática y una interfaz web. NZBGet utiliza pocos recursos de sistema.
-RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = NZBGet
-CHANGELOG = "1) Use generic NZBGet installer, allows for in-app upgrading. 2) Use DSM 5+6 generic service approach for correct permissions."
+CHANGELOG = "1. Remove DSM5 -> DSM6 migration.<br/>2. Support for DS-x20 models."
 
 HOMEPAGE = https://nzbget.net
 LICENSE  = GPLv2
@@ -30,15 +29,11 @@ ADMIN_PORT = $(SERVICE_PORT)
 
 POST_STRIP_TARGET = nzbget_extra_install
 
-BUSYBOX_CONFIG = usrmng
-ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
-
 include ../../mk/spksrc.spk.mk
 
 .PHONY: nzbget_extra_install
 nzbget_extra_install:
-	install -m 755 -d $(STAGING_DIR)/var
-	install -m 755 -d $(STAGING_DIR)/share/nzbget/scripts
+	install -m 755 -d $(STAGING_DIR)/var $(STAGING_DIR)/share/nzbget/scripts
 	# Include usefull scripts
 	cd $(STAGING_DIR)/share/nzbget/scripts && git clone https://github.com/clinton-hall/nzbToMedia.git
 	cd $(STAGING_DIR)/share/nzbget/scripts && git clone https://github.com/clinton-hall/GetScripts.git


### PR DESCRIPTION
_Motivation:_  Some cleanup to get new package version to publish for new archs
_Linked issues:_  closes #4631

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Remarks
- remove dsm5 -> dsm6 migration
- remove busybox dependency
- not compatible with DSM7 yet (still missing shared folders from wizard for DSM7).