### PR TITLE
synocli-devel: avoid llvm for DSM 5.2

### DIFF
--- a/spk/synocli-devel/Makefile
+++ b/spk/synocli-devel/Makefile
@@ -18,7 +18,7 @@ OPTIONAL_DEPENDS = cross/llvm
 
 include ../../mk/spksrc.common.mk
 
-ifneq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(OLD_PPC_ARCHS)),$(ARCH))
+ifneq ($(call version_lt, $(TC_GCC), 4.8.1),1)
 DEPENDS += cross/llvm
 endif
 
@@ -104,7 +104,7 @@ endif
 ##
 ## LLVM
 ##
-ifneq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(OLD_PPC_ARCHS)),$(ARCH))
+ifneq ($(call version_lt, $(TC_GCC), 4.8.1),1)
 ifeq ($(call version_ge, $(TC_GCC), 5.1),1)
 OPTIONAL_DESC += ", LLVM 16.0.6"
 SPK_COMMANDS += bin/clang-16


### PR DESCRIPTION
## Description

followup to #5882 to avoid build of llvm for x86-5.2.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created



