### PR TITLE
Rename requirement entries to match strict Pypi naming

### DIFF
--- a/spk/homeassistant/src/requirements-crossenv.txt
+++ b/spk/homeassistant/src/requirements-crossenv.txt
@@ -47,7 +47,7 @@ aiohttp==3.7.4.post0
 cffi==1.14.1
 greenlet==1.1.1
 multidict==5.1.0
-sqlalchemy==1.4.23
+SQLAlchemy==1.4.23
 
 
 # Failed to build: av clx-sdk-xms homeassistant-pyozw python-twitch-client

--- a/spk/sabnzbd/src/requirements-crossenv.txt
+++ b/spk/sabnzbd/src/requirements-crossenv.txt
@@ -1,5 +1,5 @@
 # cross-compiled wheels
 cffi==1.15.0
-cheetah3==3.2.6
+Cheetah3==3.2.6
 cryptography==3.3.2
 sabyenc3==4.0.2


### PR DESCRIPTION
_Motivation:_  Rename requirement entries to match strict Pypi naming
_Linked issues:_  #4971

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
