### PR TITLE
Selfoss: Fix bug in wizard scripts

### DIFF
--- a/spk/selfoss/Makefile
+++ b/spk/selfoss/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = selfoss
 SPK_VERS = 2.19
-SPK_REV = 7
+SPK_REV = 8
 SPK_ICON = src/selfoss.png
 
 DEPENDS  = cross/selfoss

--- a/spk/selfoss/src/wizard/install_uifile.sh
+++ b/spk/selfoss/src/wizard/install_uifile.sh
@@ -20,12 +20,11 @@ page_append ()
 check_php_profiles ()
 {
 	PHP_CFG_PATH="/usr/syno/etc/packages/WebStation/PHPSettings.json"
-	if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
-		if jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-selfoss")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
-			return 0  # true
-		else
-			return 1  # false
-		fi
+	if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ] && \
+		jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-selfoss")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
+		return 0  # true
+	else
+		return 1  # false
 	fi
 }
 

--- a/spk/selfoss/src/wizard/install_uifile_fre.sh
+++ b/spk/selfoss/src/wizard/install_uifile_fre.sh
@@ -20,12 +20,11 @@ page_append ()
 check_php_profiles ()
 {
 	PHP_CFG_PATH="/usr/syno/etc/packages/WebStation/PHPSettings.json"
-	if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
-		if jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-selfoss")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
-			return 0  # true
-		else
-			return 1  # false
-		fi
+	if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ] && \
+		jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-selfoss")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
+		return 0  # true
+	else
+		return 1  # false
 	fi
 }
 


### PR DESCRIPTION
## Description

This addresses a bug identified in pull request #5916, where the installation wizard incorrectly detects multiple PHP profiles. This issue is specific to DSM 7 installations, making the concern irrelevant for these cases. It's important to clarify that the initial implementation was intended as an enhancement exclusively for DSM 6 users.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
