### PR TITLE
Framework: fix for wizard file permissions

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -370,6 +370,7 @@ WIZARD_FILE_NAMES += -or -name "uninstall_uifile_???"
 WIZARD_FILE_NAMES += -or -name "uninstall_uifile.sh"
 WIZARD_FILE_NAMES += -or -name "uninstall_uifile_???.sh"
 
+WIZARD_FILE_LIST := $(shell find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name ".*" 2> /dev/null)
 
 .PHONY: wizards
 wizards:
@@ -390,10 +391,11 @@ ifneq ($(strip $(WIZARDS_DIR)),)
 	    $(MSG) "Create DSM Version specific Wizards: $(WIZARDS_DIR)$(TCVERSION)"; \
 		find $${SPKSRC_WIZARDS_DIR}$(TCVERSION) -maxdepth 1 -type f -and \( $(WIZARD_FILE_NAMES) \) -print -exec cp -f {} $(DSM_WIZARDS_DIR) \; ;\
 	fi
-endif
-ifneq ($(wildcard $(DSM_WIZARDS_DIR)/*),)
-	@find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name "*.sh" -print -exec chmod 0644 {} \;
-	@find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -name "*.sh" -print -exec chmod 0755 {} \;
+	@$(MSG) "Set permissions for DSM Wizards"
+	@if [ -z "$(WIZARD_FILE_LIST)" ]; then \
+		find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name "*.sh" -print -exec chmod 0644 {} \; ;\
+		find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -name "*.sh" -print -exec chmod 0755 {} \; ;\
+	fi
 endif
 
 .PHONY: conf

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -370,7 +370,6 @@ WIZARD_FILE_NAMES += -or -name "uninstall_uifile_???"
 WIZARD_FILE_NAMES += -or -name "uninstall_uifile.sh"
 WIZARD_FILE_NAMES += -or -name "uninstall_uifile_???.sh"
 
-WIZARD_FILE_LIST := $(shell find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name ".*" 2> /dev/null)
 
 .PHONY: wizards
 wizards:
@@ -391,8 +390,7 @@ ifneq ($(strip $(WIZARDS_DIR)),)
 	    $(MSG) "Create DSM Version specific Wizards: $(WIZARDS_DIR)$(TCVERSION)"; \
 		find $${SPKSRC_WIZARDS_DIR}$(TCVERSION) -maxdepth 1 -type f -and \( $(WIZARD_FILE_NAMES) \) -print -exec cp -f {} $(DSM_WIZARDS_DIR) \; ;\
 	fi
-	@$(MSG) "Set permissions for DSM Wizards"
-	@if [ -z "$(WIZARD_FILE_LIST)" ]; then \
+	@if [ -d "$(DSM_WIZARDS_DIR)" ]; then \
 		find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -not -name "*.sh" -print -exec chmod 0644 {} \; ;\
 		find $(DSM_WIZARDS_DIR) -maxdepth 1 -type f -name "*.sh" -print -exec chmod 0755 {} \; ;\
 	fi


### PR DESCRIPTION
## Description

In some builds that included wizard UI files based on shell scripts, the shell scripts didn't execute during the installation wizard under DSM6 because they lacked the execute bit set (https://github.com/SynoCommunity/spksrc/pull/5524#issuecomment-1374808403 and https://github.com/SynoCommunity/spksrc/pull/5455#issuecomment-1432118636). This issue occurred because the current [`spksrc.spk.mk`](https://github.com/SynoCommunity/spksrc/blob/master/mk/spksrc.spk.mk) set the execute bit as part of a block that evaluated the contents of the parent folder based on wildcards. However, for Makefiles, wildcards are evaluated during parsing and are not re-evaluated when the containing statement is executed (see: [The Trouble with $(wildcard)](https://www.cmcrossroads.com/article/trouble-wildcard)).

~~To solve this issue, we define a new variable called `WIZARD_FILE_LIST` that generates a list of files in the directory. Then we reference this variable from the wizards target in an `if` statement to check if the variable has a value. This approach ensures that the variable has the correct value when evaluated, and we no longer rely on wildcards to evaluate the contents of the parent folder.~~

To solve this issue, the code was modified to check the existence of the `DSM_WIZARDS_DIR` directory instead. If the `WIZARDS_DIR` variable was already evaluated as not null, this directory would exist, ensuring that the files within it are consistently processed for file permissions. This approach removes the reliance on wildcards to evaluate the contents of the parent folder and ensures that the shell scripts have the correct file permissions during the installation wizard.

Follow up of #5383
Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
