### PR TITLE
deluge:Enforce listen ports 6881-6891 like previously

### DIFF
--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = deluge
 SPK_VERS = 2.1.1
-SPK_REV = 16
+SPK_REV = 17
 SPK_ICON = src/deluge.png
 
 BUILD_DEPENDS = cross/python310
@@ -13,7 +13,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = Deluge is a cross platform BitTorrent client, based on libtorrent rasterbar. This package integrates both the deluge deamon \(deluged\), as well as its web counterpart \(deluge-web\), which serves the deluge web UI.
 DESCRIPTION_FRE = Deluge est un client BitTorrent multi-plateforme, basé sur libtorrent rasterbar. Ce paquet intègre à la fois le démon deluge \(deluged\) ainsi que son penchant web \(deluge-web\), desservant l\'interface utilisateur web deluge.
 STARTABLE = yes
-CHANGELOG = "1. Update to v2.1.1<br/>2. Update to libtorrent DSM7-2.0.7 and DSM6-1.2.17<br/>3. Update to Python 3.10<br/>4. Update to OpenSSL 1.1.1q<br/>5. Fix Tracker Status Error certificate verify failed"
+CHANGELOG = "1. Update to v2.1.1<br/>2. Update to libtorrent DSM7-2.0.7 and DSM6-1.2.17<br/>3. Update to Python 3.10<br/>4. Update to OpenSSL 1.1.1q<br/>5. Fix Tracker Status Error certificate verify failed and Unspecified system error<br/>6. Enforce listen ports 6881-6891 like previously"
 DISPLAY_NAME = Deluge
 
 HOMEPAGE = https://deluge-torrent.org

--- a/spk/deluge/src/core.conf
+++ b/spk/deluge/src/core.conf
@@ -29,7 +29,7 @@
         6881,
         6891
     ],
-    "listen_random_port": 64225,
+    "listen_random_port": null,
     "listen_reuse_port": true,
     "listen_use_sys_port": false,
     "lsd": true,
@@ -84,7 +84,7 @@
     "proxy_tracker_connections": true,
     "queue_new_to_top": false,
     "random_outgoing_ports": true,
-    "random_port": true,
+    "random_port": false,
     "rate_limit_ip_overhead": true,
     "remove_seed_at_ratio": false,
     "seed_time_limit": 180,


### PR DESCRIPTION
## Description

deluge:Enforce listen ports 6881-6891 like previously

Fixes #5425

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
