### PR TITLE
add github download action

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -25,6 +25,7 @@ echo "::endgroup::"
 echo "::group:: ---- find dependent packages"
 
 # filter for changes made in the spk directories and take unique package name (without spk folder)
+SPK_TO_BUILD+=" "
 SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
 
 # filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
@@ -50,10 +51,10 @@ done
 
 # fix for packages with different names
 if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
-    SPK_TO_BUILD+=sonarr
+    SPK_TO_BUILD+=" sonarr"
 fi
 if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
-    SPK_TO_BUILD+=python2
+    SPK_TO_BUILD+=" python2"
 fi
 
 # remove duplicate packages

--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# github action to build the packages depending on changed files
+# Part of github build action
+# 
+# build the packages depending on evaluated packages (see prepare.sh)
 #
 # Functions:
-# - Build all packages depending on files defined in ${GH_FILES}.
+# - Build all packages depending on files defined in ${ARCH_PACKAGES} or ${NOARCH_PACKAGES}.
 # - Build for arch defined by ${GH_ARCH} (e.g. x64-6.1, noarch, ...).
 # - Successfully built packages are logged to $BUILD_SUCCESS_FILE.
 # - Failed builds are logged to ${BUILD_ERROR_FILE} and annotated as error.
@@ -11,7 +13,7 @@
 # - As the disk space in the workflow environment is limitted, we clean the
 #   work folder of each package after build. At 2020.06 this limit is 14GB.
 # - ffmpeg is not cleaned to be available for dependents.
-# - Therefore ffmpeg is built first if triggered by its own or a dependent.
+# - Therefore ffmpeg is built first if triggered by its own or a dependent (see prepare.sh).
 
 set -o pipefail
 
@@ -22,87 +24,14 @@ sed -i -e "s|#PARALLEL_MAKE\s*=.*|PARALLEL_MAKE=max|" \
     local.mk
 echo "::endgroup::"
 
-echo "::group:: ---- find dependent packages"
-
-# filter for changes made in the spk directories and take unique package name (without spk folder)
-SPK_TO_BUILD+=" "
-SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
-
-# filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
-DEPENDENT_PACKAGES=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(cross|native)/[^\/]*" | sort -u | tr '\n' ' ')
-
-# get dependency list
-# dependencies in this list include the cross or native folder (i.e. native/python cross/glib)
-echo "Building dependency list..."
-DEPENDENCY_LIST=
-for package in $(find spk/ -maxdepth 1 -type d | cut -c 5- | sort)
-do
-    DEPENDENCY_LIST+=$(make -s -C spk/${package} dependency-list)$'\n'
-done
-
-# search for dependent spk packages
-for package in ${DEPENDENT_PACKAGES}
-do
-    echo "===> Searching for dependent package: ${package}"
-    packages=$(echo "${DEPENDENCY_LIST}" | grep -w "${package}" | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
-    echo "===> Found: ${packages}"
-    SPK_TO_BUILD+=${packages}
-done
-
-# fix for packages with different names
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
-    SPK_TO_BUILD+=" sonarr"
-fi
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
-    SPK_TO_BUILD+=" python2"
-fi
-
-# remove duplicate packages
-packages=$(printf %s "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-
-
-# find all packages that depend on spk/ffmpeg is built before.
-all_ffmpeg_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "export FFMPEG_DIR" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
-
-# if ffmpeg or one of its dependents is to build, ensure
-# ffmpeg is first package in the list of packages to build.
-for package in ${packages}
-do
-    if [ "$(echo ffmpeg ${all_ffmpeg_packages} | grep -ow ${package})" != "" ]; then
-        packages_without_ffmpeg=$(echo "${packages}" | tr ' ' '\n' | grep -v "ffmpeg" | tr '\n' ' ')
-        packages="ffmpeg ${packages_without_ffmpeg}"
-        break;
-    fi
-done
-
-
-# find all noarch packages
-all_noarch=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "override ARCH" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
-
-# separate noarch and arch specific packages
-# and filter out packages that are removed or do not exist (e.g. nzbdrone)
-arch_packages=
-noarch_packages=
-for package in ${packages}
-do
-    if [ -f "./spk/${package}/Makefile" ]; then
-        if [ "$(echo ${all_noarch} | grep -ow ${package})" = "" ]; then
-            arch_packages+="${package} "
-        else
-            noarch_packages+="${package} "
-        fi
-    fi
-done
-
 echo "===> TARGET: ${GH_ARCH}"
-echo "===> ARCH   packages: ${arch_packages}"
-echo "===> NOARCH packages: ${noarch_packages}"
-echo "::endgroup::"
+echo "===> ARCH   packages: ${ARCH_PACKAGES}"
+echo "===> NOARCH packages: ${NOARCH_PACKAGES}"
 
 if [ "${GH_ARCH%%-*}" = "noarch" ]; then
-    build_packages=${noarch_packages}
+    build_packages=${NOARCH_PACKAGES}
 else
-    build_packages=${arch_packages}
+    build_packages=${ARCH_PACKAGES}
 fi
 
 echo ""

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -1,69 +1,20 @@
 #!/bin/bash
 
-# github action to download source files.
+# Part of github build action
+#
+# Download source files.
 #
 # Functions:
 # - Download all referenced native and cross source files for packages to build.
 
 set -o pipefail
 
-echo "::group:: ---- find dependent packages"
-
-# filter for changes made in the spk directories and take unique package name (without spk folder)
-SPK_TO_BUILD+=" "
-SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
-
-# filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
-DEPENDENT_PACKAGES=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(cross|native)/[^\/]*" | sort -u | tr '\n' ' ')
-
-# get dependency list
-# dependencies in this list include the cross or native folder (i.e. native/python cross/glib)
-echo "Building dependency list..."
-DEPENDENCY_LIST=
-for package in $(find spk/ -maxdepth 1 -type d | cut -c 5- | sort)
-do
-    DEPENDENCY_LIST+=$(make -s -C spk/${package} dependency-list)$'\n'
-done
-
-# search for dependent spk packages
-for package in ${DEPENDENT_PACKAGES}
-do
-    echo "===> Searching for dependent package: ${package}"
-    packages=$(echo "${DEPENDENCY_LIST}" | grep -w "${package}" | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
-    echo "===> Found: ${packages}"
-    SPK_TO_BUILD+=${packages}
-done
-
-# fix for packages with different names
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
-    SPK_TO_BUILD+=" sonarr"
-fi
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
-    SPK_TO_BUILD+=" python2"
-fi
-
-# remove duplicate packages
-packages=$(printf %s "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-
-
-echo "::endgroup::"
-
-if [ -z "${packages}" ]; then
+if [ -z "${DOWNLOAD_PACKAGES}" ]; then
     echo "===> No packages to download. <==="
 else
-    echo "===> PACKAGES to download references for: ${packages}"
-    echo "::group:: ---- download"
-    DOWNLOAD_LIST=
-    for package in ${packages}
-    do
-        DOWNLOAD_LIST+=$(echo "${DEPENDENCY_LIST}" | grep "^${package}:" | grep -o ":.*" | tr ':' ' ' | sort -u | tr '\n' ' ')
-    done
-    # remove duplicate downloads
-    downloads=$(printf %s "${DOWNLOAD_LIST}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-    echo "===> References to download: ${downloads}"
-    for download in ${downloads}
+    echo "===> Download packages: ${DOWNLOAD_PACKAGES}"
+    for download in ${DOWNLOAD_PACKAGES}
     do
         make -C ${download} download
     done
-    echo "::endgroup::"
 fi

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# github action to download source files.
+#
+# Functions:
+# - Download all referenced native and cross source files for packages to build.
+
+set -o pipefail
+
+echo "::group:: ---- find dependent packages"
+
+# filter for changes made in the spk directories and take unique package name (without spk folder)
+SPK_TO_BUILD+=" "
+SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
+
+# filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
+DEPENDENT_PACKAGES=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(cross|native)/[^\/]*" | sort -u | tr '\n' ' ')
+
+# get dependency list
+# dependencies in this list include the cross or native folder (i.e. native/python cross/glib)
+echo "Building dependency list..."
+DEPENDENCY_LIST=
+for package in $(find spk/ -maxdepth 1 -type d | cut -c 5- | sort)
+do
+    DEPENDENCY_LIST+=$(make -s -C spk/${package} dependency-list)$'\n'
+done
+
+# search for dependent spk packages
+for package in ${DEPENDENT_PACKAGES}
+do
+    echo "===> Searching for dependent package: ${package}"
+    packages=$(echo "${DEPENDENCY_LIST}" | grep -w "${package}" | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
+    echo "===> Found: ${packages}"
+    SPK_TO_BUILD+=${packages}
+done
+
+# fix for packages with different names
+if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
+    SPK_TO_BUILD+=" sonarr"
+fi
+if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
+    SPK_TO_BUILD+=" python2"
+fi
+
+# remove duplicate packages
+packages=$(printf %s "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+
+echo "::endgroup::"
+
+if [ -z "${packages}" ]; then
+    echo "===> No packages to download. <==="
+else
+    echo "===> PACKAGES to download references for: ${packages}"
+    echo "::group:: ---- download"
+    DOWNLOAD_LIST=
+    for package in ${packages}
+    do
+        DOWNLOAD_LIST+=$(echo "${DEPENDENCY_LIST}" | grep "^${package}:" | grep -o ":.*" | tr ':' ' ' | sort -u | tr '\n' ' ')
+    done
+    # remove duplicate downloads
+    downloads=$(printf %s "${DOWNLOAD_LIST}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+    echo "===> References to download: ${downloads}"
+    for download in ${downloads}
+    do
+        make -C ${download} download
+    done
+    echo "::endgroup::"
+fi

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Part of github build action
+# 
+# Evaluate packages to build and referenced source files to download.
+#
+# Functions:
+# - Evaluate all packages to build depending on files defined in ${GH_FILES}.
+# - ffmpeg is moved to head of packages to built first if triggered by its own or a dependent.
+# - Referenced native and cross packages of the packages to build are added to the download list.
+
+set -o pipefail
+
+echo "::group:: ---- find dependent packages"
+
+# filter for changes made in the spk directories and take unique package name (without spk folder)
+SPK_TO_BUILD+=" "
+SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
+
+# filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
+DEPENDENT_PACKAGES=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(cross|native)/[^\/]*" | sort -u | tr '\n' ' ')
+
+# get dependency list
+# dependencies in this list include the cross or native folder (i.e. native/python cross/glib)
+echo "Building dependency list..."
+DEPENDENCY_LIST=
+for package in $(find spk/ -maxdepth 1 -type d | cut -c 5- | sort)
+do
+    DEPENDENCY_LIST+=$(make -s -C spk/${package} dependency-list)$'\n'
+done
+
+# search for dependent spk packages
+for package in ${DEPENDENT_PACKAGES}
+do
+    echo "===> Searching for dependent package: ${package}"
+    packages=$(echo "${DEPENDENCY_LIST}" | grep -w "${package}" | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
+    echo "===> Found: ${packages}"
+    SPK_TO_BUILD+=${packages}
+done
+
+# fix for packages with different names
+if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
+    SPK_TO_BUILD+=" sonarr"
+fi
+if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
+    SPK_TO_BUILD+=" python2"
+fi
+
+# remove duplicate packages
+packages=$(printf %s "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+
+# find all packages that depend on spk/ffmpeg is built before.
+all_ffmpeg_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "export FFMPEG_DIR" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
+
+# if ffmpeg or one of its dependents is to build, ensure
+# ffmpeg is first package in the list of packages to build.
+for package in ${packages}
+do
+    if [ "$(echo ffmpeg ${all_ffmpeg_packages} | grep -ow ${package})" != "" ]; then
+        packages_without_ffmpeg=$(echo "${packages}" | tr ' ' '\n' | grep -v "ffmpeg" | tr '\n' ' ')
+        packages="ffmpeg ${packages_without_ffmpeg}"
+        break;
+    fi
+done
+
+
+# find all noarch packages
+all_noarch=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "override ARCH" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
+
+# separate noarch and arch specific packages
+# and filter out packages that are removed or do not exist (e.g. nzbdrone)
+arch_packages=
+noarch_packages=
+for package in ${packages}
+do
+    if [ -f "./spk/${package}/Makefile" ]; then
+        if [ "$(echo ${all_noarch} | grep -ow ${package})" = "" ]; then
+            arch_packages+="${package} "
+        else
+            noarch_packages+="${package} "
+        fi
+    fi
+done
+
+echo "::set-output name=arch_packages::${arch_packages}"
+echo "::set-output name=noarch_packages::${noarch_packages}"
+
+echo "::endgroup::"
+
+if [ -z "${packages}" ]; then
+    echo "===> No packages to download. <==="
+    echo "::set-output name=download_packages::"
+else
+    echo "===> PACKAGES to download references for: ${packages}"
+    echo "::group:: ---- download"
+    DOWNLOAD_LIST=
+    for package in ${packages}
+    do
+        DOWNLOAD_LIST+=$(echo "${DEPENDENCY_LIST}" | grep "^${package}:" | grep -o ":.*" | tr ':' ' ' | sort -u | tr '\n' ' ')
+    done
+    # remove duplicate downloads
+    downloads=$(printf %s "${DOWNLOAD_LIST}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+    echo "::set-output name=download_packages::${downloads}"
+    echo "::endgroup::"
+fi

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -93,7 +93,6 @@ if [ -z "${packages}" ]; then
     echo "::set-output name=download_packages::"
 else
     echo "===> PACKAGES to download references for: ${packages}"
-    echo "::group:: ---- download"
     DOWNLOAD_LIST=
     for package in ${packages}
     do
@@ -102,5 +101,4 @@ else
     # remove duplicate downloads
     downloads=$(printf %s "${DOWNLOAD_LIST}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
     echo "::set-output name=download_packages::${downloads}"
-    echo "::endgroup::"
 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,49 @@ on:
     - 'native/**'
 
 jobs:
+  download:
+    name: Download
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+            persist-credentials: false
+
+      - name: Get changed files for pull request
+        if: github.event_name == 'pull_request'
+        id: getfile_pr
+        run: |
+          git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs
+          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs)"
+
+      - name: Get changed files for push
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') == false
+        id: getfile
+        run: |
+          git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs
+          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)"
+
+      - name: Download source files
+        continue-on-error: true
+        uses: docker://ghcr.io/synocommunity/spksrc:latest
+        with:
+          entrypoint: ./.github/actions/download.sh
+        env:
+          GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
+          SPK_TO_BUILD: ${{ github.event.inputs.package }}
+
+      - name: Cache downloaded files
+        uses: actions/cache@v2
+        with:
+          path: distrib
+          # use run_id in key to cache within workflow only.
+          key: distrib-${{ github.run_id }}
+
   build:
     name: Build
+    needs: download    
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -50,6 +91,12 @@ jobs:
           path: toolchain/*/work
           key: toolchain-${{ matrix.arch }}-v2-${{ hashFiles('toolchain/*/digests') }}
           restore-keys: toolchain-${{ matrix.arch }}
+
+      - name: Use cache of downloaded files
+        uses: actions/cache@v2
+        with:
+          path: distrib
+          key: distrib-${{ github.run_id }}
 
       - name: Get changed files for pull request
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,7 @@ jobs:
 
       - name: Evaluate dependencies
         id: dependencies
-        uses: docker://ghcr.io/synocommunity/spksrc:latest
-        with:
-          entrypoint: ./.github/actions/prepare.sh
+        run: ./.github/actions/prepare.sh
         env:
           GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
           SPK_TO_BUILD: ${{ github.event.inputs.package }}
@@ -84,9 +82,7 @@ jobs:
           key: distrib-${{ github.run_id }}
 
       - name: Download source files
-        uses: docker://ghcr.io/synocommunity/spksrc:latest
-        with:
-          entrypoint: ./.github/actions/download.sh
+        run: ./.github/actions/download.sh
         env:
           DOWNLOAD_PACKAGES: ${{ needs.prepare.outputs.download_packages }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,14 @@ on:
     - 'native/**'
 
 jobs:
-  download:
-    name: Download
+  prepare:
+    name: Prepare for Build
     runs-on: ubuntu-latest
+    # provide results to other jobs
+    outputs:
+        arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
+        noarch_packages: ${{ steps.dependencies.outputs.noarch_packages }}
+        download_packages: ${{ steps.dependencies.outputs.download_packages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -51,14 +56,25 @@ jobs:
           git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs
           echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)"
 
-      - name: Download source files
-        continue-on-error: true
+      - name: Evaluate dependencies
+        id: dependencies
         uses: docker://ghcr.io/synocommunity/spksrc:latest
         with:
-          entrypoint: ./.github/actions/download.sh
+          entrypoint: ./.github/actions/prepare.sh
         env:
           GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
           SPK_TO_BUILD: ${{ github.event.inputs.package }}
+
+  download:
+    name: Download sources
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+            persist-credentials: false
 
       - name: Cache downloaded files
         uses: actions/cache@v2
@@ -67,9 +83,16 @@ jobs:
           # use run_id in key to cache within workflow only.
           key: distrib-${{ github.run_id }}
 
+      - name: Download source files
+        uses: docker://ghcr.io/synocommunity/spksrc:latest
+        with:
+          entrypoint: ./.github/actions/download.sh
+        env:
+          DOWNLOAD_PACKAGES: ${{ needs.prepare.outputs.download_packages }}
+
   build:
     name: Build
-    needs: download    
+    needs: [ download, prepare ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -98,20 +121,6 @@ jobs:
           path: distrib
           key: distrib-${{ github.run_id }}
 
-      - name: Get changed files for pull request
-        if: github.event_name == 'pull_request'
-        id: getfile_pr
-        run: |
-          git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs)"
-
-      - name: Get changed files for push
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') == false
-        id: getfile
-        run: |
-          git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs
-          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)"
-
       - name: Build Package (file changes)
         if: startsWith(github.ref, 'refs/tags/') == false
         # We don't want to stop the build on errors.
@@ -121,8 +130,8 @@ jobs:
         with:
           entrypoint: ./.github/actions/build.sh
         env:
-          GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
-          SPK_TO_BUILD: ${{ github.event.inputs.package }}
+          ARCH_PACKAGES: ${{ needs.prepare.outputs.arch_packages }}
+          NOARCH_PACKAGES: ${{ needs.prepare.outputs.noarch_packages }}
           PUBLISH: ${{ github.event.inputs.publish }}
           API_KEY: ${{ secrets.PUBLISH_API_KEY }}
           # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules


### PR DESCRIPTION
_Motivation:_  Try to cache downloaded files in digests folder for faster run of github build action
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/4866#issuecomment-922116351

### Remarks
This gives some improvements for the github build action, as the dependency-list is created only once in the prepare job and not for the download and every build job again.
The download job downloads all referenced source files and add those to the cache for the current workflow.
And the build jobs use the source files in distrib folder from that cache.
