### PR TITLE
Fixed PLIST.auto support

### DIFF
--- a/cross/dotnet-runtime/Makefile
+++ b/cross/dotnet-runtime/Makefile
@@ -4,7 +4,7 @@ PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS)-$(PKG_DIST_ARCH).$(PKG_EXT)
 PKG_DIST_SITE = https://download.visualstudio.microsoft.com/download/pr/$(PKG_DIST_FOLDER)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
-EXTRACT_PATH = $(INSTALL_DIR)/$(INSTALL_PREFIX)/share/dotnet
+EXTRACT_PATH = $(WORK_DIR)/$(PKG_DIR)
 
 include ../../mk/spksrc.archs.mk
 
@@ -37,7 +37,11 @@ HOMEPAGE = https://dotnet.microsoft.com/
 COMMENT  = Free. Cross-platform. Open source. A developer platform for building all apps.
 LICENSE  = MIT
 
-# source is extracted directly to the install folder
-INSTALL_TARGET = nop
+INSTALL_TARGET = dotnet_runtime_custom_install
 
 include ../../mk/spksrc.install-resources.mk
+
+.PHONY: dotnet_runtime_custom_install
+dotnet_runtime_custom_install:
+	mkdir -p "$(INSTALL_DIR)/$(INSTALL_PREFIX)/share/dotnet/"
+	tar -cf - -C $(EXTRACT_PATH) . | tar -xf - -C "$(INSTALL_DIR)/$(INSTALL_PREFIX)/share/dotnet/"

--- a/mk/spksrc.plist.mk
+++ b/mk/spksrc.plist.mk
@@ -21,7 +21,7 @@ cat_PLIST:
 	# If there is a PLIST.auto file or if parent directory is kernel \
 	elif [ -f PLIST.auto -o $$(basename $$(dirname $$(pwd))) = "kernel" ] ; \
 	then \
-	  cat $(WORK_DIR)/$(PKG_NAME).plist.tmp | sort | while read -r file ; \
+	  cat $(WORK_DIR)/$(PKG_NAME).plist | sort | while read -r file ; \
 	  do \
 	    type=$$(file --brief "$(INSTALL_DIR)/$(INSTALL_PREFIX)/$$file" | cut -d , -f1) ; \
 	    case $$type in \


### PR DESCRIPTION
## Description

PLIST.auto support was broken since it was always generating PLIST which would be including everything which **preexisted** before a package installation procedure was run.

Fixes #5233

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)


### Type of change

- [x] Includes small framework changes
