### PR TITLE
cross-cc.mk: Msg. to run make setup first when using all-supported

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -89,8 +89,17 @@ all-supported:
 	    env $(ENV) $(MAKE) -C ../../$$depend 2>&1 | tee --append build-$${depend%/*}-$${depend#*/}.log ; \
 	    [ $${PIPESTATUS[0]} -eq 0 ] || false ; \
 	  fi ; \
-	done ; \
+	done
+ifeq ($(strip $(SUPPORTED_ARCHS)),)
+	$(MAKE) supported-arch-error
+else
 	$(MAKE) $(addprefix supported-arch-,$(SUPPORTED_ARCHS))
+endif
+
+supported-arch-error:
+	@$(MSG) ########################################################
+	@$(MSG) ERROR - Please run make setup from spksrc root directory
+	@$(MSG) ########################################################
 
 supported-arch-%:
 	@$(MSG) BUILDING package for arch $* with SynoCommunity toolchain


### PR DESCRIPTION
## Description

cross-cc.mk: Echo an error message indicating to first run `make setup` when using `make all-supported` from cross

Fixes #5994

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
