### PR TITLE
fix libjpeg download

### DIFF
--- a/cross/libjpeg/Makefile
+++ b/cross/libjpeg/Makefile
@@ -1,13 +1,13 @@
 PKG_NAME = libjpeg
-PKG_VERS = 09e
+PKG_VERS = 9e
 PKG_EXT = tar.gz
 PKG_DIST_NAME = jpegsrc.v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://jpegclub.org/reference/wp-content/uploads/2022/01
-PKG_DIR = jpeg-$(subst 0,,$(PKG_VERS))
+PKG_DIST_SITE = https://www.ijg.org/files
+PKG_DIR = jpeg-$(PKG_VERS)
 
 DEPENDS =
 
-HOMEPAGE = https://jpegclub.org/reference/reference-sources/
+HOMEPAGE = https://www.ijg.org/
 COMMENT  = JPEG library
 LICENSE  = Custom BSD-like (free software)
 

--- a/cross/libjpeg/digests
+++ b/cross/libjpeg/digests
@@ -1,3 +1,3 @@
-jpegsrc.v09e.tar.gz SHA1 b8b04c2e9be23f80f8c817f4cf271923becfa4cc
-jpegsrc.v09e.tar.gz SHA256 899dfbb8e72beb438ca608dd5268f78f97e1f576c5d11424cef101b992b930dc
-jpegsrc.v09e.tar.gz MD5 25a2d733dcf622a41f3693ff02afbcb7
+jpegsrc.v9e.tar.gz SHA1 ed959b5f3551bc965fe6d0aff6ca48a26f8ce346
+jpegsrc.v9e.tar.gz SHA256 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d
+jpegsrc.v9e.tar.gz MD5 2489f1597b046425f5fcd3cf2df7d85f


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
Content of libjpeg source archive is updated again without changing the file name.
if version 9e is not stable yet, we probably might downgrade to version 9d.

This is a follow up to #5078 and #5060. The libjpeg source changed while my integration testing of #5078.
It reverts the libjpeg archve location introduced by #5053.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
