### PR TITLE
download.mk: Allow multiple retries and echo real cmd line

### DIFF
--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -155,9 +155,9 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      if [ -f $${localFile} ]; then \
 	        $(MSG) "  File $${localFile} already downloaded" ; \
 	      else \
-	        $(MSG) "  wget $${url}" ; \
+	        $(MSG) "  wget --secure-protocol=TLSv1_2 --timeout=30 --waitretry=0 --tries=5 -nv $${url}" ; \
 	        rm -f $${localFile}.part ; \
-	        wget --secure-protocol=TLSv1_2 -nv -O $${localFile}.part -nc $${url} ; \
+	        wget --secure-protocol=TLSv1_2 --timeout=30 --waitretry=0 --tries=5 -nv -O $${localFile}.part -nc $${url} ; \
 	        mv $${localFile}.part $${localFile} ; \
 	      fi ; \
 	      flock -u 9 ; \


### PR DESCRIPTION
## Description

The following options allow wget to retry in case of error.  It also print the real and full command line to the log file.

Part of https://github.com/SynoCommunity/spksrc/pull/5095 PR split.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
