### PR TITLE
mosh: update openssl library

### DIFF
--- a/cross/libutempter/Makefile
+++ b/cross/libutempter/Makefile
@@ -2,14 +2,14 @@ PKG_NAME = libutempter
 PKG_VERS = 1.2.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.altlinux.org/pub/people/ldv/utempter/
+PKG_DIST_SITE = http://ftp.altlinux.org/pub/people/ldv/utempter/
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 
-HOMEPAGE = http://freshmeat.sourceforge.net/projects/libutempter
+HOMEPAGE = https://github.com/altlinux/libutempter
 COMMENT  = libutempter provides a library interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files.
-LICENSE  = LGPLv2
+LICENSE  = LGPLv2.1
 
 CONFIGURE_TARGET = nop
 

--- a/cross/mosh/Makefile
+++ b/cross/mosh/Makefile
@@ -5,15 +5,13 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/mobile-shell/mosh/releases/download/$(PKG_NAME)-$(PKG_VERS)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-DEPENDS = cross/ncursesw cross/zlib cross/openssl cross/protobuf cross/libutempter
+DEPENDS = cross/ncursesw cross/zlib cross/openssl3 cross/protobuf cross/libutempter
 
 HOMEPAGE = https://mosh.org
 COMMENT  = Mosh: the mobile shell
 LICENSE  = GPLv3+
 
 GNU_CONFIGURE = 1
-# avoid warning: _FORTIFY_SOURCE requires compiling with optimization (-O)
-ADDITIONAL_CPPFLAGS = -O2
 CONFIGURE_ARGS += --with-utempter
 
 include ../../mk/spksrc.cross-cc.mk

--- a/spk/mosh/Makefile
+++ b/spk/mosh/Makefile
@@ -1,9 +1,9 @@
 SPK_NAME = mosh
 SPK_VERS = 1.4.0
-SPK_REV = 3
+SPK_REV = 4
 SPK_ICON = src/mosh.png
 
-DEPENDS = cross/$(SPK_NAME)
+DEPENDS = cross/mosh
 
 SPK_DEPENDS = "Perl>=5.14"
 
@@ -12,7 +12,7 @@ DESCRIPTION = mosh, the mobile shell is a remote terminal application that allow
 
 DISPLAY_NAME = mosh
 STARTABLE = no
-CHANGELOG = "1. Update Mosh to version 1.4.0.<br/>2. Update openssl to 1.1.1t."
+CHANGELOG = "1. Update openssl library to v3.1.5."
 
 HOMEPAGE = https://mosh.org
 LICENSE  = GPLv3+


### PR DESCRIPTION
## Description

- update openssl to v3.1.5
- remove -O2 from cppflags as it is the default
- adjust links for libutempter

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Package library update
