### PR TITLE
Build docker image using github actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@ on:
         paths:
             - 'Dockerfile'
         branches:
-            - main
             - master
     pull_request:
         paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,13 @@
 name: Docker
 
 on:
+    # Trigger on file change
+    push:
+        paths:
+            - 'Dockerfile'
+    pull_request:
+        paths:
+            - 'Dockerfile'
     # Trigger build manually
     # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually
     workflow_dispatch:
@@ -20,12 +27,12 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+    #   -
+    #     name: Login to DockerHub
+    #     uses: docker/login-action@v1
+    #     with:
+    #       username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #       password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -36,8 +43,10 @@ jobs:
       -
         name: Build and push
         uses: docker/build-push-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           push: true
-          tags: |
-            SynoCommunity/spksrc:latest
-            ghcr.io/SynoCommunity/spksrc:latest
+        #   tags: |
+        #     SynoCommunity/spksrc:latest
+        #     ghcr.io/SynoCommunity/spksrc:latest
+          tags: ghcr.io/SynoCommunity/spksrc:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     push:
         paths:
             - 'Dockerfile'
+        branches:
+            - main
+            - master
     pull_request:
         paths:
             - 'Dockerfile'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,5 +39,5 @@ jobs:
         with:
           push: true
           tags: |
-            publicarray/spksrc:latest
-            ghcr.io/publicarray/spksrc:latest
+            SynoCommunity/spksrc:latest
+            ghcr.io/SynoCommunity/spksrc:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,27 @@
+name: Docker
+
+on: workflow_dispatch
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: publicarray/spksrc:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,4 +49,4 @@ jobs:
         #   tags: |
         #     SynoCommunity/spksrc:latest
         #     ghcr.io/SynoCommunity/spksrc:latest
-          tags: ghcr.io/publicarray/spksrc:latest
+          tags: ghcr.io/SynoCommunity/spksrc:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,15 @@
 name: Docker
 
-on: workflow_dispatch
-
+on:
+    # Trigger build manually
+    # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually
+    workflow_dispatch:
+    # Trigger build on a schedule
+    schedule:
+        # every fist day of the month
+        - cron: '0 0 1 * *'
+        # every 14 days
+        # - cron: '0 0 */14 * *'
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: publicarray/spksrc:latest
+          tags: |
+            publicarray/spksrc:latest
+            ghcr.io/publicarray/spksrc:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,4 +49,4 @@ jobs:
         #   tags: |
         #     SynoCommunity/spksrc:latest
         #     ghcr.io/SynoCommunity/spksrc:latest
-          tags: ghcr.io/SynoCommunity/spksrc:latest
+          tags: ghcr.io/publicarray/spksrc:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:buster
-MAINTAINER SynoCommunity <https://synocommunity.com>
+LABEL description="Framework for maintaining and compiling native community packages for Synology devices"
+LABEL maintainer="SynoCommunity <https://github.com/SynoCommunity/spksrc/graphs/contributors>"
+LABEL url="https://synocommunity.com"
+LABEL vcs-url="https://github.com/SynoCommunity/spksrc"
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
For Docker Hub the secrets need to be added to GitHub: `DOCKERHUB_USERNAME` `DOCKERHUB_TOKEN`. If docker hub is not required I can remove it. The image/package would be still be build and uploaded onto GitHub. (packages are found here https://github.com/orgs/SynoCommunity/packages?repo_name=spksrc)