### PR TITLE
homeassistant: Issue with numpy on armv5 no longer exists

### DIFF
--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -62,11 +62,6 @@ WHEELS_BUILD_ARGS += --enable-freetype
 WHEELS_BUILD_ARGS += --enable-jpeg
 WHEELS_BUILD_ARGS += --enable-zlib
 
-# [numpy]
-# gcc-4.6.4 failed with exit status 1
-# https://github.com/numpy/numpy/issues/20664
-UNSUPPORTED_ARCHS = $(ARMv5_ARCHS)
-
 include ../../mk/spksrc.spk.mk
 
 # [numpy]


### PR DESCRIPTION
## Description

homeassistant: Issue with numpy on armv5 no longer exists

Fixes # Relates to on-going work on #5043

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
