### PR TITLE
syncthing: Set Ignore Permissions option by default for new folders

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.20.1
+PKG_VERS = 1.20.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.20.2
+PKG_VERS = 1.20.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-1.20.2.tar.gz SHA1 d630940414608106d1cb92f54ecd0f95b76bd233
-syncthing-1.20.2.tar.gz SHA256 9e717e3e379682739e9cfb624307d0295d1ecb4dbb6a0a55dc102b79b23b353b
-syncthing-1.20.2.tar.gz MD5 e14ddc4d4a9703ac70d4c53ae084f2c1
+syncthing-1.20.3.tar.gz SHA1 0a1d515213cbb95451b87ecad75eb3347fe8e679
+syncthing-1.20.3.tar.gz SHA256 114f1108cf75b7a7776d6981e3aed8f238333d08d915f939c9799a48fe3af576
+syncthing-1.20.3.tar.gz MD5 d9b0ce895abd878bc36590fc582307bc

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-1.20.1.tar.gz SHA1 739117ef4aaaea37324908c6e18a8f164be3cd15
-syncthing-1.20.1.tar.gz SHA256 a88fabaea11a8df5cc134075c37dc87f1fb33b48d3d8afb1dc8ea11b3c0925bc
-syncthing-1.20.1.tar.gz MD5 9c123ff57638c5ca7d3b32075f666db6
+syncthing-1.20.2.tar.gz SHA1 d630940414608106d1cb92f54ecd0f95b76bd233
+syncthing-1.20.2.tar.gz SHA256 9e717e3e379682739e9cfb624307d0295d1ecb4dbb6a0a55dc102b79b23b353b
+syncthing-1.20.2.tar.gz MD5 e14ddc4d4a9703ac70d4c53ae084f2c1

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.20.1
+SPK_VERS = 1.20.2
 SPK_REV = 27
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
@@ -12,7 +12,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update syncthing to v1.20.1 because v1.20.0 is not available anymore for download"
+CHANGELOG = "1. Update syncthing to v1.20.2.<br />2. Set Ignore Permissions option by default for new folders (only for new installations)."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.20.2
+SPK_VERS = 1.20.3
 SPK_REV = 27
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
@@ -12,7 +12,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update syncthing to v1.20.2.<br />2. Set Ignore Permissions option by default for new folders (only for new installations)."
+CHANGELOG = "1. Update syncthing to v1.20.3.<br />2. Set Ignore Permissions option by default for new folders (only for new installations)."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes

--- a/spk/syncthing/src/config.xml
+++ b/spk/syncthing/src/config.xml
@@ -51,5 +51,7 @@
         <insecureAllowOldTLSVersions>false</insecureAllowOldTLSVersions>
     </options>
     <defaults>
+        <folder ignorePerms="true">
+        </folder>
     </defaults>
 </configuration>


### PR DESCRIPTION
## Description

When Syncthing tries to apply POSIX permissions on DSM, that will clear out the existing ACLs, leading to [strange permission problems](https://forum.syncthing.net/t/sync-frozen-on-synology-nas-dsm-7/18465).  Include a minimal folder defaults configuration in the shipped config.xml template file, which enables the option in the defaults for newly added folders.

**NOTE:** This will only apply to new installations, as the config template is only used during the first installation.  Existing folders will not be changed either.

Syncthing updated to latest upstream release v1.20.3.  The `SPK_REV` was not bumped, as the previous update to v1.20.1 had not yet been published.

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [x] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
