### PR TITLE
installer.dsm7: Use rsync to synchronize var directory

### DIFF
--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -12,6 +12,8 @@ INST_LOG="/var/log/packages/${SYNOPKG_PKGNAME}.log"
 # Optional FWPORTS file
 FWPORTS_FILE="/var/packages/${SYNOPKG_PKGNAME}/conf/${SYNOPKG_PKGNAME}.sc"
 
+# Temporary directory when the package is upgrading
+TMP_DIR="${SYNOPKG_TEMP_UPGRADE_FOLDER}"
 
 install_log ()
 {
@@ -71,19 +73,21 @@ call_func "initialize_variables"
 # (@appdata) /var/packages/<package>/target/var -> /var/packages/<package>/target/../var
 #
 syno_sync_var_folder () {
-    # Copy and delete all files except don't overwrite any existing
-    echo "$RSYNC --ignore-existing --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}"
-    $RSYNC --ignore-existing --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}
+    if [ -d ${SYNOPKG_PKGDEST}/var -a "$(ls -A ${SYNOPKG_PKGDEST}/var 2>/dev/null)" ]; then
+        # Copy and delete all files except don't overwrite any existing
+        echo "$RSYNC --ignore-existing --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}"
+        $RSYNC --ignore-existing --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}
 
-    # Rename any remaining (thus pre-existing) files with .new suffix
-    find ${SYNOPKG_PKGDEST}/var -type f -exec sh -c 'x="{}"; mv "$x" "${x}.new"' \;
+        # Rename any remaining (thus pre-existing) files with .new suffix
+        find ${SYNOPKG_PKGDEST}/var -type f -exec sh -c 'x="{}"; mv "$x" "${x}.new"' \;
 
-    # Force-copy and delete all .new files
-    echo "$RSYNC --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}"
-    $RSYNC --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}
+        # Force-copy and delete all .new files
+        echo "$RSYNC --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}"
+        $RSYNC --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}
 
-    # Remove remaining directory
-    $RM ${SYNOPKG_PKGDEST}/var
+        # Remove remaining directory
+        $RM ${SYNOPKG_PKGDEST}/var
+    fi
 }
 
 set_unix_permissions ()
@@ -217,8 +221,7 @@ postupgrade ()
     # Migrate data once to permanent storage at postupgrade
     if [ -d ${TMP_DIR} -a "$(ls -A ${TMP_DIR} 2>/dev/null)" ]; then
         echo "$RSYNC ${TMP_DIR}/ ${SYNOPKG_PKGVAR}" | install_log
-        $RSYNC ${TMP_DIR}/ ${SYNOPKG_PKGVAR} 2>&1 | install_log && chk=$?
-        [ "${chk}" = "0" ] && rm -fr ${TMP_DIR} || true
+        $RSYNC ${TMP_DIR}/ ${SYNOPKG_PKGVAR} 2>&1 | install_log
     fi
 
     # dsm7: Now sync in any new files to permanent storage

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -64,8 +64,27 @@ call_func "reload_inst_variables"
 # init variables either reloaded, from package or from wizard
 call_func "initialize_variables"
 
-
 ### Functions library
+
+#
+# New DSM7 folders: copy no-verwrite + remove source
+# (@appdata) /var/packages/<package>/target/var -> /var/packages/<package>/target/../var
+#
+syno_sync_var_folder () {
+    # Copy and delete all files except don't overwrite any existing
+    echo "$RSYNC --ignore-existing --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}"
+    $RSYNC --ignore-existing --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}
+
+    # Rename any remaining (thus pre-existing) files with .new suffix
+    find ${SYNOPKG_PKGDEST}/var -type f -exec sh -c 'x="{}"; mv "$x" "${x}.new"' \;
+
+    # Force-copy and delete all .new files
+    echo "$RSYNC --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}"
+    $RSYNC --remove-source-files ${SYNOPKG_PKGDEST}/var/ ${SYNOPKG_PKGVAR}
+
+    # Remove remaining directory
+    $RM ${SYNOPKG_PKGDEST}/var
+}
 
 set_unix_permissions ()
 {
@@ -128,9 +147,7 @@ postinst ()
 
     # copy target/var data to permanent storage
     # and don't override old configurations
-    if [ -d ${SYNOPKG_PKGDEST}/var ] && [ "$(find ${SYNOPKG_PKGVAR} -mindepth 1 -not -name '*.log' -print)" = "" ]; then
-        $CP ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
-    fi
+    call_func "syno_sync_var_folder" install_log
 
     call_func "service_postinst" install_log
 
@@ -177,10 +194,12 @@ preupgrade ()
     call_func "validate_preupgrade"
 
     # dsm6 -> dsm7
-    # Migrate data to permanent storage
-    if [ -d ${SYNOPKG_PKGDEST}/var -a ! "$(ls -A ${SYNOPKG_PKGVAR})" ]; then
-        # only migrate when destination is empty
-        $CP ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR} 2>&1 | install_log
+    # Copy first to temporary directory if upgrading from DSM6 -> DSM7
+    # Then migrate data once to permanent storage at postupgrade
+    if [ -d ${SYNOPKG_PKGDEST}/var -a "$(ls -A ${SYNOPKG_PKGDEST}/var 2>/dev/null)" ]; then
+        echo "$RSYNC ${SYNOPKG_PKGDEST}/var/ ${TMP_DIR}" | install_log
+        $RSYNC ${SYNOPKG_PKGDEST}/var/ ${TMP_DIR} 2>&1 | install_log && chk=$?
+        [ "${chk}" = "0" ] && rm -fr ${SYNOPKG_PKGDEST}/var || true
     fi
 
     call_func "service_preupgrade" install_log
@@ -193,6 +212,18 @@ postupgrade ()
     log_step "postupgrade"
 
     call_func "service_restore" install_log
+
+    # dsm6 -> dsm7
+    # Migrate data once to permanent storage at postupgrade
+    if [ -d ${TMP_DIR} -a "$(ls -A ${TMP_DIR} 2>/dev/null)" ]; then
+        echo "$RSYNC ${TMP_DIR}/ ${SYNOPKG_PKGVAR}" | install_log
+        $RSYNC ${TMP_DIR}/ ${SYNOPKG_PKGVAR} 2>&1 | install_log && chk=$?
+        [ "${chk}" = "0" ] && rm -fr ${TMP_DIR} || true
+    fi
+
+    # dsm7: Now sync in any new files to permanent storage
+    call_func "syno_sync_var_folder" install_log
     call_func "service_postupgrade" install_log
+
     exit 0
 }

--- a/mk/spksrc.service.installer.functions
+++ b/mk/spksrc.service.installer.functions
@@ -11,7 +11,8 @@ CP="/bin/cp -rfp"
 MKDIR="/bin/mkdir -p"
 LN="/bin/ln -nsf"
 TEE="/usr/bin/tee -a"
-
+RSYNC="/bin/rsync -avh"
+TAR="/bin/tar"
 
 INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
 INST_VARIABLES="${INST_ETC}/installer-variables"

--- a/spk/demoservice/Makefile
+++ b/spk/demoservice/Makefile
@@ -34,14 +34,14 @@ SERVICE_PORT_TITLE = DemoService(HTTP)
 # Admin link
 ADMIN_PORT = $(SERVICE_PORT)
 
-PRE_COPY_TARGET = demoservice_install
+PRE_COPY_TARGET = demoservice_pre_copy
 
 include ../../mk/spksrc.spk.mk
 
 .PHONY: demoservice_install
 # Replace standard copy/install targets, no sources, no content
-demoservice_install:
+demoservice_pre_copy:
 	rm -fr $(STAGING_DIR)
 	mkdir $(STAGING_DIR)
 	mkdir --parents $(STAGING_INSTALL_PREFIX)/var
-	echo "No files package" > $(STAGING_INSTALL_PREFIX)/var/README
+	echo "No files package" > $(STAGING_INSTALL_PREFIX)/var/README.var

--- a/spk/demoservice/Makefile
+++ b/spk/demoservice/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = demoservice
 SPK_VERS = 1.2
-SPK_REV = 7
+SPK_REV = 8
 SPK_ICON = src/demoservice.png
 
 override ARCH=
@@ -44,4 +44,4 @@ demoservice_pre_copy:
 	rm -fr $(STAGING_DIR)
 	mkdir $(STAGING_DIR)
 	mkdir --parents $(STAGING_INSTALL_PREFIX)/var
-	echo "No files package" > $(STAGING_INSTALL_PREFIX)/var/README.var
+	echo "Test file for $(INSTALL_PREFIX)/var" > $(STAGING_INSTALL_PREFIX)/var/README

--- a/spk/demoservice/PLIST
+++ b/spk/demoservice/PLIST
@@ -1,1 +1,1 @@
-rsc:README
+rsc:var/README.var

--- a/spk/demoservice/PLIST
+++ b/spk/demoservice/PLIST
@@ -1,1 +1,1 @@
-rsc:var/README.var
+rsc:var/README


### PR DESCRIPTION
_Motivation:_  Extract from #4797 in order to enable usage of `rsync` instead of copy.  Updated method is such as:
1. uses a dedicated function to synchronize `target/var` to `target/../var`
2. allow providing updated `var` configuration files without overwriting existing (e.g. uses `.new` suffix)
3. allow upgrading DSM6 `var` data to DSM7 at pre/postupgrade using temporary storage

_Linked issues:_  #4797

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully

### Tested against
- [x] demoservice
- [x] ffmpeg
- [x] tvheadend