### PR TITLE
native/go: update to v1.19

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 1.20.3
+PKG_VERS = 1.22.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)
@@ -10,7 +10,7 @@ PKG_DIR = $(PKG_NAME)
 DEPENDS = native/go
 
 HOMEPAGE = https://www.syncthing.net/
-COMMENT  = Syncthing replaces Dropbox and BitTorrent Sync with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how ...
+COMMENT  = Syncthing is a continuous file synchronization program. It synchronizes files between two or more computers.
 LICENSE  = MPL-2.0
 
 COMPILE_TARGET = syncthing_compile

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-1.20.3.tar.gz SHA1 0a1d515213cbb95451b87ecad75eb3347fe8e679
-syncthing-1.20.3.tar.gz SHA256 114f1108cf75b7a7776d6981e3aed8f238333d08d915f939c9799a48fe3af576
-syncthing-1.20.3.tar.gz MD5 d9b0ce895abd878bc36590fc582307bc
+syncthing-1.22.1.tar.gz SHA1 c8e0e75b0ba5b04f4f7ce8a98dcf7212733dce37
+syncthing-1.22.1.tar.gz SHA256 b024d112167e0e81a785ab98c1a044aee1ac041dfe57a62772c08284f875a5bd
+syncthing-1.22.1.tar.gz MD5 6947b7b3a1eaf03d8e6f371894c37b41

--- a/mk/spksrc.copy.mk
+++ b/mk/spksrc.copy.mk
@@ -54,7 +54,7 @@ ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 	    tar xpf - -C $(STAGING_DIR)/var --strip-components=1 --transform='s!^target/!!' ; \
 	fi
 else
-	@$(MSG) Copy target to staging [DSM6]
+	@$(MSG) [DSM6] Copy target to staging
 	@(mkdir -p $(STAGING_DIR) && cd $(STAGING_INSTALL_PREFIX) && tar cpf - $$(cat $(INSTALL_PLIST) | cut -d':' -f2)) | tar xpf - -C $(STAGING_DIR)
 endif
 

--- a/mk/spksrc.cross-go.mk
+++ b/mk/spksrc.cross-go.mk
@@ -35,8 +35,9 @@ endif
 include ../../mk/spksrc.cross-go-env.mk
 
 # avoid run of make configure
+ifeq ($(strip $(CONFIGURE_TARGET)),)
 CONFIGURE_TARGET = nop
-
+endif
 
 ifeq ($(strip $(COMPILE_TARGET)),)
 ifneq ($(strip $(GO_SRC_DIR)),)

--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.18.6
+PKG_VERS = 1.19.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
 PKG_DIST_SITE = https://go.dev/dl

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.18.6.linux-amd64.tar.gz SHA1 4c8a6f3a19e6e5b5e48a893a4558b616ea9637df
-go1.18.6.linux-amd64.tar.gz SHA256 bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8
-go1.18.6.linux-amd64.tar.gz MD5 05f1d9441a9ca2d05be54e5abc343de2
+go1.19.3.linux-amd64.tar.gz SHA1 03d7c543b8c3efa7d9128d5982dceed1ab708845
+go1.19.3.linux-amd64.tar.gz SHA256 74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
+go1.19.3.linux-amd64.tar.gz MD5 87beeed49a347ef20becab18b8da9cab

--- a/spk/demoservice/Makefile
+++ b/spk/demoservice/Makefile
@@ -15,7 +15,7 @@ LICENSE = GPLv2
 WIZARDS_DIR = src/wizard/
 
 # 'auto' reserved value grabs SPK_NAME
-SERVICE_USER         = auto
+SERVICE_USER = auto
 SERVICE_WIZARD_GROUP = wizard_group
 
 include ../../mk/spksrc.common.mk
@@ -24,12 +24,12 @@ ifneq ($(call version_ge, ${TCVERSION}, 7.0),1)
 SERVICE_WIZARD_SHARE = wizard_download_dir
 endif
 
-SERVICE_SETUP        = src/service-setup.sh
-STARTABLE            = yes
+SERVICE_SETUP = src/service-setup.sh
+STARTABLE = yes
 
 # Service configuration
 SERVICE_PORT = 8888
-SERVICE_PORT_TITLE = DemoService(HTTP)
+SERVICE_PORT_TITLE = DemoService (HTTP)
 
 # Admin link
 ADMIN_PORT = $(SERVICE_PORT)
@@ -41,7 +41,11 @@ include ../../mk/spksrc.spk.mk
 .PHONY: demoservice_install
 # Replace standard copy/install targets, no sources, no content
 demoservice_pre_copy:
+	@$(MSG) Create README and dummy file
 	rm -fr $(STAGING_DIR)
 	mkdir $(STAGING_DIR)
-	mkdir --parents $(STAGING_INSTALL_PREFIX)/var
-	echo "Test file for $(INSTALL_PREFIX)/var" > $(STAGING_INSTALL_PREFIX)/var/README
+	mkdir --parents $(STAGING_INSTALL_PREFIX_VAR)
+	echo "Test file for $(INSTALL_PREFIX_VAR)" > $(STAGING_INSTALL_PREFIX_VAR)/README
+	# create dummy file (avoid empty target folder for DSM 7 packages)
+	mkdir -p $(STAGING_INSTALL_PREFIX)
+	echo "dummy file (to avoid empty package)" > $(STAGING_INSTALL_PREFIX)/dummy

--- a/spk/demoservice/PLIST
+++ b/spk/demoservice/PLIST
@@ -1,1 +1,2 @@
 rsc:var/README
+rsc:dummy

--- a/spk/demoservice/src/service-setup.sh
+++ b/spk/demoservice/src/service-setup.sh
@@ -57,6 +57,7 @@ validate_preupgrade ()
 
 service_preinst ()
 {
+    # use echo to write to the installer log file.
     echo "service_preinst ${SYNOPKG_PKG_STATUS}"
     
     echo "PYTHON_VERSION:       ${PYTHON_VERSION}"
@@ -68,6 +69,7 @@ service_preinst ()
 
 service_postinst ()
 {
+    # use echo to write to the installer log file.
     echo "service_postinst ${SYNOPKG_PKG_STATUS}"
     
     ln -sf ${INST_LOG} ${SYNOPKG_PKGVAR}/installer.log
@@ -75,31 +77,37 @@ service_postinst ()
 
 service_preuninst ()
 {
+    # use echo to write to the installer log file.
     echo "service_preuninst ${SYNOPKG_PKG_STATUS}"
 }
 
 service_postuninst ()
 {
+    # use echo to write to the installer log file.
     echo "service_postuninst ${SYNOPKG_PKG_STATUS}"
 }
 
 service_preupgrade ()
 {
+    # use echo to write to the installer log file.
     echo "service_preupgrade ${SYNOPKG_PKG_STATUS}"
 }
 
 service_postupgrade ()
 {
+    # use echo to write to the installer log file.
     echo "service_postupgrade ${SYNOPKG_PKG_STATUS}"
 }
 
 service_prestart ()
 {
-    echo "Before service start"
+    # use echo to write to the service log file.
+    echo "service_prestart: Before service start"
 }
 
 service_poststop ()
 {
-    echo "After service stop"
+    # use echo to write to the service log file.
+    echo "service_poststop: After service stop"
 }
 

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 1.20.3
-SPK_REV = 27
+SPK_VERS = 1.22.1
+SPK_REV = 28
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update syncthing to v1.20.3.<br />2. Set Ignore Permissions option by default for new folders (only for new installations)."
+CHANGELOG = "1. Update syncthing to v1.22.1."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes

--- a/spk/syncthing/src/service-setup.sh
+++ b/spk/syncthing/src/service-setup.sh
@@ -54,10 +54,10 @@ service_preupgrade()
     CUR_VER=$(${SYNCTHING} --version | awk '{print $2}' | awk --field-separator=- '{print $1}')
     PKG_VER=$(${SYNOPKG_PKGINST_TEMP_DIR}/bin/syncthing --version | awk '{print $2}' | awk --field-separator=- '{print $1}')
     if version_le $CUR_VER $PKG_VER; then
-	install_log "Package ${PKG_VER} is newer than or same as installed binary ${CUR_VER}"
+        echo "Package ${PKG_VER} is newer than or same as installed binary ${CUR_VER}"
     else
-	install_log "Installed binary ${CUR_VER} is newer than package ${PKG_VER}, preserving a backup"
-	mkdir ${SYNOPKG_TEMP_UPGRADE_FOLDER}/bin
+        echo "Installed binary ${CUR_VER} is newer than package ${PKG_VER}, preserving a backup"
+        mkdir ${SYNOPKG_TEMP_UPGRADE_FOLDER}/bin
         cp -p ${SYNCTHING} ${SYNOPKG_TEMP_UPGRADE_FOLDER}/bin/syncthing
     fi
 }
@@ -65,7 +65,7 @@ service_preupgrade()
 service_postupgrade()
 {
     if [ -x ${SYNOPKG_TEMP_UPGRADE_FOLDER}/bin/syncthing ]; then
-	install_log "Restoring preserved binary backup"
-	mv -f ${SYNOPKG_TEMP_UPGRADE_FOLDER}/bin/syncthing ${SYNCTHING}
+        echo "Restoring preserved binary backup"
+        mv -f ${SYNOPKG_TEMP_UPGRADE_FOLDER}/bin/syncthing ${SYNCTHING}
     fi
 }


### PR DESCRIPTION
## Description

go 1.19 is required to build nomad 1.4.3

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
