### PR TITLE
fix PLIST for filenames with spaces

### DIFF
--- a/mk/spksrc.copy.mk
+++ b/mk/spksrc.copy.mk
@@ -43,7 +43,7 @@ copy_msg:
 pre_copy_target: copy_msg
 
 copy_target: $(PRE_COPY_TARGET) $(INSTALL_PLIST)
-	(cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && tar cpf - `cat $(INSTALL_PLIST) | cut -d':' -f2`) | \
+	(cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && cat $(INSTALL_PLIST) | cut -d':' -f2 | tar cpf - -T -) | \
 	  tar xpf - -C $(STAGING_DIR)
 
 post_copy_target: $(COPY_TARGET)

--- a/mk/spksrc.plist.mk
+++ b/mk/spksrc.plist.mk
@@ -6,7 +6,7 @@
 INSTALL_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)plist_done
 
 ifeq ($(strip $(PLIST_TRANSFORM)),)
-PLIST_TRANSFORM= cat
+PLIST_TRANSFORM = cat
 endif
 
 .PHONY: cat_PLIST
@@ -21,14 +21,14 @@ cat_PLIST:
 	# If there is a PLIST.auto file or if parent directory is kernel \
 	elif [ -f PLIST.auto -o $$(basename $$(dirname $$(pwd))) = "kernel" ] ; \
 	then \
-	  for file in $$(cat $(WORK_DIR)/$(PKG_NAME).plist.auto | sort) ; \
+	  cat $(WORK_DIR)/$(PKG_NAME).plist.auto | sort | while read -r file ; \
 	  do \
-	    type=$$(file -F, $(INSTALL_DIR)/$(INSTALL_PREFIX)/$$file | awk -F',[[:blank:]]' '{print $$2}') ; \
+	    type=$$(file --brief "$(INSTALL_DIR)/$(INSTALL_PREFIX)/$$file" | cut -d , -f1) ; \
 	    case $$type in \
-	       ELF*LSB[[:space:]]executable ) echo "bin:$$file" ;; \
-	                               ELF* ) echo "lib:$$file" ;; \
-	           symbolic[[:space:]]link* ) echo "lnk:$$file" ;; \
-	                                  * ) echo "rsc:$$file" ;; \
+	       ELF*LSB[[:space:]]*executable ) echo "bin:$$file" ;; \
+	                                ELF* ) echo "lib:$$file" ;; \
+	            symbolic[[:space:]]link* ) echo "lnk:$$file" ;; \
+	                                   * ) echo "rsc:$$file" ;; \
 	    esac \
 	  done \
 	else \


### PR DESCRIPTION
_Motivation:_  packages with files that have spaces in name can't be built.
_Linked issues:_  

### Remarks
Found this errors while working on a package for `Ombi` that contains a file `logo original.png`.
Got two errors:
- copy_target that uses tar failed
- When using PLIST.auto there are other errors

As latest stable ombi is still on .NET 5 and current versions with .NET 6 are prerelease (and didn't run), I want to publish this fix now.