### PR TITLE
py310-311: Re-include openssl 1.x until all py-spk migrated over

### DIFF
--- a/cross/python310/Makefile
+++ b/cross/python310/Makefile
@@ -53,7 +53,9 @@ CONFIGURE_ARGS += ac_cv_file__dev_ptmx=no
 CONFIGURE_ARGS += ac_cv_file__dev_ptc=no
 CONFIGURE_ARGS += ac_cv_have_long_long_format=yes
 
-DEPENDS += cross/openssl3
+# keep both openssl until all python packages
+# have been republished using openssl3
+DEPENDS += cross/openssl cross/openssl3
 CONFIGURE_ARGS += --with-ssl-default-suites=openssl
 
 DEPENDS += cross/gdbm

--- a/cross/python311/Makefile
+++ b/cross/python311/Makefile
@@ -54,7 +54,9 @@ CONFIGURE_ARGS += ac_cv_file__dev_ptmx=no
 CONFIGURE_ARGS += ac_cv_file__dev_ptc=no
 CONFIGURE_ARGS += ac_cv_have_long_long_format=yes
 
-DEPENDS += cross/openssl3
+# keep both openssl until all python packages
+# have been republished using openssl3
+DEPENDS += cross/openssl cross/openssl3
 CONFIGURE_ARGS += --with-ssl-default-suites=openssl
 
 DEPENDS += cross/gdbm

--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Language de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.
 STARTABLE = no
 DISPLAY_NAME = Python 3.10
-CHANGELOG = "1. Update to Python 3.10.12<br/>2. Update to OpenSSL 3.1.1<br/>3. Re-include python 1.x until all packages are migrated"
+CHANGELOG = "1. Update to Python 3.10.12<br/>2. Update to OpenSSL 3.1.1<br/>3. Re-include openssl 1.1 until all packages are migrated"
 
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF

--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python310
 SPK_VERS = 3.10.12
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 16
+SPK_REV = 17
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/$(SPK_NAME)
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Language de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.
 STARTABLE = no
 DISPLAY_NAME = Python 3.10
-CHANGELOG = "1. Update to Python 3.10.12<br/>2. Update to OpenSSL 3.1.1"
+CHANGELOG = "1. Update to Python 3.10.12<br/>2. Update to OpenSSL 3.1.1<br/>3. Re-include python 1.x until all packages are migrated"
 
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF

--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python311
 SPK_VERS = 3.11.4
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 5
+SPK_REV = 6
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/$(SPK_NAME)
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Language de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.
 STARTABLE = no
 DISPLAY_NAME = Python 3.11
-CHANGELOG = "1. Update to Python 3.11.4<br/>2. Update to OpenSSL 3.1.1"
+CHANGELOG = "1. Update to Python 3.11.4<br/>2. Update to OpenSSL 3.1.1<br/>3. Re-include python 1.x until all packages are migrated"
 
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF

--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -13,7 +13,7 @@ DESCRIPTION_FRE = Language de programmation Python.
 DESCRIPTION_SPN = Lenguaje de programación Python.
 STARTABLE = no
 DISPLAY_NAME = Python 3.11
-CHANGELOG = "1. Update to Python 3.11.4<br/>2. Update to OpenSSL 3.1.1<br/>3. Re-include python 1.x until all packages are migrated"
+CHANGELOG = "1. Update to Python 3.11.4<br/>2. Update to OpenSSL 3.1.1<br/>3. Re-include openssl 1.1 until all packages are migrated"
 
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF


### PR DESCRIPTION
## Description

py310-311: Re-include openssl 1.x until all py-spk migrated over

Fixes #5800

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
