### PR TITLE
20220802 bump homeassistant 2022 7 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ If you can't find an answer, or if you want to open a package request, read [CON
 cd spksrc # Go to the cloned repository's root folder.
 
 # If running on Linux:
-docker run -it -v $(pwd):/spksrc ghcr.io/synocommunity/spksrc /bin/bash
+docker run -it -v $(pwd):/spksrc -w /spksrc ghcr.io/synocommunity/spksrc /bin/bash
 
 # If running on macOS:
-docker run -it -v $(pwd):/spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
+docker run -it -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
 ```
 5. From there, follow the instructions in the [Developers HOW TO].
 

--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = homeassistant
-SPK_VERS = 2021.9.7
-SPK_REV = 17
+SPK_VERS = 2022.7.7
+SPK_REV = 18
 SPK_ICON = src/${SPK_NAME}.png
 
 SPK_DEPENDS = "python310"
@@ -10,7 +10,7 @@ BUILD_DEPENDS = cross/python310
 MAINTAINER = hgy59
 DESCRIPTION = "Home Assistant is an open-source home automation platform running on Python 3. Track and control all devices at home and automate control."
 DISPLAY_NAME = Home Assistant Core
-CHANGELOG = "Update homeassistant to 2021.9.7.<br/>Only arch specific python modules are included in the package. Other modules are downloaded at installation time."
+CHANGELOG = "Update homeassistant to 2022.7.7.<br/>Only arch specific python modules are included in the package. Other modules are downloaded at installation time."
 STARTABLE = yes
 
 HOMEPAGE = https://www.home-assistant.io/

--- a/spk/homeassistant/src/requirements-crossenv.txt
+++ b/spk/homeassistant/src/requirements-crossenv.txt
@@ -45,7 +45,7 @@ yarl==1.6.3
 ### other default dependencies that need cross compiled wheel
 MarkupSafe==2.0.1
 aiohttp==3.7.4.post0
-cffi==1.14.1
+cffi==1.15.1
 greenlet==1.1.1
 multidict==5.1.0
 SQLAlchemy==1.4.23


### PR DESCRIPTION
## Description

This is a simple repack of the latest (at time of branch) HomeAssistant.  This seems to work on the few uses I have on my DS1819+ (denverton-7.0) (running DSM 7.0.1-42218 Update 4).  Install did stop me until Python-3.10 was installed (which is probably @th0ma7 's work).

Of note, several concerns and blockers have been raised to consider around a HomeAssistant update; I don't specifically fix any of them except half of the two-part "update HA so that <something else>" (#5362).  Indeed, I'm doing this to unblock Tuya for myself, but I've only just upgraded to this without installing a cloud-poll Tuya yet.

I want to make this available to be able to audit the other open HA issues and see if it helps them at all, or we can update this reports.

I also want to call attention(re #5043) to @th0ma7 and @hgy59 to have them weigh-in on simply releasing a re-pack for beta-review and see if it helps the community without the rust-cross compilation fully available.

Relates to: #5362 #4580 
Does not address #4183 #4977 (@mortenlj), #5125 
May Unblock: #4189 #4969 #5362 

## Checklist

- [ongoing] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
