### PR TITLE
Fix synocli-file

### DIFF
--- a/cross/fontconfig/Makefile
+++ b/cross/fontconfig/Makefile
@@ -17,11 +17,10 @@ CONFIGURE_ARGS += -Dcache-build=disabled
 
 ADDITIONAL_CFLAGS = -O
 
-include ../../mk/spksrc.common.mk
+include ../../mk/spksrc.cross-meson.mk
+
 ifeq ($(call version_lt, $(TC_GCC), 4.8),1) 
 ADDITIONAL_CFLAGS += -std=c99
 else
 ADDITIONAL_CFLAGS += -std=c11
 endif
-
-include ../../mk/spksrc.cross-meson.mk

--- a/cross/fontconfig/Makefile
+++ b/cross/fontconfig/Makefile
@@ -15,12 +15,7 @@ CONFIGURE_ARGS  = -Ddoc=disabled
 CONFIGURE_ARGS += -Dtests=disabled
 CONFIGURE_ARGS += -Dcache-build=disabled
 
-ADDITIONAL_CFLAGS = -O
+ADDITIONAL_CFLAGS  = -O
+ADDITIONAL_CFLAGS += -std=c99
 
 include ../../mk/spksrc.cross-meson.mk
-
-ifeq ($(call version_lt, $(TC_GCC), 4.8),1) 
-ADDITIONAL_CFLAGS += -std=c99
-else
-ADDITIONAL_CFLAGS += -std=c11
-endif

--- a/cross/gdb-latest/Makefile
+++ b/cross/gdb-latest/Makefile
@@ -15,11 +15,7 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --enable-host-shared
 CONFIGURE_ARGS += --with-system-zlib
 
-include ../../mk/spksrc.common.mk
-
-ifeq ($(call version_lt, $(TC_GCC), 4.8.1),1)
-UNSUPPORTED_ARCHS = $(ARCHS)
-endif
+include ../../mk/spksrc.archs.mk
 
 ifeq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
 # sim/ppc is broken
@@ -45,3 +41,8 @@ PLIST_TRANSFORM = sed $(PLIST_TRANSFORM_SED_ARGS)
 endif
 
 include ../../mk/spksrc.cross-cc.mk
+
+ifeq ($(call version_lt, $(TC_GCC), 4.8.1),1)
+# archs without C++11 support are not supported:
+UNSUPPORTED_ARCHS = $(ARCHS)
+endif

--- a/spk/sickchill/Makefile
+++ b/spk/sickchill/Makefile
@@ -7,9 +7,6 @@ PYTHON_PACKAGE = python311
 
 SPK_DEPENDS = "python311>=3.11.5-8"
 
-# archs without C++11 support are not supported:
-UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
-
 # [lxml]
 DEPENDS += cross/libxml2
 DEPENDS += cross/libxslt
@@ -21,13 +18,6 @@ ENV += SODIUM_INSTALL=system
 # [cryptography]
 DEPENDS += cross/cryptography
 
-include ../../mk/spksrc.common.mk
-
-# [greenlet]
-ifeq ($(call version_lt, ${TC_GCC}, 5.0),1)
-WHEELS_CPPFLAGS = [greenlet] -std=c++11 -fpermissive
-endif
-
 WHEELS = src/requirements-crossenv.txt src/requirements-pure.txt
 
 
@@ -37,8 +27,8 @@ STARTABLE = yes
 DISPLAY_NAME = SickChill
 CHANGELOG = "1. A wheel based install, git installs are not supported by upstream.<br/>2. Python update to 3.11<br/>3. Deprecated ARMv5 (88f628x) as no compiler support for updated dependencies<br/>4. Migrate to OpenSSL 3.1.2<br/>5. Fix for newer shared python"
 
-HOMEPAGE   = https://sickchill.github.io/
-LICENSE    = GPLv3+
+HOMEPAGE = https://sickchill.github.io/
+LICENSE = GPLv3+
 
 SERVICE_USER = auto
 
@@ -57,8 +47,19 @@ POST_STRIP_TARGET = sickchill_extra_install
 
 include ../../mk/spksrc.python.mk
 
+
+ifeq ($(call version_lt, $(TC_GCC), 4.8.1),1)
+# archs without C++11 support are not supported:
+UNSUPPORTED_ARCHS = $(ARCHS)
+endif
+
+# [greenlet]
+ifeq ($(call version_lt, ${TC_GCC}, 5.0),1)
+WHEELS_CPPFLAGS = [greenlet] -std=c++11 -fpermissive
+endif
+
 # prefere native python tools (pip, maturin, ...)
-ENV += PATH=$(realpath $(WORK_DIR)/../../../native/python311/work-native/install/usr/local/bin):$(PATH)
+ENV += PATH=$(abspath $(WORK_DIR)/../../../native/python311/work-native/install/usr/local/bin):$(PATH)
 
 .PHONY: sickchill_extra_install
 sickchill_extra_install:

--- a/spk/sickchill/Makefile
+++ b/spk/sickchill/Makefile
@@ -7,6 +7,9 @@ PYTHON_PACKAGE = python311
 
 SPK_DEPENDS = "python311>=3.11.5-8"
 
+# archs without C++11 support are not supported:
+UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
+
 # [lxml]
 DEPENDS += cross/libxml2
 DEPENDS += cross/libxslt

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -43,12 +43,6 @@ endif
 # packages depending on cross/zlib
 DEPENDS += cross/mc cross/pcre2 cross/fdupes cross/zstd
 
-ifeq ($(call version_ge, $(TC_GCC), 4.8.1),1)
-# A compiler with support for C++11 language features is required.
-DEPENDS += cross/rnm
-OPTIONAL_DESC := $(OPTIONAL_DESC)", rnm"
-endif
-
 ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 OPTIONAL_DESC := $(OPTIONAL_DESC)", nnn (n³)"
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
@@ -104,7 +98,6 @@ SPK_COMMANDS += bin/file
 SPK_COMMANDS += bin/detox
 SPK_COMMANDS += bin/pcre2grep bin/pcre2test
 SPK_COMMANDS += bin/rmlint
-SPK_COMMANDS += bin/rnm
 SPK_COMMANDS += bin/zstd bin/unzstd bin/zstdcat bin/zstdmt bin/zstdgrep bin/zstdless
 SPK_COMMANDS += bin/lzip bin/plzip
 SPK_COMMANDS += bin/fdupes
@@ -135,6 +128,13 @@ SPK_COMMANDS += bin/tth-hash
 SPK_COMMANDS += bin/whirlpool-hash
 
 include ../../mk/spksrc.spk.mk
+
+ifeq ($(call version_ge, $(TC_GCC), 4.8.1),1)
+# A compiler with support for C++11 language features is required.
+DEPENDS += cross/rnm
+OPTIONAL_DESC := $(OPTIONAL_DESC)", rnm"
+SPK_COMMANDS += bin/rnm
+endif
 
 .PHONY: synocli-file_extra_install
 synocli-file_extra_install:


### PR DESCRIPTION
## Description

follow-up to #5897
rnm tool was not included in packages after #5897. The evaluation of variable TC_GCC must be done after the include of the main *.mk file (spksrc.spk.mk for Makefiles under spksrc/spk/)
Otherwise the variable TC_GCC is not set and the version comparisions evaluate to false.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
