### PR TITLE
go: update to 1.18.2 (security update)

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.20.0
+PKG_VERS = 1.20.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-1.20.0.tar.gz SHA1 068e8c9311031ae7f5b9cc5bd15edda8f5175286
-syncthing-1.20.0.tar.gz SHA256 6dc78dbe046f2fa9a4f70b04cf2500705d3a22618f5cf430ffcb7338cce968c7
-syncthing-1.20.0.tar.gz MD5 5e4adf738b2f9ed6abbf2c8086a9d865
+syncthing-1.20.1.tar.gz SHA1 739117ef4aaaea37324908c6e18a8f164be3cd15
+syncthing-1.20.1.tar.gz SHA256 a88fabaea11a8df5cc134075c37dc87f1fb33b48d3d8afb1dc8ea11b3c0925bc
+syncthing-1.20.1.tar.gz MD5 9c123ff57638c5ca7d3b32075f666db6

--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.18.1
+PKG_VERS = 1.18.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
 PKG_DIST_SITE = https://go.dev/dl

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.18.1.linux-amd64.tar.gz SHA1 0336c9e0a98e517c0f2c9607f50349b3fea7e60c
-go1.18.1.linux-amd64.tar.gz SHA256 b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
-go1.18.1.linux-amd64.tar.gz MD5 6289fcaa5401e8fa38dbe28b6c16072d
+go1.18.2.linux-amd64.tar.gz SHA1 2373713ca2cc6bdcbfcdb4be262785c4acd6c4d8
+go1.18.2.linux-amd64.tar.gz SHA256 e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+go1.18.2.linux-amd64.tar.gz MD5 0a819821dc1861fddee2fae352b115b7

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.20.0
-SPK_REV = 26
+SPK_VERS = 1.20.1
+SPK_REV = 27
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update syncthing to v1.20.0.<br/>2. Fix failure to start after upgrade with newer config file version."
+CHANGELOG = "1. Update syncthing to v1.20.1 because v1.20.0 is not available anymore for download"
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes


### PR DESCRIPTION
## Description

Update go to latest release.

Fixes:  "syscall: check correct group in Faccessat" https://go-review.googlesource.com/c/go/+/399539/

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
