### PR TITLE
go: update to 1.19.5 (security update)

### DIFF
--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.19.3
+PKG_VERS = 1.19.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
 PKG_DIST_SITE = https://go.dev/dl

--- a/native/go/Makefile
+++ b/native/go/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = go
-PKG_VERS = 1.19.4
+PKG_VERS = 1.19.5
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
 PKG_DIST_SITE = https://go.dev/dl

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.19.4.linux-amd64.tar.gz SHA1 11da89094dc9a60cda37f872b8c10102c0738dc0
-go1.19.4.linux-amd64.tar.gz SHA256 c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
-go1.19.4.linux-amd64.tar.gz MD5 b169b57d37b5d10df5fb2652ec6add06
+go1.19.5.linux-amd64.tar.gz SHA1 16d0f3caa4968749ca9c488cc5298ff9e0fbb6d0
+go1.19.5.linux-amd64.tar.gz SHA256 36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
+go1.19.5.linux-amd64.tar.gz MD5 68a99766b7f2ea9bb6f5e431c8cfb658

--- a/native/go/digests
+++ b/native/go/digests
@@ -1,3 +1,3 @@
-go1.19.3.linux-amd64.tar.gz SHA1 03d7c543b8c3efa7d9128d5982dceed1ab708845
-go1.19.3.linux-amd64.tar.gz SHA256 74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
-go1.19.3.linux-amd64.tar.gz MD5 87beeed49a347ef20becab18b8da9cab
+go1.19.4.linux-amd64.tar.gz SHA1 11da89094dc9a60cda37f872b8c10102c0738dc0
+go1.19.4.linux-amd64.tar.gz SHA256 c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
+go1.19.4.linux-amd64.tar.gz MD5 b169b57d37b5d10df5fb2652ec6add06


### PR DESCRIPTION
## Description

Update go to latest release which includes security fixes.

Fixes CVE-2022-41717, CVE-2022-41720

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
