### PR TITLE
rutorrent: upgrade 3.10 => 4.1.5

### DIFF
--- a/cross/rutorrent/Makefile
+++ b/cross/rutorrent/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = ruTorrent
-PKG_VERS = 4.0.2
+PKG_VERS = 4.1.5
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/Novik/ruTorrent/archive/refs/tags

--- a/cross/rutorrent/Makefile
+++ b/cross/rutorrent/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = ruTorrent
-PKG_VERS = 3.10
+PKG_VERS = 4.0.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/Novik/ruTorrent/archive
+PKG_DIST_SITE = https://github.com/Novik/ruTorrent/archive/refs/tags
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 

--- a/cross/rutorrent/digests
+++ b/cross/rutorrent/digests
@@ -1,3 +1,3 @@
-ruTorrent-3.10.tar.gz SHA1 d797fa58a54061e73e71ebdaff671efd6cf823fc
-ruTorrent-3.10.tar.gz SHA256 dac1e3e0079eb475066d6be738b8372596fa382b074792db5ecab31bce6cfa6d
-ruTorrent-3.10.tar.gz MD5 632964bab3ce949abb1fb9ce8d0fba31
+ruTorrent-4.0.2.tar.gz SHA1 898d2c018f9cf6f2d308b60fbcb8f307dbdd4c78
+ruTorrent-4.0.2.tar.gz SHA256 f64c164f6312d4268149731b2874abf63433699f4d75c4bd0a53aaf8f306f771
+ruTorrent-4.0.2.tar.gz MD5 205de9fdd6c4a10b0750c58d263f279c

--- a/cross/rutorrent/digests
+++ b/cross/rutorrent/digests
@@ -1,3 +1,3 @@
-ruTorrent-4.0.2.tar.gz SHA1 898d2c018f9cf6f2d308b60fbcb8f307dbdd4c78
-ruTorrent-4.0.2.tar.gz SHA256 f64c164f6312d4268149731b2874abf63433699f4d75c4bd0a53aaf8f306f771
-ruTorrent-4.0.2.tar.gz MD5 205de9fdd6c4a10b0750c58d263f279c
+ruTorrent-4.1.5.tar.gz SHA1 1e5ef5c381a218a40ce373c968432c7a3e581684
+ruTorrent-4.1.5.tar.gz SHA256 b84da2c9169444aa50b438ce2fdb0ce81f7bbcdd3e3138b3cc215dd27c58b2bf
+ruTorrent-4.1.5.tar.gz MD5 19e906f37be308ee7c9030ad6091c64f

--- a/cross/rutorrent/patches/002-fixing-default-value-for-local-hosted-mode.patch
+++ b/cross/rutorrent/patches/002-fixing-default-value-for-local-hosted-mode.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] Change default localHostedMode
+---
+Index: conf/config.php
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/conf/config.php b/conf/config.php
+--- conf/config.php.orig	(revision 48933089370b667e8d3b19fb8f9b92bc6db5409d)
++++ conf/config.php	(date 1683473924000)
+@@ -66,7 +66,7 @@
+		"mediainfo"	=> '',			// Something like /usr/bin/mediainfo. If empty, will be found in PATH
+ 	);
+ 
+-	$localHostedMode = false;		// Set to true if rTorrent is hosted on the SAME machine as ruTorrent
++	$localHostedMode = true;		// Set to false if rTorrent is NOT hosted on the SAME machine as ruTorrent
+ 	
+ 	$cachedPluginLoading = false;		// Set to true to enable rapid cached loading of ruTorrent plugins
+ 										// Required to clear web browser cache when upgrading versions	

--- a/cross/rutorrent/patches/002-fixing-default-value-for-local-hosted-mode.patch
+++ b/cross/rutorrent/patches/002-fixing-default-value-for-local-hosted-mode.patch
@@ -8,7 +8,7 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 diff --git a/conf/config.php b/conf/config.php
 --- conf/config.php.orig	(revision 48933089370b667e8d3b19fb8f9b92bc6db5409d)
 +++ conf/config.php	(date 1683473924000)
-@@ -66,7 +66,7 @@
+@@ -63,7 +63,7 @@
 		"mediainfo"	=> '',			// Something like /usr/bin/mediainfo. If empty, will be found in PATH
  	);
  

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = rutorrent
-SPK_VERS = 3.10
-SPK_REV = 14
+SPK_VERS = 4.0.2
+SPK_REV = 15
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
@@ -27,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Remove outdated resources</li><li>Fix missing dependency declaration on Apache 2.4</li><li>Fixed invalid handling of volume customization upon installation</li><li>Fix handling of watch directory by creating it if it does not exist.</li></ol>"
+CHANGELOG = "<ol><li>Upgrade rutorrent to 4.0.2</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -4,9 +4,6 @@ SPK_REV = 15
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
-# WebStation is only DSM 6+
-REQUIRE_MIN_DSM = 6.0
-
 SPK_DEPENDS = "WebStation:python310:PHP7.4:Apache2.4"
 WHEELS = src/requirements-pure.txt
 
@@ -30,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li><li>Drop support of DSM 5</li></ol>"
+CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -4,7 +4,7 @@ SPK_REV = 15
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
-SPK_DEPENDS = "WebStation:python310:PHP7.4:Apache2.4"
+SPK_DEPENDS = "WebStation:python311:PHP7.4:Apache2.4"
 WHEELS = src/requirements-pure.txt
 
 DEPENDS = cross/busybox cross/curl cross/mediainfo cross/rtorrent cross/rutorrent cross/screen cross/unzip
@@ -27,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
+CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.11</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -4,6 +4,9 @@ SPK_REV = 15
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
+# WebStation is only DSM 6+
+REQUIRE_MIN_DSM = 6.0
+
 SPK_DEPENDS = "WebStation:python310:PHP7.4:Apache2.4"
 WHEELS = src/requirements-pure.txt
 
@@ -27,7 +30,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
+CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li><li>Drop support of DSM 5</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3
@@ -45,10 +48,6 @@ FWPORTS = src/rutorrent.sc
 CONF_DIR = src/conf/
 WIZARDS_DIR = $(WORK_DIR)/generated-wizards
 WIZARDS = install_uifile upgrade_uifile
-
-INSTALL_DEP_SERVICES = apache-web
-START_DEP_SERVICES = apache-web
-INSTUNINST_RESTART_SERVICES = apache-web
 
 POST_STRIP_TARGET = rutorrent_extra_install
 

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = rutorrent
-SPK_VERS = 4.0.2
+SPK_VERS = 4.1.5
 SPK_REV = 15
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
@@ -27,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Upgrade rutorrent to 4.0.2</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
+CHANGELOG = "<ol><li>Upgrade rutorrent to 4.1.5</li><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/src/requirements-pure.txt
+++ b/spk/rutorrent/src/requirements-pure.txt
@@ -1,1 +1,1 @@
-cloudscraper==1.2.58
+cloudscraper==1.2.71

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -208,6 +208,27 @@ service_save ()
         sed -i -e "s|http_cacert = .*|http_cacert = /etc/ssl/certs/ca-certificates.crt|g" ${RTORRENT_RC}
     fi
 
+    # Revision 15 introduces backward incompatible changes in the configuration
+    if [ `echo "${SYNOPKG_OLD_PKGVER}" | sed -r "s/^.*-([0-9]+)$/\1/"` -lt 15 ]; then
+        sed -i -E -e "s/@define\(\s*'HTTP_USER_AGENT'\s*,\s*'(.*)'\s*(,\s*(true|false)\s*)?\)/\$httpUserAgent = '\\1'/g" \
+              -e "s/@define\(\s*'HTTP_TIME_OUT'\s*,\s*([0-9]*)\s*(,\s*(true|false)\s*)?\)/\$httpTimeOut = \\1/g" \
+              -e "s/@define\(\s*'HTTP_USE_GZIP'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$httpUseGzip = \\1/g" \
+              -e "s/@define\(\s*'RPC_TIME_OUT'\s*,\s*([0-9]*)\s*(,\s*(true|false)\s*)?\)/\$rpcTimeOut = \\1/g" \
+              -e "s/@define\(\s*'LOG_RPC_CALLS'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$rpcLogCalls = \\1/g" \
+              -e "s/@define\(\s*'LOG_RPC_FAULTS'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$rpcLogFaults = \\1/g" \
+              -e "s/@define\(\s*'PHP_USE_GZIP'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$phpUseGzip = \\1/g" \
+              -e "s/@define\(\s*'PHP_GZIP_LEVEL'\s*,\s*([0-9]*)\s*(,\s*(true|false)\s*)?\)/\$phpGzipLevel = \\1/g" \
+          ${RTORRENT_RC}
+        echo '  $throttleMaxSpeed = 327625*1024;	// DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!'  >> ${RTORRENT_RC}
+        echo "  // Can't be greater then 327625*1024 due to limitation in libtorrent ResourceManager::set_max_upload_unchoked function." >> ${RTORRENT_RC}
+        echo "  \$al_diagnostic = true; // Diagnose auto-loader. Set to \"false\" to make composer plugins work." >> ${RTORRENT_RC}
+        echo "  \$localHostedMode = false;		// Set to true if rTorrent is hosted on the SAME machine as ruTorrent" >> ${RTORRENT_RC}
+        echo "  \$cachedPluginLoading = false;		// Set to true to enable rapid cached loading of ruTorrent plugins" >> ${RTORRENT_RC}
+        echo "  \$enableCSRFCheck = false;		// If true then Origin and Referer will be checked" >> ${RTORRENT_RC}
+	      echo "  \$enabledOrigins = array();		// List of enabled domains for CSRF check (only hostnames, without protocols, port etc.)." >> ${RTORRENT_RC}
+        echo "  // If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST" >> ${RTORRENT_RC}
+    fi
+
     # Save the configuration file
     cp -ap -t "${TMP_DIR}" "${source_directory}/conf/config.php"
     if [ -f "${source_directory}/.htaccess" ]; then
@@ -240,6 +261,29 @@ is_not_defined_external_program()
     program=$1
     php -r "require_once('${RUTORRENT_WEB_DIR}/conf/config.php'); if (isset(\$pathToExternals['${program}']) && !empty(\$pathToExternals['${program}'])) { exit(1); } else { exit(0); }"
     return $?
+}
+
+is_not_defined_variable()
+{
+    local $variable_name=$1
+    php -r "require_once('${RUTORRENT_WEB_DIR}/conf/config.php'); if (isset(\$${variable_name})) { exit(1); } else { exit(0); }"
+    return $?
+}
+
+define_variable()
+{
+    local $variable_name="$1"
+    shift
+    local $value="$1"
+    shift
+    local $comment="$1"
+    shift
+    echo "\$${variable_name} = ${value}; // ${comment}" \
+        >> "${RUTORRENT_WEB_DIR}/conf/config.php"
+    while [ "$#" -ne 0 ]; do
+      echo "// $1" >> "${RUTORRENT_WEB_DIR}/conf/config.php"
+      shift
+    done
 }
 
 define_external_program()
@@ -336,6 +380,14 @@ service_restore ()
 
     if is_not_defined_external_program 'php'; then
         define_external_program 'php' '/bin/php' '/usr/bin/php'
+    fi
+    
+    if is_not_defined_variable 'enableCSRFCheck'; then
+      define_variable 'enableCSRFCheck' 'false' 'If true then Origin and Referer will be checked'
+    fi
+    
+    if is_not_defined_variable 'enabledOrigins'; then
+      define_variable 'enabledOrigins' 'array()' 'List of enabled domains for CSRF check (only hostnames, without protocols, port etc.).' 'If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST'
     fi
 
     if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 -a ! -f "${SYNOPKG_PKGVAR}/.dsm7_migrated" ]; then

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -223,7 +223,7 @@ service_save ()
         echo '  $throttleMaxSpeed = 327625*1024;	// DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!'  >> ${RTORRENT_RC}
         echo "  // Can't be greater then 327625*1024 due to limitation in libtorrent ResourceManager::set_max_upload_unchoked function." >> ${RTORRENT_RC}
         echo "  \$al_diagnostic = true; // Diagnose auto-loader. Set to \"false\" to make composer plugins work." >> ${RTORRENT_RC}
-        echo "  \$localHostedMode = false;		// Set to true if rTorrent is hosted on the SAME machine as ruTorrent" >> ${RTORRENT_RC}
+        echo "  \$localHostedMode = true;		// Set to false if rTorrent is NOT hosted on the SAME machine as ruTorrent" >> ${RTORRENT_RC}
         echo "  \$cachedPluginLoading = false;		// Set to true to enable rapid cached loading of ruTorrent plugins" >> ${RTORRENT_RC}
         echo "  \$enableCSRFCheck = false;		// If true then Origin and Referer will be checked" >> ${RTORRENT_RC}
 	      echo "  \$enabledOrigins = array();		// List of enabled domains for CSRF check (only hostnames, without protocols, port etc.)." >> ${RTORRENT_RC}

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -266,18 +266,18 @@ is_not_defined_external_program()
 
 is_not_defined_variable()
 {
-    local $variable_name=$1
+    local variable_name="$1"
     php -r "require_once('${RUTORRENT_WEB_DIR}/conf/config.php'); if (isset(\$${variable_name})) { exit(1); } else { exit(0); }"
     return $?
 }
 
 define_variable()
 {
-    local $variable_name="$1"
+    local variable_name="$1"
     shift
-    local $value="$1"
+    local value="$1"
     shift
-    local $comment="$1"
+    local comment="$1"
     shift
     echo "\$${variable_name} = ${value}; // ${comment}" \
         >> "${RUTORRENT_WEB_DIR}/conf/config.php"

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -1,9 +1,9 @@
 # Package
 PACKAGE="rutorrent"
 
-# Define python310 binary path
-PYTHON_DIR="/var/packages/python310/target/bin"
-# Add local bin, virtualenv along with python310 to the default PATH
+# Define python311 binary path
+PYTHON_DIR="/var/packages/python311/target/bin"
+# Add local bin, virtualenv along with python311 to the default PATH
 PATH="${SYNOPKG_PKGDEST}/env/bin:${SYNOPKG_PKGDEST}/bin:${SYNOPKG_PKGDEST}/usr/bin:${PYTHON_DIR}:${PATH}"
 # Others
 DSM6_WEB_DIR="/var/services/web"

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -218,6 +218,7 @@ service_save ()
               -e "s/@define\(\s*'LOG_RPC_FAULTS'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$rpcLogFaults = \\1/g" \
               -e "s/@define\(\s*'PHP_USE_GZIP'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$phpUseGzip = \\1/g" \
               -e "s/@define\(\s*'PHP_GZIP_LEVEL'\s*,\s*([0-9]*)\s*(,\s*(true|false)\s*)?\)/\$phpGzipLevel = \\1/g" \
+              -e "s|\\\$profilePath(\s*)=(\s*)'\\.\\./share'|\\\$profilePath\\1=\\2'../../share'|g" \
           ${RTORRENT_RC}
         echo '  $throttleMaxSpeed = 327625*1024;	// DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!'  >> ${RTORRENT_RC}
         echo "  // Can't be greater then 327625*1024 due to limitation in libtorrent ResourceManager::set_max_upload_unchoked function." >> ${RTORRENT_RC}

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -202,6 +202,7 @@ service_save ()
     if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ] && [ ! -f "${SYNOPKG_PKGVAR}/.dsm7_migrated" ]; then
       source_directory="${DSM6_WEB_DIR}/${PACKAGE}"
     fi
+    local ruTorrentConfigFile="${source_directory}/conf/config.php"
 
     # Revision 8 introduces backward incompatible changes
     if [ `echo "${SYNOPKG_OLD_PKGVER}" | sed -r "s/^.*-([0-9]+)$/\1/"` -le 8 ]; then
@@ -219,19 +220,19 @@ service_save ()
               -e "s/@define\(\s*'PHP_USE_GZIP'\s*,\s*(true|false)\s*(,\s*(true|false)\s*)?\)/\$phpUseGzip = \\1/g" \
               -e "s/@define\(\s*'PHP_GZIP_LEVEL'\s*,\s*([0-9]*)\s*(,\s*(true|false)\s*)?\)/\$phpGzipLevel = \\1/g" \
               -e "s|\\\$profilePath(\s*)=(\s*)'\\.\\./share'|\\\$profilePath\\1=\\2'../../share'|g" \
-          ${RTORRENT_RC}
-        echo '  $throttleMaxSpeed = 327625*1024;	// DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!'  >> ${RTORRENT_RC}
-        echo "  // Can't be greater then 327625*1024 due to limitation in libtorrent ResourceManager::set_max_upload_unchoked function." >> ${RTORRENT_RC}
-        echo "  \$al_diagnostic = true; // Diagnose auto-loader. Set to \"false\" to make composer plugins work." >> ${RTORRENT_RC}
-        echo "  \$localHostedMode = true;		// Set to false if rTorrent is NOT hosted on the SAME machine as ruTorrent" >> ${RTORRENT_RC}
-        echo "  \$cachedPluginLoading = false;		// Set to true to enable rapid cached loading of ruTorrent plugins" >> ${RTORRENT_RC}
-        echo "  \$enableCSRFCheck = false;		// If true then Origin and Referer will be checked" >> ${RTORRENT_RC}
-	      echo "  \$enabledOrigins = array();		// List of enabled domains for CSRF check (only hostnames, without protocols, port etc.)." >> ${RTORRENT_RC}
-        echo "  // If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST" >> ${RTORRENT_RC}
+          "${ruTorrentConfigFile}"
+        echo '  $throttleMaxSpeed = 327625*1024;	// DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!'  >> "${ruTorrentConfigFile}"
+        echo "  // Can't be greater then 327625*1024 due to limitation in libtorrent ResourceManager::set_max_upload_unchoked function." >> "${ruTorrentConfigFile}"
+        echo "  \$al_diagnostic = true; // Diagnose auto-loader. Set to \"false\" to make composer plugins work." >> "${ruTorrentConfigFile}"
+        echo "  \$localHostedMode = true;		// Set to false if rTorrent is NOT hosted on the SAME machine as ruTorrent" >> "${ruTorrentConfigFile}"
+        echo "  \$cachedPluginLoading = false;		// Set to true to enable rapid cached loading of ruTorrent plugins" >> "${ruTorrentConfigFile}"
+        echo "  \$enableCSRFCheck = false;		// If true then Origin and Referer will be checked" >> "${ruTorrentConfigFile}"
+	      echo "  \$enabledOrigins = array();		// List of enabled domains for CSRF check (only hostnames, without protocols, port etc.)." >> "${ruTorrentConfigFile}"
+        echo "  // If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST" >> "${ruTorrentConfigFile}"
     fi
 
     # Save the configuration file
-    cp -ap -t "${TMP_DIR}" "${source_directory}/conf/config.php"
+    cp -ap -t "${TMP_DIR}" "${ruTorrentConfigFile}"
     if [ -f "${source_directory}/.htaccess" ]; then
         cp -ap -t "${TMP_DIR}" "${source_directory}/.htaccess"
     fi
@@ -383,14 +384,6 @@ service_restore ()
         define_external_program 'php' '/bin/php' '/usr/bin/php'
     fi
     
-    if is_not_defined_variable 'enableCSRFCheck'; then
-      define_variable 'enableCSRFCheck' 'false' 'If true then Origin and Referer will be checked'
-    fi
-    
-    if is_not_defined_variable 'enabledOrigins'; then
-      define_variable 'enabledOrigins' 'array()' 'List of enabled domains for CSRF check (only hostnames, without protocols, port etc.).' 'If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST'
-    fi
-
     if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 -a ! -f "${SYNOPKG_PKGVAR}/.dsm7_migrated" ]; then
       touch "${SYNOPKG_PKGVAR}/.dsm7_migrated"
     fi


### PR DESCRIPTION
## Description

Upgrade rutorrent 3.10 to 4.1.5 + migrated to python 3.11

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)


### Type of change

- [x] Package update

### Testing

- [x] Upgrading 3.10 => 4.1.5

Binaries are available here: https://github.com/smaarn/spksrc/releases/tag/rutorrent-4.1.5-rc-1 
