### PR TITLE
lirc: Fix build for 88f6281 arch and declare all PPC unsupported

### DIFF
--- a/cross/lirc-0.8.7/Makefile
+++ b/cross/lirc-0.8.7/Makefile
@@ -13,7 +13,7 @@ COMMENT  = LIRC daemon decodes infrared signals and provides them on a Unix doma
 LICENSE  = GPLv2
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --with-transmitter --with-driver=all --with-moduledir=$(MOD_DIR) --enable-sandboxed  --with-kerneldir=$(KERNEL_DIR)
+CONFIGURE_ARGS = --with-transmitter --with-driver=all --with-moduledir=$(MOD_DIR) --enable-sandboxed  --with-kerneldir=$(KERNEL_ROOT)
 
 POST_CONFIGURE_TARGET = lirc_kill_drivers
 

--- a/cross/lirc-0.9.0/Makefile
+++ b/cross/lirc-0.9.0/Makefile
@@ -13,6 +13,6 @@ COMMENT  = LIRC daemon decodes infrared signals and provides them on a Unix doma
 LICENSE  = GPLv2
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --with-transmitter --with-driver=userspace --with-moduledir=$(MOD_DIR) --enable-sandboxed  --with-kerneldir=$(KERNEL_DIR)
+CONFIGURE_ARGS = --with-transmitter --with-driver=userspace --with-moduledir=$(MOD_DIR) --enable-sandboxed  --with-kerneldir=$(KERNEL_ROOT)
 
 include ../../mk/spksrc.cross-cc.mk

--- a/spk/lirc/Makefile
+++ b/spk/lirc/Makefile
@@ -7,7 +7,7 @@ FIRMWARE = 4.3-3776
 LIRC_SUPPORTED_DRIVERS =
 
 # Abort for ARCHs that won't compile LIRC cleanly
-UNSUPPORTED_ARCHS = powerpc
+UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 
 # include arch definitions
 include ../../mk/spksrc.archs.mk


### PR DESCRIPTION
_Motivation:_  Extracting trivial build fixes from #4797 to keep only things in scope of that rather large PR.
_Linked issues:_  #4797

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
