### PR TITLE
syncthing: fix SERVICE_CERT_RELOAD

### DIFF
--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -12,7 +12,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "Update syncthing to v1.19.0. Add wizard page to preconfigure credentials for the Web GUI. Integrate with the certificate management UI in Control Panel. Fix DSM 7 data migration."
+CHANGELOG = "1. Update syncthing to v1.19.0.<br/>2. Add wizard page to preconfigure credentials for the Web GUI.<br/>3. Integrate with the certificate management UI in Control Panel.<br/>4. Fix DSM 7 data migration."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes
@@ -24,6 +24,7 @@ SERVICE_SETUP = src/service-setup.sh
 SERVICE_PORT = 8384
 SERVICE_PORT_TITLE = $(DISPLAY_NAME)
 SERVICE_CERT = syncthing_webui
+SERVICE_CERT_RELOAD = tools/ca_reloader.sh
 
 # Admin link for in DSM UI
 ADMIN_PORT = $(SERVICE_PORT)
@@ -39,4 +40,4 @@ syncthing_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var $(STAGING_DIR)/tools
 	install -m 600 src/config.xml $(STAGING_DIR)/var/
 	install -m 644 src/options.conf $(STAGING_DIR)/var/
-	install -m 700 src/ca_reloader.sh $(STAGING_DIR)/tools/
+	install -m 700 src/ca_reloader.sh $(STAGING_DIR)/$(SERVICE_CERT_RELOAD)

--- a/spk/syncthing/src/ca_reloader.sh
+++ b/spk/syncthing/src/ca_reloader.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CERT_DIR=/usr/local/etc/certificate/syncthing/syncthing-webui
+CERT_DIR=/usr/local/etc/certificate/syncthing/syncthing_webui
 CONF_DIR=/var/packages/syncthing/var
 if [ ! -d "$CONF_DIR" ]; then
    CONF_DIR=/var/packages/syncthing/target/var


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
follow up of #5117
- revert to use SERVICE_CERT_RELOAD

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
