### PR TITLE
ownCloud: Update PHP FPM in DSM 6

### DIFF
--- a/spk/owncloud/Makefile
+++ b/spk/owncloud/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = owncloud
 SPK_VERS = 10.13.2
-SPK_REV = 12
+SPK_REV = 13
 SPK_ICON = src/owncloud.png
 
 DEPENDS = cross/owncloud
@@ -18,7 +18,7 @@ HOMEPAGE = https://owncloud.org/
 
 LICENSE = AGPL
 
-WIZARDS_TEMPLATES_DIR = src/wizard_templates/
+WIZARDS_TEMPLATES_DIR = src/wizard_templates
 SERVICE_WIZARD_SHARENAME = wizard_data_share
 USE_DATA_SHARE_WORKER = yes
 
@@ -31,6 +31,13 @@ ADMIN_PROTOCOL = https
 DSM_UI_DIR = app
 DSM_UI_CONFIG = src/app/config
 CONF_DIR = src/conf/
+
+include ../../mk/spksrc.common.mk
+
+# Alternate conf dir for DSM 6
+ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
+CONF_DIR = src/conf_6/
+endif
 
 SERVICE_SETUP = src/service-setup.sh
 STARTABLE = no

--- a/spk/owncloud/src/conf_6/resource
+++ b/spk/owncloud/src/conf_6/resource
@@ -1,0 +1,11 @@
+{
+	"data-share": {
+		"shares": [{
+			"name": "{{wizard_data_share}}",
+			"permission": {
+				"rw": ["http"]
+			},
+			"once": true
+		}]
+	}
+}

--- a/spk/owncloud/src/service-setup.sh
+++ b/spk/owncloud/src/service-setup.sh
@@ -356,6 +356,7 @@ service_postuninst ()
             ${MV} ${WS_CFG_PATH}/${PHP_CFG_FILE} ${WS_CFG_PATH}/${PHP_CFG_FILE}.bak
             rsync -aX ${TEMPDIR}/${PHP_CFG_FILE} ${WS_CFG_PATH}/ 2>&1
             ${RM} ${TEMPDIR}/${PHP_CFG_FILE}
+            ${RM} "${WS_CFG_PATH}/php_profile/com-synocommunity-packages-owncloud"
             CFG_UPDATE="yes"
         fi
         # Check for ownCloud Apache config

--- a/spk/owncloud/src/service-setup.sh
+++ b/spk/owncloud/src/service-setup.sh
@@ -195,8 +195,12 @@ service_postinst ()
         fi
         # Restart Apache if configs have changed
         if [ "$CFG_UPDATE" = "yes" ]; then
-            echo "Restart Apache to load new configs"
-            ${SYNOSVC} --restart pkgctl-Apache2.4
+            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+                echo " [WARNING] Multiple PHP profiles detected, will require restart of DSM to load new configs"
+            else
+                echo "Restart Apache to load new configs"
+                ${SYNOSVC} --restart pkgctl-Apache2.4
+            fi
         fi
         # Clean-up temporary files
         ${RM} ${TEMPDIR}
@@ -297,7 +301,7 @@ service_preuninst ()
             echo "Copying previous configuration from ${OCROOT}"
             ${MKDIR} "${TEMPDIR}/configs/root"
             rsync -aX "${OCROOT}/.user.ini" "${OCROOT}/.htaccess" "${TEMPDIR}/configs/root/" 2>&1
-            rsync -aX "${OCROOT}/config" "${OCROOT}/data" "${OCROOT}/apps" "${OCROOT}/apps-external" "${TEMPDIR}/configs/" 2>&1
+            rsync -aX "${OCROOT}/config" "${OCROOT}/apps" "${OCROOT}/apps-external" "${TEMPDIR}/configs/" 2>&1
 
             # Backup user data
             echo "Copying previous user data from ${DATADIR}"
@@ -362,8 +366,12 @@ service_postuninst ()
         fi
         # Restart Apache if configs have changed
         if [ "$CFG_UPDATE" = "yes" ]; then
-            echo "Restart Apache to load new configs"
-            ${SYNOSVC} --restart pkgctl-Apache2.4
+            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+                echo " [WARNING] Multiple PHP profiles detected, will require restart of DSM to load new configs"
+            else
+                echo "Restart Apache to load new configs"
+                ${SYNOSVC} --restart pkgctl-Apache2.4
+            fi
         fi
         # Clean-up temporary files
         ${RM} ${TEMPDIR}
@@ -392,8 +400,12 @@ service_postupgrade()
         fi
         # Restart Apache if configs have changed
         if [ "$CFG_UPDATE" = "yes" ]; then
-            echo "Restart Apache to load new configs"
-            ${SYNOSVC} --restart pkgctl-Apache2.4
+            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+                echo " [WARNING] Multiple PHP profiles detected, will require restart of DSM to load new configs"
+            else
+                echo "Restart Apache to load new configs"
+                ${SYNOSVC} --restart pkgctl-Apache2.4
+            fi
         fi
         # Clean-up temporary files
         ${RM} ${TEMPDIR}

--- a/spk/owncloud/src/service-setup.sh
+++ b/spk/owncloud/src/service-setup.sh
@@ -151,51 +151,50 @@ service_postinst ()
         # Install web configurations
         TEMPDIR="${SYNOPKG_PKGTMP}/web"
         ${MKDIR} ${TEMPDIR}
-        WS_CFG_PATH="/usr/syno/etc/packages/WebStation"
+        WS_CFG_DIR="/usr/syno/etc/packages/WebStation"
         WS_CFG_FILE="WebStation.json"
+        WS_CFG_PATH="${WS_CFG_DIR}/${WS_CFG_FILE}"
+        TMP_WS_CFG_PATH="${TEMPDIR}/${WS_CFG_FILE}"
         PHP_CFG_FILE="PHPSettings.json"
+        PHP_CFG_PATH="${WS_CFG_DIR}/${PHP_CFG_FILE}"
+        TMP_PHP_CFG_PATH="${TEMPDIR}/${PHP_CFG_FILE}"
         PHP_PROF_NAME="Default PHP 7.4 Profile"
-        WS_BACKEND="$(${JQ} -r '.default.backend' ${WS_CFG_PATH}/${WS_CFG_FILE})"
-        WS_PHP="$(${JQ} -r '.default.php' ${WS_CFG_PATH}/${WS_CFG_FILE})"
-        CFG_UPDATE="no"
+        WS_BACKEND="$(${JQ} -r '.default.backend' ${WS_CFG_PATH})"
+        WS_PHP="$(${JQ} -r '.default.php' ${WS_CFG_PATH})"
+        RESTART_APACHE="no"
+        RSYNC_ARCH_ARGS="--backup --suffix=.bak --remove-source-files"
         # Check if Apache is the selected back-end
         if [ ! "$WS_BACKEND" = "2" ]; then
             echo "Set Apache as the back-end server"
-            ${JQ} '.default.backend = 2' ${WS_CFG_PATH}/${WS_CFG_FILE} > ${TEMPDIR}/${WS_CFG_FILE}
-            ${MV} ${WS_CFG_PATH}/${WS_CFG_FILE} ${WS_CFG_PATH}/${WS_CFG_FILE}.bak
-            rsync -aX ${TEMPDIR}/${WS_CFG_FILE} ${WS_CFG_PATH}/ 2>&1
-            ${RM} ${TEMPDIR}/${WS_CFG_FILE}
-            CFG_UPDATE="yes"
+            ${JQ} '.default.backend = 2' ${WS_CFG_PATH} > ${TMP_WS_CFG_PATH}
+            rsync -aX ${RSYNC_ARCH_ARGS} ${TMP_WS_CFG_PATH} ${WS_CFG_DIR}/ 2>&1
+            RESTART_APACHE="yes"
         fi
         # Check if default PHP profile is selected
         if [ -z "$WS_PHP" ] || [ "$WS_PHP" = "null" ]; then
             echo "Enable default PHP profile"
             # Locate default PHP profile
-            PHP_PROF_ID="$(${JQ} -r '. | to_entries[] | select(.value | type == "object" and .profile_desc == "'"$PHP_PROF_NAME"'") | .key' "${WS_CFG_PATH}/${PHP_CFG_FILE}")"
-            ${JQ} ".default.php = \"$PHP_PROF_ID\"" "${WS_CFG_PATH}/${WS_CFG_FILE}" > ${TEMPDIR}/${WS_CFG_FILE}
-            ${MV} ${WS_CFG_PATH}/${WS_CFG_FILE} ${WS_CFG_PATH}/${WS_CFG_FILE}.bak
-            rsync -aX ${TEMPDIR}/${WS_CFG_FILE} ${WS_CFG_PATH}/ 2>&1
-            ${RM} ${TEMPDIR}/${WS_CFG_FILE}
-            CFG_UPDATE="yes"
+            PHP_PROF_ID="$(${JQ} -r '. | to_entries[] | select(.value | type == "object" and .profile_desc == "'"$PHP_PROF_NAME"'") | .key' "${PHP_CFG_PATH}")"
+            ${JQ} ".default.php = \"$PHP_PROF_ID\"" "${WS_CFG_PATH}" > ${TMP_WS_CFG_PATH}
+            rsync -aX ${RSYNC_ARCH_ARGS} ${TMP_WS_CFG_PATH} ${WS_CFG_DIR}/ 2>&1
+            RESTART_APACHE="yes"
         fi
         # Check for ownCloud PHP profile
-        if ! ${JQ} -e '.["com-synocommunity-packages-owncloud"]' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+        if ! ${JQ} -e '.["com-synocommunity-packages-owncloud"]' "${PHP_CFG_PATH}" >/dev/null; then
             echo "Add PHP profile for ownCloud"
-            ${JQ} --slurpfile ocNode ${SYNOPKG_PKGDEST}/web/owncloud.json '.["com-synocommunity-packages-owncloud"] = $ocNode[0]' ${WS_CFG_PATH}/${PHP_CFG_FILE} > ${TEMPDIR}/${PHP_CFG_FILE}
-            ${MV} ${WS_CFG_PATH}/${PHP_CFG_FILE} ${WS_CFG_PATH}/${PHP_CFG_FILE}.bak
-            rsync -aX ${TEMPDIR}/${PHP_CFG_FILE} ${WS_CFG_PATH}/ 2>&1
-            ${RM} ${TEMPDIR}/${PHP_CFG_FILE}
-            CFG_UPDATE="yes"
+            ${JQ} --slurpfile ocNode ${SYNOPKG_PKGDEST}/web/owncloud.json '.["com-synocommunity-packages-owncloud"] = $ocNode[0]' ${PHP_CFG_PATH} > ${TMP_PHP_CFG_PATH}
+            rsync -aX ${RSYNC_ARCH_ARGS} ${TMP_PHP_CFG_PATH} ${WS_CFG_DIR}/ 2>&1
+            RESTART_APACHE="yes"
         fi
         # Check for ownCloud Apache config
         if [ ! -f "/usr/local/etc/apache24/sites-enabled/owncloud.conf" ]; then
             echo "Add Apache config for ownCloud"
             rsync -aX ${SYNOPKG_PKGDEST}/web/owncloud.conf /usr/local/etc/apache24/sites-enabled/ 2>&1
-            CFG_UPDATE="yes"
+            RESTART_APACHE="yes"
         fi
         # Restart Apache if configs have changed
-        if [ "$CFG_UPDATE" = "yes" ]; then
-            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+        if [ "$RESTART_APACHE" = "yes" ]; then
+            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
                 echo " [WARNING] Multiple PHP profiles detected, will require restart of DSM to load new configs"
             else
                 echo "Restart Apache to load new configs"
@@ -346,28 +345,29 @@ service_postuninst ()
         # Remove web configurations
         TEMPDIR="${SYNOPKG_PKGTMP}/web"
         ${MKDIR} ${TEMPDIR}
-        WS_CFG_PATH="/usr/syno/etc/packages/WebStation"
+        WS_CFG_DIR="/usr/syno/etc/packages/WebStation"
         PHP_CFG_FILE="PHPSettings.json"
-        CFG_UPDATE="no"
+        PHP_CFG_PATH="${WS_CFG_DIR}/${PHP_CFG_FILE}"
+        TMP_PHP_CFG_PATH="${TEMPDIR}/${PHP_CFG_FILE}"
+        RESTART_APACHE="no"
+        RSYNC_ARCH_ARGS="--backup --suffix=.bak --remove-source-files"
         # Check for ownCloud PHP profile
-        if ${JQ} -e '.["com-synocommunity-packages-owncloud"]' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+        if ${JQ} -e '.["com-synocommunity-packages-owncloud"]' "${PHP_CFG_PATH}" >/dev/null; then
             echo "Removing PHP profile for ownCloud"
-            ${JQ} 'del(.["com-synocommunity-packages-owncloud"])' ${WS_CFG_PATH}/${PHP_CFG_FILE} > ${TEMPDIR}/${PHP_CFG_FILE}
-            ${MV} ${WS_CFG_PATH}/${PHP_CFG_FILE} ${WS_CFG_PATH}/${PHP_CFG_FILE}.bak
-            rsync -aX ${TEMPDIR}/${PHP_CFG_FILE} ${WS_CFG_PATH}/ 2>&1
-            ${RM} ${TEMPDIR}/${PHP_CFG_FILE}
-            ${RM} "${WS_CFG_PATH}/php_profile/com-synocommunity-packages-owncloud"
-            CFG_UPDATE="yes"
+            ${JQ} 'del(.["com-synocommunity-packages-owncloud"])' ${PHP_CFG_PATH} > ${TMP_PHP_CFG_PATH}
+            rsync -aX ${RSYNC_ARCH_ARGS} ${TMP_PHP_CFG_PATH} ${WS_CFG_DIR}/ 2>&1
+            ${RM} "${WS_CFG_DIR}/php_profile/com-synocommunity-packages-owncloud"
+            RESTART_APACHE="yes"
         fi
         # Check for ownCloud Apache config
         if [ -f "/usr/local/etc/apache24/sites-enabled/owncloud.conf" ]; then
             echo "Removing Apache config for ownCloud"
             ${RM} /usr/local/etc/apache24/sites-enabled/owncloud.conf
-            CFG_UPDATE="yes"
+            RESTART_APACHE="yes"
         fi
         # Restart Apache if configs have changed
-        if [ "$CFG_UPDATE" = "yes" ]; then
-            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+        if [ "$RESTART_APACHE" = "yes" ]; then
+            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
                 echo " [WARNING] Multiple PHP profiles detected, will require restart of DSM to load new configs"
             else
                 echo "Restart Apache to load new configs"
@@ -385,23 +385,27 @@ service_postupgrade()
     if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
         TEMPDIR="${SYNOPKG_PKGTMP}/web"
         ${MKDIR} ${TEMPDIR}
-        WS_TMPL_PATH="/var/packages/WebStation/target/misc"
+        WS_CFG_DIR="/usr/syno/etc/packages/WebStation"
+        PHP_CFG_FILE="PHPSettings.json"
+        PHP_CFG_PATH="${WS_CFG_DIR}/${PHP_CFG_FILE}"
+        WS_TMPL_DIR="/var/packages/WebStation/target/misc"
         WS_TMPL_FILE="php74_fpm.mustache"
-        CFG_UPDATE="no"
+        WS_TMPL_PATH="${WS_TMPL_DIR}/${WS_TMPL_FILE}"
+        TMP_WS_TMPL_PATH="${TEMPDIR}/${WS_TMPL_FILE}"
+        RESTART_APACHE="no"
+        RSYNC_ARCH_ARGS="--backup --suffix=.bak --remove-source-files"
         # Check for PHP template defaults
-        if ! grep -q -E '^user = http$' "${WS_TMPL_PATH}/${WS_TMPL_FILE}" || ! grep -q -E '^listen\.owner = http$' "${WS_TMPL_PATH}/${WS_TMPL_FILE}"; then
+        if ! grep -q -E '^user = http$' "${WS_TMPL_PATH}" || ! grep -q -E '^listen\.owner = http$' "${WS_TMPL_PATH}"; then
             echo "Restore default PHP template; remove previous PHP FPM configuration"
-            rsync -aX ${WS_TMPL_PATH}/${WS_TMPL_FILE} ${TEMPDIR}/ 2>&1
+            rsync -aX ${WS_TMPL_PATH} ${TEMPDIR}/ 2>&1
             SUBST_TEXT="{{#fpm_settings.user_owncloud}}sc-owncloud{{/fpm_settings.user_owncloud}}{{^fpm_settings.user_owncloud}}http{{/fpm_settings.user_owncloud}}"
-            ${SED} -i "s|^user = ${SUBST_TEXT}$|user = http|g; s|^listen.owner = ${SUBST_TEXT}$|listen.owner = http|g" "${TEMPDIR}/${WS_TMPL_FILE}"
-            ${MV} ${WS_TMPL_PATH}/${WS_TMPL_FILE} ${WS_TMPL_PATH}/${WS_TMPL_FILE}.bak
-            rsync -aX ${TEMPDIR}/${WS_TMPL_FILE} ${WS_TMPL_PATH}/ 2>&1
-            ${RM} ${TEMPDIR}/${WS_TMPL_FILE}
-            CFG_UPDATE="yes"
+            ${SED} -i "s|^user = ${SUBST_TEXT}$|user = http|g; s|^listen.owner = ${SUBST_TEXT}$|listen.owner = http|g" "${TMP_WS_TMPL_PATH}"
+            rsync -aX ${RSYNC_ARCH_ARGS} ${TMP_WS_TMPL_PATH} ${WS_TMPL_DIR}/ 2>&1
+            RESTART_APACHE="yes"
         fi
         # Restart Apache if configs have changed
-        if [ "$CFG_UPDATE" = "yes" ]; then
-            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${WS_CFG_PATH}/${PHP_CFG_FILE}" >/dev/null; then
+        if [ "$RESTART_APACHE" = "yes" ]; then
+            if ${JQ} -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
                 echo " [WARNING] Multiple PHP profiles detected, will require restart of DSM to load new configs"
             else
                 echo "Restart Apache to load new configs"
@@ -439,10 +443,11 @@ service_save ()
     SAVE_STATE="normal"
     if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
         # Check for modification to PHP template defaults from previous versions
-        WS_TMPL_PATH="/var/packages/WebStation/target/misc"
+        WS_TMPL_DIR="/var/packages/WebStation/target/misc"
         WS_TMPL_FILE="php74_fpm.mustache"
+        WS_TMPL_PATH="${WS_TMPL_DIR}/${WS_TMPL_FILE}"
         # Check for PHP template defaults
-        if ! grep -q -E '^user = http$' "${WS_TMPL_PATH}/${WS_TMPL_FILE}" || ! grep -q -E '^listen\.owner = http$' "${WS_TMPL_PATH}/${WS_TMPL_FILE}"; then
+        if ! grep -q -E '^user = http$' "${WS_TMPL_PATH}" || ! grep -q -E '^listen\.owner = http$' "${WS_TMPL_PATH}"; then
             SAVE_STATE="migrate"
         fi
     fi

--- a/spk/owncloud/src/service-setup.sh
+++ b/spk/owncloud/src/service-setup.sh
@@ -234,7 +234,7 @@ service_postinst ()
 
                 # Restore configuration files and directories
                 rsync -aX --update -I "${TEMPDIR}/configs/root/.user.ini" "${TEMPDIR}/configs/root/.htaccess" "${OCROOT}/" 2>&1
-                rsync -aX --update -I "${TEMPDIR}/configs/config" "${TEMPDIR}/configs/data" "${TEMPDIR}/configs/apps" "${TEMPDIR}/configs/apps-external" "${OCROOT}/" 2>&1
+                rsync -aX --update -I "${TEMPDIR}/configs/config" "${TEMPDIR}/configs/apps" "${TEMPDIR}/configs/apps-external" "${OCROOT}/" 2>&1
 
                 # Restore user data
                 echo "Restoring user data to ${DATA_DIR}"

--- a/spk/owncloud/src/web/owncloud.json
+++ b/spk/owncloud/src/web/owncloud.json
@@ -26,8 +26,7 @@
 		"max_spare_servers": 3,
 		"min_spare_servers": 1,
 		"mode": "dynamic",
-		"start_servers": 2,
-		"user_owncloud": true
+		"start_servers": 2
 	},
 	"open_basedir": "",
 	"php_settings": {},

--- a/spk/owncloud/src/wizard_templates/install_uifile.yml
+++ b/spk/owncloud/src/wizard_templates/install_uifile.yml
@@ -23,3 +23,6 @@ OWNCLOUD_TRUSTED_DOMAIN_3_LABEL: "Domain or IP address"
 
 OWNCLOUD_CONFIRM_RESTORE_STEP_TITLE: "ownCloud confirm restore"
 OWNCLOUD_CONFIRM_RESTORE_DESCRIPTION: "The installation will now proceed, and your previous configuration will be restored from the backup. Please verify that the file path is accurate and that the user 'sc-owncloud' has read permissions for that path; otherwise, a new installation will be initiated."
+
+PHP_PROFILES_TITLE: "Multiple PHP profiles"
+PHP_PROFILES_DESCRIPTION: "Attention: Multiple PHP profiles detected; the package webpage will not display until a DSM restart is performed to load new configurations."

--- a/spk/owncloud/src/wizard_templates/install_uifile_fre.yml
+++ b/spk/owncloud/src/wizard_templates/install_uifile_fre.yml
@@ -23,3 +23,6 @@ OWNCLOUD_TRUSTED_DOMAIN_3_LABEL: "Domaine ou adresse IP"
 
 OWNCLOUD_CONFIRM_RESTORE_STEP_TITLE: "Confirmer la restauration ownCloud"
 OWNCLOUD_CONFIRM_RESTORE_DESCRIPTION: "L'installation va maintenant se poursuivre et votre configuration précédente sera restaurée à partir de la sauvegarde. Veuillez vérifier que le chemin du fichier est exact et que l'utilisateur « sc-owncloud » dispose des autorisations de lecture pour ce chemin ; sinon, une nouvelle installation sera lancée."
+
+PHP_PROFILES_TITLE: "Plusieurs profils PHP"
+PHP_PROFILES_DESCRIPTION: "Attention : Plusieurs profils PHP détectés ; la page Web du package ne s'affichera pas tant qu'un redémarrage de DSM n'aura pas été effectué pour charger de nouvelles configurations."

--- a/spk/owncloud/src/wizard_templates/uninstall_uifile.sh
+++ b/spk/owncloud/src/wizard_templates/uninstall_uifile.sh
@@ -10,7 +10,8 @@ if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
 	fi
 fi
 
-quote_json () {
+quote_json ()
+{
 	sed -e 's|\\|\\\\|g' -e 's|\"|\\\"|g'
 }
 

--- a/spk/owncloud/src/wizard_templates/upgrade_uifile.sh
+++ b/spk/owncloud/src/wizard_templates/upgrade_uifile.sh
@@ -3,7 +3,8 @@
 OC_NEW_VER=$(echo ${SYNOPKG_PKGVER} | cut -d '-' -f 1)
 OC_OLD_VER=$(echo ${SYNOPKG_OLD_PKGVER} | cut -d '-' -f 1)
 
-quote_json () {
+quote_json ()
+{
 	sed -e 's|\\|\\\\|g' -e 's|\"|\\\"|g'
 }
 


### PR DESCRIPTION
## Description

This is a follow-on from #5912 which fixes the PHP FPM handling in DSM 6 by making all functions run as the `http` user. Code has also been added to revert modification to PHP template defaults from previous versions.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
