### PR TITLE
ownCloud: Fix bug in wizard scripts

### DIFF
--- a/spk/owncloud/Makefile
+++ b/spk/owncloud/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = owncloud
 SPK_VERS = 10.13.3
-SPK_REV = 14
+SPK_REV = 15
 SPK_ICON = src/owncloud.png
 
 DEPENDS = cross/owncloud

--- a/spk/owncloud/src/wizard_templates/install_uifile.sh
+++ b/spk/owncloud/src/wizard_templates/install_uifile.sh
@@ -5,7 +5,6 @@ if [ -z ${SYNOPKG_PKGDEST_VOL} ]; then
 	SYNOPKG_PKGDEST_VOL="/volume1"
 fi
 SHAREDIR="${SYNOPKG_PKGNAME}"
-DIR_VALID="/^[\\w _-]+$/"
 
 quote_json ()
 {
@@ -195,7 +194,7 @@ PAGE_ADMIN_CONFIG=$(/bin/cat<<EOF
 			"validator": {
 				"allowBlank": false,
 				"regex": {
-					"expr": "$(echo ${DIR_VALID} | quote_json)",
+					"expr": "/^[\\w.][\\w. -]{0,30}[\\w.-]\\$?$|^[\\w]$/",
 					"errorText": "{{{OWNCLOUD_DATA_DIRECTORY_VALIDATION_ERROR_TEXT}}}"
 				}
 			}

--- a/spk/owncloud/src/wizard_templates/install_uifile.sh
+++ b/spk/owncloud/src/wizard_templates/install_uifile.sh
@@ -143,12 +143,11 @@ EOF
 check_php_profiles ()
 {
 	PHP_CFG_PATH="/usr/syno/etc/packages/WebStation/PHPSettings.json"
-	if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
-		if jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
-			return 0  # true
-		else
-			return 1  # false
-		fi
+	if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ] && \
+		jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-owncloud")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
+		return 0  # true
+	else
+		return 1  # false
 	fi
 }
 

--- a/spk/owncloud/src/wizard_templates/install_uifile.sh
+++ b/spk/owncloud/src/wizard_templates/install_uifile.sh
@@ -193,7 +193,7 @@ PAGE_ADMIN_CONFIG=$(/bin/cat<<EOF
 			"validator": {
 				"allowBlank": false,
 				"regex": {
-					"expr": "/^[\\w.][\\w. -]{0,30}[\\w.-]\\$?$|^[\\w]$/",
+					"expr": "/^[\\\w.][\\\w. -]{0,30}[\\\w.-][\\\\$]?$|^[\\\w][\\\\$]?$/",
 					"errorText": "{{{OWNCLOUD_DATA_DIRECTORY_VALIDATION_ERROR_TEXT}}}"
 				}
 			}

--- a/spk/owncloud/src/wizard_templates/uninstall_uifile.sh
+++ b/spk/owncloud/src/wizard_templates/uninstall_uifile.sh
@@ -33,7 +33,7 @@ getValidPath()
 	VALID_PATH=$(/bin/cat<<EOF
 {
 	var exportPath = arguments[0];
-	const pattern = /^\/volume[0-9]+\//;
+	const pattern = /^\/(volume|volumeUSB)[0-9]+\//;
 	if (exportPath === "") {
 		return true;
 	} else if (pattern.test(exportPath)) {


### PR DESCRIPTION
## Description

This aims to rectify the concern highlighted in #5949 by addressing a bug in the installation wizard that inaccurately indicates multiple PHP profiles. This issue is specifically noticed in DSM 7 installations and is a consequence of modifications introduced in #5920. The underlying cause of this bug can be traced back to a logic error within a DSM 6 feature.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
