### PR TITLE
Upgrade sonarr build to latest

### DIFF
--- a/cross/sonarr/Makefile
+++ b/cross/sonarr/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = Sonarr
-PKG_VERS = 3.0.5.1144
+PKG_VERS = 3.0.9.1549
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME).main.$(PKG_VERS).linux.$(PKG_EXT)
 PKG_DIST_SITE = https://download.sonarr.tv/v3/main/$(PKG_VERS)

--- a/cross/sonarr/digests
+++ b/cross/sonarr/digests
@@ -1,3 +1,3 @@
-Sonarr.main.3.0.5.1144.linux.tar.gz SHA1 2335133139a46f1ce0d1b2cb1f566d30285d3d1e
-Sonarr.main.3.0.5.1144.linux.tar.gz SHA256 77aff6978d4dc80027979c815bd5a79579dd9bb50d39b1b2d14b3bb9e18058aa
-Sonarr.main.3.0.5.1144.linux.tar.gz MD5 675ce0ab2f1e643860ab1daab45b2842
+Sonarr.main.3.0.9.1549.linux.tar.gz SHA1 f475b4b070df9865c5ff777d532683f753151d97
+Sonarr.main.3.0.9.1549.linux.tar.gz SHA256 05ad67aef9e599590f23e384a704a13717cd2eba714be37bc2cc776a391c1a84
+Sonarr.main.3.0.9.1549.linux.tar.gz MD5 823a85b54d4b797d966340e684a64f40

--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -16,7 +16,7 @@ DESCRIPTION_FRE = Sonarr est un PVR pour les utilisateurs de groupes de discussi
 DESCRIPTION_SPN = Sonarr es un PVR para los usuarios de grupos de noticias y torrents. Se puede controlar múltiples canales RSS para nuevos episodios de sus programas favoritos y se agarra, tipo y les cambia el nombre. También puede ser configurado para actualizar automáticamente la calidad de los archivos ya descargados si un formato de mejor calidad disponible.
 DISPLAY_NAME = Sonarr
 STARTABLE = yes
-CHANGELOG = "Enlarge the service start/stop timeout to 90 seconds."
+CHANGELOG = "Upgrade to Sonarr 3.0.9.1549"
 
 HOMEPAGE = https://sonarr.tv
 LICENSE  = GPLv3

--- a/spk/sonarr/Makefile
+++ b/spk/sonarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbdrone
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 20
+SPK_REV = 21
 SPK_ICON = src/sonarr.png
 
 # Mono not supported on ppc platforms. C.f. cross/mono/Makefile and references therein for details.


### PR DESCRIPTION
Motivation: 
The recent 7.1 DSM upgrade kicked Sonarr into a bad state and required repair.
However, there are datastore changes between the current version and the latest such that the data is incompatible with the current SPK version, meaning that Sonarr would not properly load and as a result also can't run the upgrade from the internal upgrader
This left me with the choice of either restarting from scratch (no good backups), or compiling a package from source.
Given I did the latter, it seemed sensible to push a PR for everyone else.

Fixes #5450

Checklist:

- [x] Built Sonarr package successfully (since changes are limited to it)
- [x] Package upgrade completed successfully
- [x] New installation of package completed successfully
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
