### PR TITLE
Sonarr v3: fix for service setup

### DIFF
--- a/spk/sonarr3/Makefile
+++ b/spk/sonarr3/Makefile
@@ -3,24 +3,24 @@ SPK_VERS = $(shell date +%Y%m%d)
 SPK_REV = 22
 SPK_ICON = src/sonarr.png
 
+DEPENDS = cross/curl cross/mediainfo cross/sqlite cross/sonarr3
+SPK_DEPENDS = "mono>=5.8"
+
 # Mono is not supported on ppc platforms. See cross/mono/Makefile for details.
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 
-DEPENDS = cross/curl cross/mediainfo cross/sqlite cross/sonarr3
-
-SPK_DEPENDS = "mono>=5.8"
-
 MAINTAINER = SynoCommunity
+MAINTAINER_URL = https://synocommunity.com/
 DESCRIPTION = Sonarr is a PVR for newsgroup and torrent users. It can monitor multiple RSS feeds for new episodes of your favourite shows and will grab, sorts and rename them. It can also be configured to automatically upgrade the quality of files already downloaded if a better quality format becomes available.
 DESCRIPTION_FRE = Sonarr est un PVR pour les utilisateurs de groupes de discussion et torrents. Il peut surveiller plusieurs flux RSS pour les nouveaux épisodes de vos séries préférées et saisira, sortes et les renomme. Il peut également être configuré pour mettre à jour automatiquement la qualité des fichiers déjà téléchargés si un meilleur format de qualité devient disponible.
 DESCRIPTION_SPN = Sonarr es un PVR para los usuarios de grupos de noticias y torrents. Se puede controlar múltiples canales RSS para nuevos episodios de sus programas favoritos y se agarra, tipo y les cambia el nombre. También puede ser configurado para actualizar automáticamente la calidad de los archivos ya descargados si un formato de mejor calidad disponible.
-DISPLAY_NAME = Sonarr v3
-STARTABLE = yes
 CHANGELOG = "1. Update package name to 'Sonarr v3'.<br/>2. Upgrade to Sonarr 3.0.9.1549.<br/>3. Enlarge the service start/stop timeout to 90 seconds.<br/>4. Avoid Sonarr downgrade on package update.<br/>5. Fix usage of TMPDIR and remove obsolete folders."
-
+DISPLAY_NAME = Sonarr v3
 HOMEPAGE = https://sonarr.tv
 LICENSE  = GPLv3
+HELPURL = https://wiki.servarr.com/sonarr/troubleshooting
 
+STARTABLE = yes
 SERVICE_USER = auto
 SERVICE_SETUP = src/service-setup.sh
 SERVICE_PORT = 8989

--- a/spk/sonarr3/src/service-setup.sh
+++ b/spk/sonarr3/src/service-setup.sh
@@ -1,3 +1,5 @@
+
+# Sonarr service setup
 PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
 MONO_PATH="/var/packages/mono/target/bin"
 MONO="${MONO_PATH}/mono"
@@ -5,7 +7,7 @@ SONARR="${SYNOPKG_PKGDEST}/share/Sonarr/Sonarr.exe"
 
 # Sonarr uses custom Config and PID directories
 HOME_DIR="${SYNOPKG_PKGVAR}"
-CONFIG_DIR="${SYNOPKG_PKGVAR}/.config"
+CONFIG_DIR="${HOME_DIR}/.config"
 SONARR_CONFIG_DIR="${CONFIG_DIR}/Sonarr"
 PID_FILE="${SONARR_CONFIG_DIR}/sonarr.pid"
 CMD_ARGS="-nobrowser -data=${SONARR_CONFIG_DIR}"
@@ -14,13 +16,15 @@ CMD_ARGS="-nobrowser -data=${SONARR_CONFIG_DIR}"
 LEGACY_CONFIG_DIR="${SYNOPKG_PKGDEST}/.config"
 
 # workaround for mono bug with armv5 (https://github.com/mono/mono/issues/12537)
-if [ "$SYNOPKG_DSM_ARCH" == "88f6281" ] || [ "$SYNOPKG_DSM_ARCH" == "88f6282" ]; then
+if [ "$SYNOPKG_DSM_ARCH" = "88f6281" ] || [ "$SYNOPKG_DSM_ARCH" = "88f6282" ]; then
     MONO="MONO_ENV_OPTIONS='-O=-aot,-float32' ${MONO}"
 fi
 
 # for DSM < 7 only:
-GROUP="sc-download"
-LEGACY_GROUP="sc-media"
+if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
+    GROUP="sc-download"
+    LEGACY_GROUP="sc-media"
+fi
 
 SERVICE_COMMAND="env PATH=${MONO_PATH}:${PATH} HOME=${HOME_DIR} LD_LIBRARY_PATH=${SYNOPKG_PKGDEST}/lib ${MONO} ${SONARR} ${CMD_ARGS}"
 SVC_BACKGROUND=y
@@ -29,7 +33,7 @@ SVC_WAIT_TIMEOUT=90
 validate_preupgrade ()
 {
     # check if the installed distribution is a legacy version
-    if [ -f "${SYNOPKG_PKGDEST}/share/NzbDrone/NzbDrone.exe" ]; then
+    if [ -f ${SYNOPKG_PKGDEST}/share/NzbDrone/NzbDrone.exe ]; then
         # v2 installed
         echo "Update from NzbDrone (Sonarr v2.x) is not supported."
         exit 1
@@ -40,51 +44,51 @@ service_postinst ()
 {
     echo "Set update required"
     # Make Sonarr do an update check on start to update to the latest version available
-    touch "${SONARR_CONFIG_DIR}/update_required"
+    touch ${SONARR_CONFIG_DIR}/update_required 2>&1
     
-    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
+    if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
         set_unix_permissions "${CONFIG_DIR}"
     fi
 }
 
 service_preupgrade ()
 {
-    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ]; then
+    if [ ${SYNOPKG_DSM_VERSION_MAJOR} -ge 7 ]; then
         # ensure config is in @appdata folder
         if [ -d "${LEGACY_CONFIG_DIR}" ]; then
-            if [ "$(realpath "${LEGACY_CONFIG_DIR}")" != "$(realpath "${CONFIG_DIR}")" ]; then
+            if [ "$(realpath ${LEGACY_CONFIG_DIR})" != "$(realpath ${CONFIG_DIR})" ]; then
                 echo "Move ${LEGACY_CONFIG_DIR} to ${CONFIG_DIR}"
-                mv "${LEGACY_CONFIG_DIR}" "${CONFIG_DIR}" 2>&1
+                mv ${LEGACY_CONFIG_DIR} ${CONFIG_DIR} 2>&1
             fi
         fi
     fi
 
     # remove former temp folders that were never removed
     for folder in "nzbdrone_backup" "nzbdrone_update" "sonarr_backup" "sonarr_update"; do
-        if [ -d "/tmp/${folder}" ]; then
+        if [ -d /tmp/${folder} ]; then
             echo "Remove obsolete folder /tmp/${folder}"
-            rm -rf "/tmp/${folder}" 2>&1
+            rm -rf /tmp/${folder} 2>&1
         fi
     done
 
     # never update Sonarr distribution, use internal updater only
-    [ -d "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup" ] && rm -rf "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup"
+    [ -d ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup ] && rm -rf ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup
     echo "Backup existing distribution to ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup"
-    mkdir -p "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup" 2>&1
-    rsync -aX "${SYNOPKG_PKGDEST}/share" "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/" 2>&1
+    mkdir -p ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup 2>&1
+    rsync -aX ${SYNOPKG_PKGDEST}/share ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/ 2>&1
 }
 
 service_postupgrade ()
 {
     # restore Sonarr distribution
-    if [ -d "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share" ]; then
+    if [ -d ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share ]; then
         echo "Restore previous distribution from ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup"
-        rm -rf "${SYNOPKG_PKGDEST}/share/Sonarr/bin" 2>&1
+        rm -rf ${SYNOPKG_PKGDEST}/share/Sonarr/bin 2>&1
         # prevent overwrite of updated package_info
-        rsync -aX --exclude=package_info "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share/" "${SYNOPKG_PKGDEST}/share" 2>&1
+        rsync -aX --exclude=package_info ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share/ ${SYNOPKG_PKGDEST}/share 2>&1
     fi
 
-    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
+    if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
         set_unix_permissions "${SYNOPKG_PKGDEST}/share"
     fi
 }


### PR DESCRIPTION
## Description

Amends https://github.com/SynoCommunity/spksrc/pull/5591 to update service setup `GROUP` variable to exclude DSM7 (deprecated in DSM7).