### PR TITLE
Framework: Amend publish validation check

### DIFF
--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -439,9 +439,9 @@ endif
 	response_code=$$(echo "$$response" | grep -Fi "HTTP/1.1" | awk '{print $$2}'); \
 	if [ "$$response_code" = "201" ]; then \
 		output=$$(echo "$$response" | awk '/^[[:space:]]*$$/ {p=1;next} p'); \
-		echo -e "Package published successfully\n$$output" | tee --append publish-$*.log; \
+		echo "Package published successfully\n$$output" | tee --append publish-$*.log; \
 	else \
-		echo -e "ERROR: Failed to publish package - HTTP response code $$response_code\n$$output" | tee --append publish-$*.log; \
+		echo "ERROR: Failed to publish package - HTTP response code $$response_code\n$$output" | tee --append publish-$*.log; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
## Description

This is a follow-on from #5701 to remove the `-e` option for echo which is not POSIX compliant.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
