### PR TITLE
ffmpeg: Add dash demuxer support (requires libxml2)

### DIFF
--- a/cross/ffmpeg/Makefile
+++ b/cross/ffmpeg/Makefile
@@ -52,7 +52,7 @@ OPTIONAL_DEPENDS += cross/x265
 OPTIONAL_DEPENDS += cross/shine
 
 DEPENDS += cross/libxml2
-CONFIGURE_ARGS += --enable-demuxer=dash
+CONFIGURE_ARGS += --enable-demuxer=dash --enable-libxml2
 
 DEPENDS += cross/freetype
 CONFIGURE_ARGS += --enable-libfreetype

--- a/cross/ffmpeg/Makefile
+++ b/cross/ffmpeg/Makefile
@@ -52,7 +52,8 @@ OPTIONAL_DEPENDS += cross/x265
 OPTIONAL_DEPENDS += cross/shine
 
 DEPENDS += cross/libxml2
-CONFIGURE_ARGS += --enable-demuxer=dash --enable-libxml2
+CONFIGURE_ARGS += --enable-libxml2
+CONFIGURE_ARGS += --enable-demuxer=dash
 
 DEPENDS += cross/freetype
 CONFIGURE_ARGS += --enable-libfreetype

--- a/cross/ffmpeg/Makefile
+++ b/cross/ffmpeg/Makefile
@@ -51,6 +51,9 @@ OPTIONAL_DEPENDS += cross/x264
 OPTIONAL_DEPENDS += cross/x265
 OPTIONAL_DEPENDS += cross/shine
 
+DEPENDS += cross/libxml2
+CONFIGURE_ARGS += --enable-demuxer=dash
+
 DEPENDS += cross/freetype
 CONFIGURE_ARGS += --enable-libfreetype
 


### PR DESCRIPTION
_Motivation:_  Add support for DASH Demuxing
_Linked issues:_  #4639

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
