### PR TITLE
arch.mk: Fix BASEDIR to manage github-action workspace directory

### DIFF
--- a/mk/spksrc.archs.mk
+++ b/mk/spksrc.archs.mk
@@ -3,8 +3,9 @@
 ###
 
 # Set basedir in case called from spkrc/ or from normal sub-dir
+# Note that github-action uses workspace/ in place of spksrc/
 ifeq ($(BASEDIR),)
-ifneq ($(shell basename $(CURDIR)),spksrc)
+ifeq ($(filter spksrc workspace,$(shell basename $(CURDIR))),)
 BASEDIR = ../../
 endif
 endif

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -3,6 +3,7 @@
 ###
 
 # Set basedir in case called from spkrc/ or from normal sub-dir
+# Note that github-action uses workspace/ in place of spksrc/
 ifeq ($(BASEDIR),)
 ifeq ($(filter spksrc workspace,$(shell basename $(CURDIR))),)
 BASEDIR = ../../


### PR DESCRIPTION
## Description

arch.mk: Fix BASEDIR to manage github-action workspace directory

Fixes: https://github.com/SynoCommunity/spksrc/pull/6061
Follow-up to: https://github.com/SynoCommunity/spksrc/pull/6066 and https://github.com/SynoCommunity/spksrc/pull/6064 (thnx @hgy59) and broken by https://github.com/SynoCommunity/spksrc/pull/6002

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relavent tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
