### PR TITLE
ruby: Upgrade ruby to v3.1.0

### DIFF
--- a/cross/ruby/Makefile
+++ b/cross/ruby/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = ruby
-PKG_VERS = 3.0.2
+PKG_VERS = 3.1.0
 PKG_SHORT_VERS = $(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)

--- a/cross/ruby/PLIST
+++ b/cross/ruby/PLIST
@@ -10,5 +10,5 @@ rsc:bin/rdoc
 rsc:bin/ri
 rsc:bin/ruby
 rsc:bin/typeprof
-rsc:lib/ruby/3.0.0
+rsc:lib/ruby/3.1.0
 rsc:lib/ruby/gems

--- a/cross/ruby/digests
+++ b/cross/ruby/digests
@@ -1,3 +1,3 @@
-ruby-3.0.2.tar.gz SHA1 e00784956ed2083a40e269d8b14e571b8fae9a0f
-ruby-3.0.2.tar.gz SHA256 5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1
-ruby-3.0.2.tar.gz MD5 b973af486291a1e17ad50d88472bfa86
+ruby-3.1.0.tar.gz SHA1 e4e8c20dd2a1fdef4d3e5bd5a3461000dd17f226
+ruby-3.1.0.tar.gz SHA256 50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854
+ruby-3.1.0.tar.gz MD5 1ca89d713f2c18a20104befed51b3b9a

--- a/native/ruby/Makefile
+++ b/native/ruby/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = ruby
-PKG_VERS = 3.0.2
+PKG_VERS = 3.1.0
 PKG_SHORT_VERS = $(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)

--- a/native/ruby/digests
+++ b/native/ruby/digests
@@ -1,3 +1,3 @@
-ruby-3.0.2.tar.gz SHA1 e00784956ed2083a40e269d8b14e571b8fae9a0f
-ruby-3.0.2.tar.gz SHA256 5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1
-ruby-3.0.2.tar.gz MD5 b973af486291a1e17ad50d88472bfa86
+ruby-3.1.0.tar.gz SHA1 e4e8c20dd2a1fdef4d3e5bd5a3461000dd17f226
+ruby-3.1.0.tar.gz SHA256 50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854
+ruby-3.1.0.tar.gz MD5 1ca89d713f2c18a20104befed51b3b9a

--- a/spk/ruby/Makefile
+++ b/spk/ruby/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ruby
-SPK_VERS = 3.0.2
-SPK_REV = 9
+SPK_VERS = 3.1.0
+SPK_REV = 10
 SPK_ICON = src/ruby.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -8,7 +8,7 @@ DEPENDS = cross/$(SPK_NAME)
 # even it compiles with older cross/gdbm, ruby crashes at runtime
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-CHANGELOG = "1. Update ruby to v3.0.2.<br/>2. Update OpenSSL to v1.1.1l.<br/>3. Update bdb to v6.2.32."
+CHANGELOG = "1. Update ruby to v3.1.0."
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Ruby Programming Language.


### PR DESCRIPTION
## Description

Upgrade ruby to latest stable release v3.1.0.

https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

## Checklist

- [x] New installation of package completed successfully
- [x] Build rule `all-supported` completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)


## Tophat

### Synology RS820+

DSM: 7.0
Arch: denverton

```shell
$ uname -a
Linux nas 4.4.180+ #42218 SMP Mon Oct 18 19:26:24 CST 2021 x86_64 GNU/Linux synology_denverton_rs820+

$ sudo synopkg install ~/work/ruby_denverton-7.0_3.1.0-10.spk 
Password: 
{"error":{"code":0},"results":[{"action":"upgrade","beta":false,"betaIncoming":false,"error":{"code":0},"finished":true,"installReboot":false,"installing":true,"language":"enu","last_stage":"started","package":"ruby","packageName":"Ruby","pid":2567,"scripts":[{"code":0,"message":"","type":"stop"},{"code":0,"message":"","type":"preupgrade"},{"code":0,"message":"","type":"preuninst"},{"code":0,"message":"","type":"postuninst"},{"code":0,"message":"","type":"preinst"},{"code":0,"message":"","type":"postinst"},{"code":0,"message":"","type":"postupgrade"},{"code":0,"message":"","type":"start"}],"spk":"/var/services/homes/user/work/ruby_denverton-7.0_3.1.0-10.spk","stage":"installed_and_started","status":"running","success":true,"username":""}],"success":true}

$ /usr/local/bin/ruby --version
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]

$ /usr/local/bin/irb 
> require "open-uri"; URI.open("https://www.ruby-lang.org/") {|f| f.each_line {|line| p line} }
```