### PR TITLE
uriparser: Update from broken 0.91 to version 0.95 and use cmake

### DIFF
--- a/cross/uriparser/Makefile
+++ b/cross/uriparser/Makefile
@@ -2,12 +2,12 @@ PKG_NAME = uriparser
 PKG_VERS = 0.9.5
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://downloads.sourceforge.net/project/$(PKG_NAME)/Sources/$(PKG_VERS)
+PKG_DIST_SITE = https://github.com/uriparser/uriparser/releases/download/$(PKG_NAME)-$(PKG_VERS)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-HOMEPAGE = http://sourceforge.net/projects/uriparser
-COMMENT  = Strictly RFC 3986 compliant URI parsing and handling library 
-LICENSE  = New BSD license
+HOMEPAGE = https://uriparser.github.io/
+COMMENT  = Strictly RFC 3986 compliant URI parsing and handling library written in C89 ("ANSI C").
+LICENSE  = 3-Clause BSD
 
 CMAKE_ARGS  = -DCMAKE_BUILD_TYPE=Release
 CMAKE_ARGS += -DURIPARSER_BUILD_DOCS=OFF

--- a/cross/uriparser/Makefile
+++ b/cross/uriparser/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = uriparser
-PKG_VERS = 0.9.1
+PKG_VERS = 0.9.5
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://downloads.sourceforge.net/project/$(PKG_NAME)/Sources/$(PKG_VERS)
@@ -9,7 +9,9 @@ HOMEPAGE = http://sourceforge.net/projects/uriparser
 COMMENT  = Strictly RFC 3986 compliant URI parsing and handling library 
 LICENSE  = New BSD license
 
-GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --disable-test --disable-doc
+CMAKE_ARGS  = -DCMAKE_BUILD_TYPE=Release
+CMAKE_ARGS += -DURIPARSER_BUILD_DOCS=OFF
+# Requires Gtest
+CMAKE_ARGS += -DURIPARSER_BUILD_TESTS=OFF
 
-include ../../mk/spksrc.cross-cc.mk
+include ../../mk/spksrc.cross-cmake.mk

--- a/cross/uriparser/PLIST
+++ b/cross/uriparser/PLIST
@@ -1,4 +1,4 @@
 bin:bin/uriparse
 lnk:lib/liburiparser.so
 lnk:lib/liburiparser.so.1
-lib:lib/liburiparser.so.1.0.24
+lib:lib/liburiparser.so.1.0.28

--- a/cross/uriparser/digests
+++ b/cross/uriparser/digests
@@ -1,3 +1,3 @@
-uriparser-0.9.1.tar.bz2 SHA1 35b0f326bad6749c6a08da854e8ad0638d2fd198
-uriparser-0.9.1.tar.bz2 SHA256 75248f3de3b7b13c8c9735ff7b86ebe72cbb8ad043291517d7d53488e0893abe
-uriparser-0.9.1.tar.bz2 MD5 c00ac34aaf4ab66c69d1100db3b79a62
+uriparser-0.9.5.tar.bz2 SHA1 b9f27e36de938f69ffd28226ace8620b78500936
+uriparser-0.9.5.tar.bz2 SHA256 dd8061eba7f2e66c151722e6db0b27c972baa6215cf16f135dbe0f0a4bc6606c
+uriparser-0.9.5.tar.bz2 MD5 0206f4e4e8cbd9c45a4318020cab5293


### PR DESCRIPTION
_Motivation:_  Version 0.91 declared buggy, need to update to newer version AND migrate to using `cmake`
_Linked issues:_  #4681

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
