### PR TITLE
Fix bazarr build to use PLIST.auto

### DIFF
--- a/cross/bazarr/PLIST
+++ b/cross/bazarr/PLIST
@@ -1,1 +1,0 @@
-rsc:share/bazarr/**

--- a/mk/spksrc.install.mk
+++ b/mk/spksrc.install.mk
@@ -64,7 +64,7 @@ $(INSTALL_PLIST):
 	find $(INSTALL_DIR)/$(INSTALL_PREFIX)/ \! -type d -printf '%P\n' | sort | \
 	  diff $(PRE_INSTALL_PLIST) -  | grep '>' | cut -d' ' -f2- > $@
 	# Generate $(PKG_NAME).plist.auto for newly added files (diff against .tmp)
-	comm -3 $(PRE_INSTALL_PLIST) $(INSTALL_PLIST) > $(INSTALL_PLIST).auto
+	comm -13 $(PRE_INSTALL_PLIST) $(INSTALL_PLIST) > $(INSTALL_PLIST).auto
 
 install_correct_lib_files: $(INSTALL_PLIST)
 	@for pc_file in `grep -e "^lib/pkgconfig/.*\.pc$$" $(INSTALL_PLIST)` ; \


### PR DESCRIPTION
_Motivation:_  bazarr was no longer packaged properly

### Checklist
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
