### PR TITLE
syncthing: update to v1.20.0 (go 1.18 compatibility)

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.19.1
+PKG_VERS = 1.20.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)
@@ -7,12 +7,7 @@ PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 EXTRACT_PATH = $(WORK_DIR)/src/github.com/$(PKG_NAME)
 PKG_DIR = $(PKG_NAME)
 
-# use go 1.17
-# as soon as syncthing builds with go 1.18:
-# - use native/go
-# - remove path overwrite below
-# - remove native/go_1.17
-BUILD_DEPENDS = native/go_1.17
+DEPENDS = native/go
 
 HOMEPAGE = https://www.syncthing.net/
 COMMENT  = Syncthing replaces Dropbox and BitTorrent Sync with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how ...
@@ -24,9 +19,6 @@ GO_SRC_DIR = $(EXTRACT_PATH)/$(PKG_NAME)
 GO_BIN_DIR = $(GO_SRC_DIR)/$(PKG_NAME)
 
 include ../../mk/spksrc.cross-go.mk
-
-# use go 1.17
-ENV += PATH=$(WORK_DIR)/../../../native/go_1.17/work-native/go/bin/:$$PATH
 
 BUILD_ARGS = -goos=$(GOOS) -goarch=$(GO_ARCH) -version=v$(PKG_VERS)
 

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-1.19.1.tar.gz SHA1 39a0b299a3ea7932cd2b68f1ab5cce72b31396c8
-syncthing-1.19.1.tar.gz SHA256 ffc5ec2f232314122a216884f63a48eea7c8739f9779e249be1f4776d7a55127
-syncthing-1.19.1.tar.gz MD5 fbee22aad507ef5aa4e36fcf9bd082a6
+syncthing-1.20.0.tar.gz SHA1 068e8c9311031ae7f5b9cc5bd15edda8f5175286
+syncthing-1.20.0.tar.gz SHA256 6dc78dbe046f2fa9a4f70b04cf2500705d3a22618f5cf430ffcb7338cce968c7
+syncthing-1.20.0.tar.gz MD5 5e4adf738b2f9ed6abbf2c8086a9d865

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.19.1
-SPK_REV = 26
+SPK_VERS = 1.20.0
+SPK_REV = 27
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update syncthing to v1.19.0.<br/>2. Add wizard page to preconfigure credentials for the Web GUI.<br/>3. Integrate with the certificate management UI in Control Panel.<br/>4. Fix DSM 7 data migration."
+CHANGELOG = "1. Update syncthing to v1.20.0.<br/>2. Build using go 1.18."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes


### PR DESCRIPTION
## Description

Update syncthing to latest release which includes go 1.18 compatibility.

Should we also remove golang 1.17 support in this PR?

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
