### PR TITLE
dsm5/6 installer: fix share creation (close #4357)

### DIFF
--- a/mk/spksrc.service.installer.dsm5
+++ b/mk/spksrc.service.installer.dsm5
@@ -283,12 +283,12 @@ postinst ()
         # Create share if does not exist
         #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
         if ! synoshare --get "${SHARE_NAME}" &> /dev/null; then
-            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 2>&1 | install_log
+            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "" "" 1 0 2>&1 | install_log
         fi
 
         # Add user permission if no GROUP is set in UI
         # GROUP permission will be added in set_syno_permissions
-        if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
+        if [ -z "$GROUP" ] && [ -n "${EFF_USER}" ]; then
             synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" 2>&1 | install_log
         fi
         synoshare --build 2>&1 | install_log

--- a/mk/spksrc.service.installer.dsm6
+++ b/mk/spksrc.service.installer.dsm6
@@ -270,12 +270,12 @@ postinst ()
         # Create share if does not exist
         #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
         if ! synoshare --get "${SHARE_NAME}" &> /dev/null; then
-            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 2>&1 | install_log
+            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "" "" 1 0 2>&1 | install_log
         fi
 
         # Add user permission if no GROUP is set in UI
         # GROUP permission will be added in set_syno_permissions
-        if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
+        if [ -z "$GROUP" ] && [ -n "${EFF_USER}" ]; then
             synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" 2>&1 | install_log
         fi
         synoshare --build 2>&1 | install_log


### PR DESCRIPTION
## Description

fix shared folder creation in installers for dsm5 and dsm6
- create shares with empty user lists for rw access.

Fixes #4357

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
