### PR TITLE
Update jellyfin 10.7.7

### DIFF
--- a/cross/jellyfin-web/Makefile
+++ b/cross/jellyfin-web/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin-web
-PKG_VERS = 10.7.6
+PKG_VERS = 10.7.7
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin-web/archive

--- a/cross/jellyfin-web/digests
+++ b/cross/jellyfin-web/digests
@@ -1,3 +1,3 @@
-jellyfin-web-10.7.6.tar.gz SHA1 355df10c3847f18c5f72fd8127311a6939883da6
-jellyfin-web-10.7.6.tar.gz SHA256 1013e3be80d744684093ad4c4df3a16bcbeda8364978608d5c65b0bbc7940f77
-jellyfin-web-10.7.6.tar.gz MD5 591dd04548fc8466c1d623ab49a4cbe4
+jellyfin-web-10.7.7.tar.gz SHA1 26aa73dc4ad3d6a3b6e9aa4d17615b228cbe4b33
+jellyfin-web-10.7.7.tar.gz SHA256 67b237b05bbc463828229971ce509d860b9d69cfee6aef4ba57b0c15d844bd78
+jellyfin-web-10.7.7.tar.gz MD5 994cea7af3efeafea7e47f367bd47439

--- a/cross/jellyfin/Makefile
+++ b/cross/jellyfin/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin
-PKG_VERS = 10.7.6
+PKG_VERS = 10.7.7
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin/archive

--- a/cross/jellyfin/digests
+++ b/cross/jellyfin/digests
@@ -1,3 +1,3 @@
-jellyfin-10.7.6.tar.gz SHA1 17699d751d67614ddbc5c5deff195870f04bf5e8
-jellyfin-10.7.6.tar.gz SHA256 fb54ef3862f03ec50f8c6e1c95df98601e53947bb2891f369d1533d8711f2ec9
-jellyfin-10.7.6.tar.gz MD5 431be2cb8203b37037a772a693bf90ed
+jellyfin-10.7.7.tar.gz SHA1 df81aff2486f4f1f06ffb1bebb987f372c97d4bd
+jellyfin-10.7.7.tar.gz SHA256 9cc1ff3c6c48afb1c7e4a8c63d05e9c501f5d05485ca56b74d1c72736a43221d
+jellyfin-10.7.7.tar.gz MD5 6973f08eef7fd6c2cc2cdeeeb2a2a403

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
-SPK_VERS = 10.7.6
-SPK_REV = 3
+SPK_VERS = 10.7.7
+SPK_REV = 4
 SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
@@ -12,7 +12,7 @@ MAINTAINER = publicarray
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "Update jellyfin to 10.7.6"
+CHANGELOG = "Update jellyfin to 10.7.7"
 HOMEPAGE = https://jellyfin.org
 HELPURL    = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html


### PR DESCRIPTION
_Motivation:_  Update jellyfin to 10.7.7
_Linked issues:_

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
