### PR TITLE
spkclean: TC cmake filename changed to tc_vars.cmake

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -404,7 +404,7 @@ spkclean:
 	       work-*/scripts \
 	       work-*/staging \
 	       work-*/tc_vars.mk \
-	       work-*/*-toolchain.cmake \
+	       work-*/tc_vars.cmake \
 	       work-*/wheelhouse \
 	       work-*/package.tgz \
 	       work-*/INFO \


### PR DESCRIPTION
## Description

spkclean: TC cmake filename changed to tc_vars.cmake

Follow-up to #5280

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
