### PR TITLE
common.mk: Fix PSTAT_LOG value when not in cross/* or spk/*

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -87,7 +87,12 @@ PSTAT_TIME = time -o $(PSTAT_LOG) --append
 else
 PSTAT_TIME =
 endif
-ifneq ($(wildcard $(WORK_DIR)),)
+
+# Always send PSTAT output to proper log file
+# independantly from active Makefile location
+ifeq ($(filter cross spk,$(shell basename $(dir $(abspath $(dir $$PWD))))),)
+PSTAT_LOG = $(shell pwdx $$(ps -o ppid= $$(echo $$PPID)) | cut -f2 -d:)/build.stats.log
+else ifneq ($(wildcard $(WORK_DIR)),)
 PSTAT_LOG = $(WORK_DIR)/../build.stats.log
 else
 PSTAT_LOG = $(shell pwd)/build.stats.log

--- a/mk/spksrc.compile.mk
+++ b/mk/spksrc.compile.mk
@@ -30,7 +30,11 @@ endif
 compile_msg:
 	@$(MSG) "Compiling for $(NAME)"
 ifneq ($(filter 1 on ON,$(PSTAT)),)
+ifeq ($(filter cross spk,$(shell basename $(dir $(abspath $(dir $$PWD))))),)
+	@$(MSG) MAKELEVEL: $(MAKELEVEL), PARALLEL_MAKE: $(PARALLEL_MAKE), ARCH: $(shell basename $(dir $(abspath $(dir $$PWD)))), NAME: $(NAME) >> $(PSTAT_LOG)
+else
 	@$(MSG) MAKELEVEL: $(MAKELEVEL), PARALLEL_MAKE: $(PARALLEL_MAKE), ARCH: $(ARCH)-$(TCVERSION), NAME: $(NAME) >> $(PSTAT_LOG)
+endif
 endif
 
 pre_compile_target: compile_msg


### PR DESCRIPTION
_Motivation:_  
1. PSTAT_LOG value is not redirected to the proper directory when ran outside of `spk/*` or `cross/*` for native, toolchain or other directories.  The following captures the parent pid to try to figure out where the "real" working directory is, and thus send PSTAT_LOG output always at the right place.
2. It now also shows the arch as being native, toolchain, toolkit, etc... when ran outside of `spk/*` or `cross/*`

_Linked issues:_  Follow-up to #4859

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
