### PR TITLE
openssl: CVE-2023-2650

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.1.1t
+PKG_VERS = 1.1.1u
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1t.tar.gz SHA1 a06b067b7e3bd6a2cb52a06f087ff13346ce7360
-openssl-1.1.1t.tar.gz SHA256 8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b
-openssl-1.1.1t.tar.gz MD5 1cfee919e0eac6be62c88c5ae8bcd91e
+openssl-1.1.1u.tar.gz SHA1 227f922048e132ca2d4181aabd34079cd82dd3be
+openssl-1.1.1u.tar.gz SHA256 e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
+openssl-1.1.1u.tar.gz MD5 72f7ba7395f0f0652783ba1089aa0dcc

--- a/cross/openssl3/Makefile
+++ b/cross/openssl3/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl3
-PKG_VERS = 3.1.0
+PKG_VERS = 3.1.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = openssl-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source
@@ -48,10 +48,6 @@ OPENSSL_PLATFORM = linux-armv4
 endif
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
 OPENSSL_PLATFORM = linux-aarch64
-ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
-# asm of gcc for DSM<7 does not support ".arch	armv8.2-a+crypto"
-CONFIGURE_ARGS += no-asm
-endif
 endif
 ifeq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
 OPENSSL_PLATFORM = linux-ppc

--- a/cross/openssl3/digests
+++ b/cross/openssl3/digests
@@ -1,3 +1,3 @@
-openssl-3.1.0.tar.gz SHA1 323b175eda887b33fb23f5806ef307b4dda2df00
-openssl-3.1.0.tar.gz SHA256 aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
-openssl-3.1.0.tar.gz MD5 f6c520aa2206d4d1fa71ea30b5e9a56d
+openssl-3.1.1.tar.gz SHA1 d01a0f243672d514aee14bdd74a5d109b6394a78
+openssl-3.1.1.tar.gz SHA256 b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674
+openssl-3.1.1.tar.gz MD5 1864b75e31fb4a6e0a07fd832529add3


### PR DESCRIPTION
## Description

- openssl3 update to v3.1.1
- activate asm for aarch64 < DSM 7
  - forgot to activate asm after fix with patch ()
  - patch is still required as fix is merged after 3.1.1 (will be fixed in 3.1.2)
 - openssl update to v1.1.1u

### Type of change

<!--Please use any relavent tags.-->
- [x] Library update
- [x] Secureity fix
