### PR TITLE
common.mk: Fix BASEDIR to manage github-action workspace directory

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -4,7 +4,7 @@
 
 # Set basedir in case called from spkrc/ or from normal sub-dir
 ifeq ($(BASEDIR),)
-ifneq ($(shell basename $(CURDIR)),spksrc)
+ifeq ($(filter spksrc workspace,$(shell basename $(CURDIR))),)
 BASEDIR = ../../
 endif
 endif


### PR DESCRIPTION
## Description

common.mk: Fix BASEDIR to manage github-action workspace directory.

When using github-action the `spksrc` repository sits under `/github/workspace`.  Therefore the `BASEDIR` value set in `spksrc.common.mk` is not taking this into account, making publishing to file as `make setup-synocommunity` had failed previously with the following:
```
2024-04-06T10:42:28.7394231Z ##[group] ---- initialize build
2024-04-06T10:42:29.5904113Z mk/spksrc.common.mk:59: ../../mk/spksrc.archs.mk: No such file or directory
2024-04-06T10:42:29.5905666Z make: *** No rule to make target '../../mk/spksrc.archs.mk'.  Stop.
2024-04-06T10:42:29.7350751Z sed: can't read local.mk: No such file or directory
2024-04-06T10:42:29.7510857Z ##[endgroup]
```
Above that error can be seen the actual path being used by github-action:
```
"/github/file_commands" -v "/home/runner/work/spksrc/spksrc":"/github/workspace" ghcr.io/synocommunity/spksrc:latest
```

Fixes: #6061
Follow-up to: #6064 (thnx @hgy59) and broken by #6002

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
