### PR TITLE
fix make publish

### DIFF
--- a/mk/spksrc.publish.mk
+++ b/mk/spksrc.publish.mk
@@ -42,7 +42,7 @@ publish-arch-%:
 ###
 
 publish-build-arch-%: SHELL:=/bin/bash
-publish-build-arch-%:
+publish-build-arch-%: build-arch-%
 	@$(MSG) PUBLISHING package for arch $* to http://synocommunity.com | tee --append build-$*.log
 	@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) publish 2>&1 | tee --append publish-$*.log >(grep -e '^http' -e '^{"package":' -e '^{"message":' >> status-publish.log) ; \
 	status=$${PIPESTATUS[0]} ; \


### PR DESCRIPTION
## Description

- make publish-arch-* must include make arch-* (broken by #6002)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
