### PR TITLE
Docker: Install rustc & upgrade image to Debian 11 bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 LABEL description="Framework for maintaining and compiling native community packages for Synology devices"
 LABEL maintainer="SynoCommunity <https://github.com/SynoCommunity/spksrc/graphs/contributors>"
 LABEL url="https://synocommunity.com"
@@ -15,13 +15,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		autogen \
 		automake \
 		autopoint \
+		bash \
 		bc \
 		bison \
 		build-essential \
 		check \
 		cmake \
 		curl \
-		cython \
+		cython3 \
 		debootstrap \
 		ed \
 		expect \
@@ -51,11 +52,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		lzip \
 		mercurial \
 		moreutils \
-		ncurses-dev \
 		ninja-build \
 		patchelf \
 		php \
 		pkg-config \
+		python2 \
 		python3 \
 		python3-distutils \
 		rename \
@@ -88,5 +89,24 @@ RUN pip3 install meson==0.62.2
 
 # Volume pointing to spksrc sources
 VOLUME /spksrc
-
 WORKDIR /spksrc
+
+# Set cargo/rustc default path
+ENV CARGO_HOME=/opt/cargo
+ENV RUSTUP_HOME=/opt/rustup
+RUN mkdir -p $CARGO_HOME $RUSTUP_HOME
+ENV PATH="$VENV_PATH/bin:$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
+
+# Install rustc - environment located in /opt/rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install rustc stable toolchain
+RUN rustup toolchain install stable
+RUN rustup default stable
+# Install all rustc targets
+RUN rustup target add x86_64-unknown-linux-gnu
+RUN rustup target add i686-unknown-linux-gnu
+RUN rustup target add armv5te-unknown-linux-gnueabi
+RUN rustup target add armv7-unknown-linux-gnueabihf
+RUN rustup target add armv7-unknown-linux-gnueabi
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup target add powerpc-unknown-linux-gnu


### PR DESCRIPTION
## Description

Docker: Install `rustc` & upgrade image to Debian 11 bullseye.  This PR is only aimed at adding `rustc` compiler onto our default docker image.  It's integration is within PR #5435 but it requires the docker image being updated in master in order to allow github-action to work.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [x] This change requires a documentation update (e.g. Wiki)

### Testing HOWTO
Clone my copy of this PR:
```
$ git clone https://github.com/th0ma7/spksrc.git
$ cd spksrc
$ git checkout docker-rustc-debian11
```
Create the updated docker image (may need `$ sudo usermod -aG docker $USER` for proper user permissions):
```
$ docker build - < Dockerfile
...
Successfully built 882a0451f1bb
```
Access the docker image:
```
$ docker run -it -v $(pwd):/spksrc 882a0451f1bb /bin/bash
```
Build a `python310` package or what ever you are interested at testing:
```
root@2ff602f23b71:/spksrc# cd spk/python310
root@2ff602f23b71:/spksrc/spk/python310/# make all-supported
```
To remove all docker images afterwards:
```
$ docker container rm -f $(docker container ls -aq)
```

### Testing completed succesfully (`all-supported`)
- [x] ffmpeg