### PR TITLE
Disable supported archs checks for dependency evaluation

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -30,7 +30,7 @@ echo "Building dependency list..."
 DEPENDENCY_LIST=
 for package in $(find spk/ -maxdepth 1 -type d | cut -c 5- | sort)
 do
-    DEPENDENCY_LIST+=$(make -s -C spk/${package} dependency-list)$'\n'
+    DEPENDENCY_LIST+=$(DEPENDENCY_WALK=1 make -s -C spk/${package} dependency-list 2> /dev/null)$'\n'
 done
 
 # search for dependent spk packages

--- a/mk/spksrc.pre-check.mk
+++ b/mk/spksrc.pre-check.mk
@@ -9,6 +9,9 @@
 #                          use SERVICE_SETUP instead, this includes support for DSM >= 7.
 #
 
+# disable checks for dependency targets
+ifneq ($(DEPENDENCY_WALK),1)
+
 # SPK_FOLDER    
 # name of the spk package folder
 # github status check does not rely on the (SPK) NAME but uses the folder name
@@ -101,4 +104,6 @@ ifneq ($(REQUIRED_MIN_SRM),)
   endif
 endif
 
-endif
+endif # ifneq ($(TCVERSION),)
+
+endif # ifneq ($(DEPENDENCY_WALK),1)


### PR DESCRIPTION
## Description

Avoid log output of `UNSUPPORTED_ARCHS` when dependency-list (or dependency-tree) target is used.

### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
