### PR TITLE
doc: Enhance Docker platform specification in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ If you can't find an answer, or if you want to open a package request, read [CON
 cd spksrc # Go to the cloned repository's root folder.
 
 # If running on Linux:
-docker run -it -v $(pwd):/spksrc -w /spksrc ghcr.io/synocommunity/spksrc /bin/bash
+docker run -it --platform=linux/amd64 -v $(pwd):/spksrc -w /spksrc ghcr.io/synocommunity/spksrc /bin/bash
 
 # If running on macOS:
-docker run -it -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
+docker run -it --platform=linux/amd64 -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
 ```
 5. From there, follow the instructions in the [Developers HOW TO].
 
@@ -137,7 +137,7 @@ $ lxc exec spksrc -- su --login root
 # exit
 ```
 
-#### (OPTIONAL) LXC: Shared `spksrc` user 
+#### (OPTIONAL) LXC: Shared `spksrc` user
 You can create a shared user between your Debian/Ubuntu host and the LXC Debian container which simplifies greatly file management between the two.  The following assumes you already created a user `spksrc` with uid 1001 in your Debian/Ubuntu host environment and that you which to share its `/home` userspace.
 1. Create a mapping rule between the hosts and the LXC image:
 ```bash


### PR DESCRIPTION
## Description

Allow to run ghcr.io/synocommunity/spksrc from ARM machines:

```console
$ docker run -it -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash

Unable to find image 'ghcr.io/synocommunity/spksrc:latest' locally
latest: Pulling from synocommunity/spksrc
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
See 'docker run --help'.
```

Workaround without this fix is to specify arch with `--platform=linux/amd64`:

```shell
$ docker run --platform=linux/amd64  -it -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
```

P.S.: I tried to add platform, but there is some broken package installation for i386.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [x] This change requires a documentation update (e.g. Wiki)
