### PR TITLE
Fix cross/zlib

### DIFF
--- a/cross/openjpeg/Makefile
+++ b/cross/openjpeg/Makefile
@@ -15,5 +15,7 @@ LICENSE  = BSD 2-clause simplified
 CMAKE_USE_NINJA = 1
 CMAKE_ARGS += -DBUILD_STATIC_LIBS=OFF
 CMAKE_ARGS += -DOPENJP2_COMPILE_OPTIONS="-O"
+# deactivate build of tools (we use the library only)
+CMAKE_ARGS += -DBUILD_CODEC=OFF
 
 include ../../mk/spksrc.cross-cmake.mk

--- a/cross/zlib/Makefile
+++ b/cross/zlib/Makefile
@@ -13,4 +13,9 @@ LICENSE  = zlib-license
 
 ADDITIONAL_CFLAGS = -Os -fPIC
 
-include ../../mk/spksrc.cross-cc.mk
+# fix pkgconfig file
+# build with cross-cc creates wrong pkgconfig file (prefix without missing package name)
+# build with cross-cmake creates correct pkgconfig file, but default folder is share not lib
+CMAKE_ARGS += -DINSTALL_PKGCONFIG_DIR=$(INSTALL_PREFIX)/lib/pkgconfig
+
+include ../../mk/spksrc.cross-cmake.mk


### PR DESCRIPTION
## Description

This is an extract of #5414 where it fixed the usage of OpenEXR format, rsvg-convert (at runtime) and gdk-pixbuf.

- the generated zlib.pc had wrong prefix 
- this caused problems in dependent libraries and binaries

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
