### PR TITLE
directories .mk: avoid .. in INSTALL_PREFIX_VAR

### DIFF
--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -59,7 +59,7 @@ endif
 #
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 ifeq ($(lastword $(subst /, ,$(INSTALL_PREFIX))),target)
-INSTALL_PREFIX_VAR  = $(INSTALL_PREFIX)/../var
+INSTALL_PREFIX_VAR = $(shell dirname $(INSTALL_PREFIX))/var
 endif
 endif
 ifeq ($(strip $(INSTALL_PREFIX_VAR)),)


### PR DESCRIPTION
## Description

Found by @hgy59 is another fix for https://github.com/SynoCommunity/spksrc/pull/5163

> without this fix, I got the error below in urbackup.log on DSM 7
```
... ERROR: Cannot set working directory to directory /var/packages/urbackup/target/../var
```

Fixes #5163

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
