### PR TITLE
Fix rustc builds on github-action

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -28,6 +28,11 @@ echo "===> TARGET: ${GH_ARCH}"
 echo "===> ARCH   packages: ${ARCH_PACKAGES}"
 echo "===> NOARCH packages: ${NOARCH_PACKAGES}"
 
+# Remove rust toolchain status file to enfore re-installing cargo/rust
+# This fixes isees on github-action where toolchain caching omits the
+# actual installation state of cargo/rust within the distrib folder
+rm -f toolchain/syno-${GH_ARCH}/work/.rustc_done
+
 if [ "${GH_ARCH%%-*}" = "noarch" ]; then
     build_packages=${NOARCH_PACKAGES}
 else

--- a/mk/spksrc.cross-rust-env.mk
+++ b/mk/spksrc.cross-rust-env.mk
@@ -3,9 +3,9 @@
 
 # Add cargo for rust compiler to default PATH
 ifneq ($(BASE_DISTRIB_DIR),)
-export CARGO_HOME = $(BASE_DISTRIB_DIR)/cargo
-export RUSTUP_HOME = $(BASE_DISTRIB_DIR)/rustup
-export PATH := $(BASE_DISTRIB_DIR)/cargo/bin:$(PATH)
+export CARGO_HOME=$(BASE_DISTRIB_DIR)/cargo
+export RUSTUP_HOME=$(BASE_DISTRIB_DIR)/rustup
+export PATH:=$(BASE_DISTRIB_DIR)/cargo/bin:$(PATH)
 endif
 
 RUST_TOOLCHAIN ?= stable

--- a/mk/spksrc.tc-rust.mk
+++ b/mk/spksrc.tc-rust.mk
@@ -39,8 +39,13 @@ rustc_msg:
 	@$(MSG) "- default PATH: $(PATH)"
 
 pre_rustc_target: rustc_msg
-	@$(MSG) "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"
-	@curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+	@$(MSG) "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path" ; \
+	exec 5> /tmp/tc-rustc.lock ; \
+	flock --timeout $(FLOCK_TIMEOUT) --exclusive 5 || exit 1 ; \
+	pid=$$$$ ; \
+	echo "$${pid}" 1>&5 ; \
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path ; \
+	flock -u 5
 
 rustc_target: $(PRE_RUSTC_TARGET)
 	@$(MSG) "rustup toolchain install $(RUST_TOOLCHAIN)" ; \

--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -28,7 +28,7 @@ POST_STRIP_TARGET = python310_extra_install
 SPK_USR_LOCAL_LINKS = bin:bin/python3.10
 
 WHEELS  = src/requirements-pure.txt
-# WHEELS += src/requirements-crossenv.txt
+WHEELS += src/requirements-crossenv.txt
 # WHEELS += src/requirements-abi3.txt
 
 # Force building pure-python wheels
@@ -40,17 +40,17 @@ WHEELS_PURE_PYTHON_PACKAGING_ENABLE = 1
 ## various wheels.  Uncoment to enable.
 ##
 
-# # [bcrypt]
-# ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
-# ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
+# Mandatory for rustc wheel building
+#   [bcrypt]
+#   [cryptography]
+ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
+ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
 
 # # [cryptography]
-# # To generate py36-abi3 limited API:
-# DEPENDS += cross/cryptography
-# # To generate py310-py310 regular build using src/requirements-crossenv.txt:
+# # Use cross/cryptography to generate py36-abi3 limited API
 # # NOTE: It's not possible to build py36-abi3 limited API using pip due to PEP517
-# ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
-# ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
+# #       To generate py310-py310 regular build use src/requirements-crossenv.txt
+# DEPENDS += cross/cryptography
 
 # # [gevent]
 # DEPENDS += cross/libev cross/c-ares

--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -28,7 +28,7 @@ POST_STRIP_TARGET = python310_extra_install
 SPK_USR_LOCAL_LINKS = bin:bin/python3.10
 
 WHEELS  = src/requirements-pure.txt
-WHEELS += src/requirements-crossenv.txt
+# WHEELS += src/requirements-crossenv.txt
 # WHEELS += src/requirements-abi3.txt
 
 # Force building pure-python wheels

--- a/spk/python310/src/requirements-crossenv.txt
+++ b/spk/python310/src/requirements-crossenv.txt
@@ -22,6 +22,7 @@ immutables==0.19
 MarkupSafe==2.1.1
 msgpack-python==0.5.6
 netifaces==0.11.0
+psutil==5.9.4
 regex==2022.10.31
 SQLAlchemy==1.4.45
 zope.interface==5.5.2
@@ -31,48 +32,45 @@ zope.interface==5.5.2
 # Require environment variables
 #  GEVENTSETUP_EMBED_CARES=FALSE
 #  GEVENTSETUP_EMBED_LIBEV=FALSE
-gevent==22.10.2
+# gevent==22.10.2
 
 # [lxml]
 # Depends: libxml2, libxslt
-lxml==4.9.2
+# lxml==4.9.2
 
 # [mysqlclient]
 # Depends: mysql-connector-c, mariadb-connector-c
 # Require environment variables
 #  MYSQLCLIENT_CFLAGS
 #  MYSQLCLIENT_LDFLAGS
-mysqlclient==2.1.1
+# mysqlclient==2.1.1
 
 # [Pillow]
 # Require --global-options arguments
 #  WHEELS_BUILD_ARGS = [Pillow] build_ext --disable-platform-guessing
-Pillow==9.3.0
-
-# [psutil]
-psutil==5.9.4
+# Pillow==9.3.0
 
 # [pycares]
 # Depends: c-ares
 # Require environment variables
 #  PYCARES_USE_SYSTEM_LIB=1
-pycares==4.3.0
+# pycares==4.3.0
 
 # [pycurl]
 # Depends: curl
 # Require environment variables
 #  PYCURL_CURL_CONFIG
-pycurl==7.45.2
+# pycurl==7.45.2
 
 # [PyNaCl]
 # Depends: cross/libsodium
 # Require environment variables
 #  SODIUM_INSTALL=system
-PyNaCl==1.5.0
+# PyNaCl==1.5.0
 
 # [PyYAML]
 # Depends: libyaml
-PyYAML==6.0
+# PyYAML==6.0
 
 # [rencode]
 # Updated fork of the project
@@ -80,7 +78,7 @@ PyYAML==6.0
 git+https://github.com/totaam/rencode.git@f6254ab26161f90b9c5e97915b9193fee805fc1f#egg=rencode==1.0.7
 
 # [ujson]
-#   - Require setuptools-scm in cross/python310 crossenv
+#   - Require setuptools-scm in cross/python3* crossenv
 ujson==5.6.0
 
 # [webrtcvad]

--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -28,8 +28,8 @@ POST_STRIP_TARGET = python311_extra_install
 SPK_USR_LOCAL_LINKS = bin:bin/python3.11
 
 WHEELS  = src/requirements-pure.txt
-#WHEELS += src/requirements-crossenv.txt
-#WHEELS += src/requirements-abi3.txt
+WHEELS += src/requirements-crossenv.txt
+# WHEELS += src/requirements-abi3.txt
 
 # Force building pure-python wheels
 WHEELS_PURE_PYTHON_PACKAGING_ENABLE = 1
@@ -40,17 +40,17 @@ WHEELS_PURE_PYTHON_PACKAGING_ENABLE = 1
 ## various wheels.  Uncoment to enable.
 ##
 
-# # [bcrypt]
-# ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
-# ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
+# Mandatory for rustc wheel building
+#   [bcrypt]
+#   [cryptography]
+ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
+ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
 
 # # [cryptography]
-# # To generate py36-abi3 limited API:
-# DEPENDS += cross/cryptography
-# # To generate py311-py311 regular build using src/requirements-crossenv.txt:
+# # Use cross/cryptography to generate py36-abi3 limited API
 # # NOTE: It's not possible to build py36-abi3 limited API using pip due to PEP517
-# ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
-# ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
+# #       To generate py310-py310 regular build use src/requirements-crossenv.txt
+# DEPENDS += cross/cryptography
 
 # # [gevent]
 # DEPENDS += cross/libev cross/c-ares

--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -28,7 +28,7 @@ POST_STRIP_TARGET = python311_extra_install
 SPK_USR_LOCAL_LINKS = bin:bin/python3.11
 
 WHEELS  = src/requirements-pure.txt
-WHEELS += src/requirements-crossenv.txt
+# WHEELS += src/requirements-crossenv.txt
 # WHEELS += src/requirements-abi3.txt
 
 # Force building pure-python wheels

--- a/spk/python311/src/requirements-crossenv.txt
+++ b/spk/python311/src/requirements-crossenv.txt
@@ -22,6 +22,7 @@ immutables==0.19
 MarkupSafe==2.1.1
 msgpack-python==0.5.6
 netifaces==0.11.0
+psutil==5.9.4
 regex==2022.10.31
 SQLAlchemy==1.4.45
 zope.interface==5.5.2
@@ -31,48 +32,45 @@ zope.interface==5.5.2
 # Require environment variables
 #  GEVENTSETUP_EMBED_CARES=FALSE
 #  GEVENTSETUP_EMBED_LIBEV=FALSE
-gevent==22.10.2
+# gevent==22.10.2
 
 # [lxml]
 # Depends: libxml2, libxslt
-lxml==4.9.2
+# lxml==4.9.2
 
 # [mysqlclient]
 # Depends: mysql-connector-c, mariadb-connector-c
 # Require environment variables
 #  MYSQLCLIENT_CFLAGS
 #  MYSQLCLIENT_LDFLAGS
-mysqlclient==2.1.1
+# mysqlclient==2.1.1
 
 # [Pillow]
 # Require --global-options arguments
 #  WHEELS_BUILD_ARGS = [Pillow] build_ext --disable-platform-guessing
-Pillow==9.3.0
-
-# [psutil]
-psutil==5.9.4
+# Pillow==9.3.0
 
 # [pycares]
 # Depends: c-ares
 # Require environment variables
 #  PYCARES_USE_SYSTEM_LIB=1
-pycares==4.3.0
+# pycares==4.3.0
 
 # [pycurl]
 # Depends: curl
 # Require environment variables
 #  PYCURL_CURL_CONFIG
-pycurl==7.45.2
+# pycurl==7.45.2
 
 # [PyNaCl]
 # Depends: cross/libsodium
 # Require environment variables
 #  SODIUM_INSTALL=system
-PyNaCl==1.5.0
+# PyNaCl==1.5.0
 
 # [PyYAML]
 # Depends: libyaml
-PyYAML==6.0
+# PyYAML==6.0
 
 # [rencode]
 # Updated fork of the project
@@ -80,7 +78,7 @@ PyYAML==6.0
 git+https://github.com/totaam/rencode.git@f6254ab26161f90b9c5e97915b9193fee805fc1f#egg=rencode==1.0.7
 
 # [ujson]
-#   - Require setuptools-scm in cross/python310 crossenv
+#   - Require setuptools-scm in cross/python3* crossenv
 ujson==5.6.0
 
 # [webrtcvad]


### PR DESCRIPTION
## Description

This tries to fix #5581

- fix export of CARGO_HOME and RUSTUP_HOME
- fix issue when toolchain caching keeps rustc status file (`toolchain/syno-<arch>-<tcversion>/work/.rustc_done`) in cases where distrib folder install of cargo/rustc isn't existing.


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
