### PR TITLE
avoid use of cross/libstc++ for PPC archs

### DIFF
--- a/mk/spksrc.install-resources.mk
+++ b/mk/spksrc.install-resources.mk
@@ -35,6 +35,8 @@ endif
 
 #####
 
+include ../../mk/spksrc.pre-check.mk
+
 include ../../mk/spksrc.cross-env.mk
 
 include ../../mk/spksrc.download.mk

--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -48,7 +48,10 @@ include ../../mk/spksrc.common.mk
 # this is a fix for integrations depending on grpcio (google nest, google generativeai and starlink)
 # the fix requires to additionally set the LD_LIBRARY_PATH to homeassistant/target/lib
 ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
+# libstdc++ is not available for PPC archs
+ifneq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
 DEPENDS += cross/libstdc++
+endif
 endif
 
 # [voip_utils]


### PR DESCRIPTION
## Description

- add check for unsupported archs in spksrc.install-resources.mk (originally designed for arch independent packages only)
- homeassistant: avoid adding libstc++ for qoriq

Fixes #5684

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created

### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [x] Includes small framework changes
