### PR TITLE
Fix KVER to omit extra-version and fix UDEV rule check

### DIFF
--- a/spk/synocli-kernel/Makefile
+++ b/spk/synocli-kernel/Makefile
@@ -10,7 +10,7 @@ DESCRIPTION   = "SynoCli Kernel Tools provides a set of small command-line utili
 OPTIONAL_DESC =
 DISPLAY_NAME  = SynoCli Kernel Tools
 STARTABLE     = no
-CHANGELOG     = "1. Fix issue #5286 where 2.6 kernels presents extra-version and mismatch<br/>2. Fix UDEV rule check"
+CHANGELOG     = "1. Fix issue \#5286 where 2.6 kernels presents extra-version and mismatch<br/>2. Fix UDEV rule check"
 
 HOMEPAGE = https://synocommunity.com/
 LICENSE  = Each tool is licensed under it\'s respective license.

--- a/spk/synocli-kernel/Makefile
+++ b/spk/synocli-kernel/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-kernel
-SPK_VERS = 1.0
-SPK_REV = 7
+SPK_VERS = 1.1
+SPK_REV = 8
 SPK_ICON = src/synocli-kernel.png
 
 DEPENDS = cross/usbutils cross/psmisc
@@ -10,7 +10,7 @@ DESCRIPTION   = "SynoCli Kernel Tools provides a set of small command-line utili
 OPTIONAL_DESC =
 DISPLAY_NAME  = SynoCli Kernel Tools
 STARTABLE     = no
-CHANGELOG     = "1. Add ability to manage multiple config options from files<br/>2. Ability to enable udev rules"
+CHANGELOG     = "1. Fix issue #5286 where 2.6 kernels presents extra-version and mismatch<br/>2. Fix UDEV rule check"
 
 HOMEPAGE = https://synocommunity.com/
 LICENSE  = Each tool is licensed under it\'s respective license.

--- a/spk/synocli-kernel/src/synocli-kernelmodule.sh
+++ b/spk/synocli-kernel/src/synocli-kernelmodule.sh
@@ -165,6 +165,7 @@ SPK_CFG_PATH=""                                                        # SynoCom
 ACTION=""                                                              # Module action insmod|rmmod|reload|status
 VERBOSE="FALSE"                                                        # Set verbose mode
 HELP="FALSE"                                                           # Print help
+URULE="FALSE"                                                          # Set udev rules to false by default
 
 while [ $# -gt 0 ] 
 do
@@ -190,7 +191,7 @@ done
 ARCH=$(uname -a | awk '{print $NF}' | cut -f2 -d_)                     # Synology NAS arch
 DSM_VERSION=$(sed -n 's/^productversion="\(.*\)"/\1/p' /etc/VERSION)   # Synology DSM version
 FPATH_SYS="/sys/module/firmware_class/parameters/path"                 # System module firmware path file index
-KVER=$(uname -r)                                                       # Running kernel version
+KVER=$(uname -r | awk -F. '{print $1 "." $2 "." $3}')                  # Running kernel version
 FPATH=""                                                               # Device firmware path
 KPATH=""                                                               # Full kernel modules path
 MPATH=""                                                               # Kernel modules path
@@ -252,7 +253,7 @@ if [ ! -d ${KPATH} ]; then
 fi
 
 # Check that udev rules file exist
-if [ ! -f ${UPATH}/${URULE} ]; then
+if [ ! ${URULE} "FALSE" -a ! -f ${UPATH}/${URULE} ]; then
    usage
    echo -ne "\nERROR: udev rules.d file [${UPATH}/${URULE}] does not exist or inaccessible...\n\n"
    exit 1


### PR DESCRIPTION
## Description

Fix KVER to omit extra-version and fix UDEV rule check

Fixes #5286

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
