### PR TITLE
update meson build

### DIFF
--- a/mk/spksrc.cross-meson.mk
+++ b/mk/spksrc.cross-meson.mk
@@ -25,7 +25,7 @@ meson_configure_target:
 	@$(MSG)    - Build path = $(WORK_DIR)/$(PKG_DIR)/$(MESON_BUILD_DIR)
 	@$(MSG)    - Configure ARGS = $(CONFIGURE_ARGS)
 	@$(MSG)    - Install prefix = $(INSTALL_PREFIX)
-	cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV) meson $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS)
+	cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV) meson setup $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS)
 
 # call-up ninja build process
 include ../../mk/spksrc.cross-ninja.mk


### PR DESCRIPTION
- avoid WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.

### Type of change
- [x] Includes small framework changes
