### PR TITLE
DSM7: Set synocommunity as the default group

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -256,12 +256,6 @@ $(DSM_CONF_DIR)/privilege:
 	@$(MSG) '(privilege) run-as: package'
 	@$(MSG) "(privilege) DSM >= 7 $(DSM_CONF_DIR)/privilege"
 # Apply variables to privilege file
-ifneq ($(strip $(GROUP)),)
-# Creates group but is different from the groups the user can create, they are invisible in the UI an are only usefull to access another packages permissions (ffmpeg comes to mind)
-# For DSM7 I recommend setting permissions for individual packages (System Internal User)
-# or use the shared folder resource worker to add permissions, ask user from wizard see transmission package for an example
-	@jq --arg packagename $(GROUP) '."join-pkg-groupnames" += [{$$packagename}]' $@ | sponge $@
-endif
 ifneq ($(strip $(SYSTEM_GROUP)),)
 # options: http, system
 	@jq '."join-groupname" = "$(SYSTEM_GROUP)"' $@ | sponge $@
@@ -269,8 +263,8 @@ endif
 ifneq ($(strip $(SPK_USER)),)
 	@jq '."username" = "sc-$(SPK_USER)"' $@ | sponge $@
 endif
-ifneq ($(strip $(SPK_GROUP)),)
-	@jq '."groupname" = "$(SPK_GROUP)"' $@ | sponge $@
+ifneq ($(strip $(GROUP)),)
+	@jq '."groupname" = "$(GROUP)"' $@ | sponge $@
 else
 	@jq '."groupname" = "sc-$(SPK_USER)"' $@ | sponge $@
 endif

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -266,7 +266,11 @@ endif
 ifneq ($(strip $(GROUP)),)
 	@jq '."groupname" = "$(GROUP)"' $@ | sponge $@
 else
+ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+	@jq '."groupname" = "synocommunity"' $@ | sponge $@
+else
 	@jq '."groupname" = "sc-$(SPK_USER)"' $@ | sponge $@
+endif
 endif
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf


### PR DESCRIPTION
It was a beta thing and never worked correctly, or more likely I did not know how it was supposed to work.

`SPK_GROUP` was never used (proof with `rg -g 'spk/**/Makefile' 'SPK_GROUP'` ) and should be `GROUP` anyway e.g. `sc-download` 

Files will have `$username:$groupname` as the package file owners.

Relates to conversation here: https://github.com/SynoCommunity/spksrc/issues/4524#issuecomment-877112301

starts around: https://github.com/SynoCommunity/spksrc/issues/4524#issuecomment-871166899 and https://github.com/SynoCommunity/spksrc/issues/4524#issuecomment-869634575