### PR TITLE
Framework: Update dotnet 6.0 exclusions

### DIFF
--- a/mk/spksrc.archs.mk
+++ b/mk/spksrc.archs.mk
@@ -60,12 +60,12 @@ DOTNET_UNSUPPORTED_ARCHS += $(SRM_ARMv7_ARCHS)
 
 # Exclusions for dotnet 6.0 core apps
 ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370 alpine alpine4k
     UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1 armv7-1.2
 endif
 
 # Exclusions for dotnet 6.0 servarr apps (except x86)
 ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine alpine4k
     UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1 armv7-1.2
 endif


### PR DESCRIPTION
## Description

This is a follow-on from #5602 and adds the exclusions for `alpine` and `alpine4k` based on investigation in https://github.com/SynoCommunity/spksrc/issues/5302#issuecomment-1487986989 and https://github.com/SynoCommunity/spksrc/issues/5574#issuecomment-1488478681.

Fixes # <!--Optionally, add links to existing issues or other PR's-->
Closes #5302
Closes #4546

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
