### PR TITLE
native/yasm: use github release & cross/libsodium: update digests

### DIFF
--- a/cross/libsodium/digests
+++ b/cross/libsodium/digests
@@ -1,3 +1,3 @@
-libsodium-1.0.18-stable.tar.gz SHA1 e78debf512a8f7465c00c1f7bb62d9745e57e905
-libsodium-1.0.18-stable.tar.gz SHA256 81869090064d09e9ff3be5a5fff52f9ed94cd06b0dc3b20e2aaa0d63be9395c6
-libsodium-1.0.18-stable.tar.gz MD5 e81038f2a8cf174b822e756271b3a5ac
+libsodium-1.0.18-stable.tar.gz SHA1 4b3436c574981404d972a46e4272f10e7343aa51
+libsodium-1.0.18-stable.tar.gz SHA256 5cf5c44cb1ebebb2f0cee71423b3bb676c3c0c7d775f1d6c22a6fd9e172a779d
+libsodium-1.0.18-stable.tar.gz MD5 29aeaf20216b065b31f7c22e404a8519

--- a/native/yasm/Makefile
+++ b/native/yasm/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = yasm
 PKG_VERS = 1.3.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://www.tortall.net/projects/yasm/releases
+PKG_DIST_SITE = https://github.com/yasm/yasm/releases/download/v$(PKG_VERS)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =


### PR DESCRIPTION
See: https://github.com/SynoCommunity/spksrc/pull/4951#discussion_r746493700

Just in-case the cert expires again

### Checklist
- [x] native build