### PR TITLE
Fix ripgrep #4878

### DIFF
--- a/cross/ripgrep/Makefile
+++ b/cross/ripgrep/Makefile
@@ -12,9 +12,11 @@ DEPENDS =
 UNSUPPORTED_ARCHS += $(OLD_PPC_ARCHS)
 
 HOMEPAGE = https://github.com/BurntSushi/ripgrep
-COMMENT  = ripgrep recursively searches directories for a regex pattern 
+COMMENT  = ripgrep recursively searches directories for a regex pattern
 LICENSE  = public domain/Unlicense
 
+# https://github.com/SynoCommunity/spksrc/issues/4878
+ENV += PCRE2_SYS_STATIC=1
 CARGO_BUILD_ARGS += --features 'pcre2'
 
 include ../../mk/spksrc.cross-rust.mk

--- a/cross/ripgrep/Makefile
+++ b/cross/ripgrep/Makefile
@@ -15,7 +15,7 @@ HOMEPAGE = https://github.com/BurntSushi/ripgrep
 COMMENT  = ripgrep recursively searches directories for a regex pattern
 LICENSE  = public domain/Unlicense
 
-# https://github.com/SynoCommunity/spksrc/issues/4878
+# Force static build when pcre2 is detected in synocli-file build environment
 ENV += PCRE2_SYS_STATIC=1
 CARGO_BUILD_ARGS += --features 'pcre2'
 

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -49,7 +49,7 @@ export PCRE2_CLI_FULL
 
 DESCRIPTION = "SynoCli File Tools provides a set of small command-line utilities: less, tree, ncdu, jdupes, fdupes, rhash, mc \(midnight commander\), mg \(emacs-like text editor\), nano, file, detox, pcre2, zstd, lzip, plzip, detox$(OPTIONAL_DESC)."
 STARTABLE = no
-CHANGELOG = "fix ripgrep"
+CHANGELOG = "1. Fix ripgrep<br>2. Fix mc for comcerto2k"
 
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliFile
 LICENSE  = Each tool is licensed under it's respective license.

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-file
 SPK_VERS = 2.3
-SPK_REV = 10
+SPK_REV = 11
 SPK_ICON = src/synocli-file.png
 
 DEPENDS = cross/less cross/tree cross/ncdu cross/jdupes cross/rhash cross/mc cross/nano cross/file
@@ -49,7 +49,7 @@ export PCRE2_CLI_FULL
 
 DESCRIPTION = "SynoCli File Tools provides a set of small command-line utilities: less, tree, ncdu, jdupes, fdupes, rhash, mc \(midnight commander\), mg \(emacs-like text editor\), nano, file, detox, pcre2, zstd, lzip, plzip, detox$(OPTIONAL_DESC)."
 STARTABLE = no
-CHANGELOG = "1. Add rg (ripgrep).<br/>2. Add fd (fd-find).<br/>3. Add mg (emacs-like text editor)."
+CHANGELOG = "fix ripgrep"
 
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliFile
 LICENSE  = Each tool is licensed under it's respective license.


### PR DESCRIPTION
When building synocli-file the dependencies from other packages include
PCRE2 and contaminate the build for ripgrep. The lib was found and
dynamically linked. Setting PCRE2_SYS_STATIC=1 ensures static linking

>Enabling the PCRE2 feature works with a stable Rust compiler and will attempt to automatically find and link with your system's PCRE2 library via pkg-config. If one doesn't exist, then ripgrep will build PCRE2 from source using your system's C compiler and then statically link it into the final executable. Static linking can be forced even when there is an available PCRE2 system library by either building ripgrep with the MUSL target or by setting PCRE2_SYS_STATIC=1.

From https://github.com/BurntSushi/ripgrep#building

_Linked issues:_  #4878

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
