### PR TITLE
aria2: fix supported archs

### DIFF
--- a/cross/aria2/Makefile
+++ b/cross/aria2/Makefile
@@ -10,6 +10,12 @@ DEPENDS = cross/libssh2 cross/gnutls cross/libgcrypt cross/libexpat cross/c-ares
 # archs with too old c++ compiler (c++ 11 is required)
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
+include ../../mk/spksrc.common.mk
+ifeq ($(call version_lt,${TCVERSION},6.0)$(call version_gt,${TCVERSION},2.0),11)
+# compiler too old
+UNSUPPORTED_ARCHS += $(ARCH)
+endif
+
 HOMEPAGE = https://aria2.github.io/
 COMMENT  = aria2 is a lightweight multi-protocol & multi-source command-line download utility. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.
 LICENSE  = GPLv2

--- a/spk/aria2/Makefile
+++ b/spk/aria2/Makefile
@@ -5,6 +5,15 @@ SPK_ICON = src/aria2.png
 
 DEPENDS = cross/aria2
 
+# archs with too old c++ compiler (c++ 11 is required)
+UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
+
+include ../../mk/spksrc.common.mk
+ifeq ($(call version_lt,${TCVERSION},6.0)$(call version_gt,${TCVERSION},2.0),11)
+# compiler too old
+UNSUPPORTED_ARCHS += $(ARCH)
+endif
+
 MAINTAINER = cnrat
 DESCRIPTION = aria2 is a lightweight multi-protocol and multi-source command-line download utility.
 DESCRIPTION_CHS = Aria2是一个命令行下运行、多协议、多来源下载工具（HTTP/HTTPS、FTP、BitTorrent、Metalink）。

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -11,7 +11,7 @@ DEPENDS += cross/inetutils
 
 OPTIONAL_DEPENDS = cross/sshfs cross/ser2net cross/bind cross/aria2
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 
 OPTIONAL_DESC =
 
@@ -24,8 +24,10 @@ OPTIONAL_DESC := $(OPTIONAL_DESC)", sshfs, ser2net"
 endif
 
 ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5_ARCHS)),$(ARCH))
+ifneq ($(call version_lt,${TCVERSION},6.0)$(call version_gt,${TCVERSION},2.0),11)
 DEPENDS += cross/aria2
 OPTIONAL_DESC := $(OPTIONAL_DESC)", aria2c"
+endif
 endif
 
 


### PR DESCRIPTION
## Description

aria2: DSM < 6.0 is not supported
exclude aria2c from **synocli-net** for unsupported archs

this is another follow up to #5486

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
