### PR TITLE
prepare deluge for publish

### DIFF
--- a/cross/libtorrent/Makefile
+++ b/cross/libtorrent/Makefile
@@ -6,7 +6,8 @@ PKG_DIST_SITE = https://github.com/arvidn/$(PKG_NAME)/releases/download/$(PKG_NA
 PKG_DIR = $(PKG_NAME)-rasterbar-$(PKG_VERS)
 
 # for boost python binding (BOOST_LIBRARIES = python), the dependency on cross/python2 must appear before cross/boost
-DEPENDS = cross/python2 cross/boost cross/geoip cross/libiconv cross/openssl
+BUILD_DEPENDS = cross/python2 
+DEPENDS = cross/boost cross/geoip cross/libiconv cross/openssl
 
 # cross/boost: archs lacking C++11 compiler (88f6281 and ppc archs except QorIQ)
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PCC_ARCHS)


### PR DESCRIPTION
_Motivation:_  deluge fails to install on armada370 based diskstations and was not yet published with current openssl (v1.1.x)
_Linked issues:_  closes #4516

### Checklist
- [x] Build rule `all-supported` completed successfully (DSM7 not supported yet)
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Remarks
Just a build on the current master fixed the installtion on my DS115j.
The package size shrinks by > 50% by removing the full python2 code from the package.
As the deluge package is built on the fly at installation, on my DS115j the installation needed > 30 minutes to complete (256 MB RAM)

This package is not ready for DSM7, as there is no solution for shared folders by wizard variables yet.
