### PR TITLE
fix dsm 6 installer log

### DIFF
--- a/mk/spksrc.service.installer.dsm6
+++ b/mk/spksrc.service.installer.dsm6
@@ -356,7 +356,7 @@ postupgrade ()
 {
     log_step "postupgrade"
 
-    call_func "service_restore"
+    call_func "service_restore" install_log
 
     # Restore some stuff, has to be cp otherwise fails on directories
     $CP "${TMP_DIR}"/. "${SYNOPKG_PKGVAR}" 2>&1 | install_log


### PR DESCRIPTION
_Motivation:_  output of service_restore function is not added to linterller log on DSM 6

@th0ma7 thanks for the hint 