### PR TITLE
Mono: fix DSM 7 compatibility

### DIFF
--- a/cross/mono/Makefile
+++ b/cross/mono/Makefile
@@ -14,6 +14,8 @@ LICENSE  = https://www.mono-project.com/docs/faq/licensing
 # Although qoriq can be compiled successfully it won't run as classic floating point unit not available
 # For details see: https://github.com/SynoCommunity/spksrc/issues/3470#issuecomment-469391052
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
+# Mono versions newer than 5.8.0 have an incompatibility with aarch64 on DSM 6.x (issue #3666)
+UNSUPPORTED_ARCHS_TCVERSION = aarch64-6.1
 
 PRE_CONFIGURE_TARGET = mono_pre_configure
 GNU_CONFIGURE = 1

--- a/native/mono/patches/001-relocate-specialfolders.patch
+++ b/native/mono/patches/001-relocate-specialfolders.patch
@@ -5,7 +5,7 @@
  				return ReadXdgUserDir (config, home, "XDG_VIDEOS_DIR", "Videos");
  			case SpecialFolder.CommonTemplates:
 -				return "/usr/share/templates";
-+				return "/var/packages/mono/target/var/templates";
++				return "/var/packages/mono/var/templates";
  			case SpecialFolder.Fonts:
  				if (Platform == PlatformID.MacOSX)
  					return Path.Combine (home, "Library", "Fonts");
@@ -14,7 +14,7 @@
  			// This is where data common to all users goes
  			case SpecialFolder.CommonApplicationData:
 -				return "/usr/share";
-+				return "/var/packages/mono/target/var";
++				return "/var/packages/mono/var";
  			default:
  				throw new ArgumentException ("Invalid SpecialFolder");
  			}
@@ -26,8 +26,8 @@
              {
 -                case SpecialFolder.CommonApplicationData: return "/usr/share";
 -                case SpecialFolder.CommonTemplates: return "/usr/share/templates";
-+                case SpecialFolder.CommonApplicationData: return "/var/packages/mono/target/var";
-+                case SpecialFolder.CommonTemplates: return "/var/packages/mono/target/var/templates";
++                case SpecialFolder.CommonApplicationData: return "/var/packages/mono/var";
++                case SpecialFolder.CommonTemplates: return "/var/packages/mono/var/templates";
              }
              if (IsMac)
              {

--- a/native/mono_58/patches/001-relocate-specialfolders.patch
+++ b/native/mono_58/patches/001-relocate-specialfolders.patch
@@ -5,7 +5,7 @@
  				return ReadXdgUserDir (config, home, "XDG_VIDEOS_DIR", "Videos");
  			case SpecialFolder.CommonTemplates:
 -				return "/usr/share/templates";
-+				return "/var/packages/mono/target/var/templates";
++				return "/var/packages/mono/var/templates";
  			case SpecialFolder.Fonts:
  				if (Platform == PlatformID.MacOSX)
  					return Path.Combine (home, "Library", "Fonts");
@@ -14,7 +14,7 @@
  			// This is where data common to all users goes
  			case SpecialFolder.CommonApplicationData:
 -				return "/usr/share";
-+				return "/var/packages/mono/target/var";
++				return "/var/packages/mono/var";
  			default:
  				throw new ArgumentException ("Invalid SpecialFolder");
  			}
@@ -26,8 +26,8 @@
              {
 -                case SpecialFolder.CommonApplicationData: return "/usr/share";
 -                case SpecialFolder.CommonTemplates: return "/usr/share/templates";
-+                case SpecialFolder.CommonApplicationData: return "/var/packages/mono/target/var";
-+                case SpecialFolder.CommonTemplates: return "/var/packages/mono/target/var/templates";
++                case SpecialFolder.CommonApplicationData: return "/var/packages/mono/var";
++                case SpecialFolder.CommonTemplates: return "/var/packages/mono/var/templates";
              }
              if (IsMac)
              {

--- a/spk/mono/Makefile
+++ b/spk/mono/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mono
 SPK_VERS = 5.20.1.34
-SPK_REV = 18
+SPK_REV = 19
 SPK_ICON = src/mono.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -15,7 +15,7 @@ MAINTAINER = hgy59
 DESCRIPTION = Cross platform, open source .NET development framework.
 DISPLAY_NAME = Mono
 STARTABLE = no
-CHANGELOG = "1. Update to version 5.20.1.34<br/>2. Fix workaround for ARMv5 (88f628x archs)<br/>3. Remove static libraries."
+CHANGELOG = "Fix DSM 7 compatibility."
 
 HOMEPAGE = https://mono-project.com
 LICENSE  = https://www.mono-project.com/docs/faq/licensing

--- a/spk/mono/Makefile
+++ b/spk/mono/Makefile
@@ -10,6 +10,8 @@ REQUIRED_MIN_DSM = 5.0
 # Although qoriq can be compiled successfully it won't run as classic floating point unit not available
 # For details see: https://github.com/SynoCommunity/spksrc/issues/3470#issuecomment-469391052
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
+# Mono versions newer than 5.8.0 have an incompatibility with aarch64 on DSM 6.x (issue #3666)
+UNSUPPORTED_ARCHS_TCVERSION = aarch64-6.1
 
 MAINTAINER = hgy59
 DESCRIPTION = Cross platform, open source .NET development framework.


### PR DESCRIPTION
## Description

This PR is to update the patch files to use `/var/packages/mono/var` instead of `/var/packages/mono/target/var` for DSM 7 compatibility.

Follow up of #5522
Fixes #5051, #5354

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
