### PR TITLE
openssl3: update to v3.1.0

### DIFF
--- a/cross/openssl3/Makefile
+++ b/cross/openssl3/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl3
-PKG_VERS = 3.0.7
+PKG_VERS = 3.1.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = openssl-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source
@@ -7,15 +7,20 @@ PKG_DIR = openssl-$(PKG_VERS)
 
 DEPENDS = cross/zlib
 
-# atomic operations are not supported on ARMv5 and PPC archs except qoriq.
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
-
 HOMEPAGE = https://www.openssl.org
 COMMENT  = TLS/SSL and crypto library.
 LICENSE  = Apache-2.0
 
 CONFIGURE_TARGET = openssl3_configure
-INSTALL_TARGET = openssl3_install
+INSTALL_MAKE_OPTIONS = install_sw DESTDIR=$(INSTALL_DIR)
+
+CONFIGURE_ARGS  = --prefix=$(INSTALL_PREFIX)
+CONFIGURE_ARGS += --openssldir=$(OPENSSL_DATA_DIR)
+CONFIGURE_ARGS += zlib-dynamic
+CONFIGURE_ARGS += shared
+CONFIGURE_ARGS += no-tests
+# avoid multilib postfix (like lib64 for 64-bit archs):
+CONFIGURE_ARGS += --libdir=lib
 
 include ../../mk/spksrc.cross-cc.mk
 
@@ -23,37 +28,45 @@ include ../../mk/spksrc.cross-cc.mk
 # OpenSSL data area, such as openssl.cnf, certificates and keys.
 OPENSSL_DATA_DIR=/etc/ssl
 
-# Map ARCH to arch expected by openssl Configure
-OPENSSL_ARCH =
+# Map ARCH to platform expected by openssl Configure
+OPENSSL_PLATFORM =
 
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
-OPENSSL_ARCH = linux-x86_64
+OPENSSL_PLATFORM = linux-x86_64
 endif
 ifeq ($(findstring $(ARCH),$(i686_ARCHS)),$(ARCH))
-OPENSSL_ARCH = linux-x86
+OPENSSL_PLATFORM = linux-x86
 endif
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
-OPENSSL_ARCH = linux-armv4 -march=armv5
+OPENSSL_PLATFORM = linux-armv4
+CONFIGURE_ARGS += -march=armv5
+# threads need libatomic that is missing in ARMv5 toolchain
+CONFIGURE_ARGS += no-threads
 endif
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
-OPENSSL_ARCH = linux-armv4
+OPENSSL_PLATFORM = linux-armv4
 endif
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
-OPENSSL_ARCH = linux-aarch64
+OPENSSL_PLATFORM = linux-aarch64
+ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
+# asm of gcc for DSM<7 does not support ".arch	armv8.2-a+crypto"
+CONFIGURE_ARGS += no-asm
+endif
 endif
 ifeq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
-OPENSSL_ARCH = linux-ppc
+OPENSSL_PLATFORM = linux-ppc
+CONFIGURE_ARGS += no-asm
+ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
+# threads need libatomic that is missing in OLD_PPC_ARCHS toolchains
+CONFIGURE_ARGS += no-threads
+endif
 endif
 
-ifeq ($(strip $(OPENSSL_ARCH)),)
+ifeq ($(strip $(OPENSSL_PLATFORM)),)
 # Unexpected CPU architecture. Please add arch to mk/spksrc.archs.mk
 $(error Arch $(ARCH) not expected yet)
 endif
 
 .PHONY: openssl3_configure
 openssl3_configure:
-	$(RUN) ./Configure --openssldir=$(OPENSSL_DATA_DIR) --prefix=$(INSTALL_PREFIX) --libdir=lib $(OPENSSL_ARCH) zlib-dynamic shared threads
-
-.PHONY: openssl3_install
-openssl3_install:
-	$(RUN) $(MAKE) install_sw DESTDIR=$(INSTALL_DIR)
+	$(RUN) ./Configure $(OPENSSL_PLATFORM) $(CONFIGURE_ARGS)

--- a/cross/openssl3/digests
+++ b/cross/openssl3/digests
@@ -1,3 +1,3 @@
-openssl-3.0.7.tar.gz SHA1 f20736d6aae36bcbfa9aba0d358c71601833bf27
-openssl-3.0.7.tar.gz SHA256 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
-openssl-3.0.7.tar.gz MD5 545478ce41b96bf3beacb4dc58b36c77
+openssl-3.1.0.tar.gz SHA1 323b175eda887b33fb23f5806ef307b4dda2df00
+openssl-3.1.0.tar.gz SHA256 aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
+openssl-3.1.0.tar.gz MD5 f6c520aa2206d4d1fa71ea30b5e9a56d

--- a/cross/openssl3/patches/aarch64-6.1/001-fix-asm-arch-for-old-gcc.patch
+++ b/cross/openssl3/patches/aarch64-6.1/001-fix-asm-arch-for-old-gcc.patch
@@ -1,0 +1,25 @@
+# fix march for older gcc for aarch64
+# - downgrade to use armv8-a instead of armv8.2-a for ASM sources
+# 
+--- crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl.orig	2023-03-14 12:59:07.000000000 +0000
++++ crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl	2023-05-14 15:18:21.261988014 +0000
+@@ -174,7 +174,7 @@
+ 
+ #if __ARM_MAX_ARCH__>=8
+ ___
+-$code.=".arch   armv8.2-a+crypto\n.text\n";
++$code.=".arch   armv8-a+crypto\n.text\n";
+ 
+ $input_ptr="x0";  #argument block
+ $bit_length="x1";
+--- crypto/sm3/asm/sm3-armv8.pl.orig	2023-03-14 12:59:07.000000000 +0000
++++ crypto/sm3/asm/sm3-armv8.pl	2023-05-14 15:07:33.531335243 +0000
+@@ -109,7 +109,7 @@
+ 
+ $code=<<___;
+ #include "arm_arch.h"
+-.arch	armv8.2-a
++.arch	armv8-a
+ .text
+ ___
+ 

--- a/cross/openssl3/patches/aarch64-6.1/001-fix-asm-arch-for-old-gcc.patch
+++ b/cross/openssl3/patches/aarch64-6.1/001-fix-asm-arch-for-old-gcc.patch
@@ -1,6 +1,9 @@
 # fix march for older gcc for aarch64
 # - downgrade to use armv8-a instead of armv8.2-a for ASM sources
 # 
+# this patch will get obsolete, when https://github.com/openssl/openssl/pull/20967 
+# is merged into a future release
+# 
 --- crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl.orig	2023-03-14 12:59:07.000000000 +0000
 +++ crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl	2023-05-14 15:18:21.261988014 +0000
 @@ -174,7 +174,7 @@


### PR DESCRIPTION
## Description

As openssl 1.1.1 will be EOL in a few months, it is time to provide a openssl v3 package for all archs.

_OpenSSL 1.1.1 was released on 11th September 2018, and so it will be considered EOL on 11th September 2023. It will no longer be receiving publicly available security fixes after that date._

Currently all of the spk packages depending on openssl use version 1.1.1.
Shortly I will provide an update of erlang that supports openssl v3.
Since openssl v1.1 and v3 have some differences in the API it will take some time, until all packages and their dependencies are updated (if ever).

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Library update
