### PR TITLE
Fix build disk space - System.IO.IOException: No space left on device

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -72,6 +72,8 @@ do
         else
             echo "$ make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package}" >>build.log
             make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
+            make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} clean-source |& tee >(tail -15 >>build.log)
+            make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} spkclean |& tee >(tail -15 >>build.log)
         fi
     else
         if [ "${GH_ARCH}" = "noarch" ]; then

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -496,6 +496,22 @@ endif
 clean:
 	rm -fr work work-* build-*.log publish-*.log
 
+# Remove work-*/<pkgname>* directories while keeping
+# work-*/.<pkgname>*|<pkgname>.plist status files
+# This is in order to resolve: 
+#    System.IO.IOException: No space left on device
+# when building online thru github-action
+clean-source:
+	@make --no-print-directory dependency-flat | sort -u | grep cross/ | while read depend ; do \
+	   makefile="../../$${depend}/Makefile" ; \
+	   pkgstr=$$(grep ^PKG_NAME $${makefile}) ; \
+	   pkgname=$$(echo $${pkgstr#*=} | xargs) ; \
+	   if [ -d work-*/$${pkgname}-* ] ; then \
+	      printf "rm -fr " && find work-*/$${pkgname}-* -maxdepth 0 -type d ; \
+	      find work-*/$${pkgname}-*/. -mindepth 1 -maxdepth 2 -exec rm -fr {} \; 2>/dev/null || true ; \
+	   fi ; \
+	done
+
 spkclean:
 	rm -fr work-*/.copy_done \
 	       work-*/.depend_done \


### PR DESCRIPTION
## Description

Fix build disk space - System.IO.IOException: No space left on device
- Create a new cleanup call `make clean-source` which only removes the `work-<package>*` source directories
- Call both `make clean-source` and `make spkclean` after builds through github-action

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
