### PR TITLE
minio: fix username and password validation in installer wizard

### DIFF
--- a/spk/minio/Makefile
+++ b/spk/minio/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = minio
 SPK_VERS = 2021.10.23
-SPK_REV = 10
+SPK_REV = 11
 SPK_ICON = src/minio.png
 DSM_UI_DIR = app
 
@@ -11,7 +11,7 @@ UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 MAINTAINER = fgma
 DESCRIPTION = MinIO is a high performance object storage server compatible with Amazon S3 APIs.
 DISPLAY_NAME = MinIO
-CHANGELOG = "Update to MinIO 2021-10-23T03-28-24Z. Multiple feature releases and a security bugfix release."
+CHANGELOG = "Fix username and password validation in installer wizard."
 LICENSE_FILE = $(WORK_DIR)/src/github.com/minio/minio/LICENSE
 HOMEPAGE = https://min.io/
 LICENSE = AGPLv3.0

--- a/spk/minio/src/wizard/install_uifile
+++ b/spk/minio/src/wizard/install_uifile
@@ -64,7 +64,7 @@
 							"allowBlank": false,
 							"minLength": 3,
 							"regex": {
-								"expr": "/^[^<>:*/?\"|]*$/",
+								"expr": "/^[a-zA-Z0-9-_]*$/",
 								"errorText": "Not allowed character in username"
 							}
 						}
@@ -82,7 +82,7 @@
 							"allowBlank": false,
 							"minLength": 8,
 							"regex": {
-								"expr": "/^[^\"|]*$/",
+								"expr": "/^[a-zA-Z0-9-_!@#]*$/",
 								"errorText": "Not allowed character in password"
 							}
 						}

--- a/spk/minio/src/wizard/upgrade_uifile.sh
+++ b/spk/minio/src/wizard/upgrade_uifile.sh
@@ -76,7 +76,7 @@ cat <<EOF > $SYNOPKG_TEMP_LOGFILE
 							"allowBlank": false,
 							"minLength": 3,
 							"regex": {
-								"expr": "/^[^<>:*/?\"|]*$/",
+								"expr": "/^[a-zA-Z0-9-_]*$/",
 								"errorText": "Not allowed character in username"
 							}
 						}
@@ -94,7 +94,7 @@ cat <<EOF > $SYNOPKG_TEMP_LOGFILE
 							"allowBlank": false,
 							"minLength": 8,
 							"regex": {
-								"expr": "/^[^\"|]*$/",
+								"expr": "/^[a-zA-Z0-9-_!@#]*$/",
 								"errorText": "Not allowed character in password"
 							}
 						}


### PR DESCRIPTION
_Motivation:_  Invalid characters in username or password break installation.
_Linked issues:_  https://github.com/SynoCommunity/spksrc/issues/4933

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully


Proposed fix only restricts characters in username and password to a defined set of characters.