### PR TITLE
Update DSM6 default version from 6.1 to 6.2.4 due to toolchain removals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         # x64=x86_64, evansport=i686, aarch64=armv8, armv7, hi3535=armv7l, 88f6281=armv5, qoriq=ppc
         # https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures
-        arch: [noarch, noarch-6.2.4, noarch-7.1, x64-6.2.4, x64-7.1, evansport-6.2.4, evansport-7.1, aarch64-6.2.4, aarch64-7.1, armv7-6.2.4, armv7-7.1, hi3535-6.2.4, 88f6281-6.2.4, qoriq-6.2.4, comcerto2k-7.1]
+        arch: [noarch, noarch-6.1, noarch-7.0, x64-6.2.4, x64-7.1, evansport-6.2.4, evansport-7.1, aarch64-6.2.4, aarch64-7.1, armv7-6.2.4, armv7-7.1, hi3535-6.2.4, 88f6281-6.2.4, qoriq-6.2.4, comcerto2k-7.1]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         # x64=x86_64, evansport=i686, aarch64=armv8, armv7, hi3535=armv7l, 88f6281=armv5, qoriq=ppc
         # https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures
-        arch: [noarch, noarch-6.1, noarch-7.0, x64-6.1, x64-7.1, evansport-6.1, evansport-7.1, aarch64-6.1, aarch64-7.1, armv7-6.1, armv7-7.1, hi3535-6.1, 88f6281-6.1, qoriq-6.1, comcerto2k-7.1]
+        arch: [noarch, noarch-6.2.4, noarch-7.1, x64-6.2.4, x64-7.1, evansport-6.2.4, evansport-7.1, aarch64-6.2.4, aarch64-7.1, armv7-6.2.4, armv7-7.1, hi3535-6.2.4, 88f6281-6.2.4, qoriq-6.2.4, comcerto2k-7.1]
 
     steps:
       - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ toolchain-%:
 kernel-%:
 	-@cd kernel/syno-$*/ && MAKEFLAGS= $(MAKE)
 
-setup: local.mk dsm-6.1 dsm-7.1
+setup: local.mk dsm-6.2.4 dsm-7.1
 
 local.mk:
 	@echo "Creating local configuration \"local.mk\"..."

--- a/spk/umurmur/Makefile
+++ b/spk/umurmur/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = umurmur
 SPK_VERS = 0.2.20
-SPK_REV = 9
+SPK_REV = 8
 SPK_ICON = src/umurmur.png
 
 DEPENDS = cross/$(SPK_NAME)

--- a/spk/umurmur/Makefile
+++ b/spk/umurmur/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = umurmur
 SPK_VERS = 0.2.20
-SPK_REV = 8
+SPK_REV = 9
 SPK_ICON = src/umurmur.png
 
 DEPENDS = cross/$(SPK_NAME)

--- a/toolchain/syno-aarch64-6.2.4/patches/define_scsi_ioctl_tagged_enable_disable.patch
+++ b/toolchain/syno-aarch64-6.2.4/patches/define_scsi_ioctl_tagged_enable_disable.patch
@@ -1,0 +1,22 @@
+#---
+#
+# Solves build issue when compiling a LLVM or GCC compiler:
+#
+# sanitizer_platform_limits_posix.cc:874:46: error: ‘SCSI_IOCTL_TAGGED_DISABLE’ was not declared in this scope
+# unsigned IOCTL_SCSI_IOCTL_TAGGED_DISABLE = SCSI_IOCTL_TAGGED_DISABLE;
+# sanitizer_platform_limits_posix.cc:875:45: error: ‘SCSI_IOCTL_TAGGED_ENABLE’ was not declared in this scope
+# unsigned IOCTL_SCSI_IOCTL_TAGGED_ENABLE = SCSI_IOCTL_TAGGED_ENABLE;
+#
+#----
+diff -uprN ../../work.orig/aarch64-unknown-linux-gnueabi/aarch64-unknown-linux-gnueabi/sysroot/usr/include/scsi/scsi.h ./aarch64-unknown-linux-gnueabi/sysroot/usr/include/scsi/scsi.h
+--- ../../work.orig/aarch64-unknown-linux-gnueabi/aarch64-unknown-linux-gnueabi/sysroot/usr/include/scsi/scsi.h	2017-08-03 01:08:13.000000000 +0000
++++ ./aarch64-unknown-linux-gnueabi/sysroot/usr/include/scsi/scsi.h	2023-03-06 23:41:00.328424414 +0000
+@@ -264,6 +264,8 @@ struct ccs_modesel_head {
+ #define SCSI_IOCTL_GET_IDLUN		0x5382
+ 
+ /* 0x5383 and 0x5384 were used for SCSI_IOCTL_TAGGED_{ENABLE,DISABLE} */
++#define SCSI_IOCTL_TAGGED_ENABLE		0x5383
++#define SCSI_IOCTL_TAGGED_DISABLE		0x5384
+ 
+ /* Used to obtain the host number of a device. */
+ #define SCSI_IOCTL_PROBE_HOST		0x5385

--- a/toolchain/syno-evansport-6.2.4/patches/define_scsi_ioctl_tagged_enable_disable.patch
+++ b/toolchain/syno-evansport-6.2.4/patches/define_scsi_ioctl_tagged_enable_disable.patch
@@ -1,0 +1,22 @@
+#---
+#
+# Solves build issue when compiling a LLVM or GCC compiler:
+#
+# sanitizer_platform_limits_posix.cc:874:46: error: ‘SCSI_IOCTL_TAGGED_DISABLE’ was not declared in this scope
+# unsigned IOCTL_SCSI_IOCTL_TAGGED_DISABLE = SCSI_IOCTL_TAGGED_DISABLE;
+# sanitizer_platform_limits_posix.cc:875:45: error: ‘SCSI_IOCTL_TAGGED_ENABLE’ was not declared in this scope
+# unsigned IOCTL_SCSI_IOCTL_TAGGED_ENABLE = SCSI_IOCTL_TAGGED_ENABLE;
+#
+#----
+diff -uprN ../../work/i686-pc-linux-gnu/i686-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h ./i686-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h
+--- ../../work/i686-pc-linux-gnu/i686-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h	2017-08-02 22:33:56.000000000 +0000
++++ ./i686-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h	2023-03-08 23:59:38.080468616 +0000
+@@ -517,6 +517,8 @@ static __inline__ int scsi_is_wlun(unsig
+ #define SCSI_IOCTL_GET_IDLUN		0x5382
+ 
+ /* 0x5383 and 0x5384 were used for SCSI_IOCTL_TAGGED_{ENABLE,DISABLE} */
++#define SCSI_IOCTL_TAGGED_ENABLE		0x5383
++#define SCSI_IOCTL_TAGGED_DISABLE		0x5384
+ 
+ /* Used to obtain the host number of a device. */
+ #define SCSI_IOCTL_PROBE_HOST		0x5385

--- a/toolchain/syno-x64-6.2.4/patches/define_scsi_ioctl_tagged_enable_disable.patch
+++ b/toolchain/syno-x64-6.2.4/patches/define_scsi_ioctl_tagged_enable_disable.patch
@@ -1,0 +1,22 @@
+#---
+#
+# Solves build issue when compiling a LLVM or GCC compiler:
+#
+# sanitizer_platform_limits_posix.cc:874:46: error: ‘SCSI_IOCTL_TAGGED_DISABLE’ was not declared in this scope
+# unsigned IOCTL_SCSI_IOCTL_TAGGED_DISABLE = SCSI_IOCTL_TAGGED_DISABLE;
+# sanitizer_platform_limits_posix.cc:875:45: error: ‘SCSI_IOCTL_TAGGED_ENABLE’ was not declared in this scope
+# unsigned IOCTL_SCSI_IOCTL_TAGGED_ENABLE = SCSI_IOCTL_TAGGED_ENABLE;
+#
+#----
+diff -uprN ../../work.orig/x86_64-pc-linux-gnu/x86_64-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h ./x86_64-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h
+--- ../../work.orig/x86_64-pc-linux-gnu/x86_64-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h	2017-08-02 23:34:07.000000000 +0000
++++ ./x86_64-pc-linux-gnu/sys-root/usr/include/scsi/scsi.h	2023-03-08 23:44:59.732785430 +0000
+@@ -518,6 +518,8 @@ static __inline__ int scsi_is_wlun(unsig
+ #define SCSI_IOCTL_GET_IDLUN		0x5382
+ 
+ /* 0x5383 and 0x5384 were used for SCSI_IOCTL_TAGGED_{ENABLE,DISABLE} */
++#define SCSI_IOCTL_TAGGED_ENABLE		0x5383
++#define SCSI_IOCTL_TAGGED_DISABLE		0x5384
+ 
+ /* Used to obtain the host number of a device. */
+ #define SCSI_IOCTL_PROBE_HOST		0x5385


### PR DESCRIPTION
## Description

Update DSM6 default version from 6.1 to 6.2.4 due to toolchain removals

Fixes n/a

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
