### PR TITLE
synocli-file: fix include of nnn and rnm tools (#5351)

### DIFF
--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-file
 SPK_VERS = 2.6
-SPK_REV = 15
+SPK_REV = 16
 SPK_ICON = src/synocli-file.png
 
 # packages depending on cross/zlib must be defined later, see below
@@ -43,7 +43,7 @@ endif
 
 ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5_ARCHS)),$(ARCH))
 # gcc with stdc++11 support
-ifeq ($(call version_ge, $(call version_gcc), 4.8),1)
+ifneq ($(call version_lt, ${TCVERSION}, 6.0)$(call version_ge, ${TCVERSION}, 3.0),11)
 # to build rnm, GCC >= 4.8 is required
 DEPENDS += cross/rnm
 OPTIONAL_DESC := $(OPTIONAL_DESC)", rnm"


### PR DESCRIPTION
## Description

- unfortunately version_gcc is not available in spk/ Makefile
- use DSM version to evaluate supported gcc for rnm and nnn

Fixes #5351

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
