### PR TITLE
libpng: Fix cmake args and disable static library

### DIFF
--- a/cross/libpng/Makefile
+++ b/cross/libpng/Makefile
@@ -11,7 +11,8 @@ HOMEPAGE = http://www.libpng.org/pub/png/libpng.html
 COMMENT  = Portable Network Graphics Library
 LICENSE  = http://www.libpng.org/pub/png/src/libpng-LICENSE.txt
 
-CONFIGURE_ARGS = --disable-static
+CMAKE_ARGS += -DPNG_STATIC=OFF
+CMAKE_ARGS += -DHAVE_LD_VERSION_SCRIPT=OFF
 ADDITIONAL_CFLAGS = -O -lm
 
 include ../../mk/spksrc.cross-cmake.mk


### PR DESCRIPTION
## Description

libpng: Fix cmake args and disable static library.  This in turns allow building with `debug_symbols` enabled.

Relates to #5879

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
