### PR TITLE
fix haproxy config

### DIFF
--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -7,7 +7,7 @@ DSM_APP_NAME = SYNOCOMMUNITY.HAProxy.AppInstance
 
 DEPENDS = cross/$(SPK_NAME)
 WHEELS = src/requirements.txt
-SPK_DEPENDS = "python>2.7.18-25"
+SPK_DEPENDS = "python>=2.7.18-25"
 
 MAINTAINER = Diaoul
 DESCRIPTION = HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.

--- a/spk/haproxy/src/app/application/db.py
+++ b/spk/haproxy/src/app/application/db.py
@@ -91,7 +91,7 @@ def default_config():
     session.add(Backend(id=19, name=u'deluge', servers=u'deluge localhost:8112 check'))
     session.add(Backend(id=20, name=u'sickchill', servers=u'sickchill localhost:8081 check'))
     session.add(Frontend(id=1, name=u'http', binds=u':5080', default_backend_id=1, options=ur'option http-server-close,option forwardfor'))
-    session.add(Frontend(id=2, name=u'https', binds=u':5443 ssl crt /usr/local/haproxy/var/crt/default.pem ciphers AESGCM+AES128:AES128:AESGCM+AES256:AES256:RSA+RC4+SHA:!RSA+AES:!CAMELLIA:!aECDH:!3DES:!DSS:!PSK:!SRP:!aNULL no-sslv3', options=ur'option http-server-close,option forwardfor,rspirep ^Location:\ http://(.*)$    Location:\ https://\1, rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains', default_backend_id=1))
+    session.add(Frontend(id=2, name=u'https', binds=u':5443 ssl crt /usr/local/haproxy/var/crt/default.pem ciphers AESGCM+AES128:AES128:AESGCM+AES256:AES256:RSA+RC4+SHA:!RSA+AES:!CAMELLIA:!aECDH:!3DES:!DSS:!PSK:!SRP:!aNULL no-sslv3', options=ur'option http-server-close,option forwardfor,http-response replace-header Location http://(.*) https://\1, #http-response add-header Strict-Transport-Security "max-age=31536000; includeSubDomains;"', default_backend_id=1))
     session.add(Association(frontend_id=2, backend_id=2, condition=u'if { hdr_beg(Host) -i dsm. }'))
     session.add(Association(frontend_id=2, backend_id=3, condition=u'if { hdr_beg(Host) -i sabnzbd. }'))
     session.add(Association(frontend_id=2, backend_id=4, condition=u'if { hdr_beg(Host) -i nzbget. }'))

--- a/spk/haproxy/src/app/application/db_upgrade_16.py
+++ b/spk/haproxy/src/app/application/db_upgrade_16.py
@@ -10,7 +10,7 @@ def upgrade():
     frontend = session.query(Frontend).\
         filter_by(name='https',
                   binds=':5443 ssl crt /usr/local/haproxy/var/crt/default.pem',
-                  options=r'option http-server-close,option forwardfor,rspirep ^Location:\ http://(.*)$ Location:\ https://\1').\
+                  options=r'option http-server-close,option forwardfor,http-response replace-header Location http://(.*) https://\1').\
         first()
     if frontend:
         frontend.binds += ' ciphers AESGCM+AES128:AES128:AESGCM+AES256:AES256:RSA+RC4+SHA:!RSA+AES:!CAMELLIA:!aECDH:!3DES:!DSS:!PSK:!SRP:!aNULL no-sslv3'

--- a/spk/haproxy/src/haproxy.cfg
+++ b/spk/haproxy/src/haproxy.cfg
@@ -1,5 +1,5 @@
 global
-	user sc-haproxy
+	#user sc-haproxy
 	daemon
 	maxconn 256
 	log localhost user info
@@ -17,7 +17,8 @@ defaults
 	timeout server 50s
 	timeout tunnel 1h
 
-listen stats :8280
+listen stats
+    bind :8280
 	stats uri /
 	stats show-legends
 	stats refresh 10s

--- a/spk/haproxy/src/installer.sh
+++ b/spk/haproxy/src/installer.sh
@@ -40,6 +40,7 @@ postinst ()
     if [ "${BUILDNUMBER}" -lt "7321" ]; then
         adduser -h ${INSTALL_DIR}/var -g "${DNAME} User" -G ${LEGACY_GROUP} -s /bin/sh -S -D ${LEGACY_USER}
     fi
+    synouser --add "${USER}" "" "User running haproxy" 0 "" ""
 
     # Edit the configuration according to the wizard
     sed -i -e "s/@user@/${wizard_user:=admin}/g" ${TPL_FILE}
@@ -85,6 +86,7 @@ preuninst ()
 
     if [ "${SYNOPKG_PKG_STATUS}" != "UPGRADE" ]; then
         # Remove the user (if not upgrading)
+        synouser --del "${USER}"
         delgroup ${LEGACY_USER} ${LEGACY_GROUP}
         deluser ${USER}
 


### PR DESCRIPTION
Fix python package dependency expecting a higher version than available

Fixes these alerts:
```
[ALERT] 357/152448 (15073) : parsing [/usr/local/haproxy/var/haproxy.cfg:2] : cannot find user id for 'sc-haproxy' (0:Success)
[ALERT] 357/152448 (15073) : parsing [/usr/local/haproxy/var/haproxy.cfg:3] : cannot find user id for 'sc-haproxy' (0:Success)


[ALERT] 357/153825 (21208) : parsing [/usr/local/haproxy/var/haproxy.cfg:3] : user/uid already specified. Continuing.
[ALERT] 357/153825 (21208) : parsing [/usr/local/haproxy/var/haproxy.cfg:21] : 'listen' cannot handle unexpected argument ':8280'.
[ALERT] 357/153825 (21208) : parsing [/usr/local/haproxy/var/haproxy.cfg:21] : please use the 'bind' keyword for listening addresses.
[ALERT] 357/153825 (21208) : parsing [/usr/local/haproxy/var/haproxy.cfg:38] : The 'rspirep' directive is not supported anymore since HAProxy 2.1. Use 'http-response replace-header' instead.
[ALERT] 357/153825 (21208) : parsing [/usr/local/haproxy/var/haproxy.cfg:39] : The 'rspadd' directive is not supported anymore since HAProxy 2.1. Use 'http-response add-header' instead.
```
_Linked issues:_  fixes #5005

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
