### PR TITLE
Gh action output

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -87,14 +87,14 @@ do
     fi
 done
 
-echo "::set-output name=arch_packages::${arch_packages}"
-echo "::set-output name=noarch_packages::${noarch_packages}"
+echo "arch_packages=${arch_packages}" >> $GITHUB_OUTPUT
+echo "noarch_packages=${noarch_packages}" >> $GITHUB_OUTPUT
 
 echo "::endgroup::"
 
 if [ -z "${packages}" ]; then
     echo "===> No packages to download. <==="
-    echo "::set-output name=download_packages::"
+    echo "download_packages" >> $GITHUB_OUTPUT
 else
     echo "===> PACKAGES to download references for: ${packages}"
     DOWNLOAD_LIST=
@@ -108,5 +108,5 @@ else
     done
     # remove duplicate downloads
     downloads=$(printf %s "${DOWNLOAD_LIST}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-    echo "::set-output name=download_packages::${downloads}"
+    echo "download_packages=${downloads}" >> $GITHUB_OUTPUT
 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,14 @@ jobs:
         id: getfile_pr
         run: |
           git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs
-          echo "::set-output name=files::$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs)"
+          echo "name=files::$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs)" >> $GITHUB_OUTPUT
 
       - name: Get changed files for push
         if: github.event_name == 'push'
         id: getfile
         run: |
           git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs
-          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)"
+          echo "name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
 
       - name: Evaluate dependencies
         id: dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,14 @@ jobs:
         id: getfile_pr
         run: |
           git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs
-          echo "name=files::$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs)" >> $GITHUB_OUTPUT
+          echo "files=$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | xargs)" >> $GITHUB_OUTPUT
 
       - name: Get changed files for push
         if: github.event_name == 'push'
         id: getfile
         run: |
           git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs
-          echo "name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
+          echo "files=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
 
       - name: Evaluate dependencies
         id: dependencies


### PR DESCRIPTION
## Description

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
