### PR TITLE
Sonarr: Update to 3.0.7.1477 and switch to alt tmp dir

### DIFF
--- a/cross/sonarr/Makefile
+++ b/cross/sonarr/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = Sonarr
-PKG_VERS = 3.0.5.1144
+PKG_VERS = 3.0.7.1477
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME).main.$(PKG_VERS).linux.$(PKG_EXT)
 PKG_DIST_SITE = https://download.sonarr.tv/v3/main/$(PKG_VERS)

--- a/cross/sonarr/digests
+++ b/cross/sonarr/digests
@@ -1,3 +1,3 @@
-Sonarr.main.3.0.5.1144.linux.tar.gz SHA1 2335133139a46f1ce0d1b2cb1f566d30285d3d1e
-Sonarr.main.3.0.5.1144.linux.tar.gz SHA256 77aff6978d4dc80027979c815bd5a79579dd9bb50d39b1b2d14b3bb9e18058aa
-Sonarr.main.3.0.5.1144.linux.tar.gz MD5 675ce0ab2f1e643860ab1daab45b2842
+Sonarr.main.3.0.7.1477.linux.tar.gz SHA1 4e453fc404839d33f93776b88f77ecbc69f46fb0
+Sonarr.main.3.0.7.1477.linux.tar.gz SHA256 c41ee4596c71fb2981c72c41cf063b8197f0f643078b6312b2b529f0620e8b0b
+Sonarr.main.3.0.7.1477.linux.tar.gz MD5 5c52cefe737b2b3a80f18d4e8c066307

--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbdrone
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 19
+SPK_REV = 20
 SPK_ICON = src/sonarr.png
 
 # Mono not supported on ppc platforms. C.f. cross/mono/Makefile and references therein for details.
@@ -8,7 +8,7 @@ UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 
 DEPENDS = cross/curl cross/mediainfo cross/sqlite cross/sonarr
 
-SPK_DEPENDS = "mono>3.6"
+SPK_DEPENDS = "mono>5.20"
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Sonarr is a PVR for newsgroup and torrent users. It can monitor multiple RSS feeds for new episodes of your favourite shows and will grab, sorts and rename them. It can also be configured to automatically upgrade the quality of files already downloaded if a better quality format becomes available.
@@ -16,7 +16,7 @@ DESCRIPTION_FRE = Sonarr est un PVR pour les utilisateurs de groupes de discussi
 DESCRIPTION_SPN = Sonarr es un PVR para los usuarios de grupos de noticias y torrents. Se puede controlar múltiples canales RSS para nuevos episodios de sus programas favoritos y se agarra, tipo y les cambia el nombre. También puede ser configurado para actualizar automáticamente la calidad de los archivos ya descargados si un formato de mejor calidad disponible.
 DISPLAY_NAME = Sonarr
 STARTABLE = yes
-CHANGELOG = "Update Sonarr to v3.0.5.1144"
+CHANGELOG = "Update Sonarr to v3.0.7.1477"
 
 HOMEPAGE = https://sonarr.tv
 LICENSE  = GPLv3
@@ -32,6 +32,9 @@ ADMIN_PORT = $(SERVICE_PORT)
 WIZARDS_DIR = src/wizard/
 
 POST_STRIP_TARGET = sonarr_extra_install
+
+# use alternate TMPDIR as /tmp might be too small.
+USE_ALTERNATE_TMPDIR = 1
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/sonarr/src/service-setup.sh
+++ b/spk/sonarr/src/service-setup.sh
@@ -78,6 +78,10 @@ service_preupgrade ()
 
 service_postupgrade ()
 {
+    # Make Sonarr do an update check on start to avoid possible Sonarr
+    # downgrade when synocommunity package is updated
+    touch ${CONFIG_DIR}/Sonarr/update_required
+    
     # Restore Current Sonarr Binary If Current Ver. >= SPK Ver.
     . ${CONFIG_DIR}/KEEP_VAR
     if [ "$KEEP_CUR" == "yes" ]; then
@@ -87,7 +91,9 @@ service_postupgrade ()
         set_unix_permissions "${SYNOPKG_PKGDEST}/share"
     fi
 
-    set_unix_permissions "${CONFIG_DIR}"
+    if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
+        set_unix_permissions "${CONFIG_DIR}"
+    fi
 
     # If backup was created before new-style packages
     # new updates/backups will fail due to permissions (see #3185)


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

- Updates Sonarr base package to v3.0.7
- Bumps mono min to 5.20
- Fixes users having to purge app data when reinstalling from newer v3 versions
- adds update_required file
- 
Fixes N/A

## Checklist

- Unable to Test no mac or linux box; update is a straightforward bump however
- [ ] - someone with DSM knowledge should rewrite the service file so it is cleaner and similar to radarr's file if possible
- [ ] Needs a testing
- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [X] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
