### PR TITLE
Add Vagrant config to automate the "Virtual Machine" setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ toolkit/*/work*
 local.mk
 *.DS_Store
 *~
+.vagrant

--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,9 @@ Docker
   On Mac hosts running OSX you might need to use fakeroot with tar to avoid permission errors while extracting the synology toolchain archives.
   For that reason run the container with ``docker run -it -v~/spksrc:/spksrc -e TAR_CMD="fakeroot tar" synocommunity/spksrc /bin/bash``.
 
-
 Virtual machine
 ^^^^^^^^^^^^^^^
-A virtual machine based on an 64-bit version of Debian 10 stable OS is recommended. Non-x86 architectures are not supported.
+A virtual machine based on an 64-bit version of Debian 10 stable OS is recommended (or, use the Vagrant configuration, described below). Non-x86 architectures are not supported.
 
 * Install the requirements (in sync with Dockerfile)::
 
@@ -68,6 +67,21 @@ A virtual machine based on an 64-bit version of Debian 10 stable OS is recommend
 * You may need to install some packages from testing like autoconf. Read about Apt-Pinning to know how to do that.
 * Some older toolchains may require 32-bit development versions of packages, e.g. `zlib1g-dev:i386`
 
+
+Vagrant
+^^^^^^^
+Using `Vagrant`_ automates the setup for a virtual machine build.
+
+.. code-block:: sh
+
+    vagrant up  # Bring up the development environment.
+    vagrant ssh # Log in to the development environment.
+    cd /vagrant # Go to the dev env's working directory.
+
+    # From here, follow the instructions in the linked
+    # Developer's Guide. For example:
+    make setup
+    # ...and so on.
 
 Usage
 -----
@@ -98,3 +112,4 @@ When not explicitly set, files are placed under a `3 clause BSD license`_
 .. _FAQ: https://github.com/SynoCommunity/spksrc/wiki/Frequently-Asked-Questions
 .. _Install Docker with wget: https://docs.docker.com/linux/step_one
 .. _SynoCommunity repository: http://www.synocommunity.com
+.. _Vagrant: https://vagrantup.com/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,16 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins = [
-    "vagrant-vbguest" # Automates VirtualBox Guest Additions builds.
-  ]
-
   config.vm.box = "debian/buster64"
-
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = 1024 # Minimum RAM required for VBox Guest Additions.
-  end
-
   config.vm.provision "shell", inline: <<~EOF
     dpkg --add-architecture i386
     apt-get update
@@ -29,10 +20,6 @@ Vagrant.configure("2") do |config|
     wget https://bootstrap.pypa.io/get-pip.py -O - | python3
     pip3 install meson==0.56.0
   EOF
-
-  # The upstream base box explicitly sets this type to `rsync`, but we
-  # want VirtualBox Shared Folders, so we have to override that here.
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
 
   config.vm.post_up_message = <<~EOF
     For further instructions, see:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,16 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+  config.vagrant.plugins = [
+    "vagrant-vbguest" # Automates VirtualBox Guest Additions builds.
+  ]
+
   config.vm.box = "debian/buster64"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024 # Minimum RAM required for VBox Guest Additions.
+  end
+
   config.vm.provision "shell", inline: <<~EOF
     dpkg --add-architecture i386
     apt-get update
@@ -20,6 +29,10 @@ Vagrant.configure("2") do |config|
     wget https://bootstrap.pypa.io/get-pip.py -O - | python3
     pip3 install meson==0.56.0
   EOF
+
+  # The upstream base box explicitly sets this type to `rsync`, but we
+  # want VirtualBox Shared Folders, so we have to override that here.
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
 
   config.vm.post_up_message = <<~EOF
     For further instructions, see:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/buster64"
+  config.vm.provision "shell", inline: <<~EOF
+    dpkg --add-architecture i386
+    apt-get update
+    apt-get install --yes \
+      autoconf-archive autogen automake bc bison build-essential check \
+      cmake curl cython debootstrap ed expect fakeroot flex \
+      g++-multilib gawk gettext git gperf imagemagick intltool jq\
+      libbz2-dev libc6-i386 libcppunit-dev libffi-dev libgc-dev \
+      libgmp3-dev libltdl-dev libmount-dev libncurses-dev libpcre3-dev \
+      libssl-dev libtool libunistring-dev lzip mercurial ncurses-dev \
+      ninja-build php pkg-config python3 python3-distutils rename scons \
+      subversion swig texinfo unzip xmlto zlib1g-dev
+    wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O - | python2
+    pip2 install wheel httpie
+    wget https://bootstrap.pypa.io/get-pip.py -O - | python3
+    pip3 install meson==0.56.0
+  EOF
+
+  config.vm.post_up_message = <<~EOF
+    For further instructions, see:
+      https://github.com/SynoCommunity/spksrc/wiki/Developers-HOW-TO#build-a-package
+  EOF
+end


### PR DESCRIPTION
_Motivation:_  Make it easy for people on, e.g., a macOS machine to have a build environment with Vagrant. This is just a start but the idea is to simplify the experience for contributors.
_Linked issues:_  For example, #1340, #788.

I'm not sure the following checklist applies, but leaving it as it was part of the `.github/ISSUE_TEMPLATE.md` template.

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
