### PR TITLE
tt-rss: Fix bug in wizard scripts

### DIFF
--- a/spk/tt-rss/Makefile
+++ b/spk/tt-rss/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = tt-rss
 SPK_VERS = 20230828
-SPK_REV = 17
+SPK_REV = 18
 SPK_ICON = src/tt-rss.png
 
 DEPENDS  = cross/$(SPK_NAME)
@@ -15,7 +15,7 @@ MAINTAINER = moneytoo
 DESCRIPTION = Tiny Tiny RSS is an open source web-based news feed \(RSS/Atom\) reader and aggregator, designed to allow you to read news from any location, while feeling as close to a real desktop application as possible.
 DESCRIPTION_FRE = Tiny Tiny RSS est un agrégateur et lecteur web de flux RSS et Atom open source conçu pour vous permettre de lire des nouvelles de n\'importe quel endroit, tout en se sentant aussi proche d\'une application de bureau que possible.
 DISPLAY_NAME = Tiny Tiny RSS
-CHANGELOG = "1. Update Tiny Tiny RSS to Git revision afd04d141c \(20230828\).<br/>2. Fix for DSM 6 app startup."
+CHANGELOG = "1. Update Tiny Tiny RSS to Git revision afd04d141c (20230828).<br/>2. Fix for DSM 6 app startup."
 
 HOMEPAGE   = https://tt-rss.org/
 LICENSE    = GPL

--- a/spk/tt-rss/src/wizard_templates/install_uifile.sh
+++ b/spk/tt-rss/src/wizard_templates/install_uifile.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+INTERNAL_IP=$(ip -4 route get 8.8.8.8 | awk '/8.8.8.8/ && /src/ {print $NF}')
+
 quote_json ()
 {
     sed -e 's|\\|\\\\|g' -e 's|\"|\\\"|g'
@@ -93,6 +95,7 @@ PAGE_TTRSS_SETUP=$(/bin/cat<<EOF
         "subitems": [{
             "key": "wizard_domain_name",
             "desc": "{{DOMAIN_NAME_INPUT_LABEL}}",
+            "defaultValue": "${INTERNAL_IP}",
             "validator": {
                 "allowBlank": false
             }

--- a/spk/tt-rss/src/wizard_templates/install_uifile.sh
+++ b/spk/tt-rss/src/wizard_templates/install_uifile.sh
@@ -21,7 +21,7 @@ getPasswordValidator()
     validator=$(/bin/cat<<EOF
 {
     var password = arguments[0];
-    return -1 !== password.search("(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[^A-Za-z0-9])(?=.{10,})") && ! password.includes("root");
+    return -1 !== password.search("(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[^A-Za-z0-9])(?=.{10,})");
 }
 EOF
 )
@@ -68,9 +68,8 @@ PAGE_TTRSS_SETUP=$(/bin/cat<<EOF
         "subitems": [{
             "key": "wizard_mysql_password_root",
             "desc": "{{ROOT_PASSWORD_DESCRIPTION}}",
-            "invalidText": "{{INVALID_ROOT_PASSWORD}}",
             "validator": {
-                "fn": "$(getPasswordValidator)"
+                "allowBlank": false
             }
         }]
     }, {

--- a/spk/tt-rss/src/wizard_templates/install_uifile.sh
+++ b/spk/tt-rss/src/wizard_templates/install_uifile.sh
@@ -32,12 +32,11 @@ EOF
 check_php_profiles ()
 {
     PHP_CFG_PATH="/usr/syno/etc/packages/WebStation/PHPSettings.json"
-    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
-        if jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-tt-rss")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
-            return 0  # true
-        else
-            return 1  # false
-        fi
+    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ] && \
+        jq -e 'to_entries | map(select((.key | startswith("com-synocommunity-packages-")) and .key != "com-synocommunity-packages-tt-rss")) | length > 0' "${PHP_CFG_PATH}" >/dev/null; then
+        return 0  # true
+    else
+        return 1  # false
     fi
 }
 

--- a/spk/tt-rss/src/wizard_templates/install_uifile.yml
+++ b/spk/tt-rss/src/wizard_templates/install_uifile.yml
@@ -1,10 +1,9 @@
 DB_CONFIGURATION_TITLE:             Tt-rss database configuration
 ENTER_MYSQL_PASSWORD:               Enter your MySQL password.
 ROOT_PASSWORD_DESCRIPTION:          Root password
-INVALID_ROOT_PASSWORD:              "Invalid password. Please ensure it has at least one uppercase letter, one lowercase letter, one digit, one special character, a minimum length of 10 characters, and does not contain the word 'root'."
 ENTER_TT-RSS_PASSWORD:              A 'ttrss' MySQL user and database will be created. Please enter a password for the 'ttrss' user.
 TT-RSS_PASSWORD_DESCRIPTION:        Ttrss password
-INVALID_TT-RSS_PASSWORD:            "Invalid password. Please ensure it has at least one uppercase letter, one lowercase letter, one digit, one special character, a minimum length of 10 characters, and does not contain the word 'root'."
+INVALID_TT-RSS_PASSWORD:            "Password is invalid. Ensure it includes at least one uppercase letter, one lowercase letter, one digit, one special character, and has a minimum length of 10 characters."
 TT-RSS_CONFIGURATION_TITLE:         Tt-rss configuration
 DOMAIN_NAME_SECTION_LABEL:          "Domain name of your DiskStation. For example: you.synology.me."
 DOMAIN_NAME_INPUT_LABEL:            Domain name

--- a/spk/tt-rss/src/wizard_templates/install_uifile_fre.yml
+++ b/spk/tt-rss/src/wizard_templates/install_uifile_fre.yml
@@ -1,10 +1,9 @@
 DB_CONFIGURATION_TITLE:             Configuration de la base de donnée de tt-rss
 ENTER_MYSQL_PASSWORD:               Saisissez votre mot de passe MySQL.
 ROOT_PASSWORD_DESCRIPTION:          Mot de passe Root
-INVALID_ROOT_PASSWORD:              "Mot de passe invalide. Veuillez vous assurer qu'il comporte au moins une lettre majuscule, une lettre minuscule, un chiffre, un caractère spécial, une longueur minimale de 10 caractères et qu'il ne contient pas le mot 'root'."
 ENTER_TT-RSS_PASSWORD:              Un utilisateur et une base de donnée MySQL 'ttrss' vont être créés. Saisissez un mot de passe pour l'utilisateur 'ttrss'.
 TT-RSS_PASSWORD_DESCRIPTION:        Mot de passe Ttrss
-INVALID_TT-RSS_PASSWORD:            "Mot de passe invalide. Veuillez vous assurer qu'il comporte au moins une lettre majuscule, une lettre minuscule, un chiffre, un caractère spécial, une longueur minimale de 10 caractères et qu'il ne contient pas le mot 'root'."
+INVALID_TT-RSS_PASSWORD:            "Mot de passe invalide. Assurez-vous qu'il comprend au moins une lettre majuscule, une lettre minuscule, un chiffre, un caractère spécial et qu'il a une longueur minimale de 10 caractères."
 TT-RSS_CONFIGURATION_TITLE:         Tt-rss configuration
 DOMAIN_NAME_SECTION_LABEL:          "Nom de domaine de votre DiskStation. Par exemple : vous.synology.me."
 DOMAIN_NAME_INPUT_LABEL:            Nom de domaine

--- a/spk/tt-rss/src/wizard_templates/uninstall_uifile
+++ b/spk/tt-rss/src/wizard_templates/uninstall_uifile
@@ -1,5 +1,6 @@
 [{
 	"step_title": "{{REMOVE_TT_RSS_TITLE}}",
+	"invalid_next_disabled_v2": true,
 	"items": [{
 		"desc": "{{REMOVE_TT_RSS_DESC}}"
 	}, {
@@ -7,7 +8,10 @@
 		"desc": "{{ENTER_MYSQL_PASSWORD_DESC}}",
 		"subitems": [{
 			"key": "wizard_mysql_password_root",
-			"desc": "{{ROOT_PASSWORD}}"
+			"desc": "{{ROOT_PASSWORD}}",
+			"validator": {
+				"allowBlank": false
+			}
 		}]
 	}, {
 		"type": "textfield",
@@ -18,7 +22,7 @@
 			"validator": {
 				"allowBlank": true,
 				"regex": {
-					"expr": "/^\\\/volume[0-9]+\\\//",
+					"expr": "/^\\\/(volume|volumeUSB)[0-9]+\\\//",
 					"errorText": "{{{DB_EXPORT_LOCATION_FORMAT_ERROR}}}"
 				}
 			}		

--- a/spk/tt-rss/src/wizard_templates/upgrade_uifile.sh
+++ b/spk/tt-rss/src/wizard_templates/upgrade_uifile.sh
@@ -5,6 +5,7 @@ function with_migration
   cat <<EOF >"${SYNOPKG_TEMP_LOGFILE}"
 [ {
   "step_title": "{{DB_MIGRATION_TITLE}}",
+  "invalid_next_disabled_v2": true,
   "items": [ {
     "type": "multiselect",
     "subitems": [ {
@@ -18,11 +19,11 @@ function with_migration
         "defaultValue": false,
         "hidden": true
       }, {
-         "key": "mysql_grant_user",
-         "desc": "Initializes user rights",
-         "defaultValue": true,
-         "hidden": true
-       } ]
+        "key": "mysql_grant_user",
+        "desc": "Initializes user rights",
+        "defaultValue": true,
+        "hidden": true
+      } ]
     }, {
       "type": "password",
       "desc": "{{ROOT_PASSWORD_INPUT_DESCRIPTIONS}}",
@@ -40,13 +41,13 @@ function with_migration
           }
         } ]
     }, {
-       "type": "password",
-       "desc": "{{ENTER_TT-RSS_PASSWORD}}",
-       "subitems": [{
-         "key": "wizard_mysql_password_ttrss",
-         "desc": "{{TT-RSS_PASSWORD_DESCRIPTION}}"
-       }]
-     } ]
+      "type": "password",
+      "desc": "{{ENTER_TT-RSS_PASSWORD}}",
+      "subitems": [{
+        "key": "wizard_mysql_password_ttrss",
+        "desc": "{{TT-RSS_PASSWORD_DESCRIPTION}}"
+      }]
+    } ]
   } ]  
 EOF
 }


### PR DESCRIPTION
## Description

This addresses a bug identified in pull request #5923, where the installation wizard incorrectly detects multiple PHP profiles. This issue is specific to DSM 7 installations, making the concern irrelevant for these cases. It's important to clarify that the initial implementation was intended as an enhancement exclusively for DSM 6 users.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
