### PR TITLE
spk.mk: Must call arch-<arch>-<version> insteaf of build-arch-<>

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -490,7 +490,7 @@ supported-arch-error:
 
 supported-arch-%: spk_msg
 	@$(MSG) "BUILDING package for arch $* (all-supported)" | tee --append build-$*.log
-	-@MAKEFLAGS= $(PSTAT_TIME) $(MAKE) $(addprefix build-arch-, $*)
+	-@MAKEFLAGS= $(PSTAT_TIME) $(MAKE) $(addprefix arch-, $*)
 
 publish-supported-arch-%: spk_msg
 	@$(MSG) "BUILDING and PUBLISHING package for arch $* (publish-all-supported)" | tee --append build-$*.log
@@ -498,7 +498,7 @@ publish-supported-arch-%: spk_msg
 
 latest-arch-%: spk_msg
 	@$(MSG) "BUILDING package for arch $* (all-latest)" | tee --append build-$*.log
-	-@MAKEFLAGS= $(PSTAT_TIME) $(MAKE) $(addprefix build-arch-, $*)
+	-@MAKEFLAGS= $(PSTAT_TIME) $(MAKE) $(addprefix arch-, $*)
 
 publish-latest-arch-%: spk_msg
 	@$(MSG) "BUILDING and PUBLISHING package for arch $* (publish-all-latest)" | tee --append build-$*.log


### PR DESCRIPTION
## Description

spk.mk: Typo in #5238, while code was still functional it shoulf have called `make arch-<arch>-<version>` insteaf of `make build-arch-<arch>-<version>` as otherwise it skips a section of code.

Fixes #5238

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] Build rule `all-latest` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
