### PR TITLE
Comply to DSM7 and set as broken

### DIFF
--- a/mk/spksrc.pre-check.mk
+++ b/mk/spksrc.pre-check.mk
@@ -1,5 +1,12 @@
 # Common requirement checks
 
+ifneq ($(wildcard BROKEN),)
+  ifneq ($(BUILD_UNSUPPORTED_FILE),)
+    $(shell echo $(date --date=now +"%Y.%m.%d %H:%M:%S") - $(NAME): Broken package >> $(BUILD_UNSUPPORTED_FILE))
+  endif
+  @$(error $(NAME): Broken package)
+endif
+
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
   ifneq ($(strip $(INSTALLER_SCRIPT)),)
     ifneq ($(BUILD_UNSUPPORTED_FILE),)

--- a/mk/spksrc.pre-check.mk
+++ b/mk/spksrc.pre-check.mk
@@ -10,7 +10,7 @@ endif
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
   ifneq ($(strip $(INSTALLER_SCRIPT)),)
     ifneq ($(BUILD_UNSUPPORTED_FILE),)
-      $(shell echo $(date --date=now +"%Y.%m.%d %H:%M:%S") - $(NAME): INSTALLER_SCRIPT '$(INSTALLER_SCRIPT)' cannot be used whith DSM7+ >> $(BUILD_UNSUPPORTED_FILE))
+      $(shell echo $(date --date=now +"%Y.%m.%d %H:%M:%S") - $(NAME): INSTALLER_SCRIPT '$(INSTALLER_SCRIPT)' cannot be used with DSM7+ >> $(BUILD_UNSUPPORTED_FILE))
     endif
     @$(error INSTALLER_SCRIPT '$(INSTALLER_SCRIPT)' cannot be used for DSM7+ packages)
   endif

--- a/mk/spksrc.pre-check.mk
+++ b/mk/spksrc.pre-check.mk
@@ -1,5 +1,14 @@
 # Common requirement checks
 
+ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+  ifneq ($(strip $(INSTALLER_SCRIPT)),)
+    ifneq ($(BUILD_UNSUPPORTED_FILE),)
+      $(shell echo $(date --date=now +"%Y.%m.%d %H:%M:%S") - $(NAME): INSTALLER_SCRIPT '$(INSTALLER_SCRIPT)' cannot be used whith DSM7+ >> $(BUILD_UNSUPPORTED_FILE))
+    endif
+    @$(error INSTALLER_SCRIPT '$(INSTALLER_SCRIPT)' cannot be used for DSM7+ packages)
+  endif
+endif
+
 # Check for build for generic archs, these are not supporting `require kernel`.
 ifneq ($(REQUIRE_KERNEL),)
   ifneq (,$(findstring $(ARCH),x64 aarch64 armv7))

--- a/spk/debian-chroot/BROKEN
+++ b/spk/debian-chroot/BROKEN
@@ -1,0 +1,2 @@
+2021-10-06 (@th0ma7)
+Now requires cdebootstrap which mandatory requires root access

--- a/spk/pyload/BROKEN
+++ b/spk/pyload/BROKEN
@@ -1,0 +1,2 @@
+2021-10-06 (@th0ma7)
+Should consider migrating to python3 version and remove js dependency


### PR DESCRIPTION
_Motivation:_  Extracting trivial build fixes from #4797 to keep only things in scope of that rather large PR.  This patchset enforce package to compliance to DSM7 and allow marking packages as BROKEN.

1. Packages still using non-standard setup script (e.g. `src/installer.sh`) dates from pre-DSM6 and should be marked as incompatible with DSM7 to avoid building it and provide clean github-action outputs.  This is done by checking if the package is making use of the `INSTALLER_SCRIPT` such as `INSTALLER_SCRIPT = src/installer.sh`.  This necessarily means that it hasn't been migrated to DSM6+ default framework method using `SERVICE_SETUP = src/service-setup.sh`.  As such there is not value at trying to build them for DSM7 and are being excluded from the build process, thus reducing time to build and removing false-positive.
2. Add the ability to mark certain packages as broken simply by adding a `BROKEN` file in its directory.  File can be empty or include reasons why it is currently being marked as such for future work in fixing it occurs. Simply add a `spk/<app>/BROKEN` file with what ever comments to explain reasons for it.  Starting with the following packages:
- `debian-chroot`
- `gentoo-chroot`
- `pyload`
- `sickchill`

_Linked issues:_  Build output example with this patchset applied can be looked at #4797

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
