### PR TITLE
Fix GitHub prepare action

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -37,17 +37,20 @@ done
 for package in ${DEPENDENT_PACKAGES}
 do
     echo "===> Searching for dependent package: ${package}"
-    packages=$(echo "${DEPENDENCY_LIST}" | grep -w "${package}" | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
+    packages=$(echo "${DEPENDENCY_LIST}" | grep " ${package} " | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
     echo "===> Found: ${packages}"
     SPK_TO_BUILD+=${packages}
 done
 
 # fix for packages with different names
 if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
-    SPK_TO_BUILD+=" sonarr3"
+    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "nzbdrone" | tr '\n' ' ')" sonarr3"
 fi
 if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
-    SPK_TO_BUILD+=" python2"
+    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "python" | tr '\n' ' ')" python2"
+fi
+if [ "$(echo ${SPK_TO_BUILD} | grep -ow ffmpeg)" != "" ]; then
+    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "ffmpeg" | tr '\n' ' ')" ffmpeg4"
 fi
 
 # remove duplicate packages

--- a/cross/chromaprint/Makefile
+++ b/cross/chromaprint/Makefile
@@ -9,13 +9,13 @@ HOMEPAGE = https://acoustid.org/chromaprint
 COMMENT  = Chromaprint is the core component of the AcoustID project. It\'s a client-side library that implements a custom algorithm for extracting fingerprints from any audio source.
 LICENSE  = LGPL2.1+
 
-OPTIONAL_DEPENDS = cross/ffmpeg4
+OPTIONAL_DEPENDS = cross/ffmpeg$(FFMPEG_VERSION)
 
 # compiler too old
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
 ifneq ($(wildcard $(FFMPEG_DIR)),)
-CMAKE_RPATH = /var/packages/ffmpeg$(FFMPEG_VERSION)/target/lib
+CMAKE_RPATH = /var/packages/ffmpeg$(subst 4,,$(FFMPEG_VERSION))/target/lib
 else
 DEPENDS = cross/ffmpeg$(FFMPEG_VERSION)
 CMAKE_RPATH =

--- a/cross/iperf3/Makefile
+++ b/cross/iperf3/Makefile
@@ -15,7 +15,7 @@ LICENSE  = 3-Clause BSD
 
 GNU_CONFIGURE = 1
 
-ifeq ($(findstring $(ARCH),qoriq),$(ARCH)))
+ifeq ($(findstring $(ARCH),qoriq),$(ARCH))
 # prefer netinet/tcp.h over linux/tcp.h to ensure 'TCP_USER_TIMEOUT' is declared.
 CONFIGURE_ARGS += ac_cv_header_linux_tcp_h=no
 endif

--- a/mk/spksrc.dependency-tree.mk
+++ b/mk/spksrc.dependency-tree.mk
@@ -23,7 +23,7 @@
 .PHONY: dependency-tree
 dependency-tree:
 	@echo $$(perl -e 'print "\\\t" x $(MAKELEVEL),"\n"')+ $(NAME) $(PKG_VERS)
-	@for depend in $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS) ; \
+	@for depend in $$(echo "$(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS)" | tr ' ' '\n' | sort -u | tr '\n' ' ') ; \
 	do \
 	  DEPENDENCY_WALK=1 $(MAKE) -s -C ../../$$depend dependency-tree ; \
 	done
@@ -39,7 +39,7 @@ dependency-list:
 .PHONY: dependency-flat
 dependency-flat:
 	@echo "$(CURDIR)" | grep -Po "/\K(spk|cross|native|diyspk)/.*"
-	@for depend in $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS) ; \
+	@for depend in $$(echo "$(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS)" | tr ' ' '\n' | sort -u | tr '\n' ' ') ; \
 	do \
 	  DEPENDENCY_WALK=1 $(MAKE) -s -C ../../$$depend dependency-flat ; \
 	done


### PR DESCRIPTION
## Description

This PR was initiated by the fact, that the prepare job of the github build action takes a large amount of time.
Local analysis showed that it takes > 60 seconds to evaluate the dependency-list for each package that depends on ffmpeg.

before, the "Evaluate dependencies" step of the "Prepare for Build" job took about 6 to 10 minutes.
with this fix, it takes about 3 minutes.



## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
