### PR TITLE
Fixed: resolved issue with pip not being able to install package due missing ssl

### DIFF
--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -1,11 +1,12 @@
 SPK_NAME = python310
 SPK_VERS = 3.10.13
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 19
+SPK_REV = 20
 SPK_ICON = src/python3.png
 
 DEPENDS  = cross/$(SPK_NAME)
 DEPENDS += cross/pip
+DEPENDS += cross/openssl
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Python Programming Language.


### PR DESCRIPTION
## Description

The current package 3.10.13-19 and probably earlier shows an error during installation that it cannot install pip packages due to openssl (libssl) not being included. This change adds libssl as dependency in the build process to support ssl.

Fixes #6078 

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
