### PR TITLE
copy.mk: Revert change as it does not handle * PLIST entries

### DIFF
--- a/mk/spksrc.copy.mk
+++ b/mk/spksrc.copy.mk
@@ -43,7 +43,7 @@ copy_msg:
 pre_copy_target: copy_msg
 
 copy_target: $(PRE_COPY_TARGET) $(INSTALL_PLIST)
-	(cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && cat $(INSTALL_PLIST) | cut -d':' -f2 | tar cpf - -T -) | \
+	(cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && tar cpf - `cat $(INSTALL_PLIST) | cut -d':' -f2`) | \
 	  tar xpf - -C $(STAGING_DIR)
 
 post_copy_target: $(COPY_TARGET)

--- a/mk/spksrc.install.mk
+++ b/mk/spksrc.install.mk
@@ -63,8 +63,6 @@ post_install_target: $(INSTALL_TARGET)
 $(INSTALL_PLIST):
 	find $(INSTALL_DIR)/$(INSTALL_PREFIX)/ \! -type d -printf '%P\n' | sort | \
 	  diff $(PRE_INSTALL_PLIST) -  | grep '>' | cut -d' ' -f2- > $@
-	# Generate $(PKG_NAME).plist.auto for newly added files (diff against .tmp)
-	comm -3 $(PRE_INSTALL_PLIST) $(INSTALL_PLIST) > $(INSTALL_PLIST).auto
 
 install_correct_lib_files: $(INSTALL_PLIST)
 	@for pc_file in `grep -e "^lib/pkgconfig/.*\.pc$$" $(INSTALL_PLIST)` ; \

--- a/mk/spksrc.install.mk
+++ b/mk/spksrc.install.mk
@@ -64,7 +64,7 @@ $(INSTALL_PLIST):
 	find $(INSTALL_DIR)/$(INSTALL_PREFIX)/ \! -type d -printf '%P\n' | sort | \
 	  diff $(PRE_INSTALL_PLIST) -  | grep '>' | cut -d' ' -f2- > $@
 	# Generate $(PKG_NAME).plist.auto for newly added files (diff against .tmp)
-	comm -13 $(PRE_INSTALL_PLIST) $(INSTALL_PLIST) > $(INSTALL_PLIST).auto
+	comm -3 $(PRE_INSTALL_PLIST) $(INSTALL_PLIST) > $(INSTALL_PLIST).auto
 
 install_correct_lib_files: $(INSTALL_PLIST)
 	@for pc_file in `grep -e "^lib/pkgconfig/.*\.pc$$" $(INSTALL_PLIST)` ; \

--- a/mk/spksrc.plist.mk
+++ b/mk/spksrc.plist.mk
@@ -21,7 +21,7 @@ cat_PLIST:
 	# If there is a PLIST.auto file or if parent directory is kernel \
 	elif [ -f PLIST.auto -o $$(basename $$(dirname $$(pwd))) = "kernel" ] ; \
 	then \
-	  cat $(WORK_DIR)/$(PKG_NAME).plist.auto | sort | while read -r file ; \
+	  cat $(WORK_DIR)/$(PKG_NAME).plist | sort | while read -r file ; \
 	  do \
 	    type=$$(file --brief "$(INSTALL_DIR)/$(INSTALL_PREFIX)/$$file" | cut -d , -f1) ; \
 	    case $$type in \


### PR DESCRIPTION
_Motivation:_  A but was introduced in an earlier PR #5018 where PLIST entries with `*` are not being handled anymore.
_Linked issues:_  https://github.com/SynoCommunity/spksrc/pull/5044#issuecomment-1004404717

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

With https://github.com/SynoCommunity/spksrc/pull/5046/commits/d442ce2c46d8aa41683375733def1a54134feb7f commit I tested succesfully:
- [x] `bazarr` : Uses `PLIST.auto`
- [x] `python310` (update to 3.10.1) : Uses `*` plist entries through `cross/pip`

### Mandatory required for releasing
- [ ] `python310` - 3.10.1-6
- [ ] `bazarr` - 1.0.2-3