### PR TITLE
Remove Release step from Build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,19 +173,3 @@ jobs:
           name: Packages for ${{ matrix.arch }}
           path: packages/*.spk
           if-no-files-found: ignore
-
-  release:
-    needs: build
-    name: Release
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: 'packages/*.spk'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we never use it, let's remove it.