### PR TITLE
update openssl to v1.1.1o

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.1.1n
+PKG_VERS = 1.1.1o
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/PLIST
+++ b/cross/openssl/PLIST
@@ -1,4 +1,3 @@
-rsc:bin/c_rehash
 bin:bin/openssl
 lib:lib/engines-1.1/afalg.so
 lib:lib/engines-1.1/capi.so

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1n.tar.gz SHA1 4b0936dd798f60c97c68fc62b73033ecba6dfb0c
-openssl-1.1.1n.tar.gz SHA256 40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
-openssl-1.1.1n.tar.gz MD5 2aad5635f9bb338bc2c6b7d19cbc9676
+openssl-1.1.1o.tar.gz SHA1 860fa10381ff0a121833583ccaa011bf266bcc63
+openssl-1.1.1o.tar.gz SHA256 9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
+openssl-1.1.1o.tar.gz MD5 d05e96e200d2ff0aef20c114cb5f17bf


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
security and bug fixes
- The c_rehash script allows command injection (CVE-2022-1292)
- remove c_rehash script as declared obsolete anyway

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
