### PR TITLE
toolchain: aarch64 cannot be a sub-arch of itself

### DIFF
--- a/toolchain/syno-aarch64-6.1/Makefile
+++ b/toolchain/syno-aarch64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-aarch64
 
-TC_ARCH = rtd1296 armada37xx aarch64
+TC_ARCH = rtd1296 armada37xx
 TC_VERS = 6.1
 TC_KERNEL = 4.4.15
 TC_GLIBC = 2.20

--- a/toolchain/syno-aarch64-6.2.2/Makefile
+++ b/toolchain/syno-aarch64-6.2.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-aarch64
 
-TC_ARCH = rtd1296 armada37xx aarch64
+TC_ARCH = rtd1296 armada37xx
 TC_VERS = 6.2.2
 TC_KERNEL = 4.4.59
 TC_GLIBC = 2.20

--- a/toolchain/syno-aarch64-6.2.3/Makefile
+++ b/toolchain/syno-aarch64-6.2.3/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-aarch64
 
-TC_ARCH = rtd1296 armada37xx aarch64
+TC_ARCH = rtd1296 armada37xx
 TC_VERS = 6.2.3
 TC_KERNEL = 4.4.59
 TC_GLIBC = 2.20

--- a/toolchain/syno-aarch64-6.2.4/Makefile
+++ b/toolchain/syno-aarch64-6.2.4/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-aarch64
 
-TC_ARCH = rtd1296 armada37xx aarch64
+TC_ARCH = rtd1296 armada37xx
 TC_VERS = 6.2.4
 TC_KERNEL = 4.4.59
 TC_GLIBC = 2.20

--- a/toolchain/syno-aarch64-6.2/Makefile
+++ b/toolchain/syno-aarch64-6.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-aarch64
 
-TC_ARCH = rtd1296 armada37xx aarch64
+TC_ARCH = rtd1296 armada37xx
 TC_VERS = 6.2
 TC_KERNEL = 4.4.59
 TC_GLIBC = 2.20

--- a/toolchain/syno-aarch64-7.0/Makefile
+++ b/toolchain/syno-aarch64-7.0/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-aarch64
 
-TC_ARCH = rtd1296 armada37xx aarch64
+TC_ARCH = rtd1296 armada37xx
 TC_VERS = 7.0
 TC_BUILD = 41890
 TC_KERNEL = 4.4.180


### PR DESCRIPTION
## Description

toolchain: aarch64 cannot be a sub-arch of itself.

Post #5238 aarch64 disapeared from the radar... 

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
