### PR TITLE
Sickchill: Followup

### DIFF
--- a/spk/sickchill/src/requirements.txt
+++ b/spk/sickchill/src/requirements.txt
@@ -2,7 +2,7 @@
 poetry==1.2.0a2
 poetry-core==1.1.0a6
 poetry-date-version-plugin==2021.7.16-6
-###py38 appdirs==1.4.4 
+###py38 appdirs==1.4.4
 babelfish==0.6.0
 beautifulsoup4==4.10.0
 beekeeper-alt==2021.7.16
@@ -35,7 +35,7 @@ Mako==1.1.5
 markdown2==2.4.1
 new-rtorrent-python==1.0.1a0
 oauthlib==3.1.1
-packaging==21.2
+packaging==20.9
 pbr==5.7.0
 profilehooks==1.12.0
 putio.py==8.7.0
@@ -48,7 +48,7 @@ pyjwt==2.3.0
 pymediainfo==5.1.0
 pynma==1.0
 ###py38 pyopenssl==20.0.1
-pyparsing==3.0.4
+pyparsing==2.4.7
 pysocks==1.7.1
 pysrt==1.1.2
 ###python-dateutil==2.8.2


### PR DESCRIPTION
Continuation from https://github.com/SynoCommunity/spksrc/pull/4920#issuecomment-961795426

fixes:

```
2021/11/05 17:45:12	ERROR: Cannot install cloudscraper==1.2.58, httplib2==0.20.2, packaging==21.2 and pyparsing 3.0.4 (from /volume1/@appstore/sickchill/share/wheelhouse/pyparsing-3.0.4-py3-none-any.whl) because these package versions have conflicting dependencies.
2021/11/05 17:45:12	The conflict is caused by:
2021/11/05 17:45:12	    The user requested pyparsing 3.0.4 (from /volume1/@appstore/sickchill/share/wheelhouse/pyparsing-3.0.4-py3-none-any.whl)
2021/11/05 17:45:12	    cloudscraper 1.2.58 depends on pyparsing>=2.4.7
2021/11/05 17:45:12	    httplib2 0.20.2 depends on pyparsing!=3.0.0, !=3.0.1, !=3.0.2, !=3.0.3, <4 and >=2.4.2; python_version > "3.0"
2021/11/05 17:45:12	    packaging 21.2 depends on pyparsing<3 and >=2.0.2


2021/11/05 18:10:07	ERROR: Cannot install packaging 21.2 (from /volume1/@appstore/sickchill/share/wheelhouse/packaging-21.2-py3-none-any.whl) and poetry==1.2.0a2 because these package versions have conflicting dependencies.
2021/11/05 18:10:07	The conflict is caused by:
2021/11/05 18:10:07	    The user requested packaging 21.2 (from /volume1/@appstore/sickchill/share/wheelhouse/packaging-21.2-py3-none-any.whl)
2021/11/05 18:10:07	    poetry 1.2.0a2 depends on packaging<21.0 and >=20.4
```