### PR TITLE
nettle: update and fix for older compilers

### DIFF
--- a/cross/gmp/Makefile
+++ b/cross/gmp/Makefile
@@ -14,8 +14,9 @@ LICENSE  = LGPLv3 or GPLv2
 GNU_CONFIGURE = 1
 
 CONFIGURE_ARGS = --disable-static
-
 # create c++ library of gmp. This is required by cross/rnm
 CONFIGURE_ARGS += --enable-cxx
+
+ADDITIONAL_CFLAGS = -O2
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/nettle/Makefile
+++ b/cross/nettle/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = nettle
-PKG_VERS = 3.7.2
+PKG_VERS = 3.8.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://ftp.gnu.org/gnu/$(PKG_NAME)
+PKG_DIST_SITE = https://ftp.gnu.org/gnu/nettle
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/gmp
@@ -12,5 +12,14 @@ COMMENT  = Nettle is a cryptographic library that is designed to fit easily in m
 LICENSE  = LGPLv3
 
 GNU_CONFIGURE = 1
+CONFIGURE_ARGS = --disable-static
+
+include ../../mk/spksrc.common.mk
+ifeq ($(call version_lt,${TCVERSION},6.0)$(call version_gt,${TCVERSION},2.0),11) 
+# older compilers to not support x86/x64 assembler code
+CONFIGURE_ARGS += --disable-assembler
+endif
+
+ADDITIONAL_CFLAGS = -O2
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/nettle/PLIST
+++ b/cross/nettle/PLIST
@@ -5,7 +5,7 @@ bin:bin/pkcs1-conv
 bin:bin/sexp-conv
 lnk:lib/libhogweed.so
 lnk:lib/libhogweed.so.6
-lib:lib/libhogweed.so.6.3
+lib:lib/libhogweed.so.6.6
 lnk:lib/libnettle.so
 lnk:lib/libnettle.so.8
-lib:lib/libnettle.so.8.3
+lib:lib/libnettle.so.8.6

--- a/cross/nettle/digests
+++ b/cross/nettle/digests
@@ -1,3 +1,3 @@
-nettle-3.7.2.tar.gz SHA1 d617fbcf8d301dfd887129c3883629d4d097c579
-nettle-3.7.2.tar.gz SHA256 8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162
-nettle-3.7.2.tar.gz MD5 22849db27ed563ebbc829273f0c97e35
+nettle-3.8.1.tar.gz SHA1 1be40366f8db2d5bb65e45883d6d76a96b39eb73
+nettle-3.8.1.tar.gz SHA256 364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe
+nettle-3.8.1.tar.gz MD5 e15c5fd5cc901f5dde6a271d7f2320d1


### PR DESCRIPTION
## Description
- update nettle to v3.8.1
- disable assembler for older compilers (i.e. DSM < 6.0)
- optimize code

This is a follow up to #5486 as the build for arch-x86-5.2 failed (aria2 depends on cross/nettle via cross/gnutls)

## Checklist for synocli-net 

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [x] Package update
