### PR TITLE
meson-env.mk: Fix typo in arm architecture failing for armv7-7l

### DIFF
--- a/mk/spksrc.cross-meson-env.mk
+++ b/mk/spksrc.cross-meson-env.mk
@@ -24,13 +24,13 @@ ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
 endif
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS)),$(ARCH))
   MESON_BUILTIN_CPP_ARGS = -fPIC
-  MESON_HOST_CPU_FAMILY = armv
+  MESON_HOST_CPU_FAMILY = arm
   MESON_HOST_CPU = armv7
   MESON_HOST_ENDIAN = little
 endif
 ifeq ($(findstring $(ARCH),$(ARMv7L_ARCHS)),$(ARCH))
   MESON_BUILTIN_CPP_ARGS = -fPIC
-  MESON_HOST_CPU_FAMILY = armv
+  MESON_HOST_CPU_FAMILY = arm
   MESON_HOST_CPU = armv7l
   MESON_HOST_ENDIAN = little
 endif


### PR DESCRIPTION
## Description

A typo in armv7 and armv7l `MESON_HOST_CPU_FAMILY` variable leads to failure to build on arm.


## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
