### PR TITLE
python310: Re-enable wheel+setuptools isntallation

### DIFF
--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python310
 SPK_VERS = 3.10.1
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 6
+SPK_REV = 7
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/$(SPK_NAME)

--- a/spk/python310/src/requirements-pure.txt
+++ b/spk/python310/src/requirements-pure.txt
@@ -1,7 +1,7 @@
 # basic default wheels
 #pip==21.3.1             ==> Always install latest version (service-setup.sh:install_python_virtualenv)
-#setuptools==60.2.0      ==> Version provided by default with Python 3.10.1
-#wheel==0.37.1           ==> Version provided by default with Python 3.10.1
+setuptools==60.2.0
+wheel==0.37.1
 
 # Always use latest version available
 # certifi==2021.10.8


### PR DESCRIPTION
_Motivation:_  I had forgotten to re-enable `wheel` + `setuptools` at python310 install.  Re-enabling.
_Linked issues:_  n/a, caught-up before activating latest update.

### Checklist
- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
