### PR TITLE
rTorrent: improve session saving support

### DIFF
--- a/spk/rutorrent/src/rtorrent.rc
+++ b/spk/rutorrent/src/rtorrent.rc
@@ -13,3 +13,5 @@ dht.mode.set = auto
 dht.port.set = 6881
 protocol.pex.set= yes
 port_range = 6881-6999
+schedule2 = session_save, 1200, 3600, ((session.save))
+method.set_key = event.download.inserted, 2_save_session, ((d.save_full_session))


### PR DESCRIPTION
## Description

This commit improves session saving support for rTorrent to prevent unnecessary loss of torrent files. It also increases the session saving interval from 20 minutes to 1 hour to reduce disk i/o usage with thousands of torrents. Session saving is a very intensive task that can take minutes. Torrents fail to save into session by default when added and can be lost if a crash occurs between saving intervals. These two fixes improve the performance and stability of the rTorrent client.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
