### PR TITLE
Separate packages for each arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v2
         with:
-          name: packages
+          name: Packages for ${{ matrix.arch }}
           path: packages/*.spk
 
   release:


### PR DESCRIPTION
Instead of having 1 huge result, lets split the results based on `arch`.
Is there any reason not to do this?