### PR TITLE
wheel.mk: Use default sheel to fix makefile eval

### DIFF
--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -75,6 +75,7 @@ pre_wheel_target: wheel_msg_target
 
 # Build cross compiled wheels first, to fail fast.
 # There might be an issue with some pure python wheels when built after that.
+build_wheel_target: SHELL:=/bin/sh
 build_wheel_target: $(PRE_WHEEL_TARGET)
 	@if [ -n "$(WHEELS)" ] ; then \
 		$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e))) \


### PR DESCRIPTION


_Motivation:_  The cat python-cc.mk + eval ends-up producing the following error:
```
/bin/bash: line 0: .: filename argument required
.: usage: . filename [arguments]
```
There probably is another workaround but in the meantime this fixes it.
_Linked issues:_  N/A

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
