### PR TITLE
cloudflared: update to 2022.12.1

### DIFF
--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2022.11.1
+PKG_VERS = 2022.12.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2022.11.1.tar.gz SHA1 6f5ad2bd070c302b2a0ac06464b81e80266a7e41
-cloudflared-2022.11.1.tar.gz SHA256 d4b1133057a721087a0a5387ea6d4d1ebf3b1f5135396da25a1e88e873cd5203
-cloudflared-2022.11.1.tar.gz MD5 99af8ff8550b65eec2d314aace2a41ba
+cloudflared-2022.12.1.tar.gz SHA1 ae2de7713fd701bec80c17428fe7cdf7707221b1
+cloudflared-2022.12.1.tar.gz SHA256 8cc5c41ea98a9d72687d5f62e733a9033191e834e4fa9b2aecc557f0ccfbda56
+cloudflared-2022.12.1.tar.gz MD5 5ca63e0e29df90338ba92bb9c589315e

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2022.11.1
-SPK_REV = 4
+SPK_VERS = 2022.12.1
+SPK_REV = 5
 SPK_ICON = src/cloudflared.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ DISPLAY_NAME = cloudflared
 DESCRIPTION = Cloudflare Tunnel client (formerly Argo Tunnel).
 HOMEPAGE = https://github.com/cloudflare/cloudflared
 LICENSE = Apache-2.0
-CHANGELOG = "Update to 2022.11.1"
+CHANGELOG = "Update to 2022.12.1"
 
 WIZARDS_DIR = src/wizard/
 


### PR DESCRIPTION
## Description

Update to 2022.12.1

### Improvements
- cloudflared now attempts to try other edge addresses before falling back to a lower protoocol.
- cloudflared tunnel no longer spins up a quick tunnel. The call has to be explicit and provide a --url flag.
- cloudflared will now randomly pick the first or second region to connect to instead of always connecting to region2 first.

Upstream changelog: https://github.com/cloudflare/cloudflared/blob/master/RELEASE_NOTES

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
