### PR TITLE
Sabnzbd: Fix service setup script

### DIFF
--- a/spk/sabnzbd/src/service-setup.sh
+++ b/spk/sabnzbd/src/service-setup.sh
@@ -7,9 +7,7 @@ SABNZBD="${SYNOPKG_PKGDEST}/share/SABnzbd/SABnzbd.py"
 CFG_FILE="${SYNOPKG_PKGVAR}/config.ini"
 LANGUAGE="env LANG=en_US.UTF-8"
 
-if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ]; then
-    GROUP="synocommunity"
-else
+if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
     GROUP="sc-download"
 fi
 
@@ -81,7 +79,7 @@ service_postupgrade ()
                 mkdir -p "$NEW_WATCH_FOLDER"
                 mv -nv "$OLD_WATCH_FOLDER"/* "$NEW_WATCH_FOLDER/"
             fi
-            shopt -d dotglob
+            shopt -u dotglob
 
         else
             # add group (DSM6)


### PR DESCRIPTION
## Description

This is a minor correction to the service setup script to address the following:
1. Only set `GROUP` variable for DSM 6 (deprecated in DSM 7)
2. Correct option for `shopt` function call (https://github.com/SynoCommunity/spksrc/pull/5594#issuecomment-1429534830)

Follow up of #4748
Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
