### PR TITLE
Mono: Fix TLS on DSM7

### DIFF
--- a/cross/mono/Makefile
+++ b/cross/mono/Makefile
@@ -26,6 +26,7 @@ CONFIGURE_ARGS = --disable-mcs-build
 CONFIGURE_ARGS += --enable-btls
 CONFIGURE_ARGS += --disable-dependency-tracking
 CONFIGURE_ARGS += --without-mcs-docs
+CONFIGURE_ARGS += --prefix=$(INSTALL_PREFIX)
 
 # Optimize compilation for size
 ADDITIONAL_CFLAGS = -Os
@@ -52,7 +53,7 @@ ifeq ($(findstring $(ARCH),$(i686_ARCHS)),$(ARCH))
 		PLIST_TRANSFORM = sed -e '/:lib\/libmono-btls-shared.so/d'
 	endif
 endif
-AG_ARGS += --disable-mcs-build
+AG_ARGS += --disable-mcs-build --with-mcs-docs=no --prefix=$(INSTALL_PREFIX)
 
 .PHONY: mono_pre_configure
 mono_pre_configure:

--- a/cross/mono/patches/002-change-share-path.patch
+++ b/cross/mono/patches/002-change-share-path.patch
@@ -1,0 +1,34 @@
+--- mcs/class/corlib/System/Environment.cs.org	2022-01-26 14:48:46.677004670 +1100
++++ mcs/class/corlib/System/Environment.cs	2022-01-26 14:48:56.449000000 +1100
+@@ -676,7 +676,7 @@
+ 			case SpecialFolder.MyVideos:
+ 				return ReadXdgUserDir (config, home, "XDG_VIDEOS_DIR", "Videos");
+ 			case SpecialFolder.CommonTemplates:
+-				return "/usr/share/templates";
++				return "/var/packages/mono/target/share/templates";
+ 			case SpecialFolder.Fonts:
+ 				if (Platform == PlatformID.MacOSX)
+ 					return Path.Combine (home, "Library", "Fonts");
+@@ -739,7 +739,7 @@
+ 				return String.Empty;
+ 			// This is where data common to all users goes
+ 			case SpecialFolder.CommonApplicationData:
+-				return "/usr/share";
++				return "/var/packages/mono/target/share";
+ 			default:
+ 				throw new ArgumentException ("Invalid SpecialFolder");
+ 			}
+
+--- external/corefx/src/System.Runtime.Extensions/src/System/Environment.Unix.cs.org	2022-01-26 14:52:41.987541663 +1100
++++ external/corefx/src/System.Runtime.Extensions/src/System/Environment.Unix.cs	2022-01-26 14:52:37.914000000 +1100
+@@ -98,8 +98,8 @@
+             // https://www.freedesktop.org/software/systemd/man/file-hierarchy.html
+             switch (folder)
+             {
+-                case SpecialFolder.CommonApplicationData: return "/usr/share";
+-                case SpecialFolder.CommonTemplates: return "/usr/share/templates";
++                case SpecialFolder.CommonApplicationData: return "/var/packages/mono/target/share";
++                case SpecialFolder.CommonTemplates: return "/var/packages/mono/target/share/templates";
+             }
+             if (IsMac)
+             {

--- a/spk/mono/src/service-setup.sh
+++ b/spk/mono/src/service-setup.sh
@@ -4,5 +4,6 @@
 service_postinst ()
 {
     # Sync ca certificates
-    ${SYNOPKG_PKGDEST}/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
+    curl -Lko ${SYNOPKG_PKGDEST}/ca-certificates.crt https://curl.se/ca/cacert.pem
+    ${SYNOPKG_PKGDEST}/bin/cert-sync ${SYNOPKG_PKGDEST}/ca-certificates.crt
 }

--- a/spk/mono/src/service-setup.sh
+++ b/spk/mono/src/service-setup.sh
@@ -4,6 +4,5 @@
 service_postinst ()
 {
     # Sync ca certificates
-    mkdir -p ${SYNOPKG_PKGVAR}/.config ${SYNOPKG_PKGVAR}/.mono
-    HOME="${SYNOPKG_PKGVAR}" ${SYNOPKG_PKGDEST}/bin/cert-sync --user /etc/ssl/certs/ca-certificates.crt
+    ${SYNOPKG_PKGDEST}/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
 }

--- a/spk/mono/src/service-setup.sh
+++ b/spk/mono/src/service-setup.sh
@@ -4,6 +4,6 @@
 service_postinst ()
 {
     # Sync ca certificates
-    curl -Lko ${SYNOPKG_PKGDEST}/ca-certificates.crt https://curl.se/ca/cacert.pem
-    ${SYNOPKG_PKGDEST}/bin/cert-sync ${SYNOPKG_PKGDEST}/ca-certificates.crt
+    mkdir -p ${SYNOPKG_PKGVAR}/.config ${SYNOPKG_PKGVAR}/.mono
+    HOME="${SYNOPKG_PKGVAR}" ${SYNOPKG_PKGDEST}/bin/cert-sync --user /etc/ssl/certs/ca-certificates.crt
 }

--- a/spk/mono/src/service-setup.sh
+++ b/spk/mono/src/service-setup.sh
@@ -4,5 +4,6 @@
 service_postinst ()
 {
     # Sync ca certificates
-    ${SYNOPKG_PKGDEST}/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
+    mkdir -p ${SYNOPKG_PKGDEST}/share/.config ${SYNOPKG_PKGDEST}/share/.mono
+    HOME="${SYNOPKG_PKGDEST}/share" ${MONO_PATH}/cert-sync --user /etc/ssl/certs/ca-certificates.crt
 }

--- a/spk/sonarr/src/service-setup.sh
+++ b/spk/sonarr/src/service-setup.sh
@@ -43,6 +43,8 @@ SVC_BACKGROUND=y
 service_postinst ()
 {
     mkdir -p ${CONFIG_DIR}
+    mkdir -p ${HOME_DIR}/.config ${HOME_DIR}/.mono
+    HOME="${HOME_DIR}" ${MONO_PATH}/cert-sync --user /etc/ssl/certs/ca-certificates.crt
     set_unix_permissions "${CONFIG_DIR}"
 }
 

--- a/spk/sonarr/src/service-setup.sh
+++ b/spk/sonarr/src/service-setup.sh
@@ -43,8 +43,6 @@ SVC_BACKGROUND=y
 service_postinst ()
 {
     mkdir -p ${CONFIG_DIR}
-    mkdir -p ${HOME_DIR}/.config ${HOME_DIR}/.mono
-    HOME="${HOME_DIR}" ${MONO_PATH}/cert-sync --user /etc/ssl/certs/ca-certificates.crt
     set_unix_permissions "${CONFIG_DIR}"
 }
 


### PR DESCRIPTION
## Description
This should fix the trust store containing expired certificates in mono applications by using a different path. Dependent packages may need to be updated.

Fixes #5051

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
