### PR TITLE
try to fix sickchill

### DIFF
--- a/spk/sickchill/Makefile
+++ b/spk/sickchill/Makefile
@@ -1,11 +1,12 @@
 SPK_NAME = sickchill
 SPK_VERS = 20210729
-SPK_REV = 2
+SPK_REV = 3
 SPK_ICON = src/sickchill.png
 
+BUILD_DEPENDS = cross/python38 cross/setuptools cross/pip cross/wheel
 DEPENDS = cross/$(SPK_NAME)
+
 SPK_DEPENDS = "python38:git"
-PIP=pip3
 
 WHEELS = src/requirements.txt
 
@@ -14,10 +15,10 @@ DESCRIPTION = Automatic Video Library Manager for TV Shows. It watches for new e
 DESCRIPTION_SPN = Gestor automático para bibliotecas de series. Busca nuevos episodios de tus series favoritas, y cuando son publicados hace su magia.
 STARTABLE = yes
 DISPLAY_NAME = SickChill
-CHANGELOG = "Initial SickChill env fix and move to Python 3.8"
+CHANGELOG = "Fix for non intel archs and python38"
 
 HOMEPAGE   = https://sickchill.github.io/
-LICENSE    = GPL
+LICENSE    = GPLv3+
 
 SERVICE_USER = auto
 SERVICE_SETUP = src/service-setup.sh
@@ -30,9 +31,6 @@ ADMIN_PORT = $(SERVICE_PORT)
 WIZARDS_DIR = src/wizard/
 
 POST_STRIP_TARGET = sickchill_extra_install
-
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/sickchill/src/requirements.txt
+++ b/spk/sickchill/src/requirements.txt
@@ -1,4 +1,4 @@
-appdirs==1.4.4
+###appdirs==1.4.4		# python38 site-package
 attrdict==2.0.1
 babelfish==0.5.5
 beautifulsoup4==4.9.3
@@ -23,18 +23,18 @@ gntp==1.0.3
 guessit==3.1.1
 html5lib==1.1
 httplib2==0.18.1
-idna==2.10
+###idna==2.10			# python38 site-package
 ifaddr==0.1.7
 imagesize==1.2.0
 IMDbPY==2020.9.25
-ipaddress==1.0.23
+###ipaddress==1.0.23	# python38 site-package
 Js2Py==0.70
 jsonrpclib-pelix==0.4.2
 ###kodipydent==0.3.1
 ###lxml==4.6.1
 Mako==1.1.3
 markdown2==2.3.10
-MarkupSafe==1.1.1
+###MarkupSafe==1.1.1	# python38 site-package
 msgpack==1.0.0
 new-rtorrent-python==1.0.1a0
 oauthlib==3.1.0
@@ -43,13 +43,13 @@ pbr==5.5.1
 profilehooks==1.12.0
 putio.py==8.7.0
 pyaes==1.6.1
-pycparser==2.20
+###pycparser==2.20		# python38 site-package
 PyGithub==1.53
 pyjsparser==2.7.1
 PyJWT==1.7.1
 pymediainfo==4.3
 PyNMA==1.0
-pyOpenSSL==19.1.0
+###pyOpenSSL==19.1.0	# python38 site-package
 pyparsing==2.4.7
 PySocks==1.7.1
 pysrt==1.1.2
@@ -66,9 +66,9 @@ requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1
 Send2Trash==1.5.0
 sgmllib3k==1.0.0
-six==1.15.0
+###six==1.15.0			# python38 site-package
 soupsieve==2.0.1
-SQLAlchemy==1.3.20
+###SQLAlchemy==1.3.20	# python38 site-package
 stevedore==3.2.2
 subliminal==2.1.0
 text-unidecode==1.3

--- a/spk/sickchill/src/service-setup.sh
+++ b/spk/sickchill/src/service-setup.sh
@@ -1,12 +1,14 @@
+
+
 PYTHON_DIR="/var/packages/python38/target"
 PIP=${SYNOPKG_PKGDEST}/env/bin/pip3
 PATH="${SYNOPKG_PKGDEST}/bin:${SYNOPKG_PKGDEST}/env/bin:${PYTHON_DIR}/bin:${PATH}"
-HOME="${SYNOPKG_PKGDEST}/var"
-VIRTUALENV="${PYTHON_DIR}/bin/virtualenv"
+HOME="${SYNOPKG_PKGVAR}"
+VIRTUALENV="${PYTHON_DIR}/bin/python3 -m venv"
 PYTHON="${SYNOPKG_PKGDEST}/env/bin/python3"
 SC_INSTALL_DIR="${SYNOPKG_PKGDEST}/share/SickChill"
 SC_BINARY="${SC_INSTALL_DIR}/SickChill.py"
-SC_DATA_DIR="${SYNOPKG_PKGDEST}/var/data"
+SC_DATA_DIR="${SYNOPKG_PKGVAR}/data"
 SC_CFG_FILE="${SC_DATA_DIR}/config.ini"
 
 
@@ -44,18 +46,24 @@ service_postinst() {
     ${VIRTUALENV} --system-site-packages ${SYNOPKG_PKGDEST}/env
 
     # Install the wheels
-    ${PIP} install --no-deps --no-index -U --force-reinstall -f ${SYNOPKG_PKGDEST}/share/wheelhouse ${SYNOPKG_PKGDEST}/share/wheelhouse/*.whl
+    wheelhouse=${SYNOPKG_PKGDEST}/share/wheelhouse
+    ${PIP} install --no-deps --no-index --upgrade --force-reinstall --find-links ${wheelhouse} ${wheelhouse}/*.whl
 
     if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
         set_config
     fi
 
-    set_unix_permissions "${SYNOPKG_PKGDEST}"
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
+        set_unix_permissions "${SYNOPKG_PKGDEST}"
+    fi
 }
 
 service_postupgrade() {
     set_config
-    set_unix_permissions "${SYNOPKG_PKGDEST}"
+    
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
+        set_unix_permissions "${SYNOPKG_PKGDEST}"
+    fi
 }
 
 service_preupgrade ()


### PR DESCRIPTION
_Motivation:_  SickChill does not run on arm archs
_Linked issues:_  #4867

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

### Remarks
- avoid noarch due to arch specific requirements (wheels)
- remove python38 site-packages from wheelhouse
- adjust service-setup.sh for DSM 7

### TODO
- sickchill still runs on x64 (and may be on x86) only (fails to run armv7-6.1, aarch64-6.1)

