### PR TITLE
Attempt at fixing publishing whith dependent packages

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -66,8 +66,14 @@ do
     echo >build.log
 
     if [ "${GH_ARCH%%-*}" != "noarch" ]; then
-        echo "$ make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package}" >>build.log
-        make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
+        # Only publish package requested and not its parent (i.e. python*, ffmpeg*)
+        if [ "${package}" == "${SPK_TO_BUILD}" ]; then
+           echo "$ make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package}" >>build.log
+           make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
+        else
+           echo "$ make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package}" >>build.log
+           make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
+        fi
     else
         if [ "${GH_ARCH}" = "noarch" ]; then
             TCVERSION=

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -18,8 +18,8 @@ make setup-synocommunity
 DEFAULT_TC=$(grep DEFAULT_TC local.mk | cut -f2 -d= | xargs)
 
 # filter for changes made in the spk directories and take unique package name (without spk folder)
-SPK_TO_BUILD+=" "
-SPK_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
+SPKLIST_TO_BUILD="${SPK_TO_BUILD} "
+SPKLIST_TO_BUILD+=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(spk)/\K[^\/]*" | sort -u | tr '\n' ' ')
 
 # filter for changes made in the cross and native directories and take unique package name (including cross or native folder)
 DEPENDENT_PACKAGES=$(echo "${GH_FILES}" | tr ' ' '\n' | grep -oP "(cross|native)/[^\/]*" | sort -u | tr '\n' ' ')
@@ -39,22 +39,22 @@ do
     echo "===> Searching for dependent package: ${package}"
     packages=$(echo "${DEPENDENCY_LIST}" | grep " ${package} " | grep -o ".*:" | tr ':' ' ' | sort -u | tr '\n' ' ')
     echo "===> Found: ${packages}"
-    SPK_TO_BUILD+=${packages}
+    SPKLIST_TO_BUILD+=${packages}
 done
 
 # fix for packages with different names
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
-    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "nzbdrone" | tr '\n' ' ')" sonarr3"
+if [ "$(echo ${SPKLIST_TO_BUILD} | grep -ow nzbdrone)" != "" ]; then
+    SPKLIST_TO_BUILD=$(echo "${SPKLIST_TO_BUILD}" | tr ' ' '\n' | grep -v "nzbdrone" | tr '\n' ' ')" sonarr3"
 fi
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow python)" != "" ]; then
-    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "python" | tr '\n' ' ')" python2"
+if [ "$(echo ${SPKLIST_TO_BUILD} | grep -ow python)" != "" ]; then
+    SPKLIST_TO_BUILD=$(echo "${SPKLIST_TO_BUILD}" | tr ' ' '\n' | grep -v "python" | tr '\n' ' ')" python2"
 fi
-if [ "$(echo ${SPK_TO_BUILD} | grep -ow ffmpeg)" != "" ]; then
-    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "ffmpeg" | tr '\n' ' ')" ffmpeg4"
+if [ "$(echo ${SPKLIST_TO_BUILD} | grep -ow ffmpeg)" != "" ]; then
+    SPKLIST_TO_BUILD=$(echo "${SPKLIST_TO_BUILD}" | tr ' ' '\n' | grep -v "ffmpeg" | tr '\n' ' ')" ffmpeg4"
 fi
 
 # remove duplicate packages
-packages=$(printf %s "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+packages=$(printf %s "${SPKLIST_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
 # for ffmpeg v4-6 find all packages that depend on them
 for i in {4..6}; do


### PR DESCRIPTION
## Description

When publishing packages that depends on others when built, ensure to only publish the package requested and not it's dependency.  This hapens for instance when publishing `deluge` whereas `python311` will get built as pre-depend package.  Currently it will publish both packages online thus generating errors as pre-depend package is most probably already published, thus colliding.

Fixes #5870

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
