### PR TITLE
Framework: fix installer, add arch vars

### DIFF
--- a/mk/spksrc.archs.mk
+++ b/mk/spksrc.archs.mk
@@ -55,3 +55,15 @@ DOTNET_UNSUPPORTED_ARCHS += armadaxp
 
 # compatibility with .NET not yet confirmed:
 # alpine4k armada375 armada38x comcerto2k
+
+# Exclusions for dotnet 6.0 core apps
+ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370
+    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1
+endif
+
+# Exclusions for dotnet 6.0 servarr apps (except x86)
+ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370
+    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1
+endif

--- a/mk/spksrc.service.installer.dsm5
+++ b/mk/spksrc.service.installer.dsm5
@@ -35,7 +35,12 @@ call_func ()
     FUNC=$1
     if type "${FUNC}" 2>/dev/null | grep -q 'function' 2>/dev/null; then
         install_log "Begin ${FUNC}"
-        eval ${FUNC} 2>&1 | install_log
+        ARG=$2
+        if [ -z "${ARG}" ]; then
+            eval ${FUNC} 2>&1 | install_log
+        else
+            eval ${FUNC} ${ARG} 2>&1 | install_log
+        fi
         install_log "End ${FUNC}"
     fi
 }

--- a/mk/spksrc.service.installer.dsm6
+++ b/mk/spksrc.service.installer.dsm6
@@ -35,10 +35,19 @@ call_func ()
     if type "${FUNC}" 2>/dev/null | grep -q 'function' 2>/dev/null; then
         install_log "Begin ${FUNC}"
         LOG=$2
+        ARG=$3
         if [ -z "${LOG}" ]; then
-            eval ${FUNC}
+            if [ -z "${ARG}" ]; then
+                eval ${FUNC}
+            else
+                eval ${FUNC} ${ARG}
+            fi
         else
-            eval ${FUNC} 2>&1 | ${LOG}
+            if [ -z "${ARG}" ]; then
+                eval ${FUNC} 2>&1 | ${LOG}
+            else
+                eval ${FUNC} ${ARG} 2>&1 | ${LOG}
+            fi
         fi
         install_log "End ${FUNC}"
     fi
@@ -59,7 +68,7 @@ fi
 
 
 # Load (wizard) variables stored by postinst
-call_func "load_variables_from_file" ${INST_VARIABLES}
+call_func "load_variables_from_file" install_log ${INST_VARIABLES}
 
 # init variables either from ${INST_VARIABLES}, from package or from wizard
 call_func "initialize_variables"

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -36,10 +36,19 @@ call_func ()
     if type "${FUNC}" 2>/dev/null | grep -q 'function' 2>/dev/null; then
         install_log "Begin ${FUNC}"
         LOG=$2
+        ARG=$3
         if [ -z "${LOG}" ]; then
-            eval ${FUNC}
+            if [ -z "${ARG}" ]; then
+                eval ${FUNC}
+            else
+                eval ${FUNC} ${ARG}
+            fi
         else
-            eval ${FUNC} 2>&1 | ${LOG}
+            if [ -z "${ARG}" ]; then
+                eval ${FUNC} 2>&1 | ${LOG}
+            else
+                eval ${FUNC} ${ARG} 2>&1 | ${LOG}
+            fi
         fi
         install_log "End ${FUNC}"
     fi
@@ -60,7 +69,7 @@ fi
 
 
 # Load (wizard) variables stored by postinst
-call_func "load_variables_from_file" ${INST_VARIABLES}
+call_func "load_variables_from_file" install_log ${INST_VARIABLES}
 
 # init variables either from ${INST_VARIABLES}, from package or from wizard
 call_func "initialize_variables"

--- a/mk/spksrc.service.installer.functions
+++ b/mk/spksrc.service.installer.functions
@@ -6,7 +6,7 @@
 # The script must be sh/ash compatible and not use bash syntax.
 # SRM and DSM < 6.0 have only the busybox built-in shell an not bash
 # 
-    
+
 # Tools shortcuts
 MV="/bin/mv -f"
 RM="/bin/rm -rf"


### PR DESCRIPTION
## Description

These changes to the framework were motivated by (a) install errors with the `load_variables_from_file` function (b) inconsistent arch exclusions for dotnet packages. This PR contains the following:

1. Fixes bug in `call_func` arguments used by `load_variables_from_file` function
2. Add `Makefile` variables for dotnet 6.0 arch exclusions (core and servarr)

Follow up of #5570
Fixes #5574 (adds helper)

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
