### PR TITLE
add ronn to development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		python3 \
 		python3-distutils \
 		rename \
+		ronn \
 		rsync \
 		scons \
 		subversion \

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sudo apt install autoconf-archive autogen automake autopoint bash bc bison \
                  g++-multilib gawk gettext git gperf imagemagick intltool jq libbz2-dev libc6-i386 \
                  libcppunit-dev libffi-dev libgc-dev libgmp3-dev libltdl-dev libmount-dev libncurses-dev \
                  libpcre3-dev libssl-dev libtool libunistring-dev lzip mercurial moreutils ninja-build \
-                 php pkg-config python2 python3 python3-distutils rename rsync scons subversion swig \
+                 php pkg-config python2 python3 python3-distutils rename ronn rsync scons subversion swig \
                  texinfo unzip xmlto zlib1g-dev
 wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O - | sudo python2
 sudo pip2 install wheel httpie


### PR DESCRIPTION
## Description

- ronn is required to build command usage (and man) for git-lfs
- ruby 2.x is installed as dependency of ronn

prerequisite for git-lfs in #5532

## Checklist

- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
- [x] This change requires a documentation update (e.g. Wiki)
