### PR TITLE
[WIP] Predownload wheel sources

### DIFF
--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -29,12 +29,12 @@ build_packages="${NOARCH_PACKAGES} ${ARCH_PACKAGES}"
 
 if [ -z "${build_packages}" ]; then
     echo "===> No wheels to download. <==="
-    exit 0
+else
+    for package in ${build_packages}
+    do
+        echo "===> Download wheels: ${package}"
+        make -C spk/${package} download_wheel
+    done
 fi
-for package in ${build_packages}
-do
-    echo "===> Download wheels: ${package}"
-    make -C spk/${package} download_wheel
-done
 
 echo ""

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -44,6 +44,6 @@ for package in ${build_packages}
 do
     echo "===> Download wheels: ${package}"
     make -C src/${package} download_wheel
-fi
+done
 
 echo ""

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -22,13 +22,10 @@ else
     done
 fi
 
+echo ""
+
 # Download any python wheel sources
 build_packages="${NOARCH_PACKAGES} ${ARCH_PACKAGES}"
-
-echo ""
-echo "NOARCH_PACKAGES: ${NOARCH_PACKAGES}"
-echo "ARCH_PACKAGES: ${ARCH_PACKAGES}"
-echo "build_packages: ${build_packages}"
 
 if [ -z "${build_packages}" ]; then
     echo "===> No wheels to download. <==="

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -23,15 +23,9 @@ else
 fi
 
 # Download any python wheel sources
-if [ "${GH_ARCH%%-*}" = "noarch" ]; then
-    build_packages=${NOARCH_PACKAGES}
-else
-    build_packages=${ARCH_PACKAGES}
-fi
+build_packages="${NOARCH_PACKAGES} ${ARCH_PACKAGES}"
 
 echo ""
-echo "GH_ARCH: ${GH_ARCH%%-*}"
-echo "GH_ARCH: ${GH_ARCH}"
 echo "NOARCH_PACKAGES: ${NOARCH_PACKAGES}"
 echo "ARCH_PACKAGES: ${ARCH_PACKAGES}"
 echo "build_packages: ${build_packages}"
@@ -43,7 +37,7 @@ fi
 for package in ${build_packages}
 do
     echo "===> Download wheels: ${package}"
-    make -C src/${package} download_wheel
+    make -C spk/${package} download_wheel
 done
 
 echo ""

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -43,7 +43,7 @@ fi
 for package in ${build_packages}
 do
     echo "===> Download wheels: ${package}"
-    make -C ${package} download_wheel
+    make -C src/${package} download_wheel
 fi
 
 echo ""

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -30,11 +30,14 @@ else
 fi
 
 echo ""
+echo "GH_ARCH: ${GH_ARCH%%-*}"
+echo "GH_ARCH: ${GH_ARCH}"
+echo "NOARCH_PACKAGES: ${NOARCH_PACKAGES}"
+echo "ARCH_PACKAGES: ${ARCH_PACKAGES}"
+echo "build_packages: ${build_packages}"
 
 if [ -z "${build_packages}" ]; then
     echo "===> No wheels to download. <==="
-    echo "GH_ARCH: ${GH_ARCH%%-*}"
-    echo "GH_ARCH: ${GH_ARCH}"
     exit 0
 fi
 for package in ${build_packages}
@@ -42,3 +45,5 @@ do
     echo "===> Download wheels: ${package}"
     make -C ${package} download_wheel
 fi
+
+echo ""

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -9,6 +9,7 @@
 
 set -o pipefail
 
+# Download regular cross/* sources
 if [ -z "${DOWNLOAD_PACKAGES}" ]; then
     echo "===> No packages to download. <==="
 else
@@ -18,4 +19,23 @@ else
         echo "$ make -c ${download} download"
         make -C ${download} download
     done
+fi
+
+# Download any python wheel sources
+if [ "${GH_ARCH%%-*}" = "noarch" ]; then
+    build_packages=${NOARCH_PACKAGES}
+else
+    build_packages=${ARCH_PACKAGES}
+fi
+
+echo ""
+
+if [ -z "${build_packages}" ]; then
+    echo "===> No packages to build. <==="
+    exit 0
+fi
+for package in ${build_packages}
+do
+    echo "===> Download wheels: ${package}"
+    make -C ${package} download_wheel
 fi

--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -6,6 +6,7 @@
 #
 # Functions:
 # - Download all referenced native and cross source files for packages to build.
+# - Download all referenced python wheels needed to build.
 
 set -o pipefail
 
@@ -31,7 +32,9 @@ fi
 echo ""
 
 if [ -z "${build_packages}" ]; then
-    echo "===> No packages to build. <==="
+    echo "===> No wheels to download. <==="
+    echo "GH_ARCH: ${GH_ARCH%%-*}"
+    echo "GH_ARCH: ${GH_ARCH}"
     exit 0
 fi
 for package in ${build_packages}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,9 @@ jobs:
         run: ./.github/actions/download.sh
         env:
           DOWNLOAD_PACKAGES: ${{ needs.prepare.outputs.download_packages }}
+          ARCH_PACKAGES: ${{ needs.prepare.outputs.arch_packages }}
+          NOARCH_PACKAGES: ${{ needs.prepare.outputs.noarch_packages }}
+          GH_ARCH: ${{ matrix.arch }}
 
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,6 @@ jobs:
           DOWNLOAD_PACKAGES: ${{ needs.prepare.outputs.download_packages }}
           ARCH_PACKAGES: ${{ needs.prepare.outputs.arch_packages }}
           NOARCH_PACKAGES: ${{ needs.prepare.outputs.noarch_packages }}
-          GH_ARCH: ${{ matrix.arch }}
 
   build:
     name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ RUN pip2 install virtualenv httpie
 RUN wget https://bootstrap.pypa.io/get-pip.py -O - | python3
 # Install meson cross-platform build system
 RUN pip3 install meson==0.56.0
+# Install poetry to allow pre-downloading wheels
+RUN pip3 install poetry==1.1.13
 
 # Volume pointing to spksrc sources
 VOLUME /spksrc

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -23,8 +23,18 @@ PIP_HOST = $(shell which pip)
 PIP_CACHE_OPT ?= --no-cache-dir --find-links $(BASE_DISTRIB_DIR)
 
 # Define default wheel & download pip options
-PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --no-index --wheel-dir $(WHEELHOUSE)
+PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --wheel-dir $(WHEELHOUSE)
+
+# If we're only building cross-compiled wheels
+# all packages will be pre-downloaded, do not
+# check online index to ensure using local files
+ifneq ($(strip $(WHEELS_PURE_PYTHON_PACKAGING_ENABLE)),TRUE)
+PIP_WHEEL_ARGS += --no-index
+endif
+
 # BROKEN: https://github.com/pypa/pip/issues/1884
+# Current implementation is a work-around for the
+# lack of proper source download support from pip
 PIP_DOWNLOAD_ARGS = download --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --dest $(BASE_DISTRIB_DIR) --no-build-isolation
 
 # Available languages

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -21,7 +21,11 @@ PIP_SYSTEM = $(shell which pip)
 
 # Why ask for the same thing twice? Always cache downloads
 PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR)
-PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --wheel-dir $(WHEELHOUSE)
+PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --find-links $(BASE_DISTRIB_DIR) --wheel-dir $(WHEELHOUSE)
+PIP_WHEEL = $(PIP) $(PIP_WHEEL_ARGS)
+# Allow pre-downloading wheel sources
+PIP_DOWNLOAD_ARGS = download --no-binary :all: --find-links $(BASE_DISTRIB_DIR) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
+PIP_DOWNLOAD = $(PIP) $(PIP_DOWNLOAD_ARGS)
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -35,7 +35,7 @@ endif
 # BROKEN: https://github.com/pypa/pip/issues/1884
 # Current implementation is a work-around for the
 # lack of proper source download support from pip
-PIP_DOWNLOAD_ARGS = download --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --dest $(BASE_DISTRIB_DIR) --no-build-isolation
+PIP_DOWNLOAD_ARGS = download --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --dest $(BASE_DISTRIB_DIR) --no-build-isolation --exists-action w
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -20,11 +20,11 @@ PIP ?= pip
 PIP_SYSTEM = $(shell which pip)
 
 # Why ask for the same thing twice? Always cache downloads
-PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR)
-PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --find-links $(BASE_DISTRIB_DIR) --wheel-dir $(WHEELHOUSE)
+PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR) --find-links $(BASE_DISTRIB_DIR)
+PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --wheel-dir $(WHEELHOUSE)
 PIP_WHEEL = $(PIP) $(PIP_WHEEL_ARGS)
 # Allow pre-downloading wheel sources
-PIP_DOWNLOAD_ARGS = download --no-binary :all: $(PIP_CACHE_OPT) --find-links $(BASE_DISTRIB_DIR) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
+PIP_DOWNLOAD_ARGS = download --no-binary :all: $(PIP_CACHE_OPT) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
 PIP_DOWNLOAD = $(PIP) $(PIP_DOWNLOAD_ARGS)
 
 # Available languages

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -20,11 +20,12 @@ PIP ?= pip
 PIP_HOST = $(shell which pip)
 
 # Why ask for the same thing twice? Always cache downloads
-PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR) --find-links $(BASE_DISTRIB_DIR)
+PIP_CACHE_OPT ?= --no-cache-dir --find-links $(BASE_DISTRIB_DIR)
 
 # Define default wheel & download pip options
 PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --no-index --wheel-dir $(WHEELHOUSE)
-PIP_DOWNLOAD_ARGS = download --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
+# BROKEN: https://github.com/pypa/pip/issues/1884
+PIP_DOWNLOAD_ARGS = download --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --dest $(BASE_DISTRIB_DIR) --no-build-isolation
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -23,8 +23,8 @@ PIP_SYSTEM = $(shell which pip)
 PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR) --find-links $(BASE_DISTRIB_DIR)
 
 # Define default wheel & download pip options
-PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --wheel-dir $(WHEELHOUSE)
-PIP_DOWNLOAD_ARGS = download --no-binary :all: $(PIP_CACHE_OPT) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
+PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --no-index --wheel-dir $(WHEELHOUSE)
+PIP_DOWNLOAD_ARGS = download --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -28,7 +28,7 @@ PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE
 # If we're only building cross-compiled wheels
 # all packages will be pre-downloaded, do not
 # check online index to ensure using local files
-ifneq ($(strip $(WHEELS_PURE_PYTHON_PACKAGING_ENABLE)),TRUE)
+ifeq ($(filter 1 ON TRUE,$(WHEELS_PURE_PYTHON_PACKAGING_ENABLE)),)
 PIP_WHEEL_ARGS += --no-index
 endif
 

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -17,7 +17,7 @@ RUN = cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV)
 PIP ?= pip
 
 # System default pip outside from build environment
-PIP_SYSTEM = $(shell which pip)
+PIP_HOST = $(shell which pip)
 
 # Why ask for the same thing twice? Always cache downloads
 PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR) --find-links $(BASE_DISTRIB_DIR)

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -24,7 +24,7 @@ PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR)
 PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --find-links $(BASE_DISTRIB_DIR) --wheel-dir $(WHEELHOUSE)
 PIP_WHEEL = $(PIP) $(PIP_WHEEL_ARGS)
 # Allow pre-downloading wheel sources
-PIP_DOWNLOAD_ARGS = download --no-binary :all: --find-links $(BASE_DISTRIB_DIR) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
+PIP_DOWNLOAD_ARGS = download --no-binary :all: $(PIP_CACHE_OPT) --find-links $(BASE_DISTRIB_DIR) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
 PIP_DOWNLOAD = $(PIP) $(PIP_DOWNLOAD_ARGS)
 
 # Available languages

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -21,11 +21,10 @@ PIP_SYSTEM = $(shell which pip)
 
 # Why ask for the same thing twice? Always cache downloads
 PIP_CACHE_OPT ?= --cache-dir $(PIP_DIR) --find-links $(BASE_DISTRIB_DIR)
+
+# Define default wheel & download pip options
 PIP_WHEEL_ARGS = wheel --disable-pip-version-check --no-binary :all: $(PIP_CACHE_OPT) --no-deps --wheel-dir $(WHEELHOUSE)
-PIP_WHEEL = $(PIP) $(PIP_WHEEL_ARGS)
-# Allow pre-downloading wheel sources
 PIP_DOWNLOAD_ARGS = download --no-binary :all: $(PIP_CACHE_OPT) --dest $(BASE_DISTRIB_DIR) --no-build-isolation
-PIP_DOWNLOAD = $(PIP) $(PIP_DOWNLOAD_ARGS)
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -12,6 +12,9 @@
 #  DSM_SCRIPT_FILES:  List of script files that are in the scripts folder within the spk file.
 #
 
+# Allow more extensive shell commands
+SHELL := /bin/bash
+
 # Common makefiles
 include ../../mk/spksrc.common.mk
 include ../../mk/spksrc.directories.mk

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -12,9 +12,6 @@
 #  DSM_SCRIPT_FILES:  List of script files that are in the scripts folder within the spk file.
 #
 
-# Allow more extensive shell commands
-SHELL := /bin/bash
-
 # Common makefiles
 include ../../mk/spksrc.common.mk
 include ../../mk/spksrc.directories.mk

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -72,7 +72,7 @@ ifneq ($(strip $(WHEELS)),)
 	done
 endif
 
-download_wheel_target:
+download_wheel:
 	@if [ -n "$(WHEELS)" ] ; then \
 		for wheel in $(WHEELS) ; \
 		do \
@@ -86,7 +86,7 @@ download_wheel_target:
 # Build cross compiled wheels first, to fail fast.
 # There might be an issue with some pure python wheels when built after that.
 build_wheel_target: SHELL:=/bin/bash
-build_wheel_target: $(PRE_WHEEL_TARGET) download_wheel_target
+build_wheel_target: $(PRE_WHEEL_TARGET) download_wheel
 ifneq ($(strip $(WHEELS)),)
 	$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e)))
 	@if [ -s $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) -o -s $(WHEELHOUSE)/$(WHEELS_LIMITED_API) ]; then \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -72,10 +72,21 @@ ifneq ($(strip $(WHEELS)),)
 	done
 endif
 
+download_wheel_target:
+	@if [ -n "$(WHEELS)" ] ; then \
+		for wheel in $(WHEELS) ; \
+		do \
+			if [ -f $$wheel ] ; then \
+				$(MSG) "Downloading wheels from $$wheel ..." ; \
+				xargs -n 1 $(PIP_DOWNLOAD) 2>/dev/null < $$wheel || true ; \
+			fi ; \
+		done \
+	fi
+
 # Build cross compiled wheels first, to fail fast.
 # There might be an issue with some pure python wheels when built after that.
 build_wheel_target: SHELL:=/bin/bash
-build_wheel_target: $(PRE_WHEEL_TARGET)
+build_wheel_target: $(PRE_WHEEL_TARGET) download_wheel_target
 ifneq ($(strip $(WHEELS)),)
 	$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e)))
 	@if [ -s $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) -o -s $(WHEELHOUSE)/$(WHEELS_LIMITED_API) ]; then \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -39,7 +39,7 @@ download_wheel:
 	@if [ -n "$(WHEELS)" ] ; then \
 		for wheel in $(WHEELS) ; \
 		do \
-			if [ -f $$wheel ] ; then \
+			if [ -f $$wheel -a $$(basename $$wheel) != $(WHEELS_PURE_PYTHON) ] ; then \
 				$(MSG) "Downloading wheels from $$wheel ..." ; \
 				xargs -n 1 $(PIP_SYSTEM) $(PIP_DOWNLOAD_ARGS) 2>/dev/null < $$wheel || true ; \
 			fi ; \
@@ -53,7 +53,7 @@ wheel_msg_target:
 # PIP_CACHE_OPT is default "--cache-dir $(PIP_DIR)", PIP_DIR defaults to $(DISTRIB_DIR)/pip, so
 # will move if the user chooses a custom persistent distribution dir for caching downloads between
 # containers and builds.
-pre_wheel_target: wheel_msg_target
+pre_wheel_target: wheel_msg_target download_wheel
 ifneq ($(strip $(WHEELS)),)
 	@if [ -n "$(PIP_CACHE_OPT)" ] ; then \
 	   mkdir -p $(PIP_DIR) ; \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -35,6 +35,16 @@ else
 $(POST_WHEEL_TARGET): $(WHEEL_TARGET)
 endif
 
+download_wheel:
+	@if [ -n "$(WHEELS)" ] ; then \
+		for wheel in $(WHEELS) ; \
+		do \
+			if [ -f $$wheel ] ; then \
+				$(MSG) "Downloading wheels from $$wheel ..." ; \
+				xargs -n 1 $(PIP_DOWNLOAD) 2>/dev/null < $$wheel || true ; \
+			fi ; \
+		done \
+	fi
 
 wheel_msg_target:
 	@$(MSG) "Processing wheels of $(NAME)"
@@ -72,21 +82,10 @@ ifneq ($(strip $(WHEELS)),)
 	done
 endif
 
-download_wheel:
-	@if [ -n "$(WHEELS)" ] ; then \
-		for wheel in $(WHEELS) ; \
-		do \
-			if [ -f $$wheel ] ; then \
-				$(MSG) "Downloading wheels from $$wheel ..." ; \
-				xargs -n 1 $(PIP_DOWNLOAD) 2>/dev/null < $$wheel || true ; \
-			fi ; \
-		done \
-	fi
-
 # Build cross compiled wheels first, to fail fast.
 # There might be an issue with some pure python wheels when built after that.
 build_wheel_target: SHELL:=/bin/bash
-build_wheel_target: $(PRE_WHEEL_TARGET) download_wheel
+build_wheel_target: $(PRE_WHEEL_TARGET)
 ifneq ($(strip $(WHEELS)),)
 	$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e)))
 	@if [ -s $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) -o -s $(WHEELHOUSE)/$(WHEELS_LIMITED_API) ]; then \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -49,9 +49,10 @@ download_wheel:
 					query="$${query} | jq -r '.releases[][] | select(.packagetype==\"sdist\") | select(.filename|test(\"-" ; \
 					query="$${query}$${requirement##*=}.tar.gz\")) | .url'" ; \
 					localFile=$$(basename $$(eval $${query})) ; \
+					echo "wget --secure-protocol=TLSv1_2 -nv -O $(DISTRIB_DIR)/$${localFile}.part -nc $$(eval $${query})" ; \
 					wget --secure-protocol=TLSv1_2 -nv -O $(DISTRIB_DIR)/$${localFile}.part -nc $$(eval $${query}) ; \
 					mv $(DISTRIB_DIR)/$${localFile}.part $(DISTRIB_DIR)/$${localFile} ; \
-				done < $$wheel || true ; \
+				done < <(grep -v  -e "^\#" -e "^\$$" $$wheel) || true ; \
 			fi ; \
 		done \
 	fi

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -41,7 +41,7 @@ download_wheel:
 		do \
 			if [ -f $$wheel -a $$(basename $$wheel) != $(WHEELS_PURE_PYTHON) ] ; then \
 				$(MSG) "Downloading wheels from $$wheel ..." ; \
-				xargs -n 1 $(PIP_SYSTEM) $(PIP_DOWNLOAD_ARGS) 2>/dev/null < $$wheel || true ; \
+				xargs -n 1 $(PIP_HOST) $(PIP_DOWNLOAD_ARGS) 2>/dev/null < $$wheel || true ; \
 			fi ; \
 		done \
 	fi

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -46,8 +46,8 @@ download_wheel:
 				while IFS= read -r requirement ; \
 				do \
 					query="curl -s https://pypi.org/pypi/$${requirement%%=*}/json" ; \
-					query="$${query} | jq -r '.releases[][] | select(.packagetype==\"sdist\") | select(.filename|test(\"-" ; \
-					query="$${query}$${requirement##*=}.tar.gz\")) | .url'" ; \
+					query+=" | jq -r '.releases[][] | select(.packagetype==\"sdist\") | select(.filename|test(\"-" ; \
+					query+="$${requirement##*=}.tar.gz\")) | .url'" ; \
 					localFile=$$(basename $$(eval $${query})) ; \
 					echo "wget --secure-protocol=TLSv1_2 -nv -O $(DISTRIB_DIR)/$${localFile}.part -nc $$(eval $${query})" ; \
 					wget --secure-protocol=TLSv1_2 -nv -O $(DISTRIB_DIR)/$${localFile}.part -nc $$(eval $${query}) ; \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -41,7 +41,7 @@ download_wheel:
 		do \
 			if [ -f $$wheel ] ; then \
 				$(MSG) "Downloading wheels from $$wheel ..." ; \
-				xargs -n 1 $(PIP_DOWNLOAD) 2>/dev/null < $$wheel || true ; \
+				xargs -n 1 $(PIP_SYSTEM) $(PIP_DOWNLOAD_ARGS) 2>/dev/null < $$wheel || true ; \
 			fi ; \
 		done \
 	fi

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -50,12 +50,14 @@ download_wheel:
 					query+=" | select(.packagetype==\"sdist\")" ; \
 					query+=" | select((.filename|test(\"-$${requirement##*=}.tar.gz\")) or (.filename|test(\"-$${requirement##*=}.zip\"))) | .url'" ; \
 					localFile=$$(basename $$(eval $${query} 2>/dev/null) 2</dev/null) ; \
-					if [ "$${localFile}" != "" ]; then \
+					if [ "$${localFile}" = "" ]; then \
+						echo "ERROR: Invalid package name [$${requirement%%=*}]" ; \
+					elif [ -s $(DISTRIB_DIR)/$${localFile} ]; then \
+						echo "INFO: File already exists [$${localFile}]" ; \
+					else \
 						echo "wget --secure-protocol=TLSv1_2 -nv -O $(DISTRIB_DIR)/$${localFile}.part -nc $$(eval $${query})" ; \
 						wget --secure-protocol=TLSv1_2 -nv -O $(DISTRIB_DIR)/$${localFile}.part -nc $$(eval $${query}) ; \
 						mv $(DISTRIB_DIR)/$${localFile}.part $(DISTRIB_DIR)/$${localFile} ; \
-					else \
-						echo "ERROR: Invalid package name [$${requirement%%=*}]" ; \
 					fi ; \
 				done < <(grep -v  -e "^\#" -e "^\$$" $$wheel) || true ; \
 			fi ; \

--- a/spk/bazarr/Makefile
+++ b/spk/bazarr/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = bazarr
 
 SPK_VERS = 1.0.2
-SPK_REV = 3
+SPK_REV = 4
 
 SPK_ICON = src/bazarr.png
 

--- a/spk/beets/Makefile
+++ b/spk/beets/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = beets
 SPK_VERS = 1.6.0
-SPK_REV = 7
+SPK_REV = 8
 SPK_ICON = src/beets.png
 
 BUILD_DEPENDS = cross/python310

--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = homeassistant
 SPK_VERS = 2021.9.7
-SPK_REV = 17
+SPK_REV = 18
 SPK_ICON = src/${SPK_NAME}.png
 
 SPK_DEPENDS = "python310"

--- a/spk/mercurial/Makefile
+++ b/spk/mercurial/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mercurial
 SPK_VERS = 6.0
-SPK_REV = 8
+SPK_REV = 9
 SPK_ICON = src/mercurial.png
 
 BUILD_DEPENDS = cross/python310


### PR DESCRIPTION
_Motivation:_  In order to eliminate `connection timeout` try to pre-download wheels at the start of the build process so all arch builds can then refer to it afterwards.
_Linked issues:_  #4951 and #4968

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
