### PR TITLE
avoid error output for packages without wheels

### DIFF
--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -108,7 +108,7 @@ ifneq ($(strip $(WHEELS)),)
 	      $${abi3} \
 	      $${global_option} \
 	      --no-build-isolation \
-	      $${wheel} ; \
+	      $${wheel} || exit 1 ; \
 	done < <(grep -svH  -e "^\#" -e "^\$$" $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) $(WHEELHOUSE)/$(WHEELS_LIMITED_API))
 ifneq ($(filter 1 ON TRUE,$(WHEELS_PURE_PYTHON_PACKAGING_ENABLE)),)
 	@if [ -s "$(WHEELHOUSE)/$(WHEELS_PURE_PYTHON)" ]; then \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -109,7 +109,7 @@ ifneq ($(strip $(WHEELS)),)
 	      $${global_option} \
 	      --no-build-isolation \
 	      $${wheel} ; \
-	done < <(grep -svH  -e "^\#" -e "^\$$" $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) $(WHEELHOUSE)/$(WHEELS_LIMITED_API)) || true
+	done < <(grep -svH  -e "^\#" -e "^\$$" $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) $(WHEELHOUSE)/$(WHEELS_LIMITED_API))
 ifneq ($(filter 1 ON TRUE,$(WHEELS_PURE_PYTHON_PACKAGING_ENABLE)),)
 	@if [ -s "$(WHEELHOUSE)/$(WHEELS_PURE_PYTHON)" ]; then \
 	   $(MSG) "Force pure-python" ; \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -44,85 +44,81 @@ wheel_msg_target:
 # will move if the user chooses a custom persistent distribution dir for caching downloads between
 # containers and builds.
 pre_wheel_target: wheel_msg_target
-	@if [ -n "$(WHEELS)" ] ; then \
-		if [ -n "$(PIP_CACHE_OPT)" ] ; then \
-			mkdir -p $(PIP_DIR) ; \
-		fi; \
-		mkdir -p $(WHEELHOUSE) ; \
-		for wheel in $(WHEELS) ; \
-		do \
-			if [ -f $$wheel ] ; then \
-				if [ $$(basename $$wheel) = $(WHEELS_PURE_PYTHON) ]; then \
-					$(MSG) "Adding existing $$wheel file as pure-python (discarding any cross-compiled)" ; \
-					sed -e '/^cross:\|^#\|^$$/d' -e /^pure:/s/^pure://g $$wheel  >> $(WHEELHOUSE)/$(WHEELS_PURE_PYTHON) ; \
-				elif [ $$(basename $$wheel) = $(WHEELS_CROSSENV_COMPILE) ]; then \
-					$(MSG) "Adding existing $$wheel file as cross-compiled (discarding any pure-python)" ; \
-					sed -e '/^pure:\|^#\|^$$/d' -e /^cross:/s/^cross://g $$wheel >> $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) ; \
-				elif [ $$(basename $$wheel) = $(WHEELS_LIMITED_API) ]; then \
-					$(MSG) "Adding existing $$wheel file as ABI-limited" ; \
-					cat $$wheel >> $(WHEELHOUSE)/$(WHEELS_LIMITED_API) ; \
-				else \
-					$(MSG) "Adapting existing $$wheel file" ; \
-					sed -rn /^pure:/s/^pure://gp $$wheel         >> $(WHEELHOUSE)/$(WHEELS_PURE_PYTHON) ; \
-					sed -rn /^cross:/s/^cross://gp $$wheel       >> $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) ; \
-					sed -e '/^pure:\|^cross:\|^#\|^$$/d' $$wheel >> $(WHEELHOUSE)/$(WHEELS_DEFAULT_REQUIREMENT) ; \
-				fi ;\
-			else \
-				$(MSG) "ERROR: File $$wheel does not exist" ; \
-			fi ; \
-		done \
-	fi
+ifneq ($(strip $(WHEELS)),)
+	@if [ -n "$(PIP_CACHE_OPT)" ] ; then \
+	   mkdir -p $(PIP_DIR) ; \
+	fi; \
+	mkdir -p $(WHEELHOUSE) ; \
+	for wheel in $(WHEELS) ; do \
+	   if [ -f $$wheel ] ; then \
+	      if [ $$(basename $$wheel) = $(WHEELS_PURE_PYTHON) ]; then \
+	         $(MSG) "Adding existing $$wheel file as pure-python (discarding any cross-compiled)" ; \
+	         sed -e '/^cross:\|^#\|^$$/d' -e /^pure:/s/^pure://g $$wheel  >> $(WHEELHOUSE)/$(WHEELS_PURE_PYTHON) ; \
+	      elif [ $$(basename $$wheel) = $(WHEELS_CROSSENV_COMPILE) ]; then \
+	         $(MSG) "Adding existing $$wheel file as cross-compiled (discarding any pure-python)" ; \
+	         sed -e '/^pure:\|^#\|^$$/d' -e /^cross:/s/^cross://g $$wheel >> $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) ; \
+	      elif [ $$(basename $$wheel) = $(WHEELS_LIMITED_API) ]; then \
+	         $(MSG) "Adding existing $$wheel file as ABI-limited" ; \
+	         cat $$wheel >> $(WHEELHOUSE)/$(WHEELS_LIMITED_API) ; \
+	      else \
+	         $(MSG) "Adapting existing $$wheel file" ; \
+	         sed -rn /^pure:/s/^pure://gp $$wheel         >> $(WHEELHOUSE)/$(WHEELS_PURE_PYTHON) ; \
+	         sed -rn /^cross:/s/^cross://gp $$wheel       >> $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) ; \
+	         sed -e '/^pure:\|^cross:\|^#\|^$$/d' $$wheel >> $(WHEELHOUSE)/$(WHEELS_DEFAULT_REQUIREMENT) ; \
+	      fi ;\
+	   else \
+	      $(MSG) "ERROR: File $$wheel does not exist" ; \
+	   fi ; \
+	done
+endif
 
 # Build cross compiled wheels first, to fail fast.
 # There might be an issue with some pure python wheels when built after that.
 build_wheel_target: SHELL:=/bin/bash
 build_wheel_target: $(PRE_WHEEL_TARGET)
-	@if [ -n "$(WHEELS)" ] ; then \
-		$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e))) \
-		$(MSG) "Cross-compiling wheels" ; \
-		localPIP=$(PIP) ; \
-		if [ -s "$(CROSSENV)" ] ; then \
-			$(MSG) "Python crossenv found: [$(CROSSENV)]" ; \
-			. $(CROSSENV) ; \
-			localPIP=$(PIP_CROSSENV) ; \
-		fi ; \
-		while IFS= read -r requirement ; do \
-			wheel=$${requirement#*:} ; \
-			file=$$(basename $${requirement%%:*}) ; \
-			[ "$${file}" = "$(WHEELS_LIMITED_API)" ] && abi3="--build-option=--py-limited-api=$(PYTHON_LIMITED_API)" || abi3="" ; \
-			[ "$$(grep -s egg <<< $${wheel})" ] && name=$${wheel#*egg=} || name=$${wheel%%[<>=]=*} ; \
-			options=($$(echo $(WHEELS_BUILD_ARGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
-			[ "$${options}" ] && global_option=$$(printf "\x2D\x2Dglobal-option=%s " "$${options[@]}") || global_option="" ; \
-			localCFLAGS=($$(echo $(WHEELS_CFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
-			localLDFLAGS=($$(echo $(WHEELS_LDFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
-			localCPPFLAGS=($$(echo $(WHEELS_CPPFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
-			localCXXFLAGS=($$(echo $(WHEELS_CXXFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
-			$(MSG) [$${name}] $$([ "$${localCFLAGS[@]}" ] && echo "CFLAGS=$${localCFLAGS[@]} ")$$([ "$${localLDFLAGS[@]}" ] && echo "LDFLAGS=$${localLDFLAGS[@]} ")$$([ "$${localCPPFLAGS[@]}" ] && echo "CPPFLAGS=$${localCPPFLAGS[@]} ")$$([ "$${localCXXFLAGS[@]}" ] && echo "CXXFLAGS=$${localCXXFLAGS[@]} ")$$([ "$${abi3}" ] && echo "$${abi3} ")"$${global_option}" ; \
-			$(RUN) \
-				_PYTHON_HOST_PLATFORM="$(TC_TARGET)" \
-				CFLAGS="$(CFLAGS) -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) $${localCFLAGS[@]}" \
-				LDFLAGS="$(LDFLAGS) $${localLDFLAGS[@]}" \
-				CPPFLAGS="$(CPPFLAGS) $${localCPPFLAGS[@]}" \
-				CXXFLAGS="$(CXXFLAGS) $${localCXXFLAGS[@]}" \
-				$${localPIP} \
-				$(PIP_WHEEL_ARGS) \
-				$${abi3} \
-				$${global_option} \
-				--no-build-isolation \
-				$${wheel} ; \
-		done < <(grep -svH  -e "^\#" -e "^\$$" $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) $(WHEELHOUSE)/$(WHEELS_LIMITED_API)) || true ; \
-	fi
+ifneq ($(strip $(WHEELS)),)
+	$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e)))
+	$(MSG) "Cross-compiling wheels" ; \
+	localPIP=$(PIP) ; \
+	if [ -s "$(CROSSENV)" ] ; then \
+	   $(MSG) "Python crossenv found: [$(CROSSENV)]" ; \
+	   . $(CROSSENV) ; \
+	   localPIP=$(PIP_CROSSENV) ; \
+	fi ; \
+	while IFS= read -r requirement ; do \
+	   wheel=$${requirement#*:} ; \
+	   file=$$(basename $${requirement%%:*}) ; \
+	   [ "$${file}" = "$(WHEELS_LIMITED_API)" ] && abi3="--build-option=--py-limited-api=$(PYTHON_LIMITED_API)" || abi3="" ; \
+	   [ "$$(grep -s egg <<< $${wheel})" ] && name=$${wheel#*egg=} || name=$${wheel%%[<>=]=*} ; \
+	   options=($$(echo $(WHEELS_BUILD_ARGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
+	   [ "$${options}" ] && global_option=$$(printf "\x2D\x2Dglobal-option=%s " "$${options[@]}") || global_option="" ; \
+	   localCFLAGS=($$(echo $(WHEELS_CFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
+	   localLDFLAGS=($$(echo $(WHEELS_LDFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
+	   localCPPFLAGS=($$(echo $(WHEELS_CPPFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
+	   localCXXFLAGS=($$(echo $(WHEELS_CXXFLAGS) | sed -e 's/ \[/\n\[/g' | grep -i $${name} | cut -f2 -d] | xargs)) ; \
+	   $(MSG) [$${name}] $$([ "$${localCFLAGS[@]}" ] && echo "CFLAGS=$${localCFLAGS[@]} ")$$([ "$${localLDFLAGS[@]}" ] && echo "LDFLAGS=$${localLDFLAGS[@]} ")$$([ "$${localCPPFLAGS[@]}" ] && echo "CPPFLAGS=$${localCPPFLAGS[@]} ")$$([ "$${localCXXFLAGS[@]}" ] && echo "CXXFLAGS=$${localCXXFLAGS[@]} ")$$([ "$${abi3}" ] && echo "$${abi3} ")"$${global_option}" ; \
+	   $(RUN) \
+	      _PYTHON_HOST_PLATFORM="$(TC_TARGET)" \
+	      CFLAGS="$(CFLAGS) -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) $${localCFLAGS[@]}" \
+	      LDFLAGS="$(LDFLAGS) $${localLDFLAGS[@]}" \
+	      CPPFLAGS="$(CPPFLAGS) $${localCPPFLAGS[@]}" \
+	      CXXFLAGS="$(CXXFLAGS) $${localCXXFLAGS[@]}" \
+	      $${localPIP} \
+	      $(PIP_WHEEL_ARGS) \
+	      $${abi3} \
+	      $${global_option} \
+	      --no-build-isolation \
+	      $${wheel} ; \
+	done < <(grep -svH  -e "^\#" -e "^\$$" $(WHEELHOUSE)/$(WHEELS_CROSSENV_COMPILE) $(WHEELHOUSE)/$(WHEELS_LIMITED_API)) || true
 ifneq ($(filter 1 ON TRUE,$(WHEELS_PURE_PYTHON_PACKAGING_ENABLE)),)
-	@if [ -n "$(WHEELS)" ] ; then \
-		$(foreach e,$(shell cat $(WORK_DIR)/python-cc.mk),$(eval $(e))) \
-		if [ -s "$(WHEELHOUSE)/$(WHEELS_PURE_PYTHON)" ]; then \
-			$(MSG) "Force pure-python" ; \
-			export LD= LDSHARED= CPP= NM= CC= AS= RANLIB= CXX= AR= STRIP= OBJDUMP= READELF= CFLAGS= CPPFLAGS= CXXFLAGS= LDFLAGS= && $(RUN) \
-				$(PIP) \
-				$(PIP_WHEEL_ARGS) \
-				--requirement $(WHEELHOUSE)/$(WHEELS_PURE_PYTHON) ; \
-		fi ; \
+	@if [ -s "$(WHEELHOUSE)/$(WHEELS_PURE_PYTHON)" ]; then \
+	   $(MSG) "Force pure-python" ; \
+	   export LD= LDSHARED= CPP= NM= CC= AS= RANLIB= CXX= AR= STRIP= OBJDUMP= READELF= CFLAGS= CPPFLAGS= CXXFLAGS= LDFLAGS= && $(RUN) \
+	      $(PIP) \
+	      $(PIP_WHEEL_ARGS) \
+	      --requirement $(WHEELHOUSE)/$(WHEELS_PURE_PYTHON) ; \
 	fi
+endif
 endif
 
 post_wheel_target: $(WHEEL_TARGET) install_python_wheel
@@ -136,4 +132,3 @@ $(WHEEL_COOKIE): $(POST_WHEEL_TARGET)
 else
 wheel: ;
 endif
-


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
1. This is another fix to suppress obsolete build error output (like #5080) 
2. Ensure it exit with error when failure to build a wheel.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
