### PR TITLE
fix github action to build noarch 6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         # x64=x86_64, evansport=i686, aarch64=armv8, armv7, hi3535=armv7l, 88f6281=armv5, qoriq=ppc
         # https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures
-        arch: [noarch, noarch-6.0, noarch-7.0, x64-6.1, x64-7.1, evansport-6.1, evansport-7.1, aarch64-6.1, aarch64-7.1, armv7-6.1, armv7-7.1, hi3535-6.1, 88f6281-6.1, qoriq-6.1, comcerto2k-7.1]
+        arch: [noarch, noarch-6.1, noarch-7.0, x64-6.1, x64-7.1, evansport-6.1, evansport-7.1, aarch64-6.1, aarch64-7.1, armv7-6.1, armv7-7.1, hi3535-6.1, 88f6281-6.1, qoriq-6.1, comcerto2k-7.1]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

fix for publish of noarch packages (like #5236 
- noarch build for DSM 6.x must be at least version 6.1

### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
