### PR TITLE
ruby: update to use openssl3

### DIFF
--- a/cross/ruby/Makefile
+++ b/cross/ruby/Makefile
@@ -1,14 +1,14 @@
 PKG_NAME = ruby
 PKG_VERS = 3.1.2
-PKG_SHORT_VERS = $(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://cache.ruby-lang.org/pub/ruby/$(PKG_SHORT_VERS)
+PKG_DIST_SITE = https://cache.ruby-lang.org/pub/ruby/$(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 BUILD_DEPENDS = native/ruby
-DEPENDS = cross/openssl cross/readline cross/gdbm cross/berkeleydb
+DEPENDS = cross/openssl3 cross/readline cross/gdbm cross/berkeleydb
 
+# Ruby 3.1.2 is the latest version that compiles without std=c++11 support (ARMv5_ARCHS)
 # even it compiles with older cross/gdbm, ruby crashes at runtime
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
@@ -28,8 +28,7 @@ NATIVE_RUBY = $(realpath $(WORK_DIR)/../../../native/$(PKG_NAME)/work-native/ins
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --with-baseruby=$(NATIVE_RUBY) --prefix=$(INSTALL_PREFIX) --disable-install-doc
 
-# avoid warning "_FORTIFY_SOURCE requires compiling with optimization (-O)"
-ADDITIONAL_CFLAGS = -O3
+ADDITIONAL_CFLAGS = -O2
 
 include ../../mk/spksrc.cross-cc.mk
 

--- a/cross/ruby/PLIST
+++ b/cross/ruby/PLIST
@@ -13,3 +13,6 @@ rsc:bin/ruby
 rsc:bin/typeprof
 rsc:lib/ruby/3.1.0
 rsc:lib/ruby/gems
+lib:lib/ruby/*/*/*.so
+lib:lib/ruby/*/*/*/*.so
+lib:lib/ruby/*/*/*/*/*.so

--- a/spk/ruby/Makefile
+++ b/spk/ruby/Makefile
@@ -1,14 +1,14 @@
 SPK_NAME = ruby
 SPK_VERS = 3.1.2
-SPK_REV = 11
+SPK_REV = 12
 SPK_ICON = src/ruby.png
 
-DEPENDS = cross/$(SPK_NAME)
+DEPENDS = cross/ruby
 
 # even it compiles with older cross/gdbm, ruby crashes at runtime
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-CHANGELOG = "1. Update ruby to v3.1.2.<br/>2. Update openssl to v1.1.1o."
+CHANGELOG = "1. Update openssl to v3.1.4."
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Ruby Programming Language.


### PR DESCRIPTION
## Description

- update dependency to cross/openssl3
- holdback update to newer ruby version (not compatible with toolchains lacking c++11 compiler)
- update packages in repo to support newer archs (#5993)
- reduce package size (compile with -O2 instead of -O3, strip ruby *.so files)

Closes #5993 

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Package dependency update
