### PR TITLE
fix conf file creation

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -255,6 +255,7 @@ DSM_LICENSE = $(DSM_LICENSE_FILE)
 endif
 
 define dsm_resource_copy
+$(create_target_dir)
 $(MSG) "Creating $@"
 cp $< $@
 chmod 644 $@


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
- fix the creation of conf/privilege file (bugfix for #4930)
- #4930 changed the conf/resource file creation and broke the privilege file creation due to missing folder (e.g. for syncthing armv7-1.2)

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
