### PR TITLE
Pre check false-negative with github-action

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -73,7 +73,8 @@ do
     # For a build to succeed a <package>_<arch>-<version>.spk must also be generated
     if [ ${result} -eq 0 -a "$(ls -1 ./packages/$(sed -n -e '/^SPK_NAME/ s/.*= *//p' spk/${package}/Makefile)_*.spk)" ]; then
         echo "$(date --date=now +"%Y.%m.%d %H:%M:%S") - ${package}: (${GH_ARCH}) DONE"   >> ${BUILD_SUCCESS_FILE}
-    else
+    # Ensure it's not a false-positive due to pre-check
+    elif tail -15 build.log | grep -viq 'spksrc.pre-check.mk'; then
         cat build.log >> ${BUILD_ERROR_LOGFILE}
         echo "$(date --date=now +"%Y.%m.%d %H:%M:%S") - ${package}: (${GH_ARCH}) FAILED" >> ${BUILD_ERROR_FILE}
     fi


### PR DESCRIPTION
## Description

With latest changes it now `exit 2` on pre-check.mk causing an error on github-action.  The following aims at validating this before confirming that this really is an error.

Fixes https://github.com/SynoCommunity/spksrc/pull/5162#issuecomment-1078058126

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
