### PR TITLE
update openssl to v1.1.1l

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.1.1k
+PKG_VERS = 1.1.1l
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1k.tar.gz SHA1 bad9dc4ae6dcc1855085463099b5dacb0ec6130b
-openssl-1.1.1k.tar.gz SHA256 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
-openssl-1.1.1k.tar.gz MD5 c4e7d95f782b08116afa27b30393dd27
+openssl-1.1.1l.tar.gz SHA1 f8819dd31642eebea6cc1fa5c256fc9a4f40809b
+openssl-1.1.1l.tar.gz SHA256 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
+openssl-1.1.1l.tar.gz MD5 ac0d4387f3ba0ad741b0580dd45f6ff3


### PR DESCRIPTION
_Motivation:_   Fixes for CVE-2021-3711 [High severity] and CVE-2021-3712 [Moderate severity]
_Linked issues:_  https://github.com/SynoCommunity/spksrc/issues/4211#issuecomment-907757166, #4820

### Affected packages that need to be updated
- borgbackup
- boxbackup-client
- deluge
- domoticz
- duplicity
- ejabberd
- erlang
- ffmpeg
- ffsync
- flexget
- fossil-scm
- git
- haproxy
- homeassistant
- icecast
- irssi
- itools
- jackett
- memcached
- mercurial
- monit
- mosh
- mosquitto
- mtproxy
- mutt
- ntopng
- octoprint
- python
- python3
- python38
- rdiff-backup
- ruby
- rutorrent
- sabnzbd
- salt-minion
- shairport-sync
- stunnel
- synocli-disk
- synocli-file
- synocli-monitor
- synocli-net
- transmission
- tvheadend
- umurmur
- vim
- znc
