### PR TITLE
COPS: Enhance Upgrade Process for Legacy Versions

### DIFF
--- a/spk/cops/Makefile
+++ b/spk/cops/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = cops
 SPK_VERS = 1.5.4
-SPK_REV = 8
+SPK_REV = 9
 SPK_ICON = src/cops.png
 
 DEPENDS  = cross/cops

--- a/spk/cops/src/conf/resource
+++ b/spk/cops/src/conf/resource
@@ -1,57 +1,55 @@
 {
-  "data-share": {
-    "shares": [{
-      "name": "{{wizard_calibre_share}}",
-      "once": true,
-      "permission": {
-        "rw": ["sc-cops"]
-      }
-    }]
-  },
-  "webservice": {
-    "migrate": {
-      "root": [{
-        "new": "cops",
-        "old": "cops"
-      }]
-    },
-    "pkg_dir_prepare": [{
-      "group": "http",
-      "mode": "0755",
-      "source": "/var/packages/cops/target/share/cops",
-      "target": "cops",
-      "user": "sc-cops"
-      }],
-    "portals": [
-      {
-        "alias": "cops",
-        "app": "com.synocommunity.packages.cops",
-        "name": "COPS",
-        "service": "cops",
-        "type": "alias"
-      }
-    ],
-    "services": [{
-      "backend": 2,
-      "display_name": "COPS",
-      "icon": "app/images/cops-{0}.png",
-      "php": {
-        "backend": 8,
-        "extensions": [
-          "gd",
-          "intl",
-          "pdo_sqlite",
-          "sqlite3",
-          "zlib"
-        ],
-        "group": "http",
-        "profile_desc": "PHP profile used by cops",
-        "profile_name": "cops",
-        "user": "sc-cops"
-      },
-      "root": "cops",
-      "service": "cops",
-      "type": "apache_php"
-    }]
-  }
+	"data-share": {
+		"shares": [{
+			"name": "{{wizard_calibre_share}}",
+			"once": true,
+			"permission": {
+				"rw": ["sc-cops"]
+			}
+		}]
+	},
+	"webservice": {
+		"migrate": {
+			"root": [{
+				"new": "cops",
+				"old": "cops"
+			}]
+		},
+		"pkg_dir_prepare": [{
+			"group": "http",
+			"mode": "0755",
+			"source": "/var/packages/cops/target/share/cops",
+			"target": "cops",
+			"user": "sc-cops"
+		}],
+		"portals": [{
+			"alias": "cops",
+			"app": "com.synocommunity.packages.cops",
+			"name": "COPS",
+			"service": "cops",
+			"type": "alias"
+		}],
+		"services": [{
+			"backend": 2,
+			"display_name": "COPS",
+			"icon": "app/images/cops-{0}.png",
+			"php": {
+				"backend": 8,
+				"extensions": [
+					"gd",
+					"intl",
+					"pdo_sqlite",
+					"sqlite3",
+					"zlib"
+				],
+				"group": "http",
+				"profile_desc": "PHP profile used by cops",
+				"profile_name": "cops",
+				"user": "sc-cops"
+			},
+			"root": "cops",
+			"service": "cops",
+			"type": "apache_php"
+		}]
+	}
 }

--- a/spk/cops/src/conf/resource
+++ b/spk/cops/src/conf/resource
@@ -1,4 +1,13 @@
 {
+  "data-share": {
+    "shares": [{
+      "name": "{{wizard_calibre_share}}",
+      "once": true,
+      "permission": {
+        "rw": ["sc-cops"]
+      }
+    }]
+  },
   "webservice": {
     "migrate": {
       "root": [{
@@ -30,9 +39,9 @@
         "backend": 8,
         "extensions": [
           "gd",
+          "intl",
           "pdo_sqlite",
           "sqlite3",
-          "intl",
           "zlib"
         ],
         "group": "http",
@@ -43,15 +52,6 @@
       "root": "cops",
       "service": "cops",
       "type": "apache_php"
-    }]
-  },
-  "data-share": {
-    "shares": [{
-      "name": "{{wizard_calibre_share}}",
-      "permission": {
-        "rw": ["sc-cops"]
-      },
-      "once": true
     }]
   }
 }

--- a/spk/cops/src/conf_6/resource
+++ b/spk/cops/src/conf_6/resource
@@ -2,10 +2,10 @@
 	"data-share": {
 		"shares": [{
 			"name": "{{wizard_calibre_share}}",
+			"once": true,
 			"permission": {
 				"rw": ["http"]
-			},
-			"once": true
+			}
 		}]
 	}
 }

--- a/spk/cops/src/service-setup.sh
+++ b/spk/cops/src/service-setup.sh
@@ -168,12 +168,11 @@ service_save ()
 
 service_restore ()
 {
-    if [ -f "${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/config_local.php" ] && [ -f "${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/.htaccess" ]; then
+    if [ -f "${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/config_local.php" ]; then
         # Restore some stuff
         echo "Restore previous data from ${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}"
-        # Restore cops configuration files
+        # Restore cops configuration file
         rsync -aX --update -I ${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/config_local.php ${WEB_ROOT}/config_local.php 2>&1
-        rsync -aX --update -I ${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/.htaccess ${WEB_ROOT}/.htaccess 2>&1
     else
         # Backup missing, re-initialise default values
         CFG_FILE="${WEB_ROOT}/config_local.php"
@@ -187,6 +186,20 @@ service_restore ()
             sed -i -e "s|@cops_title@|${wizard_cops_title:=COPS}|g" ${CFG_FILE}
             sed -i -e "s|@use_url_rewriting@|${url_rewriting:=0}|g" ${CFG_FILE}
             chmod ga+w "${CFG_FILE}"
+        fi
+    fi
+    if [ -f "${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/.htaccess" ]; then
+        # Check if the .htaccess file has been modified
+        if [ -f ${WEB_ROOT}/.htaccess ]; then
+            SRC_FILE=${SYNOPKG_TEMP_UPGRADE_FOLDER}/${PACKAGE}/web/.htaccess
+            DST_FILE=${WEB_ROOT}/.htaccess
+            OUTPUT_FILE=${WEB_ROOT}/.htaccess.diff
+            DIFFERENCES=$(diff "$SRC_FILE" "$DST_FILE")
+            if [ -n "$DIFFERENCES" ]; then
+                # Write the differences to the output file
+                echo "$DIFFERENCES" > "$OUTPUT_FILE"
+                echo "Modifications to .htaccess file detected. Details saved to $OUTPUT_FILE"
+            fi
         fi
     fi
 

--- a/spk/cops/src/wizard_templates/upgrade_uifile.sh
+++ b/spk/cops/src/wizard_templates/upgrade_uifile.sh
@@ -2,7 +2,7 @@
 
 WEB_DIR="/var/services/web_packages"
 # for backwards compatability
-if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ];then
+if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
     WEB_DIR="/var/services/web"
 fi
 
@@ -23,12 +23,13 @@ page_append ()
 }
 
 PHP_FILE="${WEB_DIR}/cops/config_local.php"
-OLD_SHARE_NAME=$(sed -n "s/^\s*\$config\['calibre_directory'\] = '\([^']*\)';/\1/p" "$PHP_FILE" | xargs basename)
+CONFIGURED_SHARE_NAME=$(sed -n "s/^\s*\$config\['calibre_directory'\] = '\([^']*\)';/\1/p" "$PHP_FILE" | xargs basename)
+PACKAGE_SHARE_NAME=$(grep "^SHARE_NAME=" "/var/packages/cops/etc/installer-variables" | cut -d '=' -f 2)
 
 # Check for data share
 check_data_share ()
 {
-    if [ -n "${SHARE_NAME}" ]; then
+    if [ -n "${PACKAGE_SHARE_NAME}" ]; then
         return 0  # true
     else
         return 1  # false
@@ -45,7 +46,7 @@ PAGE_LIBRARY_CONFIG=$(/bin/cat<<EOF
         "subitems": [{
             "key": "wizard_calibre_share",
             "desc": "{{{UPGRADE_CALIBRE_DIRECTORY_LABEL}}}",
-            "defaultValue": "${OLD_SHARE_NAME}",
+            "defaultValue": "${CONFIGURED_SHARE_NAME}",
             "validator": {
                 "allowBlank": false,
                 "regex": {
@@ -62,7 +63,6 @@ EOF
 )
 
 main () {
-	set >> /var/log/packages/cops.log
     local upgrade_page=""
     if ! check_data_share; then
         upgrade_page=$(page_append "$upgrade_page" "$PAGE_LIBRARY_CONFIG")

--- a/spk/cops/src/wizard_templates/upgrade_uifile.sh
+++ b/spk/cops/src/wizard_templates/upgrade_uifile.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+WEB_DIR="/var/services/web_packages"
+# for backwards compatability
+if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ];then
+    WEB_DIR="/var/services/web"
+fi
+
+quote_json ()
+{
+    sed -e 's|\\|\\\\|g' -e 's|\"|\\\"|g'
+}
+
+page_append ()
+{
+    if [ -z "$1" ]; then
+        echo "$2"
+    elif [ -z "$2" ]; then
+        echo "$1"
+    else
+        echo "$1,$2"
+    fi
+}
+
+PHP_FILE="${WEB_DIR}/cops/config_local.php"
+OLD_SHARE_NAME=$(sed -n "s/^\s*\$config\['calibre_directory'\] = '\([^']*\)';/\1/p" "$PHP_FILE" | xargs basename)
+
+# Check for data share
+check_data_share ()
+{
+    if [ -n "${SHARE_NAME}" ]; then
+        return 0  # true
+    else
+        return 1  # false
+    fi
+}
+
+PAGE_LIBRARY_CONFIG=$(/bin/cat<<EOF
+{
+    "step_title": "{{{COPS_CONFIGURATION_UPGRADE_STEP_TITLE}}}",
+    "invalid_next_disabled_v2": true,
+    "items": [{
+        "type": "textfield",
+        "desc": "{{{UPGRADE_CALIBRE_DIRECTORY_DESCRIPTION}}}",
+        "subitems": [{
+            "key": "wizard_calibre_share",
+            "desc": "{{{UPGRADE_CALIBRE_DIRECTORY_LABEL}}}",
+            "defaultValue": "${OLD_SHARE_NAME}",
+            "validator": {
+                "allowBlank": false,
+                "regex": {
+                    "expr": "/^[\\\w.][\\\w. -]{0,30}[\\\w.-][\\\\$]?$|^[\\\w][\\\\$]?$/",
+                    "errorText": "{{{UPGRADE_CALIBRE_DIRECTORY_VALIDATION_ERROR_TEXT}}}"
+                }
+            }
+        }]
+    },{
+        "desc": "{{{UPGRADE_NOTE_CALIBRE_DIRECTORY_DESCRIPTION}}}"
+    }]
+}
+EOF
+)
+
+main () {
+	set >> /var/log/packages/cops.log
+    local upgrade_page=""
+    if ! check_data_share; then
+        upgrade_page=$(page_append "$upgrade_page" "$PAGE_LIBRARY_CONFIG")
+    fi
+    echo "[$upgrade_page]" > "${SYNOPKG_TEMP_LOGFILE}"
+}
+
+main "$@"

--- a/spk/cops/src/wizard_templates/upgrade_uifile.yml
+++ b/spk/cops/src/wizard_templates/upgrade_uifile.yml
@@ -1,0 +1,6 @@
+COPS_CONFIGURATION_UPGRADE_STEP_TITLE: "COPS library upgrade"
+
+UPGRADE_CALIBRE_DIRECTORY_DESCRIPTION: "The Calibre library directory must now reside within a data share. Based on the detected previous configuration, please confirm that the specified data share contains your library."
+UPGRADE_CALIBRE_DIRECTORY_LABEL: "Share name"
+UPGRADE_CALIBRE_DIRECTORY_VALIDATION_ERROR_TEXT: "Subdirectories are not supported."
+UPGRADE_NOTE_CALIBRE_DIRECTORY_DESCRIPTION: "NOTE: If your Calibre library isn't in the specified share, a new share will be created. After the upgrade, manually move the library to this new location."

--- a/spk/cops/src/wizard_templates/upgrade_uifile_fre.yml
+++ b/spk/cops/src/wizard_templates/upgrade_uifile_fre.yml
@@ -1,6 +1,6 @@
 COPS_CONFIGURATION_UPGRADE_STEP_TITLE: "Mise à jour de la bibliothèque COPS"
 
-UPGRADE_CALIBRE_DIRECTORY_DESCRIPTION: "Le répertoire de la bibliothèque Calibre doit désormais résider dans un partage de données. Sur la base de la configuration précédente détectée, veuillez confirmer que le partage de données spécifié contient votre bibliothèque."
-UPGRADE_CALIBRE_DIRECTORY_LABEL: "Partager le nom"
+UPGRADE_CALIBRE_DIRECTORY_DESCRIPTION: "Le répertoire de la bibliothèque Calibre doit désormais résider dans un dossier partagé. Sur la base de la configuration précédente détectée, veuillez confirmer que le dossier partagé spécifié contient votre bibliothèque."
+UPGRADE_CALIBRE_DIRECTORY_LABEL: "Dossier partagé"
 UPGRADE_CALIBRE_DIRECTORY_VALIDATION_ERROR_TEXT: "Les sous-répertoires ne sont pas pris en charge."
-UPGRADE_NOTE_CALIBRE_DIRECTORY_DESCRIPTION: "REMARQUE: si votre bibliothèque Calibre ne se trouve pas dans le partage spécifié, un nouveau partage sera créé. Après la mise à niveau, déplacez manuellement la bibliothèque vers ce nouvel emplacement."
+UPGRADE_NOTE_CALIBRE_DIRECTORY_DESCRIPTION: "REMARQUE: si votre bibliothèque Calibre ne se trouve pas dans le dossier partagé spécifié, un nouveau sera créé. Après la mise à niveau, déplacez manuellement la bibliothèque vers ce nouvel emplacement."

--- a/spk/cops/src/wizard_templates/upgrade_uifile_fre.yml
+++ b/spk/cops/src/wizard_templates/upgrade_uifile_fre.yml
@@ -1,0 +1,6 @@
+COPS_CONFIGURATION_UPGRADE_STEP_TITLE: "Mise à jour de la bibliothèque COPS"
+
+UPGRADE_CALIBRE_DIRECTORY_DESCRIPTION: "Le répertoire de la bibliothèque Calibre doit désormais résider dans un partage de données. Sur la base de la configuration précédente détectée, veuillez confirmer que le partage de données spécifié contient votre bibliothèque."
+UPGRADE_CALIBRE_DIRECTORY_LABEL: "Partager le nom"
+UPGRADE_CALIBRE_DIRECTORY_VALIDATION_ERROR_TEXT: "Les sous-répertoires ne sont pas pris en charge."
+UPGRADE_NOTE_CALIBRE_DIRECTORY_DESCRIPTION: "REMARQUE: si votre bibliothèque Calibre ne se trouve pas dans le partage spécifié, un nouveau partage sera créé. Après la mise à niveau, déplacez manuellement la bibliothèque vers ce nouvel emplacement."


### PR DESCRIPTION
## Description

This builds upon the developments in PR #5957 by introducing an upgrade wizard. The wizard is designed to identify the presence of a data share; if none is found, it extracts the library folder name to propose it as the designated data share for the upgrade. This enhancement addresses issues in previous packages where the absence of a defined data share led to upgrade failures.

Fixes #5961

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
