### PR TITLE
Fix setup-synocommunity command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,10 +169,10 @@ dsm-%: local.mk
 	@grep -q "^DEFAULT_TC.*=.*$*.*" local.mk || sed -i "/^DEFAULT_TC =/s/$$/ $*/" local.mk
 
 setup-synocommunity: setup
-	@sed -i -e "s|PUBLISH_URL=.*|PUBLISH_URL=https://api.synocommunity.com|" \
-		-e "s|MAINTAINER?=.*|MAINTAINER?=SynoCommunity|" \
-		-e "s|MAINTAINER_URL?=.*|MAINTAINER_URL?=https://synocommunity.com|" \
-		-e "s|DISTRIBUTOR=.*|DISTRIBUTOR=SynoCommunity|" \
-		-e "s|DISTRIBUTOR_URL=.*|DISTRIBUTOR_URL=https://synocommunity.com|" \
-		-e "s|REPORT_URL=.*|REPORT_URL=https://github.com/SynoCommunity/spksrc/issues|" \
+	@sed -i -e "s|PUBLISH_URL =.*|PUBLISH_URL = https://api.synocommunity.com|" \
+		-e "s|MAINTAINER ?=.*|MAINTAINER ?= SynoCommunity|" \
+		-e "s|MAINTAINER_URL ?=.*|MAINTAINER_URL ?= https://synocommunity.com|" \
+		-e "s|DISTRIBUTOR =.*|DISTRIBUTOR = SynoCommunity|" \
+		-e "s|DISTRIBUTOR_URL =.*|DISTRIBUTOR_URL = https://synocommunity.com|" \
+		-e "s|REPORT_URL =.*|REPORT_URL = https://github.com/SynoCommunity/spksrc/issues|" \
 		local.mk

--- a/Makefile
+++ b/Makefile
@@ -169,10 +169,10 @@ dsm-%: local.mk
 	@grep -q "^DEFAULT_TC.*=.*$*.*" local.mk || sed -i "/^DEFAULT_TC =/s/$$/ $*/" local.mk
 
 setup-synocommunity: setup
-	@sed -i -e "s|PUBLISH_URL =.*|PUBLISH_URL = https://api.synocommunity.com|" \
-		-e "s|MAINTAINER ?=.*|MAINTAINER ?= SynoCommunity|" \
-		-e "s|MAINTAINER_URL ?=.*|MAINTAINER_URL ?= https://synocommunity.com|" \
-		-e "s|DISTRIBUTOR =.*|DISTRIBUTOR = SynoCommunity|" \
-		-e "s|DISTRIBUTOR_URL =.*|DISTRIBUTOR_URL = https://synocommunity.com|" \
-		-e "s|REPORT_URL =.*|REPORT_URL = https://github.com/SynoCommunity/spksrc/issues|" \
+	@sed -i -e "s|PUBLISH_URL\s*=.*|PUBLISH_URL = https://api.synocommunity.com|" \
+		-e "s|MAINTAINER\s*?=.*|MAINTAINER ?= SynoCommunity|" \
+		-e "s|MAINTAINER_URL\s*?=.*|MAINTAINER_URL ?= https://synocommunity.com|" \
+		-e "s|DISTRIBUTOR\s*=.*|DISTRIBUTOR = SynoCommunity|" \
+		-e "s|DISTRIBUTOR_URL\s*=.*|DISTRIBUTOR_URL = https://synocommunity.com|" \
+		-e "s|REPORT_URL\s*=.*|REPORT_URL = https://github.com/SynoCommunity/spksrc/issues|" \
 		local.mk


### PR DESCRIPTION
Spaces where added at some point in local.mk. Why?

_Motivation:_  This is needed for GitHub actions, specifically when using it to publish: https://github.com/SynoCommunity/spksrc/pull/4491/files.
_Linked issues:_  Optionally, add links to existing issues or other PR's

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
