### PR TITLE
Fix cross/micro buildvcs usage

### DIFF
--- a/cross/micro/patches/001_buildvcs_false.patch
+++ b/cross/micro/patches/001_buildvcs_false.patch
@@ -1,0 +1,19 @@
+--- Makefile.orig	2023-06-13 22:54:36.923530347 +0100
++++ Makefile	2023-06-13 22:55:20.234620141 +0100
+@@ -16,13 +16,13 @@
+ build: generate build-quick
+ 
+ build-quick:
+-	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
++	go build -trimpath -buildvcs=false -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+ 
+ build-dbg:
+-	go build -trimpath -ldflags "-s -w $(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
++	go build -trimpath -buildvcs=false -ldflags "-s -w $(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
+ 
+ build-tags: fetch-tags generate
+-	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
++	go build -trimpath -buildvcs=false -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+ 
+ build-all: build
+ 


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
Found while trying to rebuild packages...


## Checklist

- [ ] Build rule `all-supported` completed successfully - can't exactly issue that on a cross/ directly I believe. Still the change is quite self contained. 
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
