### PR TITLE
use urw-base35-fonts from synocommunity repo

### DIFF
--- a/cross/urw-base35-fonts/Makefile
+++ b/cross/urw-base35-fonts/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = urw-base35-fonts
 PKG_VERS = 20151005
 PKG_EXT = zip
 PKG_DIST_NAME = urw-base35-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://ftp.icm.edu.pl/pub/unix/postscript/ghostscript/fonts
+PKG_DIST_SITE = https://github.com/SynoCommunity/spksrc/releases/download/sources
 # download and extract only
 EXTRACT_PATH = $(WORK_DIR)/share/fonts
 


### PR DESCRIPTION
## Description

This is a fix for dependent packages `ntopng` and `imagemagick`
- original archive of free ghostscript fonts is not reachable anymore


## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
