### PR TITLE
fix spksrc.python.mk

### DIFF
--- a/mk/spksrc.python.mk
+++ b/mk/spksrc.python.mk
@@ -77,7 +77,7 @@ python_pre_depend:
 	@# EXCEPTION: Ensure zlib is always built locally
 	@rm -f $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/zlib.pc $(WORK_DIR)/.zlib*
 	@# EXCEPTION: Do not symlink cross/* wheel builds
-	@make --no-print-directory dependency-flat | sort -u | grep -v spk/ | while read depend ; do \
+	@make --no-print-directory dependency-flat | sort -u | grep cross/ | while read depend ; do \
 	   makefile="../../$${depend}/Makefile" ; \
 	   if grep -q spksrc.python-wheel.mk $${makefile} ; then \
 	      pkgstr=$$(grep ^PKG_NAME $${makefile}) ; \

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -513,7 +513,7 @@ wheelclean: spkclean
 	rm -fr work-*/.wheel_done \
 	       work-*/wheelhouse \
 	       work-*/install/var/packages/**/target/share/wheelhouse
-	@make --no-print-directory dependency-flat | sort -u | grep -v spk/ | while read depend ; do \
+	@make --no-print-directory dependency-flat | sort -u | grep cross/ | while read depend ; do \
 	   makefile="../../$${depend}/Makefile" ; \
 	   if grep -q spksrc.python-wheel.mk $${makefile} ; then \
 	      pkgstr=$$(grep ^PKG_NAME $${makefile}) ; \


### PR DESCRIPTION
## Description

Related to #5820

- fix remove of symlinks for python-wheel dependencies
- take only cross/ dependencies since build prints "===>  Downloading toolchain" or "===>  Setting-up toolchain" to dependency-flat

Fixes the grep error reported in https://github.com/SynoCommunity/spksrc/pull/5869#issuecomment-1709314476


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes

