### PR TITLE
Fix for #5600 depends conflicting with sub-dependencies cookies

### DIFF
--- a/cross/glib/Makefile
+++ b/cross/glib/Makefile
@@ -1,4 +1,4 @@
-PKG_NAME = glib
+PKG_NAME = glib-main
 
 HOMEPAGE = https://developer.gnome.org/glib/
 COMMENT  = General-purpose utility library.

--- a/cross/glibmm/Makefile
+++ b/cross/glibmm/Makefile
@@ -1,4 +1,4 @@
-PKG_NAME = glibmm
+PKG_NAME = glibmm-main
 
 HOMEPAGE = https://www.gtkmm.org/en/
 COMMENT  = GLib is a low-level general-purpose library used mainly by GTK+/GNOME applications, but is useful for other programs as well. glibmm is the C++ wrapper for GLib.

--- a/cross/libsigc++/Makefile
+++ b/cross/libsigc++/Makefile
@@ -1,4 +1,4 @@
-PKG_NAME = libsigc++
+PKG_NAME = libsigc++-main
 
 HOMEPAGE = http://libsigc.sourceforge.net/
 COMMENT  = libsigc++ implements a typesafe callback system for standard C++


### PR DESCRIPTION
## Description

Issue not encountered on github-action but does hapens on local builds using containers.  When processing dependencies it hapens a collision point where `glib` main cookie conflicts with sub-dependencies.  This lead to expectation that sub-dependency (e.g. `glib-latest`) is already download while it is not the case.

Fix is relatively simple and involves renaming main `cross/glib|glibmm|ligsigc++` so `PKG_NAME` variable always differs from sub-dependency.  Adding `-main` solves the issue:
```
PKG_NAME = glib-main
PKG_NAME = glibmm-main
PKG_NAME = libsigc++-main
```

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
