### PR TITLE
Jellyfin: Update to v10.8.10

### DIFF
--- a/cross/jellyfin-web/Makefile
+++ b/cross/jellyfin-web/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin-web
-PKG_VERS = 10.8.9
+PKG_VERS = 10.8.10
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin-web/archive

--- a/cross/jellyfin-web/digests
+++ b/cross/jellyfin-web/digests
@@ -1,3 +1,3 @@
-jellyfin-web-10.8.9.tar.gz SHA1 bbef3f4865190e0005123c42c61609137537956b
-jellyfin-web-10.8.9.tar.gz SHA256 3b0909aa2b7e44e7efd3cc65210bb1f024330affaa65cc6604631600f2c5bfb6
-jellyfin-web-10.8.9.tar.gz MD5 3f658c7eccb288726c103b71288652cd
+jellyfin-web-10.8.10.tar.gz SHA1 6a6040c97fc4391c1c1d668afd175528e65f8c31
+jellyfin-web-10.8.10.tar.gz SHA256 0ed8adc9d451d69cda26ec3a8d8a5baa6f1cb3788d3f4649c435dc19bdd20b8e
+jellyfin-web-10.8.10.tar.gz MD5 c2ac00b7183eccddc62f8f939ad519dd

--- a/cross/jellyfin/Makefile
+++ b/cross/jellyfin/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin
-PKG_VERS = 10.8.9
+PKG_VERS = 10.8.10
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin/archive

--- a/cross/jellyfin/digests
+++ b/cross/jellyfin/digests
@@ -1,3 +1,3 @@
-jellyfin-10.8.9.tar.gz SHA1 be815f29adf153131d093fbcdf50fbb75bdbf78e
-jellyfin-10.8.9.tar.gz SHA256 374840a1e134f4c33660837289a5248cf6d88fe4f706385af12f7a8b6ccb6f0a
-jellyfin-10.8.9.tar.gz MD5 fda4d2ae96035423735c3e59b9b9927f
+jellyfin-10.8.10.tar.gz SHA1 9b1db92926b78f685840f348e90779c8fb0073b3
+jellyfin-10.8.10.tar.gz SHA256 a5412ae7a2470b90b51c77aee851aa1c95aaf4a51f1c830c254dc9a0cf9d0bd9
+jellyfin-10.8.10.tar.gz MD5 fff31dc0ba2eb6d484592acd08fe725d

--- a/native/dotnet-sdk-6.0/Makefile
+++ b/native/dotnet-sdk-6.0/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = dotnet-sdk-6.0
-# Version 6.0.13, SDK 6.0.405
+# Version 6.0.16, SDK 6.0.408
 # https://dotnet.microsoft.com/download/dotnet/6.0
-PKG_VERS = 6.0.405
+PKG_VERS = 6.0.408
 PKG_EXT = tar.gz
 PKG_DIST_NAME = dotnet-sdk-$(PKG_VERS)-linux-x64.$(PKG_EXT)
 PKG_DIST_SITE = https://dotnetcli.azureedge.net/dotnet/Sdk/${PKG_VERS}

--- a/native/dotnet-sdk-6.0/digests
+++ b/native/dotnet-sdk-6.0/digests
@@ -1,3 +1,3 @@
-dotnet-sdk-6.0.405-linux-x64.tar.gz SHA1 5ece002217a1ffbdc5199aa352f6769ea8f0cd89
-dotnet-sdk-6.0.405-linux-x64.tar.gz SHA256 ed25798626ba88d1912f5d018de46c5c961726dce8988e0dcd6a311bf0ed7403
-dotnet-sdk-6.0.405-linux-x64.tar.gz MD5 7224a7aff9efd2b07d72ace0e11ad4f2
+dotnet-sdk-6.0.408-linux-x64.tar.gz SHA1 e062d2bf048593bca4f3c526604f24e98459d2e1
+dotnet-sdk-6.0.408-linux-x64.tar.gz SHA256 1430024c646db07f97c102db12242f8eb140fa992eac5ff4480dc0228164eace
+dotnet-sdk-6.0.408-linux-x64.tar.gz MD5 62057726a8e83e11a6a3709ebf083099

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -6,6 +6,7 @@ SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
 
+OPTIONAL_DEPENDS = cross/libstdc++
 DEPENDS = cross/jellyfin cross/jellyfin-web
 
 # x64 and armv8 archs are supported only.

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -6,7 +6,7 @@ SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
 
-DEPENDS = cross/libstdc++ cross/libicu cross/jellyfin cross/jellyfin-web
+DEPENDS = cross/jellyfin cross/jellyfin-web
 
 # x64 and armv8 archs are supported only.
 UNSUPPORTED_ARCHS = $(32bit_ARCHS)
@@ -15,7 +15,7 @@ MAINTAINER = stevenliuit
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "1. Update jellyfin to 10.8.10<br/>2. Update dotnet to 6.0.16.<br/>3. Add dotnet dependencies for DSM 7.2."
+CHANGELOG = "1. Update jellyfin to 10.8.10<br/>2. Update dotnet to 6.0.16.<br/>3. Fix dotnet dependencies for DSM 7.2."
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html
@@ -36,4 +36,18 @@ SERVICE_PORT_TITLE = Jellyfin (HTTP)
 # Admin link
 ADMIN_PORT = $(SERVICE_PORT)
 
+include ../../mk/spksrc.common.mk
+ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
+# we do not only need the updated libstdc++ library, we also need to
+# adjust the library search path for jellyfin to use this version.
+DEPENDS += cross/libstdc++
+POST_STRIP_TARGET = jellyfin_patch_target
+endif
+
 include ../../mk/spksrc.spk.mk
+
+.PHONY: jellyfin_patch_target
+# Set library path to use bundled libstdc++
+jellyfin_patch_target:
+	@$(MSG) "Set library runpath in jellyfin executable."
+	@patchelf --set-rpath /var/packages/$(SPK_NAME)/target/lib $(STAGING_DIR)/share/$(SPK_NAME)

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
-SPK_VERS = 10.8.9
-SPK_REV = 9
+SPK_VERS = 10.8.10
+SPK_REV = 10
 SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
@@ -15,7 +15,7 @@ MAINTAINER = stevenliuit
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "1. Update jellyfin to 10.8.9<br/>2. Update dotnet to 6.0.13<br/>3. Remove support for 32-bit archs."
+CHANGELOG = "1. Update jellyfin to 10.8.10<br/>2. Update dotnet to 6.0.16."
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -6,7 +6,7 @@ SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
 
-DEPENDS = cross/libstdc++ cross/jellyfin cross/jellyfin-web
+DEPENDS = cross/libstdc++ cross/libicu cross/jellyfin cross/jellyfin-web
 
 # x64 and armv8 archs are supported only.
 UNSUPPORTED_ARCHS = $(32bit_ARCHS)
@@ -15,7 +15,7 @@ MAINTAINER = stevenliuit
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "1. Update jellyfin to 10.8.10<br/>2. Update dotnet to 6.0.16."
+CHANGELOG = "1. Update jellyfin to 10.8.10<br/>2. Update dotnet to 6.0.16.<br/>3. Add dotnet dependencies for DSM 7.2."
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html

--- a/spk/jellyfin/src/service-setup.sh
+++ b/spk/jellyfin/src/service-setup.sh
@@ -10,7 +10,7 @@ JELLYFIN_ARGS="--service \
  -w ${SYNOPKG_PKGDEST}/web \
  --ffmpeg /var/packages/ffmpeg/target/bin/ffmpeg"
 
-SERVICE_COMMAND="env LD_LIBRARY_PATH=${SYNOPKG_PKGDEST}/lib ${SYNOPKG_PKGDEST}/share/jellyfin ${JELLYFIN_ARGS}"
+SERVICE_COMMAND="${SYNOPKG_PKGDEST}/share/jellyfin ${JELLYFIN_ARGS}"
 
 SVC_BACKGROUND=y
 SVC_WRITE_PID=y


### PR DESCRIPTION
## Description

This PR includes the following:

1. Update jellyfin to 10.8.10 (Stable hotfix release for 10.8.z release branch)
2. Update dotnet to 6.0.16 (Security patch)
3. Fix dotnet dependencies for DSM 7.2

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Package update
