### PR TITLE
radarr: fix @appdata folder for DSM7

### DIFF
--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = radarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 16
+SPK_REV = 17
 SPK_ICON = src/radarr.png
 
 REQUIRED_MIN_DSM = 5.0
@@ -18,7 +18,7 @@ SUPPORTURL = https://radarr.video/\#support
 DESCRIPTION = Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
 STARTABLE = yes
 DISPLAY_NAME = Radarr
-CHANGELOG = "Update Radarr to v3.2.2.5080 .NET Core"
+CHANGELOG = "1. Update Radarr to v3.2.2.5080 .NET Core.<br/>2. Use writable temp folder to fix internal updates on DSM >= 7.1.<br/>3. Fix config folder migration for DSM 7."
 
 HOMEPAGE = https://radarr.video/
 LICENSE = GPLv3
@@ -35,7 +35,7 @@ WIZARDS_DIR = src/wizard/
 
 POST_STRIP_TARGET = radarr_extra_install
 
-# use alternate TMPDIR as /tmp might be too small.
+# use alternate TMPDIR as /tmp might be too small and not accessible on DSM >= 7.1.
 USE_ALTERNATE_TMPDIR = 1
 
 include ../../mk/spksrc.spk.mk


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
 add @appdata folder migration for DSM7 as wrong folder was used in SPK_REV 15 of the package

Fixes #5265

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
