### PR TITLE
fix digests of libjpeg

### DIFF
--- a/cross/libjpeg/digests
+++ b/cross/libjpeg/digests
@@ -1,3 +1,3 @@
-jpegsrc.v09e.tar.gz SHA1 ce2cc9f5484d793e813551ec7726b5197073a100
-jpegsrc.v09e.tar.gz SHA256 21b9b36ba3307287504459d9627da1d4b54c5f5cbd0569fa2bfffd286221f4d7
-jpegsrc.v09e.tar.gz MD5 5bb5dac6ce78a59971c061206f6e64ff
+jpegsrc.v09e.tar.gz SHA1 b8b04c2e9be23f80f8c817f4cf271923becfa4cc
+jpegsrc.v09e.tar.gz SHA256 899dfbb8e72beb438ca608dd5268f78f97e1f576c5d11424cef101b992b930dc
+jpegsrc.v09e.tar.gz MD5 25a2d733dcf622a41f3693ff02afbcb7


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

- they changed the copyright date in jcparm.c to 2022, without creating a new revision

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
