### PR TITLE
Dockerfile: Add autopoint as mandatory dependency for autogen.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN dpkg --add-architecture i386
 
 # Install required packages (in sync with README.rst instructions)
 RUN apt-get update && apt-get install --no-install-recommends -y \
-		autopoint \
 		autoconf-archive \
 		autogen \
 		automake \
+		autopoint \
 		bc \
 		bison \
 		build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN dpkg --add-architecture i386
 
 # Install required packages (in sync with README.rst instructions)
 RUN apt-get update && apt-get install --no-install-recommends -y \
+		autopoint \
 		autoconf-archive \
 		autogen \
 		automake \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A container based on 64-bit version of Debian 10 stable OS is recommended. Non-x
 3. Update apt channels: `lxc exec spksrc -- /usr/bin/apt update`
 4. Install all required packages:
 ```
-lxc exec spksrc -- /usr/bin/apt install autogen autoconf-archive automake bc bison build-essential check \
+lxc exec spksrc -- /usr/bin/apt install autogen autoconf-archive automake autopoint bc bison build-essential check \
                                 cmake curl cython debootstrap ed expect flex g++-multilib gawk gettext git gperf \
                                 imagemagick intltool jq libbz2-dev libc6-i386 libcppunit-dev libffi-dev libgc-dev \
                                 libgmp3-dev libltdl-dev libmount-dev libncurses-dev libpcre3-dev libssl-dev \


### PR DESCRIPTION
## Description

Dockerfile: Add autopoint as mandatory dependency for some use-cases for `autogen.sh`

Relates to #5095

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
