### PR TITLE
Add extract size to spk info file

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -227,6 +227,7 @@ ifneq ($(strip $(SPK_CONFLICT)),)
 	@echo install_conflict_packages=\"$(SPK_CONFLICT)\" >> $@
 endif
 	@echo checksum=\"`md5sum $(WORK_DIR)/package.tgz | cut -d" " -f1`\" >> $@
+	@echo extractsize=\"`du -sk "$(STAGING_DIR)" | awk '{print $1}'`\" >> $@
 
 ifneq ($(strip $(DEBUG)),)
 INSTALLER_OUTPUT = >> /root/$${PACKAGE}-$${SYNOPKG_PKG_STATUS}.log 2>&1

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -227,7 +227,13 @@ ifneq ($(strip $(SPK_CONFLICT)),)
 	@echo install_conflict_packages=\"$(SPK_CONFLICT)\" >> $@
 endif
 	@echo checksum=\"`md5sum $(WORK_DIR)/package.tgz | cut -d" " -f1`\" >> $@
+ifeq ($(call version_le, ${TC_OS_MIN_VER}, 5.2),1)
+# In DSM 5.2 or older, the size based on byte units.
+	@echo extractsize=\"`du -sb "$(STAGING_DIR)" | awk '{print $1}'`\" >> $@
+else
+# The size based on kilobyte units
 	@echo extractsize=\"`du -sk "$(STAGING_DIR)" | awk '{print $1}'`\" >> $@
+endif
 
 ifneq ($(strip $(DEBUG)),)
 INSTALLER_OUTPUT = >> /root/$${PACKAGE}-$${SYNOPKG_PKG_STATUS}.log 2>&1


### PR DESCRIPTION
This helps warn users in the rare case during the install when there isn't enough space to install the package.
https://help.synology.com/developer-guide/synology_package/INFO_optional_fields.html#field-name--extractsize

