### PR TITLE
[WIP] Add zap2epg TV grabber to tvheadend

### DIFF
--- a/cross/tvheadend/PLIST
+++ b/cross/tvheadend/PLIST
@@ -1,3 +1,6 @@
 bin:bin/tvheadend
+rsc:bin/tvhmeta
+rsc:bin/tv_meta_tmdb.py
+rsc:bin/tv_meta_tvdb.py
 rsc:share/tvheadend
 rsc:share/fontconfig

--- a/cross/zap2epg/Makefile
+++ b/cross/zap2epg/Makefile
@@ -1,0 +1,26 @@
+PKG_NAME = zap2epg
+PKG_VERS = 3.0
+PKG_EXT = tar.gz
+#PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_NAME = Python3-th0ma7-updates.$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/daniel-widrick/zap2it-GuideScraping/archive
+PKG_DIST_SITE = https://github.com/th0ma7/script.module.zap2epg/archive
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIR = script.module.zap2epg-Python3-th0ma7-updates
+
+DEPENDS =
+
+HOMEPAGE = https://github.com/edit4ever/script.module.zap2epg
+COMMENT  = zap2epg will generate an xmltv.xml file for USA/Canada TV lineups using zap2it source
+LICENSE  = GPLv3
+
+INSTALL_TARGET = zap2it_install
+
+include ../../mk/spksrc.install-resources.mk
+
+.PHONY: zap2it_install
+zap2it_install:
+	install -m 755 -d $(STAGING_INSTALL_PREFIX)/bin
+	install -m 755 $(WORK_DIR)/$(PKG_DIR)/tv_grab_zap2epg $(STAGING_INSTALL_PREFIX)/bin
+	install -m 750 -d $(STAGING_INSTALL_PREFIX)/var/epggrab/conf
+	install -m 640 $(WORK_DIR)/$(PKG_DIR)/epggrab/conf/zap2epg.xml $(STAGING_INSTALL_PREFIX)/var/epggrab/conf

--- a/cross/zap2epg/PLIST
+++ b/cross/zap2epg/PLIST
@@ -1,0 +1,2 @@
+bin:bin/zap2it-GuideScrape.py
+rsc:etc/zap2itconfig.ini

--- a/cross/zap2epg/PLIST
+++ b/cross/zap2epg/PLIST
@@ -1,2 +1,2 @@
-bin:bin/zap2it-GuideScrape.py
-rsc:etc/zap2itconfig.ini
+rsc:bin/tv_grab_zap2epg
+rsc:var/epggrab/conf/zap2epg.xml

--- a/cross/zap2epg/digests
+++ b/cross/zap2epg/digests
@@ -1,0 +1,3 @@
+zap2epg-3.0.tar.gz SHA1 6dbdef7a0459f151cfb06b043a5aa027af9c2011
+zap2epg-3.0.tar.gz SHA256 fefb724bcd8f460af50f56085a92db88ed839609f5c38b83e42fe8526aa5c7e7
+zap2epg-3.0.tar.gz MD5 a6a59af402b5b5fb6d5e60067a2e2b0a

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -14,7 +14,7 @@ DSM_UI_DIR = app
 export TVH_VERS
 
 DEPENDS = cross/$(SPK_NAME) cross/zap2epg
-WHEELS = requests
+WHEELS = certifi chardet requests urllib3
 SPK_DEPENDS = "python3>=3.7"
 
 MAINTAINER = th0ma7

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -15,7 +15,7 @@ export TVH_VERS
 
 DEPENDS = cross/$(SPK_NAME) cross/zap2epg
 WHEELS = certifi chardet requests urllib3
-SPK_DEPENDS = "python3>=3.7"
+SPK_DEPENDS = "python38"
 
 MAINTAINER = th0ma7
 DESCRIPTION = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT IP and HDHomeRun as input sources. Tvheadend offers HTTP, HTSP and SAT IP streaming.

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -14,7 +14,7 @@ DSM_UI_DIR = app
 export TVH_VERS
 
 DEPENDS = cross/$(SPK_NAME) cross/zap2epg
-WHEELS = certifi chardet requests urllib3
+WHEELS = src/requirements.txt
 SPK_DEPENDS = "python38"
 
 MAINTAINER = th0ma7

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -15,6 +15,7 @@ export TVH_VERS
 
 DEPENDS = cross/$(SPK_NAME) cross/zap2epg
 WHEELS = requests
+SPK_DEPENDS = "python3>=3.7"
 
 MAINTAINER = th0ma7
 DESCRIPTION = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT IP and HDHomeRun as input sources. Tvheadend offers HTTP, HTSP and SAT IP streaming.

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -13,7 +13,8 @@ DSM_UI_DIR = app
 # 000-fix-version.patch from cross/tvheadend
 export TVH_VERS
 
-DEPENDS = cross/$(SPK_NAME)
+DEPENDS = cross/$(SPK_NAME) cross/zap2epg
+WHEELS = requests
 
 MAINTAINER = th0ma7
 DESCRIPTION = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT IP and HDHomeRun as input sources. Tvheadend offers HTTP, HTSP and SAT IP streaming.

--- a/spk/tvheadend/PLIST
+++ b/spk/tvheadend/PLIST
@@ -1,0 +1,1 @@
+rsc:share/wheelhouse

--- a/spk/tvheadend/src/requirements.txt
+++ b/spk/tvheadend/src/requirements.txt
@@ -1,0 +1,4 @@
+certifi==2021.5.30
+chardet==4.0.0
+requests==2.25.1
+urllib3==1.26.5

--- a/spk/tvheadend/src/service-setup.sh
+++ b/spk/tvheadend/src/service-setup.sh
@@ -1,6 +1,9 @@
 # Package specific behaviors
 # Sourced script by generic installer and start-stop-status scripts
 
+# Add ffmpeg and ifself to path
+PATH="${SYNOPKG_PKGDEST}/bin:/var/packages/ffmpeg/target/bin:${PATH}"
+
 # Service configuration. Change http and htsp ports here and in conf/tvheadend.sc for non-standard ports
 HTTP=9981
 HTSP=9982

--- a/spk/tvheadend/src/service-setup.sh
+++ b/spk/tvheadend/src/service-setup.sh
@@ -31,13 +31,13 @@ service_postinst ()
     sed -i -e "s/@password@/${wizard_password}/g" ${SYNOPKG_PKGVAR}/passwd/a927e30a755504f9784f23a4efac5109
 
     # EPG Grabber (zap2epg) - Create a Python virtualenv
-    ${VIRTUALENV} --system-site-packages ${PYTHONENV} >> ${INST_LOG}
+    ${VIRTUALENV} --system-site-packages ${PYTHONENV}
 
     # EPG Grabber (zap2epg) - Install the wheels/requirements
     ${SYNOPKG_PKGDEST}/env/bin/pip install \
              --no-deps --no-index --no-input --upgrade \
              --force-reinstall --find-links \
-             ${WHEELHOUSE} ${WHEELHOUSE}/*.whl >> ${INST_LOG}  2>&1
+             ${WHEELHOUSE} ${WHEELHOUSE}/*.whl
 
     # EPG Grabber (zap2epg) - Adjust permissions
     set_unix_permissions "${PYTHONENV}"

--- a/spk/tvheadend/src/service-setup.sh
+++ b/spk/tvheadend/src/service-setup.sh
@@ -38,9 +38,6 @@ service_postinst ()
              --no-deps --no-index --no-input --upgrade \
              --force-reinstall --find-links \
              ${WHEELHOUSE} ${WHEELHOUSE}/*.whl
-
-    # EPG Grabber (zap2epg) - Adjust permissions
-    set_unix_permissions "${PYTHONENV}"
 }
 
 service_preupgrade ()

--- a/spk/tvheadend/src/service-setup.sh
+++ b/spk/tvheadend/src/service-setup.sh
@@ -6,7 +6,7 @@ PYTHON_DIR="/var/packages/python38/target"
 PYTHONENV="${SYNOPKG_PKGDEST}/env"
 VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
 WHEELHOUSE=${SYNOPKG_PKGDEST}/share/wheelhouse
-FFMPEG_DIR="/usr/local/ffmpeg"
+FFMPEG_DIR="/var/packages/ffmpeg/target"
 PATH="${SYNOPKG_PKGDEST}/env/bin:${SYNOPKG_PKGDEST}/bin:${FFMPEG_DIR}/bin:${PYTHON_DIR}/bin:${PATH}"
 
 # Service configuration. Change http and htsp ports here and in conf/tvheadend.sc for non-standard ports

--- a/spk/tvheadend/src/service-setup.sh
+++ b/spk/tvheadend/src/service-setup.sh
@@ -2,7 +2,12 @@
 # Sourced script by generic installer and start-stop-status scripts
 
 # Add ffmpeg and ifself to path
-PATH="${SYNOPKG_PKGDEST}/bin:/var/packages/ffmpeg/target/bin:${PATH}"
+PYTHON_DIR="/var/packages/python38/target"
+PYTHONENV="${SYNOPKG_PKGDEST}/env"
+VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
+WHEELHOUSE=${SYNOPKG_PKGDEST}/share/wheelhouse
+FFMPEG_DIR="/usr/local/ffmpeg"
+PATH="${SYNOPKG_PKGDEST}/env/bin:${SYNOPKG_PKGDEST}/bin:${FFMPEG_DIR}/bin:${PYTHON_DIR}/bin:${PATH}"
 
 # Service configuration. Change http and htsp ports here and in conf/tvheadend.sc for non-standard ports
 HTTP=9981
@@ -24,6 +29,18 @@ service_postinst ()
 
     # Edit the password configuration according to the wizard
     sed -i -e "s/@password@/${wizard_password}/g" ${SYNOPKG_PKGVAR}/passwd/a927e30a755504f9784f23a4efac5109
+
+    # EPG Grabber (zap2epg) - Create a Python virtualenv
+    ${VIRTUALENV} --system-site-packages ${PYTHONENV} >> ${INST_LOG}
+
+    # EPG Grabber (zap2epg) - Install the wheels/requirements
+    ${SYNOPKG_PKGDEST}/env/bin/pip install \
+             --no-deps --no-index --no-input --upgrade \
+             --force-reinstall --find-links \
+             ${WHEELHOUSE} ${WHEELHOUSE}/*.whl >> ${INST_LOG}  2>&1
+
+    # EPG Grabber (zap2epg) - Adjust permissions
+    set_unix_permissions "${PYTHONENV}"
 }
 
 service_preupgrade ()


### PR DESCRIPTION
_Motivation:_  TVH lacks of built-in TV grabber as the XMLTV project is pretty much all using perl with target compiled CPAN modules making cross-build not sustainable with the framework.  Changes in this PR incorporate zap2epg python EPG grabber directly to TVH.  This allows using built-in routine tasks from TVH without needing additional cron jobs.
_Linked issues:_  Superseeds previous `zap2it` standalone package #4608 and include `requests` python wheels which closes #4678

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

### Notes
- Currently pending the merge upstream of https://github.com/edit4ever/script.module.zap2epg/pull/37 