### PR TITLE
Nano 6.0 with default config and syntax highlighting

### DIFF
--- a/cross/nano/Makefile
+++ b/cross/nano/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = nano
-PKG_VERS = 5.9
+PKG_VERS = 6.0
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.nano-editor.org/dist/v$(firstword $(subst ., ,$(PKG_VERS)))
@@ -12,5 +12,6 @@ COMMENT  = nano is a text editor for Unix-like computing systems or operating en
 LICENSE  = GPLv2
 
 GNU_CONFIGURE = 1
+CONFIGURE_ARGS += --prefix=$(INSTALL_PREFIX)
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/nano/Makefile
+++ b/cross/nano/Makefile
@@ -12,6 +12,5 @@ COMMENT  = nano is a text editor for Unix-like computing systems or operating en
 LICENSE  = GPLv2
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS += --prefix=$(INSTALL_PREFIX)
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/nano/digests
+++ b/cross/nano/digests
@@ -1,3 +1,3 @@
-nano-5.9.tar.xz SHA1 18df28d3d896a4100e80f02ed9511b0308082d8f
-nano-5.9.tar.xz SHA256 757db8cda4bb2873599e47783af463e3b547a627b0cabb30ea7bf71fb4c24937
-nano-5.9.tar.xz MD5 24b67a7a2e731d3a5ec6d154b4521d08
+nano-6.0.tar.xz SHA1 aa65957c3ad0d67b895a624a1353bcdf43fc9bfe
+nano-6.0.tar.xz SHA256 93ac8cb68b4ad10e0aaeb80a2dd15c5bb89eb665a4844f7ad01c67efcb169ea2
+nano-6.0.tar.xz MD5 5b6ff59f2490db80a3498c4cd3eda085

--- a/diyspk/nano/Makefile
+++ b/diyspk/nano/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nano
-SPK_VERS = 5.9
-SPK_REV = 7
+SPK_VERS = 6.0
+SPK_REV = 8
 SPK_ICON = src/nano.png
 
 DEPENDS = cross/nano
@@ -13,6 +13,8 @@ STARTABLE = no
 
 HOMEPAGE   = http://www.nano-editor.org
 LICENSE    = GPLv2
+
+SERVICE_SETUP = src/service-setup.sh
 
 SPK_COMMANDS = bin/nano bin/rnano
 

--- a/diyspk/nano/src/service-setup.sh
+++ b/diyspk/nano/src/service-setup.sh
@@ -1,0 +1,5 @@
+service_postinst ()
+{
+    mkdir -p /var/packages/${SYNOPKG_PKGNAME}/target/etc/
+    echo "include /var/packages/${SYNOPKG_PKGNAME}/target/share/nano/*.nanorc" > /var/packages/${SYNOPKG_PKGNAME}/target/etc/nanorc
+}

--- a/diyspk/nano/src/service-setup.sh
+++ b/diyspk/nano/src/service-setup.sh
@@ -1,5 +1,5 @@
 service_postinst ()
 {
-    mkdir -p /var/packages/${SYNOPKG_PKGNAME}/target/etc/
-    echo "include /var/packages/${SYNOPKG_PKGNAME}/target/share/nano/*.nanorc" > /var/packages/${SYNOPKG_PKGNAME}/target/etc/nanorc
+    mkdir -p ${SYNOPKG_PKGDEST}/etc/
+    echo "include ${SYNOPKG_PKGDEST}/share/nano/*.nanorc" > ${SYNOPKG_PKGDEST}/etc/nanorc
 }

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -64,6 +64,8 @@ DESCRIPTION = "SynoCli File Tools provides a set of small command-line utilities
 STARTABLE = no
 CHANGELOG = "1. Add jupp editor."
 
+SERVICE_SETUP = src/service-setup.sh
+
 HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliFile
 LICENSE  = Each tool is licensed under it's respective license.
 

--- a/spk/synocli-file/src/service-setup.sh
+++ b/spk/synocli-file/src/service-setup.sh
@@ -1,0 +1,5 @@
+service_postinst ()
+{
+    mkdir -p /var/packages/${SYNOPKG_PKGNAME}/target/etc/
+    echo "include /var/packages/${SYNOPKG_PKGNAME}/target/share/nano/*.nanorc" > /var/packages/${SYNOPKG_PKGNAME}/target/etc/nanorc
+}

--- a/spk/synocli-file/src/service-setup.sh
+++ b/spk/synocli-file/src/service-setup.sh
@@ -1,5 +1,5 @@
 service_postinst ()
 {
-    mkdir -p /var/packages/${SYNOPKG_PKGNAME}/target/etc/
-    echo "include /var/packages/${SYNOPKG_PKGNAME}/target/share/nano/*.nanorc" > /var/packages/${SYNOPKG_PKGNAME}/target/etc/nanorc
+    mkdir -p ${SYNOPKG_PKGDEST}/etc/
+    echo "include ${SYNOPKG_PKGDEST}/share/nano/*.nanorc" > ${SYNOPKG_PKGDEST}/etc/nanorc
 }


### PR DESCRIPTION
Enables a default config with syntax highlighting support

**Usage:**
e.g. `env TERM=xterm-color nano /volume1/web_packages/adminer/index.php`

An alternative per user setting:

```sh
echo "include /var/packages/synocli-file/target/share/nano/*.nanorc" >> ~/.nanorc
env TERM=xterm-color nano /volume1/web_packages/adminer/index.php
```

_Linked issues:_  https://discord.com/channels/732558169863225384/732559466721181738/926808496236806165 @bokkoman

FYI More syntax support is available from: https://github.com/scopatz/nanorc

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
