### PR TITLE
sickchill: remove BROKEN

### DIFF
--- a/spk/sickchill/BROKEN
+++ b/spk/sickchill/BROKEN
@@ -1,3 +1,0 @@
-source of 2021.11.10 is not available for download anymore.
-all 2021.* sources are gone.
-needs update to 2022.*


### PR DESCRIPTION
## Description

- sickchill was declared as broken with #5414, but meanwhile fixed in #5458
