### PR TITLE
beets: Enforce strict requirement versions

### DIFF
--- a/spk/beets/src/requirements-crossenv.txt
+++ b/spk/beets/src/requirements-crossenv.txt
@@ -1,5 +1,5 @@
 # Cross-compiled Dependencies
 
-MarkupSafe>=0.23
-PyYAML>=3.12
+MarkupSafe==2.0.1
+PyYAML==6.0
 #Pillow==8.2.0               ==> cross/pillow


### PR DESCRIPTION
_Motivation:_  With latest python310 update beets requirements versions where not enforced using `==`.  This address this using strict enforcing.
_Linked issues:_  #4971

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
