### PR TITLE
[Framework] Update arch exclusions for dotnet

### DIFF
--- a/mk/spksrc.archs.mk
+++ b/mk/spksrc.archs.mk
@@ -40,32 +40,21 @@ OLD_PPC_ARCHS = powerpc ppc824x ppc853x ppc854x
 # outdated unsupported archs
 DEPRECATED_ARCHS = powerpc ppc824x ppc854x ppc853x
 
-DOTNET_UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) 
-# .NET for x86 (32-bit) is supported on windows only (for linux, it must be built from source)
-DOTNET_UNSUPPORTED_ARCHS += $(i686_ARCHS)
-# ARMv7_ARCHS without full vfpv3 support (having only vfpv3-d16) are not supported
-# issue #5315
-DOTNET_UNSUPPORTED_ARCHS += armada370
-# issue #5302
-DOTNET_UNSUPPORTED_ARCHS += alpine
-# issue #5089
-DOTNET_UNSUPPORTED_ARCHS += monaco
-# issue #4790
-DOTNET_UNSUPPORTED_ARCHS += armadaxp
-# SRM armv7 archs are not supported
-DOTNET_UNSUPPORTED_ARCHS += $(SRM_ARMv7_ARCHS)
-
-# compatibility with .NET not yet confirmed:
-# alpine4k armada375 armada38x comcerto2k
+# Notes for .NET 6 compatibility:
+# 1. dotnet for x86 (32-bit) is unsupported on linux and must be built from source
+# 2. ARMv7_ARCHS without full vfpv3 support (having only vfpv3-d16) are not supported
+# 3. SRM ARMv7 archs are not supported
+# 4. Certain combinations of ARMv7 and DSM are incompatible (issues #4790, #5089, #5302, #5315)
+# 5. Comprehensive ARMv7 testing conducted under issue #5574 resulted in the following exclusions
 
 # Exclusions for dotnet 6.0 core apps
 ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370 alpine alpine4k
-    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1 armv7-1.2
+    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1 armv7-6.2 armv7-1.2
 endif
 
 # Exclusions for dotnet 6.0 servarr apps (except x86)
 ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine alpine4k
-    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1 armv7-1.2
+    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.1 armv7-6.2 armv7-1.2
 endif


### PR DESCRIPTION
## Description

This pull request enhances the clarity of dotnet 6.x exclusions by revising existing definitions, streamlines the documentation by consolidating notes and history, and introduces specific exclusions for ARMv7 under DSM 6.2.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
