### PR TITLE
spksrc: Allow downloading without extracting the toolchain

### DIFF
--- a/.github/actions/download.sh
+++ b/.github/actions/download.sh
@@ -15,6 +15,7 @@ else
     echo "===> Download packages: ${DOWNLOAD_PACKAGES}"
     for download in ${DOWNLOAD_PACKAGES}
     do
+        echo "$ make -c ${download} download"
         make -C ${download} download
     done
 fi

--- a/mk/spksrc.cross-env.mk
+++ b/mk/spksrc.cross-env.mk
@@ -24,13 +24,23 @@ export INSTALL_PREFIX
 
 $(TC_VARS_MK):
 	$(create_target_dir)
-	@$(MSG) "Set up toolchain "
+ifeq ($(strip $(MAKECMDGOALS)),download)
+	@$(MSG) "Downloading toolchain"
+	@if env $(MAKE) --no-print-directory -C ../../toolchain/$(TC) download ; \
+	then \
+	  env $(MAKE) --no-print-directory -C ../../toolchain/$(TC) tc_vars > $@ ; \
+	else \
+	  echo "$$""(error An error occured while downloading the toolchain, please check the messages above)" > $@; \
+	fi
+else
+	@$(MSG) "Setting-up toolchain "
 	@if env $(MAKE) --no-print-directory -C ../../toolchain/$(TC) ; \
 	then \
 	  env $(MAKE) --no-print-directory -C ../../toolchain/$(TC) tc_vars > $@ ; \
 	else \
 	  echo "$$""(error An error occured while setting up the toolchain, please check the messages above)" > $@; \
 	fi
+endif
 
 -include $(TC_VARS_MK)
 ENV += TC=$(TC)

--- a/mk/spksrc.tc.mk
+++ b/mk/spksrc.tc.mk
@@ -50,14 +50,14 @@ include ../../mk/spksrc.tc-flags.mk
 fix: flag
 include ../../mk/spksrc.tc-fix.mk
 
-all: $(TC_LOCAL_VARS_MK)
+all: fix $(TC_LOCAL_VARS_MK)
 
 .PHONY: $(TC_LOCAL_VARS_MK)
 $(TC_LOCAL_VARS_MK): fix
 	env $(MAKE) --no-print-directory tc_vars > $@ 2>/dev/null;
 
-.PHONY: tc_vars
-tc_vars: fix
+.PHONY:
+tc_vars:
 	@echo TC_ENV :=
 	@for tool in $(TOOLS) ; \
 	do \


### PR DESCRIPTION
## Description

This allows from spksrc/kernel/syno* directories to call-up `make download` which will only download the toolchain without
actually extracting it.

This greatly reduces disk size on github-action when pre-downloading kernels.

Part of https://github.com/SynoCommunity/spksrc/pull/5095 PR split.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
