### PR TITLE
rutorrent: fix volume customization in installation procedure and package dependencies

### DIFF
--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -27,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Remove no outdated resources</li><li>Fix missing dependency declaration on Apache 2.4</li><li>Fixed invalid handling of volume customization upon installation</li></ol>"
+CHANGELOG = "<ol><li>Remove no outdated resources</li><li>Fix missing dependency declaration on Apache 2.4</li><li>Fixed invalid handling of volume customization upon installation</li><li>Fix handling of watch directory by creating it if it does not exist.</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -27,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Remove no outdated resources</li><li>Fix missing dependency declaration on Apache 2.4</li><li>Fixed invalid handling of volume customization upon installation</li><li>Fix handling of watch directory by creating it if it does not exist.</li></ol>"
+CHANGELOG = "<ol><li>Remove outdated resources</li><li>Fix missing dependency declaration on Apache 2.4</li><li>Fixed invalid handling of volume customization upon installation</li><li>Fix handling of watch directory by creating it if it does not exist.</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = rutorrent
 SPK_VERS = 3.10
-SPK_REV = 13
+SPK_REV = 14
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
@@ -27,7 +27,7 @@ DESCRIPTION = ruTorrent is a front-end for the popular Bittorrent client rTorren
 ADMIN_URL = /rutorrent/
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "<ol><li>Update to Python 3.10</li><li>Update to PHP 7.4</li><li>Remove tools from procps-ng</li><li>Fix support of DSM 7.</li><li>Fix torrent creation wizard (\#5288)</li><li>Add service port declarations</li></ol>"
+CHANGELOG = "<ol><li>Remove no outdated resources</li><li>Fix missing dependency declaration on Apache 2.4</li><li>Fixed invalid handling of volume customization upon installation</li></ol>"
 
 HOMEPAGE = https://github.com/Novik/ruTorrent
 LICENSE = GPLv3

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -98,7 +98,3 @@ rutorrent_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var/.session
 	install -m 644 src/rtorrent.rc $(STAGING_DIR)/var/rtorrent.rc
 	install -m 775 -d $(STAGING_DIR)/tmp
-ifeq ($(call version_lt, $(TCVERSION), 7.0),1)
-	install -m 755 -d $(STAGING_DIR)/etc/php/conf.d/
-	install -m 644 src/etc/php/conf.d/com.synocommunity.rutorrent.ini $(STAGING_DIR)/etc/php/conf.d/com.synocommunity.rutorrent.ini
-endif

--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -4,7 +4,7 @@ SPK_REV = 13
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
-SPK_DEPENDS = "WebStation:python310:PHP7.4"
+SPK_DEPENDS = "WebStation:python310:PHP7.4:Apache2.4"
 WHEELS = src/requirements-pure.txt
 
 DEPENDS = cross/busybox cross/curl cross/mediainfo cross/rtorrent cross/rutorrent cross/screen cross/unzip

--- a/spk/rutorrent/src/conf/resource
+++ b/spk/rutorrent/src/conf/resource
@@ -1,10 +1,4 @@
 {
-    "php56": {
-		"php-ini": [{
-			"relpath": "etc/php/conf.d/com.synocommunity.rutorrent.ini",
-			"destpath": "/usr/local/etc/php56/conf.d"
-		}]
-    },
 	"webservice": {
 		"services": [{
 			"service": "rutorrent",

--- a/spk/rutorrent/src/etc/php/conf.d/com.synocommunity.rutorrent.ini
+++ b/spk/rutorrent/src/etc/php/conf.d/com.synocommunity.rutorrent.ini
@@ -1,3 +1,0 @@
-
-[PATH=/var/services/web/rutorrent/]
-open_basedir = Null

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -80,12 +80,6 @@ fix_shared_folders_rights()
 
 service_postinst ()
 {
-    if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
-      if [ -n "${wizard_watch_dir}" ]; then
-          mkdir -p "${wizard_download_dir}${wizard_watch_dir}"
-      fi
-    fi
-
     # Install busybox stuff
     "${SYNOPKG_PKGDEST}/bin/busybox" --install "${SYNOPKG_PKGDEST}/bin"
 
@@ -114,8 +108,7 @@ service_postinst ()
 
     # Configure files
     if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
-        local effective_download_dir="${wizard_download_volume:=/volume1}/${wizard_download_share:=downloads}"
-        TOP_DIR=`echo "${effective_download_dir}" | cut -d "/" -f 2`
+        TOP_DIR=`echo "${wizard_download_dir}" | cut -d "/" -f 2`
         MAX_MEMORY=`awk '/MemTotal/{memory=$2*1024*0.25; if (memory > 512*1024*1024) memory=512*1024*1024; printf "%0.f", memory}' /proc/meminfo`
 
         sed -i -e "s|scgi_port = 5000;|scgi_port = ${SERVICE_PORT};|g" \
@@ -132,13 +125,13 @@ service_postinst ()
                -e "s|\"php\"\(\\s*\)=>\(\\s*\)'.*'\(\\s*\),\(\\s*\)|\"php\"\1=>\2'/bin/php'\3,\4|g" \
                "${RUTORRENT_WEB_DIR}/conf/config.php"
 
-        sed -i -e "s|@download_dir@|${effective_download_dir}|g" \
+        sed -i -e "s|@download_dir@|${wizard_download_dir}|g" \
                -e "s|@max_memory@|$MAX_MEMORY|g" \
                -e "s|@service_port@|${SERVICE_PORT}|g" \
                "${RTORRENT_RC}"
 
-        if [ -d "${wizard_watch_dir}" ]; then
-            local effective_watch_dir="${effective_download_dir}/${wizard_watch_dir}"
+        if [ -n "${wizard_watch_dir}" ]; then
+            local effective_watch_dir="${wizard_download_dir}${wizard_watch_dir}"
             mkdir -p "${effective_watch_dir}"
             sed -i -e "s|@watch_dir@|${effective_watch_dir}|g" ${RTORRENT_RC}
         else

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -82,7 +82,7 @@ service_postinst ()
 {
     if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
       if [ -n "${wizard_watch_dir}" ]; then
-          mkdir -p "${wizard_watch_dir}"
+          mkdir -p "${wizard_download_dir}${wizard_watch_dir}"
       fi
     fi
 

--- a/spk/rutorrent/src/service-setup.sh
+++ b/spk/rutorrent/src/service-setup.sh
@@ -34,18 +34,6 @@ SVC_WRITE_PID=y
 
 SERVICE_COMMAND="env RUTORRENT_WEB_DIR=${RUTORRENT_WEB_DIR} SYNOPKG_PKGVAR=${SYNOPKG_PKGVAR} SYNOPKG_PKGDEST=${SYNOPKG_PKGDEST} ${SERVICE_COMMAND}"
 
-validate_preinst ()
-{
-    if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
-        if [ -n "${wizard_watch_dir}" -a ! -d "${wizard_watch_dir}" ]; then
-            echo "Watch directory ${wizard_watch_dir} does not exist."
-            exit 1
-        fi
-    fi
-
-    return 0
-}
-
 check_acl()
 {
     acl_path=$1
@@ -92,6 +80,12 @@ fix_shared_folders_rights()
 
 service_postinst ()
 {
+    if [ "${SYNOPKG_PKG_STATUS}" == "INSTALL" ]; then
+      if [ -n "${wizard_watch_dir}" ]; then
+          mkdir -p "${wizard_watch_dir}"
+      fi
+    fi
+
     # Install busybox stuff
     "${SYNOPKG_PKGDEST}/bin/busybox" --install "${SYNOPKG_PKGDEST}/bin"
 

--- a/spk/rutorrent/src/wizard_templates/install_uifile.sh
+++ b/spk/rutorrent/src/wizard_templates/install_uifile.sh
@@ -14,7 +14,7 @@ wizard_download_volume_validator()
   jsonify "{
   var value = arguments[0];
   var step = arguments[2];
-  step.items.map['wizard_download_dir'].setValue('/' + value + '/' + step.items.map['wizard_download_volume'].value);
+  step.items.map['wizard_download_dir'].setValue('/' + value + '/' + step.items.map['wizard_download_share'].value);
   return true;
 }"
 }

--- a/spk/rutorrent/src/wizard_templates/install_uifile.sh
+++ b/spk/rutorrent/src/wizard_templates/install_uifile.sh
@@ -4,7 +4,7 @@ wizard_download_share_validator()
   jsonify "{
   var value = arguments[0];
   var step = arguments[2];
-  step.items.map['wizard_download_dir'].setValue('/' + step.items.map['wizard_download_volume'].value + '/' + value + '/');
+  step.items.map['wizard_download_dir'].setValue(step.items.map['wizard_download_volume'].value + '/' + value + '/');
   return true;
 }"
 }
@@ -14,7 +14,7 @@ wizard_download_volume_validator()
   jsonify "{
   var value = arguments[0];
   var step = arguments[2];
-  step.items.map['wizard_download_dir'].setValue('/' + value + '/' + step.items.map['wizard_download_share'].value + '/');
+  step.items.map['wizard_download_dir'].setValue(value + '/' + step.items.map['wizard_download_share'].value + '/');
   return true;
 }"
 }

--- a/spk/rutorrent/src/wizard_templates/install_uifile.sh
+++ b/spk/rutorrent/src/wizard_templates/install_uifile.sh
@@ -4,7 +4,7 @@ wizard_download_share_validator()
   jsonify "{
   var value = arguments[0];
   var step = arguments[2];
-  step.items.map['wizard_download_dir'].setValue(step.items.map['wizard_download_volume'].value + '/' + value);
+  step.items.map['wizard_download_dir'].setValue('/' + step.items.map['wizard_download_volume'].value + '/' + value + '/');
   return true;
 }"
 }
@@ -14,7 +14,7 @@ wizard_download_volume_validator()
   jsonify "{
   var value = arguments[0];
   var step = arguments[2];
-  step.items.map['wizard_download_dir'].setValue('/' + value + '/' + step.items.map['wizard_download_share'].value);
+  step.items.map['wizard_download_dir'].setValue('/' + value + '/' + step.items.map['wizard_download_share'].value + '/');
   return true;
 }"
 }


### PR DESCRIPTION
## Description

This is fixing basically installation related concerns:

* When customizing the volume an invalid value was defined for the full path of the download location
* There were left over files from the previous PHP integration (5.6)
* Apache 2.4 dependency wasn't explicitely declared
* Watch dir configuration wasn't appropriately supported

Should fix #5668 

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)


### Type of change

- [x] Bug fix
