### PR TITLE
Update syncthing to 1.18.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd spksrc # Go to the cloned repository's root folder.
 docker run -it -v $(pwd):/spksrc ghcr.io/synocommunity/spksrc /bin/bash
 
 # If running on macOS:
-docker run -it -v $(pwd):/spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
+docker run --rm --pull=always -it -v $(pwd):/spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
 ```
 5. From there, follow the instructions in the [Developers HOW TO].
 

--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.18.5
+PKG_VERS = 1.18.6
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-1.18.5.tar.gz SHA1 f7c05ca20837d4d68f93f438de970563b818f15d
-syncthing-1.18.5.tar.gz SHA256 c64db4d5fe6ae6525d2333fdd5cb41243e56430ced377c59ca69731a1183df1f
-syncthing-1.18.5.tar.gz MD5 cc1f521f0f3059eac8934eeb796eaba0
+syncthing-1.18.6.tar.gz SHA1 2b8e849a3bba74e4deadc908b733d3b8a5c36c72
+syncthing-1.18.6.tar.gz SHA256 4c479c6041bd2825e6bd8ff817f2855938a642a29f30bc4355c459bdad989e42
+syncthing-1.18.6.tar.gz MD5 2719a19b7e018790bbdbb019a6f2c9b7

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.18.5
-SPK_REV = 23
+SPK_VERS = 1.18.6
+SPK_REV = 24
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "Update syncthing to v1.18.5.  Add wizard page to preconfigure credentials for the Web GUI."
+CHANGELOG = "Update syncthing to v1.18.6."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes


### PR DESCRIPTION
## Description

Update package Syncthing from 1.18.5 to 1.18.6

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)


## Tophat

Tested upgrade on DSM 7.0 Deventon.
Spoted some magick. For some reason I had old version 1.17.0 instead of 1.18.5.
During the Manual installation the old config replaced with new one.
Then I tested uninstall and install again 1.18.6, and this time config remained the same.