### PR TITLE
Upgrade native/go to 1.17.6

### DIFF
--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.17.5
+PKG_VERS = 1.17.6
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
 PKG_DIST_SITE = https://golang.org/dl

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.17.5.linux-amd64.tar.gz SHA1 e1cb9253f3b1ca0f922a36e3bcbde3534c0f8bda
-go1.17.5.linux-amd64.tar.gz SHA256 bd78114b0d441b029c8fe0341f4910370925a4d270a6a590668840675b0c653e
-go1.17.5.linux-amd64.tar.gz MD5 3e1ecc10ceb813df3e8dadb7f63a65d6
+go1.17.6.linux-amd64.tar.gz SHA1 c084a6a85a34f32aeb22f971fa146078911a028c
+go1.17.6.linux-amd64.tar.gz SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+go1.17.6.linux-amd64.tar.gz MD5 ba9a4d13dc119a953901984292efd713


### PR DESCRIPTION
## Description

Upgrade go to 1.17.6.

```
 go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker, runtime, and the crypto/x509, net/http, and reflect packages. See the Go 1.17.6 milestone on our issue tracker for details. 
```

https://github.com/golang/go/issues?q=milestone%3AGo1.17.6+label%3ACherryPickApproved

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)


## Test

The CI is broken because of bad checksums for gitea. May be https://github.com/SynoCommunity/spksrc/pull/5088 would fix the problem