### PR TITLE
Sonarr v3: fix block on legacy (v2) upgrades

### DIFF
--- a/spk/sonarr3/Makefile
+++ b/spk/sonarr3/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nzbdrone
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 21
+SPK_REV = 22
 SPK_ICON = src/sonarr.png
 
 # Mono is not supported on ppc platforms. See cross/mono/Makefile for details.

--- a/spk/sonarr3/src/config.xml
+++ b/spk/sonarr3/src/config.xml
@@ -1,6 +1,7 @@
 <Config>
   <Branch>main</Branch>
   <LaunchBrowser>False</LaunchBrowser>
+  <Port>8989</Port>
   <UpdateAutomatically>True</UpdateAutomatically>
   <UpdateMechanism>BuiltIn</UpdateMechanism>
 </Config>

--- a/spk/sonarr3/src/service-setup.sh
+++ b/spk/sonarr3/src/service-setup.sh
@@ -25,7 +25,7 @@ SERVICE_COMMAND="env PATH=${MONO_PATH}:${PATH} HOME=${HOME_DIR} LD_LIBRARY_PATH=
 SVC_BACKGROUND=y
 SVC_WAIT_TIMEOUT=90
 
-validate_preinst ()
+validate_preupgrade ()
 {
     # check if the installed distribution is a legacy version
     if [ -f "${SYNOPKG_PKGDEST}/share/NzbDrone/NzbDrone.exe" ]; then

--- a/spk/sonarr3/src/wizard/install_uifile
+++ b/spk/sonarr3/src/wizard/install_uifile
@@ -1,11 +1,11 @@
 [{
-    "step_title": "Updating Sonarr",
-    "items": [{
-        "desc": "The first time Sonarr is started it might take a few moments for the interface to become available!<br><br>Keep Sonarr up-to-date by using Sonarr's built-in updater.<br>Navigate to System>Updates in the Sonarr UI."
-    }]
-},{
-    "step_title": "Attention! DSM Permissions",
-    "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM."
-    }]
+	"step_title": "Starting and updating Sonarr",
+	"items": [{
+		"desc": "The first time Sonarr is started it might take a few moments for the interface to become available!<br><br>Keep Sonarr up-to-date by using Sonarr's built-in updater.<br>Navigate to System>Updates in the Sonarr UI."
+	}]
+}, {
+	"step_title": "DSM Permissions",
+	"items": [{
+		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+	}]
 }]

--- a/spk/sonarr3/src/wizard/install_uifile_fre
+++ b/spk/sonarr3/src/wizard/install_uifile_fre
@@ -1,11 +1,11 @@
 [{
-    "step_title": "Mettre à jour Sonarr",
-    "items": [{
-        "desc": "Au premier démarrage de Sonarr cela peut prendre un moment avant que l'interface ne soit disponible !<br><br>Garder Sonarr à jour en utilisant System>Updates dans l'interface Sonarr."
-    }]
-},{
-    "step_title": "Attention! Permissions DSM",
-    "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM."
-    }]
+	"step_title": "Mettre à jour Sonarr",
+	"items": [{
+		"desc": "Au premier démarrage de Sonarr cela peut prendre un moment avant que l'interface ne soit disponible !<br><br>Garder Sonarr à jour en utilisant System>Updates dans l'interface Sonarr."
+	}]
+}, {
+	"step_title": "Permissions DSM",
+	"items": [{
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+	}]
 }]

--- a/spk/sonarr3/src/wizard/upgrade_uifile
+++ b/spk/sonarr3/src/wizard/upgrade_uifile
@@ -1,18 +1,13 @@
 [{
-    "step_title": "RECOMMENDATION: Download A Backup Before Upgrading",
-    "items": [{
-        "desc": "<strong style='color:red'>IMPORTANT:</strong> This update is an upgrade to Sonarr v3. We suggest that you download a manual backup as a precautionary measure before installing this update.<br><br>You can download a backup via Sonarr's built-in web-interface.<br>To do this, navigate to <b>System>Backup</b> in the Sonarr UI.<br><br>Create a backup and then download a copy of that backup before installing this upgrade."
-    }]
-},{
-    "step_title": "Updating Sonarr",
-    "items": [{
-        "desc": "Keep Sonarr up-to-date by using Sonarr's built-in updater.<br>Navigate to <b>System>Updates</b> in the Sonarr UI."
-    }]
-},{
-    "step_title": "Attention! DSM Permissions",
-    "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM."
-    },{
-        "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Sonarr, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."
-    }]
+	"step_title": "Updating Sonarr",
+	"items": [{
+		"desc": "This update is for additional libraries and DSM integration. It does not modify your current Sonarr version."
+	}, {
+		"desc": "Keep Sonarr up-to-date by using Sonarr's built-in updater.<br>Navigate to <b>System>Updates</b> in the Sonarr UI."
+	}]
+}, {
+	"step_title": "DSM Permissions",
+	"items": [{
+		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+	}]
 }]

--- a/spk/sonarr3/src/wizard/upgrade_uifile_fre
+++ b/spk/sonarr3/src/wizard/upgrade_uifile_fre
@@ -1,18 +1,13 @@
 [{
-    "step_title": "RECOMMENDATION: Télécharger une sauvegarde avant la mise à niveau",
-    "items": [{
-        "desc": "<strong style='color:red'>IMPORTANT:</strong> Cette mise à jour est une mise à niveau vers Sonarr v3. Nous vous suggérons de télécharger une sauvegarde manuelle par mesure de précaution avant d'installer cette mise à jour.<br><br>Vous pouvez télécharger une sauvegarde via l'interface Web intégrée de Sonarr.<br>Pour ce faire, accédez à <b>System>Backup</b> dans l'interface utilisateur Sonarr.<br><br>Créez une sauvegarde, puis téléchargez une copie de cette sauvegarde avant d'installer cette mise à niveau."
-    }]
-},{
-    "step_title": "Mettre à jour Sonarr",
-    "items": [{
-        "desc": "Garder Sonarr à jour en utilisant <b>System>Updates</b> dans l'interface Sonarr."
-    }]
-},{
-    "step_title": "Attention! Permissions DSM",
-    "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM."
-    },{
-        "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans Sonarr, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."
-    }]
+	"step_title": "Mettre à jour Sonarr",
+	"items": [{
+		"desc": "Cette mise à jour concerne les bibliothèques supplémentaires et l'intégration DSM. Il ne modifie pas votre version actuelle de Sonarr."
+	}, {
+		"desc": "Garder Sonarr à jour en utilisant <b>System>Updates</b> dans l'interface Sonarr."
+	}]
+}, {
+	"step_title": "Permissions DSM",
+	"items": [{
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+	}]
 }]


### PR DESCRIPTION
## Description

This corrects a bug in Sonarr v3 (#5515) where an upgrade from legacy Sonarr v2 was not blocked (in DSM6). This results in the distribution containing two sets of binaries and AppData directories which can break the deployment. This bug also creates issues with upgrades to Sonarr v4 (#5524) since the correct installed version cannot be determined.

Once published, it is recommended that Sonarr v3 (Version 20221216-21) be unpublished to avoid future use.

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix