### PR TITLE
copy.mk: Fix staging path for var & target/var

### DIFF
--- a/mk/spksrc.copy.mk
+++ b/mk/spksrc.copy.mk
@@ -45,18 +45,17 @@ copy_target: SHELL:=/bin/bash
 copy_target: $(PRE_COPY_TARGET) $(INSTALL_PLIST)
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 	@$(MSG) [DSM7+] Copy target to staging, discard var directory
-	@(mkdir -p $(STAGING_DIR) && cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && tar cpf - `cat $(INSTALL_PLIST) | sed -e '/^.*:var\/.*/d' -e 's/^.*://g'`) | \
+	@(mkdir -p $(STAGING_DIR) && cd $(STAGING_INSTALL_PREFIX) && tar cpf - $$(cat $(INSTALL_PLIST) | sed -e '/^.*:var\/.*/d' -e 's/^.*://g')) | \
 	  tar xpf - -C $(STAGING_DIR)
-	@$(MSG) "[DSM7+] Copy & merge var and target/var to $(STAGING_DIR)/var"
-	@if [ "`cat $(INSTALL_PLIST) | sed -n 's?^.*:var/??p'`" ] ; then \
+	@$(MSG) "[DSM7+] Copy and merge var and target/var to $(STAGING_DIR)/var"
+	@if [ "$$(cat $(INSTALL_PLIST) | sed -n 's?^.*:var/??p')" ] ; then \
 	  mkdir -p $(STAGING_DIR)/var ; \
-	  (cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && tar cpf - $$(eval ls -d $$(cat $(INSTALL_PLIST) | sed -n 's?^.*:var/??p' | sed -e 's?^?{var,target/var}/?') 2>/dev/null)) | \
+	  (cd $(STAGING_INSTALL_PREFIX)/../ && tar cpf - $$(eval ls -d $$(cat $(INSTALL_PLIST) | sed -n 's?^.*:var/??p' | sed -e 's?^?{var,target/var}/?') 2>/dev/null)) | \
 	    tar xpf - -C $(STAGING_DIR)/var --strip-components=1 --transform='s!^target/!!' ; \
 	fi
 else
 	@$(MSG) Copy target to staging [DSM6]
-	@(mkdir -p $(STAGING_DIR) && cd $(INSTALL_DIR)/$(INSTALL_PREFIX) && tar cpf - `cat $(INSTALL_PLIST) | cut -d':' -f2`) | \
-	  tar xpf - -C $(STAGING_DIR)
+	@(mkdir -p $(STAGING_DIR) && cd $(STAGING_INSTALL_PREFIX) && tar cpf - $$(cat $(INSTALL_PLIST) | cut -d':' -f2)) | tar xpf - -C $(STAGING_DIR)
 endif
 
 post_copy_target: $(COPY_TARGET)


### PR DESCRIPTION
## Description

Path passed to generate tar archive was missing a `/../` suffix.  Included other smaller changes as proposed by @hgy59.

Fixes #5213

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)

### Tested against
- [x] domoticz (empty var... probably useless to keep track in PLIST unless DSM6?)
- [x] ejabberd
- [x] mutt
- [x] rsnapshot
- [x] saltgui (spk: salt-master)
- [x] urbackup (#5213)
- [x] zap2epg (spk: tvheadend)