### PR TITLE
Revert "dotnet: mark armadaxp and alpine as unsupported"

### DIFF
--- a/mk/spksrc.cross-dotnet-env.mk
+++ b/mk/spksrc.cross-dotnet-env.mk
@@ -4,7 +4,7 @@
 # NOTE: 32bit (x86) is not supported:
 # https://github.com/dotnet/core/issues/5403
 # https://github.com/dotnet/core/issues/4595
-UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS) armadaxp alpine
+UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
 
 DOTNET_OS = linux
 DOTNET_DEFAULT_VERSION = 3.1

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -33,6 +33,6 @@ SERVICE_PORT_TITLE = Jellyfin (HTTP)
 # Admin link
 ADMIN_PORT = $(SERVICE_PORT)
 
-UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS) armadaxp alpine
+UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
 
 include ../../mk/spksrc.spk.mk

--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -6,7 +6,7 @@ SPK_ICON = src/radarr.png
 REQUIRED_DSM = 5.0
 
 # .NET is not supported on PPC, ARM5 or x86
-UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armadaxp alpine
+UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS)
 
 DEPENDS = cross/libstdc++ cross/libmediainfo cross/sqlite cross/radarr
 


### PR DESCRIPTION
Reverts SynoCommunity/spksrc#4793

Thanks @AnonTester So  one .NET app leads to Invalid Instruction on one CPU and the other one on a  different CPU? I give up. I'll just mark it in the wiki pages. Maybe a future .NET / jellyfin / radarr update magically fixes it. 
https://github.com/SynoCommunity/spksrc/issues/4546#issuecomment-906818900