### PR TITLE
python310: Fix display name

### DIFF
--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -28,7 +28,7 @@ DESCRIPTION = Python Programming Language.
 DESCRIPTION_FRE = Langage de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.
 STARTABLE = no
-DISPLAY_NAME = Python 3.9
+DISPLAY_NAME = Python 3.10
 CHANGELOG = "1. Initial release"
 
 HOMEPAGE = https://www.python.org


### PR DESCRIPTION
_Motivation:_  While updating from 3.9 to 3.10 this got lost in translation...
_Linked issues:_  #4937

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
