### PR TITLE
Enhance debug_info symbols + libatomic in wheels (follows-up to #5879)

### DIFF
--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -99,7 +99,7 @@ endif
 include ../../mk/spksrc.common.mk
 
 # Enable debug_info symgols for all archs
-GCC_DEBUG_INFO := 1
+#GCC_DEBUG_INFO := 1
 
 # Force compiler LTO optimizations except:
 #   - when testing all wheels

--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -31,11 +31,6 @@ WHEELS = src/requirements-pure.txt
 # Force testing all wheel builds
 WHEELS_TEST_ALL = 0
 
-# Force compiler LTO optimizations
-ifeq ($(strip $(WHEELS_TEST_ALL)),0)
-ENV += PYTHON_OPTIMIZE=1
-endif
-
 SERVICE_SETUP = src/service-setup.sh
 
 PYTHON_LIB_DIR = lib/python$(SPK_VERS_MAJOR_MINOR)
@@ -103,10 +98,20 @@ endif
 
 include ../../mk/spksrc.common.mk
 
-# # Enable debug_info builds for DSM6
-# ifeq ($(call version_lt, ${TCVERSION}, 7),1)
-# GCC_DEBUG_INFO := 1
-# endif
+# Enable debug_info symgols for all archs
+GCC_DEBUG_INFO := 1
+
+# Force compiler LTO optimizations except:
+#   - when testing all wheels
+#   - when including debug_info symbols
+#   - when using PPC arch (fails on qoriq)
+ifneq ($(strip $(WHEELS_TEST_ALL)),1)
+ifneq ($(strip $(GCC_DEBUG_INFO)),1)
+ifneq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
+ENV += PYTHON_OPTIMIZE=1
+endif
+endif
+endif
 
 ## WHEELS_TEST_ALL: Force testing all wheel building
 ifeq ($(strip $(WHEELS_TEST_ALL)),1)


### PR DESCRIPTION
## Description

This PR fixes :
1. `debug_info` symbols enablement where as at strip time symbols would be removed in some cases
2. ensures to check within wheels if `libatomic.so` is needed

In turns this removes unrelated changes from #5879 in order for it to solely focus on the qoriq rust issue.

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
