### PR TITLE
git: fix for 32bit arm and ppc archs (fixes #5196)

### DIFF
--- a/cross/git/Makefile
+++ b/cross/git/Makefile
@@ -18,7 +18,8 @@ CONFIGURE_ARGS += ac_cv_snprintf_returns_bogus=no
 CONFIGURE_ARGS += ac_cv_iconv_omits_bom=no
 
 # git (since version 2.35.0) requires C99 support (such as -std=c99, -std=gnu99, -std=c11 or -std=gnu11)
-ADDITIONAL_CPPFLAGS  = -std=c99
+# builds with -std=c99 do not run on 32 bit arm and ppc archs ("fatal: Cannot handle files this big")
+ADDITIONAL_CPPFLAGS  = -std=gnu99
 ADDITIONAL_CPPFLAGS += -O
 
 PRE_CONFIGURE_TARGET = git_pre_configure

--- a/spk/git/Makefile
+++ b/spk/git/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = git
 SPK_VERS = 2.35.1
-SPK_REV = 21
+SPK_REV = 22
 SPK_ICON = src/git.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -10,7 +10,7 @@ DESCRIPTION = Git is a fast, scalable, distributed revision control system with 
 DESCRIPTION_FRE = Git est un système de gestion de révision rapide, extensible et distribué avec un ensemble de commandes inhabituellement riche qui fournit à la fois des opérations de haut niveau et un accès complet aux structures de bas niveau.
 STARTABLE = no
 DISPLAY_NAME = Git
-CHANGELOG = "1. Update git to v2.35.1.<br/>2. Update OpenSSL to v1.1.1n.<br/>3. Update curl to v7.82.0.<br/>4. Update libexpat to v2.4.8."
+CHANGELOG = "1. Update git to v2.35.1.<br/>2. Update OpenSSL to v1.1.1n.<br/>3. Update curl to v7.82.0.<br/>4. Update libexpat to v2.4.8.<br/>5. Fix runtime errors on 32bit arm and ppc archs."
 
 HOMEPAGE = https://git-scm.com
 LICENSE  = GPLv2


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
- use -std=gnu99 instead of -std=c99 to get rid of runtime errors on 32bit archs (arm and ppc)

Fixes #5196

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
