### PR TITLE
fix shared folder handling

### DIFF
--- a/mk/spksrc.service.installer.functions
+++ b/mk/spksrc.service.installer.functions
@@ -47,7 +47,6 @@ initialize_variables ()
 
     # Extract share volume and share name from share path when provided, and not already defined
     if [ -n "${SHARE_PATH}" ]; then
-        install_log "Evaluate full path for SHARE_NAME [${SHARE_NAME}] and SHARE_PATH [${SHARE_PATH}]"
         # migrate SHARE_PATH that holds the share name only to full share path
         # this is required for installers without resource worker for file share (SRM 1, DSM 5, DSM 6 old packages)
         if [ "$(echo ${SHARE_PATH} | grep ^/)" != "${SHARE_PATH}" ]; then
@@ -58,12 +57,11 @@ initialize_variables ()
             else
                 install_log "SHARE_NAME is not an existing share [${SHARE_PATH}]."
             fi
-        else
-            install_log "SHARE_PATH is absolute path [${SHARE_PATH}]."
         fi
         if [ -z "${SHARE_NAME}" ]; then
-            SHARE_NAME=$(echo $(realpath ${SHARE_PATH}) | awk -F/ '{print $3}')
+            SHARE_NAME=$(basename ${SHARE_PATH})
         fi
+        install_log "Shared folder configured with SHARE_NAME [${SHARE_NAME}] and SHARE_PATH [${SHARE_PATH}]"
     fi
 }
 

--- a/mk/spksrc.service.installer.functions
+++ b/mk/spksrc.service.installer.functions
@@ -62,7 +62,7 @@ initialize_variables ()
             install_log "SHARE_PATH is absolute path [${SHARE_PATH}]."
         fi
         if [ -z "${SHARE_NAME}" ]; then
-            SHARE_NAME=$(echo $(abspath ${SHARE_PATH}) | awk -F/ '{print $3}')
+            SHARE_NAME=$(echo $(realpath ${SHARE_PATH}) | awk -F/ '{print $3}')
         fi
     fi
 }


### PR DESCRIPTION
## Description

This is a follow up to #5649

- fix initialization of SHARE_NAME from SHARE_PATH

## Remarks
There is another issue with migration of shared folder handling from `SERVICE_WIZARD_SHARE` to `SERVICE_WIZARD_SHARENAME` variables.
On DSM 6 the migration does not work on package upgrade without an upgrade wizard that provides the share configuration again and reloads the wizard variable from previous installation (found in etc/installer-variables).

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
