### PR TITLE
update generic x64 archs

### DIFF
--- a/toolchain/syno-x64-6.1/Makefile
+++ b/toolchain/syno-x64-6.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellntbap bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
 TC_VERS = 6.1
 TC_KERNEL = 3.10.102
 TC_GLIBC = 2.20

--- a/toolchain/syno-x64-6.2.2/Makefile
+++ b/toolchain/syno-x64-6.2.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellntbap bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
 TC_VERS = 6.2.2
 TC_KERNEL = 3.10.105
 TC_GLIBC = 2.20

--- a/toolchain/syno-x64-6.2.3/Makefile
+++ b/toolchain/syno-x64-6.2.3/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellntbap bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
 TC_VERS = 6.2.3
 TC_KERNEL = 3.10.105
 TC_GLIBC = 2.20

--- a/toolchain/syno-x64-6.2.4/Makefile
+++ b/toolchain/syno-x64-6.2.4/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellntbap bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
 TC_VERS = 6.2.4
 TC_KERNEL = 3.10.105
 TC_GLIBC = 2.20

--- a/toolchain/syno-x64-6.2/Makefile
+++ b/toolchain/syno-x64-6.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellntbap bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 v1000 x86 x86_64
 TC_VERS = 6.2
 TC_KERNEL = 3.10.102
 TC_GLIBC = 2.20

--- a/toolchain/syno-x64-7.0/Makefile
+++ b/toolchain/syno-x64-7.0/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 dockerx64 geminilake grantley purley kvmx64 r1000 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 geminilake grantley kvmx64 purley r1000 v1000
 TC_VERS = 7.0
 TC_KERNEL = 4.4.180
 TC_GLIBC = 2.26

--- a/toolchain/syno-x64-7.1/Makefile
+++ b/toolchain/syno-x64-7.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 dockerx64 geminilake grantley purley kvmx64 r1000 v1000 x86 x86_64
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 geminilake grantley kvmx64 purley r1000 v1000
 TC_VERS = 7.1
 TC_KERNEL = 4.4.180
 TC_GLIBC = 2.26


### PR DESCRIPTION
## Description

There is an issue in spkrepo (https://github.com/SynoCommunity/spkrepo/issues/86) with too long file names. This is a quick fix by removing unsupported archs from generich x64 archs with DSM 7+.

- add broadwellntbap to DSM 6
- remove unsupported archs from DSM 7 (dockerx64, x86, x86_64)

### Type of change

- [x] Includes small framework changes
