### PR TITLE
Regression Fix : PKG_CONFIG_SYSROOT_DIR and TC_SYSROOT pre-requisite variables

### DIFF
--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -69,8 +69,7 @@ endif
 	echo "set(CMAKE_BUILD_WITH_INSTALL_RPATH $(CMAKE_BUILD_WITH_INSTALL_RPATH))" ; \
 	echo
 	@echo "# set pkg-config path" ; \
-	echo 'set(ENV{PKG_CONFIG_LIBDIR} "$(abspath $(PKG_CONFIG_LIBDIR))")' ; \
-	echo 'set(ENV{PKG_CONFIG_SYSROOT_DIR} "$(abspath $(INSTALL_DIR))")'
+	echo 'set(ENV{PKG_CONFIG_LIBDIR} "$(abspath $(PKG_CONFIG_LIBDIR))")'
 
 .PHONY: cmake_configure_target
 

--- a/mk/spksrc.tc-flags.mk
+++ b/mk/spksrc.tc-flags.mk
@@ -37,11 +37,11 @@ TC_PREFIX = $(TC_TARGET)-
 endif
 
 ifeq ($(strip $(TC_INCLUDE)),)
-TC_INCLUDE = $(abspath $(TC_SYSROOT)/usr/include)
+TC_INCLUDE = $(TC_SYSROOT)/usr/include
 endif
 
 ifeq ($(strip $(TC_LIBRARY)),)
-TC_LIBRARY = $(abspath $(TC_SYSROOT)/lib)
+TC_LIBRARY = $(TC_SYSROOT)/lib
 endif
 
 CFLAGS += -I$(abspath $(WORK_DIR)/$(TC_TARGET)/$(TC_INCLUDE)) $(TC_EXTRA_CFLAGS)


### PR DESCRIPTION
## Description

This PR solves two regressions introduced in #5658
1. In extremely rare case, mostly with software sources that doesn't fully respect CMAKE, including `PKG_CONFIG_SYSROOT_DIR` makes `intel-media-driver` fails. This `PKG_CONFIG_SYSROOT_DIR` is probably something to revisit.
2. Usage of `abspath` makes the `tc_vars.mk` clean and absent of any '//' and '../'.  Altough I had introduced it in pre-requisite variables leading to double-counting the toolchain path part of the generation of `*FLAGS` variables.  This was noticed only under `libraqm` part of ImageMagick build.

Follow-up to #5658

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
