### PR TITLE
Avoid default value for TCVERSION (followup to #5390)

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -54,19 +54,20 @@ else
 # different noarch packages
 SPK_ARCH = noarch
 SPK_NAME_ARCH = noarch
-ifeq ($(strip $(TCVERSION)),)
-# default: 3.1 .. 5.2
-TCVERSION = 5.2
-endif
+ifneq ($(strip $(TCVERSION)),)
 ifeq ($(call version_ge, $(TCVERSION), 7.0),1)
 SPK_TCVERS = dsm7
 TC_OS_MIN_VER = 7.0-40000
 else ifeq ($(call version_ge, $(TCVERSION), 6.1),1)
 SPK_TCVERS = dsm6
 TC_OS_MIN_VER = 6.1-15047
-else ifeq ($(call version_lt, $(TCVERSION), 3.0),1)
+else ifeq ($(call version_ge, $(TCVERSION), 3.0),1)
+SPK_TCVERS = all
+TC_OS_MIN_VER = 3.1-1594
+else
 SPK_TCVERS = srm
 TC_OS_MIN_VER = 1.1-6931
+endif
 else
 SPK_TCVERS = all
 TC_OS_MIN_VER = 3.1-1594


### PR DESCRIPTION
## Description

The error was added by #5390
- avoid to set a default value for TCVERSION, as it might be evaluated later
- fixes the build of packages with REQUIRED_MIN_DSM (like mkvtoolnix, nodejs_v16)

Fixes mkvtoolnix and nodejs_v16 builds in #5414

### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
