### PR TITLE
spksrc: Allow multiple DSM for all-supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@ distrib
 packages
 native/*/work*
 cross/*/work*
+cross/*/build*
 kernel/*/work*
 spk/*/work*
+spk/*/build*
 diyspk/*/work*
 toolchain/*/work*
 toolchain/*/*_done

--- a/Makefile
+++ b/Makefile
@@ -150,23 +150,23 @@ toolchain-%:
 kernel-%:
 	-@cd kernel/syno-$*/ && MAKEFLAGS= $(MAKE)
 
-setup: local.mk dsm-6.1
+setup: local.mk dsm-6.1 dsm-7.0
 
 local.mk:
 	@echo "Creating local configuration \"local.mk\"..."
-	@echo "PUBLISH_URL=" > $@
-	@echo "PUBLISH_API_KEY=" >> $@
-	@echo "MAINTAINER?=" >> $@
-	@echo "MAINTAINER_URL?=" >> $@
-	@echo "DISTRIBUTOR=" >> $@
-	@echo "DISTRIBUTOR_URL=" >> $@
-	@echo "REPORT_URL=" >> $@
-	@echo "DEFAULT_TC=" >> $@
-	@echo "#PARALLEL_MAKE=max" >> $@
+	@echo "PUBLISH_URL =" > $@
+	@echo "PUBLISH_API_KEY =" >> $@
+	@echo "MAINTAINER ?=" >> $@
+	@echo "MAINTAINER_URL ?=" >> $@
+	@echo "DISTRIBUTOR =" >> $@
+	@echo "DISTRIBUTOR_URL =" >> $@
+	@echo "REPORT_URL =" >> $@
+	@echo "DEFAULT_TC =" >> $@
+	@echo "#PARALLEL_MAKE = max" >> $@
 
 dsm-%: local.mk
 	@echo "Setting default toolchain version to DSM-$*"
-	@sed -i "s|DEFAULT_TC.*|DEFAULT_TC=$*|" local.mk
+	@grep -q "^DEFAULT_TC.*=.*$*.*" local.mk || sed -i "/^DEFAULT_TC =/s/$$/ $*/" local.mk
 
 setup-synocommunity: setup
 	@sed -i -e "s|PUBLISH_URL=.*|PUBLISH_URL=https://api.synocommunity.com|" \

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -37,7 +37,7 @@ include $(LOCAL_CONFIG_MK)
 endif
 
 # Filter to exclude TC versions greater than DEFAULT_TC (from local configuration)
-TCVERSION_DUPES = $(addprefix %,$(shell echo "$(AVAILABLE_TCVERSIONS) " | sed 's|.*\<$(DEFAULT_TC)[^.]||g'))
+TCVERSION_DUPES = $(addprefix %,$(filter-out $(DEFAULT_TC),$(AVAILABLE_TCVERSIONS)))
 
 # Archs that are supported by generic archs
 ARCHS_DUPES_DEFAULT = $(addsuffix %,$(ARCHS_WITH_GENERIC_SUPPORT))

--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -9,9 +9,12 @@
 #  URLS:                 List of URL to download
 #  DISTRIB_DIR:          Downloaded files will be placed there.  
 
+# Configure file descriptor lock timeout
+ifeq ($(strip $(FLOCK_TIMEOUT)),)
+FLOCK_TIMEOUT = 300
+endif
 
 DOWNLOAD_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)download_done
-FLOCK_TIMEOUT = 300
 
 ifeq ($(strip $(PRE_DOWNLOAD_TARGET)),)
 PRE_DOWNLOAD_TARGET = pre_download_target

--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -11,8 +11,7 @@
 
 
 DOWNLOAD_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)download_done
-WAIT_MAX = 12
-FLOCK_TIMEOUT = 120
+FLOCK_TIMEOUT = 300
 
 ifeq ($(strip $(PRE_DOWNLOAD_TARGET)),)
 PRE_DOWNLOAD_TARGET = pre_download_target
@@ -66,17 +65,21 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	    git) \
 	      localFolder=$(NAME)-git$(PKG_GIT_HASH) ; \
 	      localFile=$${localFolder}.tar.gz ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -d $${localFolder}.part ] && sleep 10 || continue ; done ; \
-	      if [ ! -f $${localFile} ]; then \
-	        rm -fr $${localFolder}.part ; \
-	        echo "git clone $${url}" ; \
-	        flock --timeout $(FLOCK_TIMEOUT) --exclusive /tmp/git.$${localFolder}.lock git clone --no-checkout --quiet $${url} $${localFolder}.part ; \
+	      exec 6> /tmp/git.$${localFolder}.lock ;\
+	      flock --timeout $(FLOCK_TIMEOUT) --exclusive 6 || exit 1 ; \
+	      pid=$$$$ ; \
+	      echo "$${pid}" 1>&6 ; \
+	      if [ -f $${localFile} ]; then \
+	        $(MSG) "  File $${localFile} already downloaded" ; \
+	      else \
+	        $(MSG) "  git clone --no-checkout --quiet $${url}" ; \
+	        rm -fr $${localFolder} $${localFolder}.part ; \
+	        git clone --no-checkout --quiet $${url} $${localFolder}.part ; \
 	        mv $${localFolder}.part $${localFolder} ; \
 	        git --git-dir=$${localFolder}/.git --work-tree=$${localFolder} archive --prefix=$${localFolder}/ -o $${localFile} $(PKG_GIT_HASH) ; \
 	        rm -fr $${localFolder} ; \
-	      else \
-	        $(MSG) "  File $${localFile} already downloaded" ; \
 	      fi ; \
+	      flock -u 6 ; \
 	      ;; \
 	    svn) \
 	      if [ "$(PKG_SVN_REV)" = "HEAD" ]; then \
@@ -87,17 +90,21 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      localFolder=$(NAME)-r$${rev} ; \
 	      localFile=$${localFolder}.tar.gz ; \
 	      localHead=$(NAME)-rHEAD.tar.gz ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -d $${localFolder}.part ] && sleep 10 || continue ; done ; \
-	      if [ ! -f $${localFile} ]; then \
-	        rm -fr $${localFolder}.part ; \
-	        echo "svn co -r $${rev} $${url}" ; \
-	        flock --timeout $(FLOCK_TIMEOUT) --exclusive /tmp/svn.$${localFolder}.lock svn export -q -r $${rev} $${url} $${localFolder}.part ; \
+	      exec 7> /tmp/svn.$${localFolder}.lock ; \
+	      flock --timeout $(FLOCK_TIMEOUT) --exclusive 7 || exit 1 ; \
+	      pid=$$$$ ; \
+	      echo "$${pid}" 1>&7 ; \
+	      if [ -f $${localFile} ]; then \
+	        $(MSG) "  File $${localFile} already downloaded" ; \
+	      else \
+	        $(MSG) "  svn co -r $${rev} $${url}" ; \
+	        rm -fr $${localFolder} $${localFolder}.part ; \
+	        svn export -q -r $${rev} $${url} $${localFolder}.part ; \
 	        mv $${localFolder}.part $${localFolder} ; \
 	        tar --exclude-vcs -c $${localFolder} | gzip -n > $${localFile} ; \
 	        rm -fr $${localFolder} ; \
-	      else \
-	        $(MSG) "  File $${localFile} already downloaded" ; \
 	      fi ; \
+	      flock -u 7 ; \
 	      if [ "$(PKG_SVN_REV)" = "HEAD" ]; then \
 	        rm -f $${localHead} ; \
 	        ln -s $${localFile} $${localHead} ; \
@@ -112,17 +119,21 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      localFolder=$(NAME)-r$${rev} ; \
 	      localFile=$${localFolder}.tar.gz ; \
 	      localTip=$(NAME)-rtip.tar.gz ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -d $${localFolder}.part ] && sleep 10 || continue ; done ; \
-	      if [ ! -f $${localFile} ]; then \
-	        rm -fr $${localFolder}.part ; \
-	        echo "hg clone -r $${rev} $${url}" ; \
-	        flock --timeout $(FLOCK_TIMEOUT) --exclusive /tmp/hg.$${localFolder}.lock hg clone -r $${rev} $${url} $${localFolder}.part ; \
+	      exec 8> /tmp/hg.$${localFolder}.lock ; \
+	      flock --timeout $(FLOCK_TIMEOUT) --exclusive 8 || exit 1 ; \
+	      pid=$$$$ ; \
+	      echo "$${pid}" 1>&8 ; \
+	      if [ -f $${localFile} ]; then \
+	        $(MSG) "  File $${localFile} already downloaded" ; \
+	      else \
+	        $(MSG) "  hg clone -r $${rev} $${url}" ; \
+	        rm -fr $${localFolder} $${localFolder}.part ; \
+	        hg clone -r $${rev} $${url} $${localFolder}.part ; \
 	        mv $${localFolder}.part $${localFolder} ; \
 	        tar --exclude-vcs -c $${localFolder} | gzip -n > $${localFile} ; \
 	        rm -fr $${localFolder} ; \
-	      else \
-	        $(MSG) "  File $${localFile} already downloaded" ; \
 	      fi ; \
+	      flock -u 8 ; \
 	      if [ "$(PKG_HG_REV)" = "tip" ]; then \
 	        rm -f $${localTip} ; \
 	        ln -s $${localFile} $${localTip} ; \
@@ -133,16 +144,20 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      if [ -z "$${localFile}" ]; then \
 	        localFile=`basename $${url}` ; \
 	      fi ; \
-	      for i in {1..$${WAIT_MAX}}; do [ -f $${localFile}.part ] && sleep 10 || continue ; done ; \
-	      if [ ! -f $${localFile} ]; then \
-	        rm -f $${localFile}.part ; \
-	        url=`echo $${url} | sed -e '#^\(http://sourceforge\.net/.*\)$#\1?use_mirror=autoselect#'` ; \
-	        echo "wget $${url}" ; \
-	        flock --timeout $(FLOCK_TIMEOUT) --exclusive /tmp/wget.$${localFile}.lock wget --secure-protocol=TLSv1_2 -nv -O $${localFile}.part -nc $${url} ; \
-	        mv $${localFile}.part $${localFile} ; \
-	      else \
+	      url=`echo $${url} | sed -e '#^\(http://sourceforge\.net/.*\)$#\1?use_mirror=autoselect#'` ; \
+	      exec 9> /tmp/wget.$${localFile}.lock ; \
+	      flock --timeout $(FLOCK_TIMEOUT) --exclusive 9 || exit 1 ; \
+	      pid=$$$$ ; \
+	      echo "$${pid}" 1>&9 ; \
+	      if [ -f $${localFile} ]; then \
 	        $(MSG) "  File $${localFile} already downloaded" ; \
+	      else \
+	        $(MSG) "  wget $${url}" ; \
+	        rm -f $${localFile}.part ; \
+	        wget --secure-protocol=TLSv1_2 -nv -O $${localFile}.part -nc $${url} ; \
+	        mv $${localFile}.part $${localFile} ; \
 	      fi ; \
+	      flock -u 9 ; \
 	      ;; \
 	  esac ; \
 	done

--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -65,7 +65,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	    git) \
 	      localFolder=$(NAME)-git$(PKG_GIT_HASH) ; \
 	      localFile=$${localFolder}.tar.gz ; \
-	      exec 6> /tmp/git.$${localFolder}.lock ;\
+	      exec 6> /tmp/git.$${localFolder}.lock ; \
 	      flock --timeout $(FLOCK_TIMEOUT) --exclusive 6 || exit 1 ; \
 	      pid=$$$$ ; \
 	      echo "$${pid}" 1>&6 ; \

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -409,7 +409,12 @@ publish-all-archs: $(addprefix publish-arch-,$(AVAILABLE_TOOLCHAINS))
 # make all-supported
 ifeq (supported,$(subst all-,,$(subst publish-,,$(firstword $(MAKECMDGOALS)))))
 ACTION = supported
+# make setup not invoked
+ifeq ($(strip $(SUPPORTED_ARCHS)),)
+ALL_ACTION = error
+else
 ALL_ACTION = $(SUPPORTED_ARCHS)
+endif
 
 # make all-latest
 else ifeq (latest,$(subst all-,,$(subst publish-,,$(firstword $(MAKECMDGOALS)))))
@@ -445,6 +450,11 @@ pre-build-native:
 	$(MAKE) $(addprefix $(PUBLISH)$(ACTION)-arch-,$(ALL_ACTION))
 
 $(PUBLISH)all-$(ACTION): | pre-build-native
+
+supported-arch-error:
+	@$(MSG) ########################################################
+	@$(MSG) ERROR - Please run make setup from spksrc root directory
+	@$(MSG) ########################################################
 
 supported-arch-%:
 	@$(MSG) BUILDING package for arch $* with SynoCommunity toolchain

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -19,6 +19,9 @@ include ../../mk/spksrc.directories.mk
 # Configure the included makefiles
 NAME = $(SPK_NAME)
 
+# Configure file descriptor lock timeout
+FLOCK_TIMEOUT = 300
+
 ifneq ($(ARCH),)
 SPK_ARCH = $(TC_ARCH)
 SPK_NAME_ARCH = $(ARCH)
@@ -443,6 +446,7 @@ pre-build-native:
 	do \
 	  if [ "$${depend%/*}" = "native" ]; then \
 	    exec 5> /tmp/native.$${depend}.lock ; \
+	    flock --timeout $(FLOCK_TIMEOUT) --exclusive 5 || exit 1 ; \
 	    pid=$$$$ ; \
 	    echo "$${pid}" 1>&5 ; \
 	    $(MSG) "Pre-processing $${depend}" ; \

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -442,9 +442,13 @@ pre-build-native:
 	@for depend in $(sort $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS)) ; \
 	do \
 	  if [ "$${depend%/*}" = "native" ]; then \
-	    echo "Pre-processing $${depend}" ; \
-	    echo "env $(ENV) $(MAKE) -C ../../$$depend" ; \
+	    exec 5> /tmp/native.$${depend}.lock ; \
+	    pid=$$$$ ; \
+	    echo "$${pid}" 1>&5 ; \
+	    $(MSG) "Pre-processing $${depend}" ; \
+	    $(MSG) "  env $(ENV) $(MAKE) -C ../../$$depend" ; \
 	    env $(ENV) $(MAKE) -C ../../$$depend ; \
+	    flock -u 5 ; \
 	  fi ; \
 	done
 	$(MAKE) $(addprefix $(PUBLISH)$(ACTION)-arch-,$(ALL_ACTION))

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -380,7 +380,7 @@ endif
 
 ### Clean rules
 clean:
-	rm -fr work work-*
+	rm -fr work work-* build-*.log
 
 spkclean:
 	rm -fr work-*/.copy_done \
@@ -466,19 +466,19 @@ supported-arch-error:
 
 supported-arch-%:
 	@$(MSG) BUILDING package for arch $* with SynoCommunity toolchain
-	-@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*))
+	-@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) | tee build-$*.log
 
 publish-supported-arch-%:
 	@$(MSG) BUILDING and PUBLISHING package for arch $* with SynoCommunity toolchain
-	-@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) publish
+	-@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) publish | tee build-$*.log
 
 latest-arch-%:
 	@$(MSG) BUILDING package for arch $* with SynoCommunity toolchain
-	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))),$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))))
+	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))),$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS))))))) | tee build-$*.log
 
 publish-latest-arch-%:
 	@$(MSG) BUILDING and PUBLISHING package for arch $* with SynoCommunity toolchain
-	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))),$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS))))))) publish
+	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))),$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS))))))) publish | tee build-$*.log
 
 ####
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -406,15 +406,18 @@ all-archs: $(addprefix arch-,$(AVAILABLE_TOOLCHAINS))
 publish-all-archs: $(addprefix publish-arch-,$(AVAILABLE_TOOLCHAINS))
 
 ####
-
+# make all-supported
 ifeq (supported,$(subst all-,,$(subst publish-,,$(firstword $(MAKECMDGOALS)))))
 ACTION = supported
-ALL_ACTION = $(sort $(basename $(subst -,.,$(basename $(subst .,,$(SUPPORTED_ARCHS))))))
+ALL_ACTION = $(SUPPORTED_ARCHS)
+
+# make all-latest
 else ifeq (latest,$(subst all-,,$(subst publish-,,$(firstword $(MAKECMDGOALS)))))
 ACTION = latest
 ALL_ACTION = $(sort $(basename $(subst -,.,$(basename $(subst .,,$(DEFAULT_ARCHS))))))
 endif
 
+# make publish-all-supported | make publish-all-latest
 ifeq (publish,$(subst -all-latest,,$(subst -all-supported,,$(firstword $(MAKECMDGOALS)))))
 PUBLISH = publish-
 .NOTPARALLEL:
@@ -444,19 +447,19 @@ pre-build-native:
 $(PUBLISH)all-$(ACTION): | pre-build-native
 
 supported-arch-%:
-	@$(MSG) BUILDING package for arch $* with SynoCommunity ${ACTION} toolchain
-	-@MAKEFLAGS= PUBLISH=$(PUBLISH) $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(SUPPORTED_ARCHS)))))),$(sort $(filter $*%, $(SUPPORTED_ARCHS)))))))
+	@$(MSG) BUILDING package for arch $* with SynoCommunity toolchain
+	-@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*))
 
 publish-supported-arch-%:
-	@$(MSG) BUILDING and PUBLISHING package for arch $* with SynoCommunity ${ACTION} toolchain
-	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(SUPPORTED_ARCHS)))))),$(sort $(filter $*%, $(SUPPORTED_ARCHS))))))) publish
+	@$(MSG) BUILDING and PUBLISHING package for arch $* with SynoCommunity toolchain
+	-@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) publish
 
 latest-arch-%:
-	@$(MSG) BUILDING package for arch $* with SynoCommunity ${ACTION} toolchain
+	@$(MSG) BUILDING package for arch $* with SynoCommunity toolchain
 	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))),$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))))
 
 publish-latest-arch-%:
-	@$(MSG) BUILDING and PUBLISHING package for arch $* with SynoCommunity ${ACTION} toolchain
+	@$(MSG) BUILDING and PUBLISHING package for arch $* with SynoCommunity toolchain
 	-@MAKEFLAGS= $(MAKE) ARCH=$(basename $(subst -,.,$*)) TCVERSION=$(notdir $(subst -,/,$(sort $(filter %$(lastword $(notdir $(subst -,/,$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS)))))),$(sort $(filter $*%, $(AVAILABLE_TOOLCHAINS))))))) publish
 
 ####


### PR DESCRIPTION
_Motivation:_  As we progress into supporting DSM7 and as a perquisite to building recently merged PR, I want to be able to build both officially supported DSM in one shot using the regular `make all-supported`.  Also, downloading of distrib package files is still an issue with current code.  This PR is attempt to fix both issues:
a) allowing multi DSM builds and
b) fix parallel build download issue
c) fix parallel build of native/*
d) output individual `build-` log files for better tracking of each arch build
_Linked issues:_  

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

```
$ make setup
Creating local configuration "local.mk"...
Setting default toolchain version to DSM-6.1
Setting default toolchain version to DSM-7.0
```
That leads into the following after `make all-supported`:
```
$ tree ffmpeg -L 1
ffmpeg
├── build-88f6281-6.1.log
├── build-aarch64-6.1.log
├── build-aarch64-7.0.log
├── build-armv7-6.1.log
├── build-armv7-7.0.log
├── build-evansport-6.1.log
├── build-evansport-7.0.log
├── build-hi3535-6.1.log
├── build-qoriq-6.1.log
├── build-x64-6.1.log
├── build-x64-7.0.log
├── work-88f6281-6.1
├── work-aarch64-6.1
├── work-aarch64-7.0
├── work-armv7-6.1
├── work-armv7-7.0
├── work-evansport-6.1
├── work-evansport-7.0
├── work-hi3535-6.1
├── work-qoriq-6.1
├── work-x64-6.1
└── work-x64-7.0
```