### PR TITLE
cppunit: DSM7 build usual C99 fix

### DIFF
--- a/cross/cppunit/Makefile
+++ b/cross/cppunit/Makefile
@@ -11,4 +11,11 @@ LICENSE  =
 
 GNU_CONFIGURE = 1
 
+include ../../mk/spksrc.common.mk
+
+ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+ADDITIONAL_CPPFLAGS = -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_HAVE_OBSOLETE_ISNAN -D_GLIBCXX_HAVE_OBSOLETE_ISINF
+ADDITIONAL_CXXFLAGS = $(ADDITIONAL_CPPFLAGS)
+endif
+
 include ../../mk/spksrc.cross-cc.mk


### PR DESCRIPTION
_Motivation:_  Does not build on DSM7 otherwise.  Fix imported from `libicu`
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4576/checks?check_run_id=2867078521

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
