### PR TITLE
radarr: prevent downgrade on package update

### DIFF
--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = radarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 17
+SPK_REV = 18
 SPK_ICON = src/radarr.png
 
 REQUIRED_MIN_DSM = 5.0

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -5,7 +5,8 @@ RADARR="${SYNOPKG_PKGDEST}/share/Radarr/bin/Radarr"
 # Radarr uses custom Config and PID directories
 HOME_DIR="${SYNOPKG_PKGVAR}"
 CONFIG_DIR="${HOME_DIR}/.config"
-PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
+RADARR_CONFIG_DIR="${CONFIG_DIR}/Radarr"
+PID_FILE="${RADARR_CONFIG_DIR}/radarr.pid"
 
 # SPK_REV 15 has it in the wrong place for DSM 7
 LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
@@ -13,14 +14,14 @@ LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
 GROUP="sc-download"
 LEGACY_GROUP="sc-media"
 
-SERVICE_COMMAND="env HOME=${HOME_DIR} LD_LIBRARY_PATH=${SYNOPKG_PKGDEST}/lib ${RADARR}"
+SERVICE_COMMAND="env HOME=${HOME_DIR} LD_LIBRARY_PATH=${SYNOPKG_PKGDEST}/lib ${RADARR} -nobrowser -data=${RADARR_CONFIG_DIR}"
 SVC_BACKGROUND=y
 
 service_postinst ()
 {
     # Move config.xml to .config
-    mkdir -p ${CONFIG_DIR}/Radarr
-    mv ${SYNOPKG_PKGDEST}/app/config.xml ${CONFIG_DIR}/Radarr/config.xml
+    mkdir -p ${RADARR_CONFIG_DIR}
+    mv ${SYNOPKG_PKGDEST}/app/config.xml ${RADARR_CONFIG_DIR}/config.xml
     
     if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
         set_unix_permissions "${CONFIG_DIR}"
@@ -62,7 +63,7 @@ service_postupgrade ()
         echo "Set update required"
         # Make Radarr do an update check on start to avoid possible Radarr
         # downgrade when synocommunity package is updated
-        touch ${CONFIG_DIR}/Radarr/update_required 2>&1
+        touch ${RADARR_CONFIG_DIR}/update_required 2>&1
     fi
 
     if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then

--- a/spk/radarr/src/wizard/upgrade_uifile
+++ b/spk/radarr/src/wizard/upgrade_uifile
@@ -1,13 +1,15 @@
 [{
     "step_title": "Updating Radarr",
     "items": [{
-        "desc": "Keep Radarr up-to-date by using Radarr's built-in updater.<br>Navigate to System>Updates in the Radarr UI."
+        "desc": "This update is for additional libraries and DSM integration. It does not modify your current Radarr version."
+    },{
+        "desc": "Keep Radarr up-to-date by using Radarr's built-in updater.<br>Navigate to <b>System>Updates</b> in the Radarr UI."
     }]
 }, {
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM."
+        "desc": "Permissions for download-related packages of SynoCommunity are managed with the group <b>'sc-download'</b> in DSM."
     },{
-        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Radarr, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."
+        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to update permissions on your folders. If you get permission errors within Radarr, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."
     }]
 }]

--- a/spk/radarr/src/wizard/upgrade_uifile_fre
+++ b/spk/radarr/src/wizard/upgrade_uifile_fre
@@ -1,7 +1,9 @@
 [{
     "step_title": "Mettre à jour Radarr",
     "items": [{
-        "desc": "Garder Radarr à jour en utilisant System>Updates dans l'interface Radarr."
+        "desc": "This update is for additional libraries and DSM integration. It does not modify your current Radarr version."
+    },{
+        "desc": "Garder Radarr à jour en utilisant <b>System>Updates</b> dans l'interface Radarr."
     }]
 },{
     "step_title": "Permissions DSM",

--- a/spk/radarr/src/wizard/upgrade_uifile_fre
+++ b/spk/radarr/src/wizard/upgrade_uifile_fre
@@ -1,7 +1,7 @@
 [{
     "step_title": "Mettre à jour Radarr",
     "items": [{
-        "desc": "This update is for additional libraries and DSM integration. It does not modify your current Radarr version."
+        "desc": "Cette mise à jour concerne les bibliothèques supplémentaires et l'intégration DSM. Il ne modifie pas votre version actuelle de Radarr."
     },{
         "desc": "Garder Radarr à jour en utilisant <b>System>Updates</b> dans l'interface Radarr."
     }]


### PR DESCRIPTION
## Description

- backup and restore existing radarr distribution to prevent downgrade
- adjust upgrade wizard (fre still needs translation)

To avoid troubles as in #5271 version 20220513-17 is removed in the repository.

Fixes #5271


## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
