### PR TITLE
Remove version_gcc and use ${TC_GCC} post cross-cc.mk

### DIFF
--- a/cross/boost_1.70/Makefile
+++ b/cross/boost_1.70/Makefile
@@ -51,11 +51,6 @@ endif
 
 include ../../mk/spksrc.common.mk
 
-ifeq ($(call version_ge, $(call version_gcc), 7.5),1)
-# fix compilation with newer compilers
-ADDITIONAL_CXXFLAGS += -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_HAVE_OBSOLETE_ISNAN -D_GLIBCXX_HAVE_OBSOLETE_ISINF
-endif
-
 ifeq ($(findstring $(ARCH),$(64bit_ARCHS)),$(ARCH))
 ADDRESS_MODEL = 64
 else
@@ -63,6 +58,13 @@ ADDRESS_MODEL = 32
 endif
 
 include ../../mk/spksrc.cross-cc.mk
+
+ifeq ($(call version_ge, ${TC_GCC}, 7.5),1)
+# fix compilation with newer compilers
+ADDITIONAL_CXXFLAGS += -D_GLIBCXX_USE_C99_MATH
+ADDITIONAL_CXXFLAGS += -D_GLIBCXX_HAVE_OBSOLETE_ISNAN
+ADDITIONAL_CXXFLAGS += -D_GLIBCXX_HAVE_OBSOLETE_ISINF
+endif
 
 .PHONY: boost_configure
 boost_configure:
@@ -72,7 +74,7 @@ boost_configure:
 boost_compile:
 	@# Recreate user-config.jam to include python-cc.mk on second run
 	@rm -rf $(WORK_DIR)/$(PKG_DIR)/user-config.jam
-	@echo "using gcc : `$(TC_PATH)$(TC_PREFIX)gcc -dumpversion` : $(TC_PATH)$(TC_PREFIX)g++ : <address-model>\"$(ADDRESS_MODEL)\" <cflags>\"$(CFLAGS)\" <cxxflags>\"$(CXXFLAGS)\" <linkflags>\"$(LDFLAGS)\" <link>\"shared\" ; " > $(WORK_DIR)/$(PKG_DIR)/user-config.jam
+	@echo "using gcc : `$(TC_PATH)$(TC_PREFIX)gcc -dumpversion` : $(TC_PATH)$(TC_PREFIX)g++ : <address-model>\"$(ADDRESS_MODEL)\" <cflags>\"$(CFLAGS)\" <cxxflags>\"$(CXXFLAGS) $(ADDITIONAL_CXXFLAGS)\" <linkflags>\"$(LDFLAGS)\" <link>\"shared\" ; " > $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 ifneq ($(strip $(WITH_PYTHON)),)
 	@echo "using python : $(PYTHON_VERSION) : : $(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 endif

--- a/cross/cereal/Makefile
+++ b/cross/cereal/Makefile
@@ -20,6 +20,6 @@ include ../../mk/spksrc.cross-cmake.mk
 
 # Fix compilation with newer compilers
 # Flags to be added to CMake toolchain file
-ifeq ($(call version_ge, $(call version_gcc), 7.5),1)
+ifeq ($(call version_ge, ${TC_GCC}, 7.5),1)
 ADDITIONAL_CXXFLAGS += -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH
 endif

--- a/cross/fish/Makefile
+++ b/cross/fish/Makefile
@@ -20,6 +20,6 @@ CMAKE_ARGS += -DWITH_GETTEXT=OFF
 
 # Fix compilation with newer compilers
 # Flags to be added to CMake toolchain file
-ifeq ($(call version_ge, $(call version_gcc), 7.5),1)
+ifeq ($(call version_ge, ${TC_GCC}, 7.5),1)
 ADDITIONAL_CXXFLAGS += -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH
 endif

--- a/cross/jsoncpp/Makefile
+++ b/cross/jsoncpp/Makefile
@@ -21,6 +21,6 @@ include ../../mk/spksrc.cross-cmake.mk
 
 # Fix compilation with newer compilers
 # Flags to be added to CMake toolchain file
-ifeq ($(call version_ge, $(call version_gcc), 7.5),1)
+ifeq ($(call version_ge, ${TC_GCC}, 7.5),1)
 ADDITIONAL_CXXFLAGS += -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH
 endif

--- a/cross/libaom/Makefile
+++ b/cross/libaom/Makefile
@@ -35,7 +35,7 @@ CMAKE_ARGS += -DENABLE_TESTS=0
 
 # Fix compilation with newer compilers
 # Flags to be added to CMake toolchain file
-ifeq ($(call version_ge, $(call version_gcc), 7.5),1)
+ifeq ($(call version_ge, ${TC_GCC}, 7.5),1)
 ADDITIONAL_CXXFLAGS += -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH
 endif
 

--- a/cross/mbedtls/Makefile
+++ b/cross/mbedtls/Makefile
@@ -15,11 +15,9 @@ CMAKE_ARGS = -DUSE_SHARED_MBEDTLS_LIBRARY=On
 CMAKE_ARGS += -DENABLE_TESTING=Off
 CMAKE_ARGS += -DENABLE_PROGRAMS=Off
 
-include ../../mk/spksrc.common.mk
+include ../../mk/spksrc.cross-cmake.mk
 
 # Flags to be added to CMake toolchain file
-ifeq ($(call version_lt, $(call version_gcc), 5),1)
+ifeq ($(call version_lt, ${TC_GCC}, 5),1)
 ADDITIONAL_CFLAGS += -std=gnu99
 endif
-
-include ../../mk/spksrc.cross-cmake.mk

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -119,6 +119,3 @@ version_le = $(shell if printf '%s\n' "$(1)" "$(2)" | sort -VC ; then echo 1; fi
 version_ge = $(shell if printf '%s\n' "$(1)" "$(2)" | sort -VCr ; then echo 1; fi)
 version_lt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VC ; then echo 1; fi)
 version_gt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VCr ; then echo 1; fi)
-
-# GCC version
-version_gcc = $(shell $$(sed -n -e '/TC_ENV += TC_GCC/ s/.*= *//p' $(PWD)/$(subst arch,work,$(MAKECMDGOALS))/tc_vars.mk 2>/dev/null))


### PR DESCRIPTION
## Description

Remove version_gcc and use ${TC_GCC} post cross-cc.mk.  It hapens that function `version_gcc` does not always behave as expected as shown in issue https://github.com/SynoCommunity/spksrc/issues/5401

Fixes relates to #5398

Note that I expect `boost_1.78` to be fixed part of PR #5398

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
