### PR TITLE
ffmpeg+chromaprint+comskip+tvheadend: Version bump for release

### DIFF
--- a/spk/chromaprint/Makefile
+++ b/spk/chromaprint/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = chromaprint
 SPK_VERS = 1.5.0
-SPK_REV = 14
+SPK_REV = 15
 SPK_ICON = src/chromaprint.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -10,7 +10,7 @@ STARTABLE = no
 MAINTAINER = ymartin59
 DESCRIPTION = Chromaprint is the core component of the AcoustID project. It\'s a client-side library that implements a custom algorithm for extracting fingerprints from any audio source.
 DISPLAY_NAME = Chromaprint
-CHANGELOG = "1. Update to ffmpeg 4.3.1"
+CHANGELOG = "1. Update to ffmpeg 4.3.2"
 
 HOMEPAGE   = https://acoustid.org/chromaprint
 LICENSE    = LGPL2.1+

--- a/spk/comskip/Makefile
+++ b/spk/comskip/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = comskip
 SPK_VERS = 0.82.010
-SPK_REV = 5
+SPK_REV = 6
 SPK_ICON = src/comskip.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -10,7 +10,7 @@ STARTABLE = no
 MAINTAINER = schumi2004
 DESCRIPTION = Comskip is a free mpeg commercial detector. Read the wiki on how to use and configure it.
 DISPLAY_NAME = Comskip
-CHANGELOG = "1. Update to ffmpeg 4.3.1"
+CHANGELOG = "1. Update to ffmpeg 4.3.2"
 
 HOMEPAGE = https://www.kaashoek.com/comskip/
 LICENSE = LGPL

--- a/spk/ffmpeg/Makefile
+++ b/spk/ffmpeg/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ffmpeg
 SPK_VERS = 4.3.2
-SPK_REV = 36
+SPK_REV = 37
 SPK_ICON = src/ffmpeg.png
 CHANGELOG = "1. Update to FFMPEG 4.3.2<br/>2. Update Intel libva to version 2.10 and media drivers 2021Q1<br/>3. Multiple depedency updates (libass, SVT-AV1, libaom, x264, libbluray, libvpx)"
 

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -4,7 +4,7 @@ SPK_GIT_HASH = eb59284
 SPK_GIT_DATE = 20210612
 SPK_VERS = $(SPK_SHORT_VERS).$(SPK_GIT_DATE)
 TVH_VERS = $(SPK_SHORT_VERS)~$(SPK_GIT_HASH)
-SPK_REV = 28
+SPK_REV = 29
 SPK_ICON = src/tvheadend.png
 DSM_UI_DIR = app
 
@@ -22,7 +22,7 @@ DESCRIPTION = Tvheadend is a TV streaming server and recorder for Linux, FreeBSD
 RELOAD_UI = yes
 DISPLAY_NAME = Tvheadend
 STARTABLE = yes
-CHANGELOG = "1. Update to latest git version eb59284 as of June 12th 2021<br/>2. Update openssl to 1.1<br/>3. Updated to use FFMPEG 4.3.2<br/>4. Updated libhdhomerun to version 20210224"
+CHANGELOG = "1. Update to latest git version eb59284 as of June 12th 2021<br/>2. Update openssl to 1.1<br/>3. Updated to use FFMPEG 4.3.2<br/>4. Updated libhdhomerun to version 20210224<br/>5. Update dtv-scan-tables"
 HOMEPAGE = https://tvheadend.org/
 LICENSE = GPL v3
 


### PR DESCRIPTION
_Motivation:_  Prepare for releasing official packages for `ffmpeg`, `tvheadend`, `chromaprint`, `comskip`
_Linked issues:_  #4686, #4576, #4680, #4545

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
