### PR TITLE
deluge: Add chardet as yarss2 plugin dependency

### DIFF
--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = deluge
 SPK_VERS = 2.1.1
-SPK_REV = 18
+SPK_REV = 19
 SPK_ICON = src/deluge.png
 
 BUILD_DEPENDS = cross/python310
@@ -15,7 +15,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = Deluge is a cross platform BitTorrent client, based on libtorrent rasterbar. This package integrates both the deluge deamon \(deluged\), as well as its web counterpart \(deluge-web\), which serves the deluge web UI.
 DESCRIPTION_FRE = Deluge est un client BitTorrent multi-plateforme, basé sur libtorrent rasterbar. Ce paquet intègre à la fois le démon deluge \(deluged\) ainsi que son penchant web \(deluge-web\), desservant l\'interface utilisateur web deluge.
 STARTABLE = yes
-CHANGELOG = "1. Update to libtorrent DSM7-2.0.8 and DSM6-1.2.18<br/>2. Update to OpenSSL 1.1.1s<br/>3. Fix Error: skipping tracker announce (unreachable)<br/>4. Enable debug_info mode level 3 for DSM6 builds<br/>5. Fix issue with special characters on DSM7"
+CHANGELOG = "1. Update to libtorrent DSM7-2.0.8 and DSM6-1.2.18<br/>2. Update to OpenSSL 1.1.1s<br/>3. Fix Error: skipping tracker announce (unreachable)<br/>4. Enable debug_info mode level 3 for DSM6 builds<br/>5. Fix issue with special characters on DSM7<br/>Include chardet wheel for yarss2 plugin"
 DISPLAY_NAME = Deluge
 
 HOMEPAGE = https://deluge-torrent.org

--- a/spk/deluge/src/requirements-pure.txt
+++ b/spk/deluge/src/requirements-pure.txt
@@ -7,6 +7,7 @@ deluge==2.1.1
 # Other requirements
 attrs==22.2.0
 Automat==22.10.0
+chardet==5.1.0
 constantly==15.1.0
 #distlib==0.3.4     ==> python310
 #filelock==3.6.0    ==> python310


### PR DESCRIPTION
## Description

deluge: Add chardet as yarss2 plugin dependency

Fixes #5674

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
