### PR TITLE
common.mk: Allow more extensive Bash shell environment

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -1,5 +1,8 @@
 # Common definitions, shared by all makefiles
 
+# Allow more extensive shell commands
+SHELL := /bin/bash
+
 # all will be the default target, regardless of what is defined in the other
 # makefiles.
 default: all


### PR DESCRIPTION
_Motivation:_  Default `sh` under make is limited and PR such as #4971 requires more extensive shell functionalities.
_Linked issues:_  #4971

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
