### PR TITLE
synocli-file: try to fix build of ripgrep

### DIFF
--- a/cross/pcre2/Makefile
+++ b/cross/pcre2/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = pcre2
-PKG_VERS = 10.42
+PKG_VERS = 10.43
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/PhilipHazel/pcre2/releases/download/$(PKG_NAME)-$(PKG_VERS)

--- a/cross/pcre2/PLIST
+++ b/cross/pcre2/PLIST
@@ -2,10 +2,10 @@ bin:bin/pcre2grep
 bin:bin/pcre2test
 lnk:lib/libpcre2-32.so
 lnk:lib/libpcre2-32.so.0
-lib:lib/libpcre2-32.so.0.11.2
+lib:lib/libpcre2-32.so.0.12.0
 lnk:lib/libpcre2-8.so
 lnk:lib/libpcre2-8.so.0
-lib:lib/libpcre2-8.so.0.11.2
+lib:lib/libpcre2-8.so.0.12.0
 lnk:lib/libpcre2-posix.so
 lnk:lib/libpcre2-posix.so.3
-lib:lib/libpcre2-posix.so.3.0.4
+lib:lib/libpcre2-posix.so.3.0.5

--- a/cross/pcre2/digests
+++ b/cross/pcre2/digests
@@ -1,3 +1,3 @@
-pcre2-10.42.tar.bz2 SHA1 9876f2165ed6ee38d1853a8e2eaafdfbcb291b76
-pcre2-10.42.tar.bz2 SHA256 8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
-pcre2-10.42.tar.bz2 MD5 a8e9ab2935d428a4807461f183034abe
+pcre2-10.43.tar.bz2 SHA1 300aede670b6c514e7edcd0d603e586ea66f1ee6
+pcre2-10.43.tar.bz2 SHA256 e2a53984ff0b07dfdb5ae4486bbb9b21cca8e7df2434096cc9bf1b728c350bcb
+pcre2-10.43.tar.bz2 MD5 c8e2043cbc4abb80e76dba323f7c409f

--- a/cross/ripgrep/Makefile
+++ b/cross/ripgrep/Makefile
@@ -15,10 +15,6 @@ HOMEPAGE = https://github.com/BurntSushi/ripgrep
 COMMENT  = ripgrep recursively searches directories for a regex pattern.
 LICENSE  = public domain/Unlicense
 
-# Force static build when pcre2 is detected in synocli-file build environment
-ENV += PCRE2_SYS_STATIC=1
-CARGO_BUILD_ARGS += --features 'pcre2'
-
 include ../../mk/spksrc.common.mk
 ifeq ($(call version_le, $(TC_GCC), 5.0),1)
 # upstream/src/pcre2_script_run.c - error: .... only allowed in C99 or C11 mode

--- a/diyspk/ripgrep/Makefile
+++ b/diyspk/ripgrep/Makefile
@@ -1,9 +1,11 @@
 SPK_NAME = ripgrep
-SPK_VERS = 13.0.0
+SPK_VERS = 14.1.0
 SPK_REV = 1
 SPK_ICON = src/ripgrep.png
 
-DEPENDS = cross/$(SPK_NAME)
+# simulate existance of pcre2
+DEPENDS  = cross/pcre2
+DEPENDS += cross/ripgrep
 
 # powerpc archs (except qoriq) are not supported
 UNSUPPORTED_ARCHS += $(OLD_PPC_ARCHS)


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
The build of synocli-file package fails in the github build action, but succeeds locally.

The build was ok, when synocli-file was updates with [build #6454](https://github.com/SynoCommunity/spksrc/actions/runs/8396981472)

Error first seen in [build #6464](https://github.com/SynoCommunity/spksrc/actions/runs/8428082116)

The build is failing for ripgrep when building sys-prce2 with
```
error: failed to run custom build command for `pcre2-sys v0.2.9`
```

and the error is
```
pcre2-sys@0.2.9: upstream/src/pcre2_match.c:5448:32: error: ‘PCRE2_DISABLE_RECURSELOOP_CHECK’ undeclared (first use in this function); did you mean ‘PCRE2_ERROR_RECURSELOOP’?
```


Trying the following:
- [x] update cross/prce2 to v10.43
- [x] Remove force of static pcre2-sys for ripgrep (was `PCRE2_SYS_STATIC=1 and CARGO_BUILD_ARGS += --features 'pcre2'`)


Probably it is an issue with rust 1.77.0 realeased on 2024.03.21.
The latests successful build of synocli-file by a git-hub action was on 2024.03.22.
My working local builds are with rust 1.76.0 (except the builds for qoriq-6.2.4 with our custom rust 1.77.0 nightly of 2024.01.26).

Finally this error is gone without my changes, but I applied those anyway.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
