### PR TITLE
CI: fix parallel builds. Add manual builds and print more details on error

### DIFF
--- a/.github/actions/build-tag.sh
+++ b/.github/actions/build-tag.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 make setup-synocommunity
-sed -i -e "s|#PARALLEL_MAKE=.*|PARALLEL_MAKE=4|" \
-    -e "s|PUBLISH_API_KEY=.*|PUBLISH_API_KEY=$API_KEY|" \
+sed -i -e "s|#PARALLEL_MAKE\s*=.*|PARALLEL_MAKE=max|" \
+    -e "s|PUBLISH_API_KEY\s*=.*|PUBLISH_API_KEY=$API_KEY|" \
     local.mk
 
 # PACKAGE=$(echo "refs/tags/dnscrypt-proxy-2.0.42" | grep -oE "([0-9a-zA-Z]*-)*")

--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -119,7 +119,7 @@ do
 
     if [ "${GH_ARCH%%-*}" != "noarch" ]; then
         # use TCVERSION and ARCH to get real exit codes.
-        echo "make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package}" >>build.log
+        echo "$ make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package}" >>build.log
         make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package} |& tee >(tail -15 >>build.log)
     else
         if [ "${GH_ARCH}" = "noarch" ]; then
@@ -127,7 +127,7 @@ do
         else
             TCVERSION=${GH_ARCH##*-}
         fi
-        echo "make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package}" >>build.log
+        echo "$ make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package}" >>build.log
         make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package} |& tee >(tail -15 >>build.log)
     fi
     result=$?

--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -13,6 +13,8 @@
 # - ffmpeg is not cleaned to be available for dependents.
 # - Therefore ffmpeg is built first if triggered by its own or a dependent.
 
+set -o pipefail
+
 echo "::group:: ---- initialize build"
 make setup-synocommunity
 sed -i -e "s|#PARALLEL_MAKE\s*=.*|PARALLEL_MAKE=max|" local.mk

--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 
 # github action to build the packages depending on changed files
-# 
+#
 # Functions:
 # - Build all packages depending on files defined in ${GH_FILES}.
 # - Build for arch defined by ${GH_ARCH} (e.g. x64-6.1, noarch, ...).
 # - Successfully built packages are logged to $BUILD_SUCCESS_FILE.
 # - Failed builds are logged to ${BUILD_ERROR_FILE} and annotated as error.
 # - The build output is structured into log groups by package.
-# - As the disk space in the workflow environment is limitted, we clean the 
+# - As the disk space in the workflow environment is limitted, we clean the
 #   work folder of each package after build. At 2020.06 this limit is 14GB.
 # - ffmpeg is not cleaned to be available for dependents.
 # - Therefore ffmpeg is built first if triggered by its own or a dependent.
 
 echo "::group:: ---- initialize build"
 make setup-synocommunity
-sed -i -e "s|#PARALLEL_MAKE=.*|PARALLEL_MAKE=4|" local.mk
+sed -i -e "s|#PARALLEL_MAKE\s*=.*|PARALLEL_MAKE=max|" local.mk
 echo "::endgroup::"
 
 echo "::group:: ---- find dependent packages"
 
 # filter for changes made in the spk directories and take unique package name (without spk folder)
-SPK_TO_BUILD=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
+SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
 
 # filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
 DEPENDENT_PACKAGES=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(cross|native)/[^\/]*" | sort -u | tr '\n' ' ')
@@ -59,7 +59,7 @@ packages=$(printf %s "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 # find all packages that depend on spk/ffmpeg is built before.
 all_ffmpeg_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "export FFMPEG_DIR" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
 
-# if ffmpeg or one of its dependents is to build, ensure 
+# if ffmpeg or one of its dependents is to build, ensure
 # ffmpeg is first package in the list of packages to build.
 for package in ${packages}
 do
@@ -74,7 +74,7 @@ done
 # find all noarch packages
 all_noarch=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "override ARCH" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
 
-# separate noarch and arch specific packages 
+# separate noarch and arch specific packages
 # and filter out packages that are removed or do not exist (e.g. nzbdrone)
 arch_packages=
 noarch_packages=
@@ -117,14 +117,16 @@ do
 
     if [ "${GH_ARCH%%-*}" != "noarch" ]; then
         # use TCVERSION and ARCH to get real exit codes.
-        make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package}
+        echo "make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package}" >>build.log
+        make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package} |& tee >(tail -10 >>build.log)
     else
         if [ "${GH_ARCH}" = "noarch" ]; then
             TCVERSION=
         else
             TCVERSION=${GH_ARCH##*-}
         fi
-        make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package}
+        echo "make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package}" >>build.log
+        make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package} |& tee >(tail -10 >>build.log)
     fi
     result=$?
 
@@ -132,6 +134,8 @@ do
     then
         echo "$(date --date=now +"%Y.%m.%d %H:%M:%S") - ${package}: (${GH_ARCH}) DONE"   >> ${BUILD_SUCCESS_FILE}
     else
+        cat build.log >> ${BUILD_ERROR_LOGFILE}
+        printf "\n\n" >build.log
         echo "$(date --date=now +"%Y.%m.%d %H:%M:%S") - ${package}: (${GH_ARCH}) FAILED" >> ${BUILD_ERROR_FILE}
     fi
 

--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -120,7 +120,7 @@ do
     if [ "${GH_ARCH%%-*}" != "noarch" ]; then
         # use TCVERSION and ARCH to get real exit codes.
         echo "make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package}" >>build.log
-        make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package} |& tee >(tail -10 >>build.log)
+        make TCVERSION=${GH_ARCH##*-} ARCH=${GH_ARCH%%-*} -C ./spk/${package} |& tee >(tail -15 >>build.log)
     else
         if [ "${GH_ARCH}" = "noarch" ]; then
             TCVERSION=
@@ -128,7 +128,7 @@ do
             TCVERSION=${GH_ARCH##*-}
         fi
         echo "make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package}" >>build.log
-        make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package} |& tee >(tail -10 >>build.log)
+        make TCVERSION=${TCVERSION} ARCH= -C ./spk/${package} |& tee >(tail -15 >>build.log)
     fi
     result=$?
 

--- a/.github/actions/build_status.sh
+++ b/.github/actions/build_status.sh
@@ -61,7 +61,7 @@ if [ -f "${BUILD_ERROR_FILE}" ]; then
         echo ""
         echo "See log file of the build job to analyze the error(s)."
         echo
-        echo "Last 10 lines of every error:"
+        echo "Last 15 lines before the error:"
         cat "${BUILD_ERROR_LOGFILE}"
         echo ""
         # let build status job fail

--- a/.github/actions/build_status.sh
+++ b/.github/actions/build_status.sh
@@ -61,7 +61,8 @@ if [ -f "${BUILD_ERROR_FILE}" ]; then
         echo ""
         echo "See log file of the build job to analyze the error(s)."
         echo
-        echo "Last 15 lines before the error:"
+        echo "Last 15 lines of the build log:"
+        echo
         cat "${BUILD_ERROR_LOGFILE}"
         echo ""
         # let build status job fail

--- a/.github/actions/build_status.sh
+++ b/.github/actions/build_status.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# List the successfully built, the unsupported and the failed packages 
+# List the successfully built, the unsupported and the failed packages
 # by name and timestamp.
-# 
-# We do not want to terminate the build on errors as we want to build all 
+#
+# We do not want to terminate the build on errors as we want to build all
 # packages.
-# Therfore failed builds are logged in the build error file defined by the 
+# Therfore failed builds are logged in the build error file defined by the
 # env variable $BUILD_ERROR_FILE.
 # If this file exists and contains at least one line, we exit with error.
 # A special log file $BUILD_UNSUPPORTED_FILE contains known make errors that
@@ -60,6 +60,9 @@ if [ -f "${BUILD_ERROR_FILE}" ]; then
         echo "::error::ERRORS:%0A$(cat ${BUILD_ERROR_FILE} | sed ':a;N;$!ba;s/\n/%0A/g')"
         echo ""
         echo "See log file of the build job to analyze the error(s)."
+        echo
+        echo "Last 10 lines of every error:"
+        cat "${BUILD_ERROR_LOGFILE}"
         echo ""
         # let build status job fail
         exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
 on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package path to build'
+        required: true
+        default: 'spk/syno-magnet'
   pull_request:
     paths:
     - 'spk/**'
@@ -65,6 +71,7 @@ jobs:
           entrypoint: ./.github/actions/build.sh
         env:
           GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
+          SPK_TO_BUILD: ${{ github.event.inputs.package }}
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
           GH_ARCH: ${{ matrix.arch }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
@@ -84,6 +91,7 @@ jobs:
           GH_ARCH: ${{ matrix.arch }}
           #   API_KEY: ${{ secrets.PUBLISH_API_KEY }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
+          BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
 
@@ -96,6 +104,7 @@ jobs:
           entrypoint: ./.github/actions/build_status.sh
         env:
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
+          BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package path to build'
+        description: 'Package to build'
         required: true
-        default: 'spk/syno-magnet'
+        default: 'syno-magnet'
   pull_request:
     paths:
     - 'spk/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
         description: 'Package to build'
         required: true
         default: 'syno-magnet'
+      publish:
+        description: 'Publish to repository'
+        required: false
+        default: 'false'
   pull_request:
     paths:
     - 'spk/**'
@@ -72,6 +76,8 @@ jobs:
         env:
           GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
           SPK_TO_BUILD: ${{ github.event.inputs.package }}
+          PUBLISH: ${{ github.event.inputs.publish }}
+          API_KEY: ${{ secrets.PUBLISH_API_KEY }}
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
           GH_ARCH: ${{ matrix.arch }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
@@ -90,7 +96,7 @@ jobs:
         env:
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
           GH_ARCH: ${{ matrix.arch }}
-          #   API_KEY: ${{ secrets.PUBLISH_API_KEY }}
+          API_KEY: ${{ secrets.PUBLISH_API_KEY }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
           BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
           GH_ARCH: ${{ matrix.arch }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
+          BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -375,7 +375,7 @@ endif
 ifeq ($(PUBLISH_API_KEY),)
 	$(error Set PUBLISH_API_KEY in local.mk)
 endif
-	http --verify=no --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME)
+	http --verify=no --ignore-stdin --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME)
 
 
 ### Clean rules


### PR DESCRIPTION
_Motivation:_  Fixes `local.mk` with spaces. It makes it much easier to find the error line in a long log file. No more grepping or hunting for it. And this PR allows us to build any package on demand manually.

Here is an example build: https://github.com/publicarray/spksrc/runs/3432175214?check_suite_focus=true

And the output:

```
 BUILD STATUS

SUCCESS:
none.

UNSUPPORTED (skipped):
none.

Error: ERRORS:
2021.08.26 11:37:20 - squidguard: (x64-7.0) FAILED

See log file of the build job to analyze the error(s).

Last 15 lines of the build log:

$ make TCVERSION=7.0 ARCH=x64 -C ./spk/squidguard
make[2]: Leaving directory '/github/workspace/spk/squidguard/work-x64-7.0/unrar'
find /github/workspace/spk/squidguard/work-x64-7.0/install//usr/local/squidguard/ \! -type d -printf '%P\n' | sort | \
  diff /github/workspace/spk/squidguard/work-x64-7.0/unrar.plist.tmp -  | grep '>' | cut -d' ' -f2- > /github/workspace/spk/squidguard/work-x64-7.0/unrar.plist
# Generate unrar.plist.auto for newly added files (diff against .tmp)
comm -3 /github/workspace/spk/squidguard/work-x64-7.0/unrar.plist.tmp /github/workspace/spk/squidguard/work-x64-7.0/unrar.plist > /github/workspace/spk/squidguard/work-x64-7.0/unrar.plist.auto
make[1]: Leaving directory '/github/workspace/cross/unrar'
make[1]: Entering directory '/github/workspace/cross/squidclamav'
===>  Downloading files for squidclamav
===>    wget https://downloads.sourceforge.net/project/squidclamav/squidclamav/6.10/squidclamav-6.10.tar.gz
https://downloads.sourceforge.net/project/squidclamav/squidclamav/6.10/squidclamav-6.10.tar.gz:
2021-08-26 11:37:20 ERROR 404: Not Found.
make[1]: *** [../../mk/spksrc.download.mk:65: download_target] Error 8
make[1]: Leaving directory '/github/workspace/cross/squidclamav'
make: *** [../../mk/spksrc.depend.mk:51: depend_target] Error 2
make: Leaving directory '/github/workspace/spk/squidguard'
```