### PR TITLE
openssl: update to v1.1.1w

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.1.1v
+PKG_VERS = 1.1.1w
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.openssl.org/source

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.1.1v.tar.gz SHA1 3ec7b37aefcbcd8d4bd9b2f3687dd77948d46382
-openssl-1.1.1v.tar.gz SHA256 d6697e2871e77238460402e9362d47d18382b15ef9f246aba6c7bd780d38a6b0
-openssl-1.1.1v.tar.gz MD5 9edcfdd9b96523df82b312c404f4b169
+openssl-1.1.1w.tar.gz SHA1 76fbf3ca4370e12894a408ef75718f32cdab9671
+openssl-1.1.1w.tar.gz SHA256 cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
+openssl-1.1.1w.tar.gz MD5 3f76825f195e52d4b10c70040681a275


### PR DESCRIPTION
## Description

There are still some packages not updated to openssl3
The previous version 1.1.1v is not available for download anymore.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Library update
