### PR TITLE
mono: fix build with updated dev. env.

### DIFF
--- a/cross/mono/patches/002-explicit-use-of-python2.patch
+++ b/cross/mono/patches/002-explicit-use-of-python2.patch
@@ -1,0 +1,109 @@
+# To use python 2.x we must call python2 nowadays.
+# 
+--- scripts/submodules/versions.mk.orig	2019-07-16 18:16:12.000000000 +0000
++++ scripts/submodules/versions.mk	2022-12-14 00:04:43.894608574 +0000
+@@ -10,11 +10,11 @@
+ 
+ define ValidateVersionTemplate
+ #$(eval REPOSITORY_$(2):=$(shell test -z $(3) && echo $(1) || echo "$(3)"))
+-#$(eval DIRECTORY_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
++#$(eval DIRECTORY_$(2):=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
+ #$(eval DIRECTORY_$(2):=$(shell test -z $(DIRECTORY_$(2)) && echo $(1) || echo $(DIRECTORY_$(2))))
+-#$(eval MODULE_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
+-#$(eval NEEDED_$(2)_VERSION:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
+-#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
++#$(eval MODULE_$(2):=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
++#$(eval NEEDED_$(2)_VERSION:=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
++#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
+ 
+ #$(eval $(2)_VERSION:=$$$$(shell cd $($(2)_PATH) 2>/dev/null && git rev-parse HEAD ))
+ 
+@@ -106,17 +106,17 @@
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+
+--- mono/mini/Makefile.am.in.orig	2019-07-16 18:16:12.000000000 +0000
++++ mono/mini/Makefile.am.in	2022-12-13 22:27:01.084182200 +0000
+@@ -742,7 +742,7 @@
+ 
+ GENMDESC_OPTS=
+ 
+-GENMDESC_PRG=python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG=python2 $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ 
+ cpu-wasm.h: mini-ops.h cpu-wasm.md
+ 	$(GENMDESC_PRG) cpu-wasm.h wasm_desc $(srcdir)/cpu-wasm.md
+
+--- llvm/Makefile.in.orig	2019-07-16 18:21:48.000000000 +0000
++++ llvm/Makefile.in	2022-12-13 19:58:07.662592776 +0000
+@@ -644,11 +644,11 @@
+ 
+ define ValidateVersionTemplate
+ #$(eval REPOSITORY_$(2):=$(shell test -z $(3) && echo $(1) || echo "$(3)"))
+-#$(eval DIRECTORY_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
++#$(eval DIRECTORY_$(2):=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
+ #$(eval DIRECTORY_$(2):=$(shell test -z $(DIRECTORY_$(2)) && echo $(1) || echo $(DIRECTORY_$(2))))
+-#$(eval MODULE_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
+-#$(eval NEEDED_$(2)_VERSION:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
+-#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
++#$(eval MODULE_$(2):=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
++#$(eval NEEDED_$(2)_VERSION:=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
++#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
+ 
+ #$(eval $(2)_VERSION:=$$$$(shell cd $($(2)_PATH) 2>/dev/null && git rev-parse HEAD ))
+ 
+@@ -740,19 +740,19 @@
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ $(eval $(call ValidateVersionTemplate,llvm,LLVM))
+
+--- mono/tests/Makefile.am.orig	2019-07-16 18:16:12.000000000 +0000
++++ mono/tests/Makefile.am	2022-12-13 23:44:43.920549297 +0000
+@@ -2979,7 +2979,7 @@
+ # Tests for the Mono lldb plugin
+ EXTRA_DIST += test_lldb.py test-lldb.cs
+ test-lldb: test-lldb.exe
+-	python test_lldb.py $(JITTEST_PROG)
++	python2 test_lldb.py $(JITTEST_PROG)
+ 
+ noinst_LTLIBRARIES = libtest.la
+ 

--- a/native/mono/patches/002-explicit-use-of-python2.patch
+++ b/native/mono/patches/002-explicit-use-of-python2.patch
@@ -1,0 +1,69 @@
+# To use python 2.x we must call python2 nowadays.
+# 
+
+--- mono/mini/Makefile.in.orig	2019-07-16 18:21:49.000000000 +0000
++++ mono/mini/Makefile.in	2022-12-13 22:37:15.491317361 +0000
+@@ -1225,7 +1225,7 @@
+ libmonoinclude_HEADERS = jit.h
+ CSFLAGS = -unsafe -nowarn:0219,0169,0414,0649,0618
+ GENMDESC_OPTS = 
+-GENMDESC_PRG = python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG = python2 $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ LLVM_AOT_RUNTIME_OPTS = $(if $(LLVM),--llvm,)
+ GSHAREDVT_RUNTIME_OPTS = $(if $(GSHAREDVT),-O=gsharedvt,)
+ fullaot_regtests = $(regtests)
+
+--- llvm/Makefile.in.orig	2019-07-16 18:21:48.000000000 +0000
++++ llvm/Makefile.in	2022-12-13 19:58:07.662592776 +0000
+@@ -644,11 +644,11 @@
+ 
+ define ValidateVersionTemplate
+ #$(eval REPOSITORY_$(2):=$(shell test -z $(3) && echo $(1) || echo "$(3)"))
+-#$(eval DIRECTORY_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
++#$(eval DIRECTORY_$(2):=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
+ #$(eval DIRECTORY_$(2):=$(shell test -z $(DIRECTORY_$(2)) && echo $(1) || echo $(DIRECTORY_$(2))))
+-#$(eval MODULE_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
+-#$(eval NEEDED_$(2)_VERSION:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
+-#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
++#$(eval MODULE_$(2):=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
++#$(eval NEEDED_$(2)_VERSION:=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
++#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
+ 
+ #$(eval $(2)_VERSION:=$$$$(shell cd $($(2)_PATH) 2>/dev/null && git rev-parse HEAD ))
+ 
+@@ -740,19 +740,19 @@
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	python2 $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ $(eval $(call ValidateVersionTemplate,llvm,LLVM))
+
+--- mono/tests/Makefile.in.orig	2019-07-16 18:21:49.000000000 +0000
++++ mono/tests/Makefile.in	2022-12-13 20:01:33.560590161 +0000
+@@ -3356,7 +3356,7 @@
+ coreclr-gcstress:
+ 	$(MAKE) -C $(mono_build_root)/acceptance-tests coreclr-gcstress
+ test-lldb: test-lldb.exe
+-	python test_lldb.py $(JITTEST_PROG)
++	python2 test_lldb.py $(JITTEST_PROG)
+ 
+ test-internalsvisibleto: test-runner.exe $(INTERNALSVISIBLETO_TEST) $(INTERNALSVISIBLETO_TESTAOT) $(INTERNALSVISIBLETO_TESTAOT_LIBS)
+ 	$(TOOLS_RUNTIME) $(TEST_RUNNER) --testsuite-name $@ $(INTERNALSVISIBLETO_TEST)


### PR DESCRIPTION
## Description

This is another followup to #5441.
With the updated dev. env. default python is not python 2 anymore.
- patch makefile templates for explicit use of python 2

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
