### PR TITLE
Add toolchains for DSM 5.2 and SRM 1.2

### DIFF
--- a/toolchain/syno-88f6281-5.2/Makefile
+++ b/toolchain/syno-88f6281-5.2/Makefile
@@ -4,7 +4,8 @@ TC_KERNEL = 2.6.32
 TC_GLIBC = 2.15
 
 TC_DIST = 6281-gcc464_glibc215_88f6281-GPL
-TC_DIST_SITE_PATH = Marvell%2088F628x%20Linux%202.6.32
+TC_DIST_SITE_URL = https://github.com/SynoCommunity/spksrc/releases/download/
+TC_DIST_SITE_PATH = toolchains%2Fdsm5.2
 
 TC_TARGET = arm-marvell-linux-gnueabi
 TC_SYSROOT = $(TC_TARGET)/libc

--- a/toolchain/syno-armv7-1.2/Makefile
+++ b/toolchain/syno-armv7-1.2/Makefile
@@ -9,7 +9,8 @@ TC_GLIBC = 2.20
 
 TC_DIST = gcc493_glibc220_hard-GPL
 TC_EXT = tgz
-TC_DIST_SITE_PATH = QUALCOMM%20IPQ806X%20Linux%204.4.60
+TC_DIST_SITE_URL = https://github.com/SynoCommunity/spksrc/releases/download/
+TC_DIST_SITE_PATH = toolchains%2Fsrm1.2
 TC_DIST_FILE = ipq806x-$(TC_DIST_NAME)
 
 TC_TARGET = arm-unknown-linux-gnueabi

--- a/toolchain/syno-ipq806x-1.2/Makefile
+++ b/toolchain/syno-ipq806x-1.2/Makefile
@@ -6,7 +6,8 @@ TC_GLIBC = 2.20
 
 TC_DIST = gcc493_glibc220_hard-GPL
 TC_EXT = tgz
-TC_DIST_SITE_PATH = QUALCOMM%20IPQ806X%20Linux%204.4.60
+TC_DIST_SITE_URL = https://github.com/SynoCommunity/spksrc/releases/download/
+TC_DIST_SITE_PATH = toolchains%2Fsrm1.2
 TC_DIST_FILE = $(TC_ARCH)-$(TC_DIST_NAME)
 
 TC_TARGET = arm-unknown-linux-gnueabi

--- a/toolchain/syno-ppc853x-5.2/Makefile
+++ b/toolchain/syno-ppc853x-5.2/Makefile
@@ -4,7 +4,8 @@ TC_KERNEL = 2.6.32
 TC_GLIBC = 2.8
 
 TC_DIST = 853x-gcc4374_eglibc2874_qoriq-GPL
-TC_DIST_SITE_PATH = PowerPC%20853x%20Linux%202.6.32
+TC_DIST_SITE_URL = https://github.com/SynoCommunity/spksrc/releases/download/
+TC_DIST_SITE_PATH = toolchains%2Fdsm5.2
 
 TC_TARGET = powerpc-none-linux-gnuspe
 TC_SYSROOT = $(TC_TARGET)

--- a/toolchain/syno-x64-5.2/Makefile
+++ b/toolchain/syno-x64-5.2/Makefile
@@ -6,7 +6,8 @@ TC_KERNEL = 3.2.40
 TC_GLIBC = 2.17
 
 TC_DIST = x64-gcc473_glibc217_x86_64-GPL
-TC_DIST_SITE_PATH = Intel%20x86%20Linux%203.2.40%20%28Pineview%29
+TC_DIST_SITE_URL = https://github.com/SynoCommunity/spksrc/releases/download/
+TC_DIST_SITE_PATH = toolchains%2Fdsm5.2
 
 TC_TARGET = x86_64-pc-linux-gnu
 TC_SYSROOT = $(TC_TARGET)/sys-root

--- a/toolchain/syno-x86-5.2/Makefile
+++ b/toolchain/syno-x86-5.2/Makefile
@@ -4,7 +4,8 @@ TC_KERNEL = 3.2.40
 TC_GLIBC = 2.17
 
 TC_DIST = x64-gcc473_glibc217_x86_64-GPL
-TC_DIST_SITE_PATH = Intel%20x86%20Linux%203.2.40%20%28Pineview%29
+TC_DIST_SITE_URL = https://github.com/SynoCommunity/spksrc/releases/download/
+TC_DIST_SITE_PATH = toolchains%2Fdsm5.2
 
 TC_TARGET = x86_64-pc-linux-gnu
 TC_SYSROOT = $(TC_TARGET)/sys-root


### PR DESCRIPTION
## Description

- add DSM 5.2 toolchains not provided by Synology anymore
- limited to toolchains for models that do not support DSM 6
- add SRM 1.2 toolchains not provided by Synology anymore
- for SRM only generic armv7-1.2 and ipq806x-1.2 are provided
