### PR TITLE
spksrc.publish.mk: add checks for empty variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Include framework self-test
-#include mk/spksrc.test-rules.mk
+include mk/spksrc.test-rules.mk
 
 AVAILABLE_TCS = $(notdir $(wildcard toolchain/syno-*))
 AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Include framework self-test
-include mk/spksrc.test-rules.mk
+#include mk/spksrc.test-rules.mk
 
 AVAILABLE_TCS = $(notdir $(wildcard toolchain/syno-*))
 AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))

--- a/mk/spksrc.publish.mk
+++ b/mk/spksrc.publish.mk
@@ -43,7 +43,7 @@ publish-arch-%:
 
 publish-build-arch-%: SHELL:=/bin/bash
 publish-build-arch-%: build-arch-%
-	@$(MSG) PUBLISHING package for arch $* to http://synocommunity.com | tee --append build-$*.log
+	@$(MSG) PUBLISHING package for arch $* to $(PUBLISH_URL)| tee --append build-$*.log
 	@MAKEFLAGS= $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) publish 2>&1 | tee --append publish-$*.log >(grep -e '^http' -e '^{"package":' -e '^{"message":' >> status-publish.log) ; \
 	status=$${PIPESTATUS[0]} ; \
 	[ $${status[0]} -eq 0 ] || false
@@ -51,6 +51,12 @@ publish-build-arch-%: build-arch-%
 ###
 
 publish:
+ifeq ($(PUBLISH_URL),)
+	$(error Set PUBLISH_URL in local.mk)
+endif
+ifeq ($(PUBLISH_API_KEY),)
+	$(error Set PUBLISH_API_KEY in local.mk)
+endif
 	@response=$$(http --verify=no --ignore-stdin --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME) --print=hb) ; \
 	response_code=$$(echo "$$response" | grep -Fi "HTTP/1.1" | awk '{print $$2}') ; \
 	if [ "$$response_code" = "201" ] ; then \


### PR DESCRIPTION
## Description

This is another attempt to fix the publishing of packages by github action (broken by #6002)
- ~make setup-synocommunity triggers "make setup" and this fails when mk/spksrc.test-rules.mk is included~ 
   fixed in #6066
- add checks for empty PUBLISH_URL and PUBLISH_API_KEY in spksrc.publish.mk
- print PUBLISH_URL variable when publishing


## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Includes small framework changes
