### PR TITLE
update go to 1.18.1

### DIFF
--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.18
+PKG_VERS = 1.18.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
 PKG_DIST_SITE = https://go.dev/dl

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.18.linux-amd64.tar.gz SHA1 425881fcf20e1798bb17d25be5735d1b43221bb1
-go1.18.linux-amd64.tar.gz SHA256 e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
-go1.18.linux-amd64.tar.gz MD5 67622d8e307cb055b8ce2c2e03cb58cf
+go1.18.1.linux-amd64.tar.gz SHA1 0336c9e0a98e517c0f2c9607f50349b3fea7e60c
+go1.18.1.linux-amd64.tar.gz SHA256 b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+go1.18.1.linux-amd64.tar.gz MD5 6289fcaa5401e8fa38dbe28b6c16072d


### PR DESCRIPTION
## Description

Update go to 1.18.1

Fixes CVE-2022-28327, CVE-2022-24675, CVE-2022-27536

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
