### PR TITLE
rabbitmq: fix setup for dsm5

### DIFF
--- a/spk/rabbitmq/src/service-setup.sh
+++ b/spk/rabbitmq/src/service-setup.sh
@@ -1,7 +1,10 @@
 
-# evaluate version dependent path
-PATTERN=( ${SYNOPKG_PKGDEST}/lib/rabbitmq_server-*/sbin )
-RABBITMQ_SBIN=${PATTERN[0]}
+
+# evaluate version dependent path (do it /bin/sh compatible)
+for config_dir in ${SYNOPKG_PKGDEST}/lib/rabbitmq_server-*/sbin; do
+    RABBITMQ_SBIN=${config_dir}
+    break
+done
 
 SERVICE_COMMAND="${RABBITMQ_SBIN}/rabbitmq-server"
 SVC_CWD="${SYNOPKG_PKGDEST}"


### PR DESCRIPTION
_Motivation:_  recent update of rabbitmq did not work on DSM-5
_Linked issues:_  fixes #4806

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
