### PR TITLE
[WIP] Wheel name fix

### DIFF
--- a/mk/spksrc.wheel-env.mk
+++ b/mk/spksrc.wheel-env.mk
@@ -47,11 +47,7 @@ ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
 PYTHON_ARCH = armv5tel
 endif
 
-ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS)),$(ARCH))
-PYTHON_ARCH = armv7
-endif
-
-ifeq ($(findstring $(ARCH),$(ARMv7L_ARCHS)),$(ARCH))
+ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
 PYTHON_ARCH = armv7l
 endif
 

--- a/mk/spksrc.wheel-env.mk
+++ b/mk/spksrc.wheel-env.mk
@@ -64,7 +64,7 @@ PYTHON_ARCH = x86_64
 endif
 
 ifeq ($(findstring $(ARCH),$(i686_ARCHS)),$(ARCH))
-PYTHON_ARCH += i686
+PYTHON_ARCH = i686
 endif
 
 install_python_wheel:

--- a/mk/spksrc.wheel-env.mk
+++ b/mk/spksrc.wheel-env.mk
@@ -90,7 +90,9 @@ install_python_wheel:
 		else \
 			for w in *.whl; do \
 				$(MSG) Copying to wheelhouse: $$(echo $$w | sed -E "s/(.*linux_).*(\.whl)/\1$(PYTHON_ARCH)\2/") ; \
-				cp -f $$w $(STAGING_INSTALL_WHEELHOUSE)/$$(echo $$w | sed -E "s/(.*linux_).*(\.whl)/\1$(PYTHON_ARCH)\2/") ; \
+				cp -f $$w $(STAGING_INSTALL_WHEELHOUSE)/$$(echo $$w \
+					| sed -E "s/(.*-).*(linux_.*\.whl)/\1\2/" \
+					| sed -E "s/(.*linux_).*(\.whl)/\1$(PYTHON_ARCH)\2/") ; \
 			done ; \
 		fi ; \
 	fi

--- a/mk/spksrc.wheel-env.mk
+++ b/mk/spksrc.wheel-env.mk
@@ -85,10 +85,9 @@ install_python_wheel:
 			done ; \
 		else \
 			for w in *.whl; do \
-				$(MSG) Copying to wheelhouse: $$(echo $$w | sed -E "s/(.*linux_).*(\.whl)/\1$(PYTHON_ARCH)\2/") ; \
-				cp -f $$w $(STAGING_INSTALL_WHEELHOUSE)/$$(echo $$w \
-					| sed -E "s/(.*-).*(linux_.*\.whl)/\1\2/" \
-					| sed -E "s/(.*linux_).*(\.whl)/\1$(PYTHON_ARCH)\2/") ; \
+				_new_name=$$(echo $$w | sed -E "s/(.*-).*(linux_).*(\.whl)/\1\2$(PYTHON_ARCH)\3/") ; \
+				$(MSG) Copying to wheelhouse: $$_new_name ; \
+				cp -f $$w $(STAGING_INSTALL_WHEELHOUSE)/$$_new_name ; \
 			done ; \
 		fi ; \
 	fi

--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -9,9 +9,11 @@ DEPENDS  = cross/$(SPK_NAME)
 # setup during package install
 DEPENDS += cross/setuptools cross/pip cross/wheel
 
-# Required for misc wheels
+# Required for lxml wheel
 DEPENDS += cross/libxml2
 DEPENDS += cross/libxslt
+
+# Required for PyYAML
 DEPENDS += cross/libyaml
 
 # Required for pycurl wheel

--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python310
 SPK_VERS = 3.10.0
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 3
+SPK_REV = 4
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/$(SPK_NAME)

--- a/spk/python310/src/requirements-crossenv.txt
+++ b/spk/python310/src/requirements-crossenv.txt
@@ -14,6 +14,7 @@ chardet==4.0.0
 charset-normalizer==2.0.7
 click==8.0.3
 cryptography==3.3.2
+Cython==0.29.24
 distlib==0.3.3
 Flask==2.0.2
 future==0.18.2

--- a/spk/python310/src/requirements-crossenv.txt
+++ b/spk/python310/src/requirements-crossenv.txt
@@ -14,7 +14,6 @@ chardet==4.0.0
 charset-normalizer==2.0.7
 click==8.0.3
 cryptography==3.3.2
-Cython==0.29.24
 distlib==0.3.3
 Flask==2.0.2
 future==0.18.2
@@ -25,7 +24,7 @@ immutables==0.16
 ipaddress==1.0.23
 itsdangerous==2.0.1
 Jinja2==3.0.2
-lxml==4.6.3
+lxml==4.6.4
 MarkupSafe==2.0.1
 msgpack-python==0.5.6
 netifaces==0.11.0


### PR DESCRIPTION
_Motivation:_  With the redesign wheels no longer uses `none-any` suffix but rather the mathing `uname -m` of the NAS architecture machine name.  This PR address some of the shortfalls where wheels have extra arguments in their platform tag that needs to be reworked.
_Linked issues:_  #4980 and https://github.com/SickChill/SickChill/issues/7672#issuecomment-980395077

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
