### PR TITLE
cloudflared: update to 2023.5.1

### DIFF
--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2023.3.1
+PKG_VERS = 2023.5.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive

--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2023.5.0
+PKG_VERS = 2023.5.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2023.3.1.tar.gz SHA1 15b934fcd873bf8294c84a3e3b87e2f4fa5d8a22
-cloudflared-2023.3.1.tar.gz SHA256 cdd0f02fc4170842c8210db2b700bad88d8a7b5d00fb8f7336073737f11fc718
-cloudflared-2023.3.1.tar.gz MD5 6a49d6ccb64ea81eb7e49d4dd50dcff1
+cloudflared-2023.5.0.tar.gz SHA1 106da27abf53965270a1626a929506ba17cff80e
+cloudflared-2023.5.0.tar.gz SHA256 38d72e35fbb894c43161ee7c6871c44d9771bc9a1f3bc54602baf66e69acefd3
+cloudflared-2023.5.0.tar.gz MD5 adbdfbf248b118df1b19fd361105f4f5

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2023.5.0.tar.gz SHA1 106da27abf53965270a1626a929506ba17cff80e
-cloudflared-2023.5.0.tar.gz SHA256 38d72e35fbb894c43161ee7c6871c44d9771bc9a1f3bc54602baf66e69acefd3
-cloudflared-2023.5.0.tar.gz MD5 adbdfbf248b118df1b19fd361105f4f5
+cloudflared-2023.5.1.tar.gz SHA1 3d03b6143c8526b070514742e7e00e97dc89c883
+cloudflared-2023.5.1.tar.gz SHA256 ee2c2a4b0c290c39475f79ab74972dfbce817df8e5090813cad0e58f33836194
+cloudflared-2023.5.1.tar.gz MD5 a70041c8e1a5dab20451a36823faa13f

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2023.3.1
-SPK_REV = 7
+SPK_VERS = 2023.5.0
+SPK_REV = 8
 SPK_ICON = src/cloudflared.png
 DSM_UI_DIR = app
 
@@ -12,7 +12,7 @@ DISPLAY_NAME = cloudflared
 DESCRIPTION = Cloudflare Tunnel client (formerly Argo Tunnel).
 HOMEPAGE = https://github.com/cloudflare/cloudflared
 LICENSE = Apache-2.0
-CHANGELOG = "Update to 2023.3.1"
+CHANGELOG = "Update to 2023.5.0"
 
 WIZARDS_DIR = src/wizard/
 

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2023.5.0
+SPK_VERS = 2023.5.1
 SPK_REV = 8
 SPK_ICON = src/cloudflared.png
 DSM_UI_DIR = app
@@ -12,7 +12,7 @@ DISPLAY_NAME = cloudflared
 DESCRIPTION = Cloudflare Tunnel client (formerly Argo Tunnel).
 HOMEPAGE = https://github.com/cloudflare/cloudflared
 LICENSE = Apache-2.0
-CHANGELOG = "Update to 2023.5.0"
+CHANGELOG = "Update to 2023.5.1"
 
 WIZARDS_DIR = src/wizard/
 


### PR DESCRIPTION
## Description

Update to 2023.5.1
### New Features
- You can now stream your logs from your remote cloudflared to your local terminal with `cloudflared tail <TUNNEL-ID>`. This new feature requires the remote cloudflared to be version 2023.4.1 or higher.
- Migrated to devincarr/quic-go to unblock go 1.20 support as the old lucas-clemente/quic-go will not get go 1.20 support.

### Notices
- Due to the nature of QuickTunnels (https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare/) and its intended usage for testing and experiment of Cloudflare Tunnels, starting from 2023.3.2, QuickTunnels only make a single connection to the edge. If users want to use Tunnels in a production environment, they should move to Named Tunnels instead. (https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/remote/#set-up-a-tunnel-remotely-dashboard-setup)

Upstream changelog: https://github.com/cloudflare/cloudflared/blob/master/RELEASE_NOTES

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
