### PR TITLE
libjpeg: Update from version 9d to 9e and change URL source

### DIFF
--- a/cross/libjpeg/Makefile
+++ b/cross/libjpeg/Makefile
@@ -1,17 +1,16 @@
 PKG_NAME = libjpeg
-PKG_VERS = 9d
+PKG_VERS = 09e
 PKG_EXT = tar.gz
 PKG_DIST_NAME = jpegsrc.v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://www.ijg.org/files
-PKG_DIR = jpeg-$(PKG_VERS)
+PKG_DIST_SITE = http://jpegclub.org/reference/wp-content/uploads/2022/01
+PKG_DIR = jpeg-$(subst 0,,$(PKG_VERS))
 
 DEPENDS =
 
-HOMEPAGE = https://www.ijg.org/
+HOMEPAGE = https://jpegclub.org/reference/reference-sources/
 COMMENT  = JPEG library
-LICENSE  =
+LICENSE  = Custom BSD-like (free software)
 
 GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.cross-cc.mk
-

--- a/cross/libjpeg/PLIST
+++ b/cross/libjpeg/PLIST
@@ -5,4 +5,4 @@ bin:bin/rdjpgcom
 bin:bin/wrjpgcom
 lnk:lib/libjpeg.so
 lnk:lib/libjpeg.so.9
-lib:lib/libjpeg.so.9.4.0
+lib:lib/libjpeg.so.9.5.0

--- a/cross/libjpeg/digests
+++ b/cross/libjpeg/digests
@@ -1,3 +1,3 @@
-jpegsrc.v9d.tar.gz SHA1 e44187fc7717896d4372271ddd4aa1d465c811b8
-jpegsrc.v9d.tar.gz SHA256 6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee
-jpegsrc.v9d.tar.gz MD5 ad7e40dedc268f97c44e7ee3cd54548a
+jpegsrc.v09e.tar.gz SHA1 ce2cc9f5484d793e813551ec7726b5197073a100
+jpegsrc.v09e.tar.gz SHA256 21b9b36ba3307287504459d9627da1d4b54c5f5cbd0569fa2bfffd286221f4d7
+jpegsrc.v09e.tar.gz MD5 5bb5dac6ce78a59971c061206f6e64ff


### PR DESCRIPTION
_Motivation:_  Build failures in #5050 due to changes in libjpeg related to the newer release version 9e (as it seems they also repackaged the older version 9d).  Using the opportunity to update the library.
_Linked issues:_  #5050

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
