### PR TITLE
INFO and config alignment spksrc.service.mk

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -406,7 +406,7 @@ $(STAGING_DIR)/$(DSM_UI_DIR)/config:
 	$(create_target_dir)
 	@echo '{}' | jq --arg name "${DISPLAY_NAME}" \
 		--arg desc "${DESC}" \
-		--arg id "com.synocommunity.packages.${SPK_NAME}" \
+		--arg id "com.synocommunity.${SPK_NAME}" \
 		--arg icon "images/${SPK_NAME}-{0}.png" \
 		--arg prot "${SERVICE_PORT_PROTOCOL}" \
 		--arg port "${SERVICE_PORT}" \

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -39,7 +39,7 @@
 #                                           folder at intallation and runtime.
 #  SSS_SCRIPT                    (optional) custom script file for service start/stop/status when the generic 
 #                                           installer generated script (SERVICE_SETUP) is not usable.
-#  NO_SERVICE_SHORTCUT           (optional) do not create 
+#  NO_SERVICE_SHORTCUT           (optional) do not create an app icon in the DSM desktop
 #  INSTALLER_SCRIPT              (deprecated) installer script file before introduction of generic installer
 #
 
@@ -406,7 +406,7 @@ $(STAGING_DIR)/$(DSM_UI_DIR)/config:
 	$(create_target_dir)
 	@echo '{}' | jq --arg name "${DISPLAY_NAME}" \
 		--arg desc "${DESC}" \
-		--arg id "com.synocommunity.${SPK_NAME}" \
+		--arg id "com.synocommunity.packages.${SPK_NAME}" \
 		--arg icon "images/${SPK_NAME}-{0}.png" \
 		--arg prot "${SERVICE_PORT_PROTOCOL}" \
 		--arg port "${SERVICE_PORT}" \

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -198,12 +198,16 @@ ifneq ($(strip $(DSM_UI_DIR)),)
 endif
 ifneq ($(strip $(DSM_APP_NAME)),)
 	@echo dsmappname=\"$(DSM_APP_NAME)\" >> $@
-	@echo dsmapppage=\"$(DSM_APP_NAME)\" >> $@
-	@echo dsmapplaunchname=\"$(DSM_APP_NAME)\" >> $@
 else
-	@echo dsmappname=\"com.synocommunity.$(SPK_NAME)\" >> $@
-	@echo dsmapppage=\"com.synocommunity.$(SPK_NAME)\" >> $@
-	@echo dsmapplaunchname=\"com.synocommunity.$(SPK_NAME)\" >> $@
+	@echo dsmappname=\"com.synocommunity.packages.$(SPK_NAME)\" >> $@
+endif
+ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+ifneq ($(strip $(DSM_APP_PAGE)),)
+	@echo dsmapppage=\"$(DSM_APP_PAGE)\" >> $@
+endif
+ifneq ($(strip $(DSM_APP_LAUNCH_NAME)),)
+	@echo dsmapplaunchname=\"$(DSM_APP_LAUNCH_NAME)\" >> $@
+endif
 endif
 ifneq ($(strip $(ADMIN_PROTOCOL)),)
 	@echo adminprotocol=\"$(ADMIN_PROTOCOL)\" >> $@


### PR DESCRIPTION
Create `config` file with same id as `INFO` file.

_Motivation:_  DSM7 notification not working as INFO file of package and config file are not aligned in naming convention.

_Linked issues:_  [https://github.com/SickChill/SickChill/issues/7694#issuecomment-986926967](https://github.com/SickChill/SickChill/issues/7694#issuecomment-986926967)

Thus `synodsmnotify` even if strings were configured correctly would not resolve their i18n text strings.

@th0ma7 I don't know the knock on effects of this modification to other parts of the build. Also the other choice may be to modify the `spksrc.spk.mk` file lines 204 to 206 to change the INFO file instead.
