### PR TITLE
fix SPK_GROUP

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -268,10 +268,11 @@ ifneq ($(strip $(SYSTEM_GROUP)),)
 endif
 ifneq ($(strip $(SPK_USER)),)
 	@jq '."username" = "sc-$(SPK_USER)"' $@ 1<>$@
-	@jq '."groupname" = "sc-$(SPK_USER)"' $@ 1<>$@
 endif
 ifneq ($(strip $(SPK_GROUP)),)
 	@jq '."groupname" = "$(SPK_GROUP)"' $@ 1<>$@
+else
+	@jq '."groupname" = "sc-$(SPK_USER)"' $@ 1<>$@
 endif
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf


### PR DESCRIPTION
Using ﻿jq would override the field incorrectly if the length of `SPK_GROUP` was shorter than
`sc-$(SPK_USER)`. Parts of the old value would still be present in the output

This is an issue with using `$@ 1<>$@` to write and read from the same file and value

_Motivation:_  Explain here what the reason for the pull request is.
_Linked issues:_  Optionally, add links to existing issues or other PR's

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
