### PR TITLE
native/nodejs: update to active LTS version (and update filebrowser)

### DIFF
--- a/cross/filebrowser/Makefile
+++ b/cross/filebrowser/Makefile
@@ -1,10 +1,10 @@
 PKG_NAME = filebrowser
-PKG_VERS = 2.22.4
+PKG_VERS = 2.23.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/filebrowser/$(PKG_NAME)/archive
+PKG_DIST_SITE = https://github.com/filebrowser/filebrowser/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIR =  $(PKG_NAME)-$(PKG_VERS)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 BUILD_DEPENDS = native/go native/nodejs
 
@@ -21,6 +21,9 @@ PRE_COMPILE_TARGET = filebrowser_pre_compile
 include ../../mk/spksrc.cross-go.mk
 
 ENV += PATH=$(realpath $(WORK_DIR)/../../../native/nodejs/work-native/node/bin):$(realpath $(WORK_DIR)/../../../native/go/work-native/go/bin):$(PATH)
+
+# avoid webpack error ERR_OSSL_EVP_UNSUPPORTED with nodejs 18
+ENV += NODE_OPTIONS=--openssl-legacy-provider
 
 .PHONY: filebrowser_pre_compile
 filebrowser_pre_compile:

--- a/cross/filebrowser/digests
+++ b/cross/filebrowser/digests
@@ -1,3 +1,3 @@
-filebrowser-2.22.4.tar.gz SHA1 70ddd3a668cb1df61e5ad383311e2e288b39e22a
-filebrowser-2.22.4.tar.gz SHA256 511f0e200c4c2c3851f92d1090804a67ed425a8290493a70af49aea93c229d91
-filebrowser-2.22.4.tar.gz MD5 7102e60822b2520fa00074ce8efdbc98
+filebrowser-2.23.0.tar.gz SHA1 cb0e8de9df868a93c652a1c284ec5d01c683ca88
+filebrowser-2.23.0.tar.gz SHA256 9a99f0c51114ff7e3df89190729a8ca1c0ed48c491a5c6f9d9e266eb6657898d
+filebrowser-2.23.0.tar.gz MD5 23af5ddafe8564af1ad64111bdbd8dd2

--- a/native/nodejs/Makefile
+++ b/native/nodejs/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = nodejs
 # https://nodejs.org/en/about/releases/
-# v16 is Active LTS Version "Gallium" from 2021-10-26 to 2022-10-18 with EOL at 2024-04-30
-PKG_VERS = 16.15.1
+# v18 is active LTS Version "Hydrogen" from 2022-10-25 to 2023-10-18 with EOL at 2025-04-30
+PKG_VERS = 18.15.0
 PKG_EXT = tar.xz
 PKG_DIST_NAME = node-v$(PKG_VERS)-linux-x64.$(PKG_EXT)
 PKG_DIST_SITE = https://nodejs.org/dist/v$(PKG_VERS)

--- a/native/nodejs/digests
+++ b/native/nodejs/digests
@@ -1,3 +1,3 @@
-node-v16.15.1-linux-x64.tar.xz SHA1 b0aaa51d02aa4e94bdce37a0cac054591034322f
-node-v16.15.1-linux-x64.tar.xz SHA256 b749f7a76e56dfd6dfb8a910b8a2a871159661557680aa95acf13c9514422c12
-node-v16.15.1-linux-x64.tar.xz MD5 daac0e498f44fd04b60a9d8fe62a50dd
+node-v18.15.0-linux-x64.tar.xz SHA1 d48194e3dda2794f9031963cfeea30f51c70059b
+node-v18.15.0-linux-x64.tar.xz SHA256 c8c5fa53ce0c0f248e45983e86368e0b1daf84b77e88b310f769c3cfc12682ef
+node-v18.15.0-linux-x64.tar.xz MD5 bd769e5856565976fbea53d9720e51a3

--- a/spk/filebrowser/Makefile
+++ b/spk/filebrowser/Makefile
@@ -1,9 +1,10 @@
 SPK_NAME = filebrowser
-SPK_VERS =  2.22.4
-SPK_REV = 2
+SPK_VERS = 2.23.0
+SPK_REV = 3
 SPK_ICON = src/filebrowser.png
 
-DEPENDS = cross/$(SPK_NAME)
+DEPENDS = cross/filebrowser
+
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 
 MAINTAINER = publicarray
@@ -12,7 +13,7 @@ DESCRIPTION = filebrowser provides a file managing interface within a specified 
 HOMEPAGE = https://filebrowser.org/
 HELPURL = https://github.com/filebrowser/filebrowser/issues
 LICENSE = Apache 2.0
-CHANGELOG = "1. Update filebrowser to v2.22.4.<br/>2. Built with go v1.18.6 and node v16.15.1."
+CHANGELOG = "1. Update filebrowser to v2.23.0.<br/>2. Built with go v1.19.5 and node v18.15.0."
 
 GROUP = synocommunity
 


### PR DESCRIPTION
## Description

So far native/nodejs is used to build the following packages

- jellyfin
- gitea
- filebrowser

filebrowser has an issue that is fixed here (while updating filebrowser to the latest version)

packages under development that depend on native/nodejs are
- navidrome #5376
- node-red #5407 

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Package update
