### PR TITLE
move libsodium to point releases

### DIFF
--- a/cross/libsodium/Makefile
+++ b/cross/libsodium/Makefile
@@ -3,7 +3,7 @@ PKG_VERS = 1.0.18
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://download.libsodium.org/libsodium/releases
-PKG_DIR = $(PKG_NAME)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 

--- a/cross/libsodium/Makefile
+++ b/cross/libsodium/Makefile
@@ -1,9 +1,9 @@
 PKG_NAME = libsodium
 PKG_VERS = 1.0.18
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-stable.$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://download.libsodium.org/libsodium/releases
-PKG_DIR = $(PKG_NAME)-stable
+PKG_DIR = $(PKG_NAME)
 
 DEPENDS =
 

--- a/cross/libsodium/digests
+++ b/cross/libsodium/digests
@@ -1,3 +1,3 @@
-libsodium-1.0.18-stable.tar.gz SHA1 94c95a7c9104b0ad710c86d9052b4b0776474af6
-libsodium-1.0.18-stable.tar.gz SHA256 419ba971f2d9fbf71f2fa96a6fe334e9618fd6c14c85d8cd6d1bfb60acc4681d
-libsodium-1.0.18-stable.tar.gz MD5 e9be23a62450d967b9bcba9d53ea2ada
+libsodium-1.0.18.tar.gz SHA1 795b73e3f92a362fabee238a71735579bf46bb97
+libsodium-1.0.18.tar.gz SHA256 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
+libsodium-1.0.18.tar.gz MD5 3ca9ebc13b6b4735acae0a6a4c4f9a95


### PR DESCRIPTION
 libsodium `-stable` is a moving target: https://github.com/SynoCommunity/spksrc/pull/4963#issuecomment-966669734