### PR TITLE
Jellyfin 10.9.1

### DIFF
--- a/cross/jellyfin-web/Makefile
+++ b/cross/jellyfin-web/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin-web
-PKG_VERS = 10.8.13
+PKG_VERS = 10.9.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin-web/archive

--- a/cross/jellyfin-web/digests
+++ b/cross/jellyfin-web/digests
@@ -1,3 +1,3 @@
-jellyfin-web-10.8.13.tar.gz SHA1 3e488e221b9c33b0ef6b472348625c75656c61bf
-jellyfin-web-10.8.13.tar.gz SHA256 ba67c8e973e0155924fc0646b165ec9a7e0d75e6ca9c39960daa7579e7af7505
-jellyfin-web-10.8.13.tar.gz MD5 dcde9c0c3b889020d9ee65bae34083f1
+jellyfin-web-10.9.1.tar.gz SHA1 f4f59bfc66732549d169d203cf2cfcca2b2c0eb8
+jellyfin-web-10.9.1.tar.gz SHA256 a4f349c836773be73d5671e00ba61cd19f17f58a9fb083c8acbfb58c710389b5
+jellyfin-web-10.9.1.tar.gz MD5 de7c4615615ae3d627c2a419dabd38ae

--- a/cross/jellyfin/Makefile
+++ b/cross/jellyfin/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin
-PKG_VERS = 10.8.13
+PKG_VERS = 10.9.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin/archive
@@ -10,7 +10,7 @@ HOMEPAGE = https://jellyfin.org
 COMMENT  = The Free Software Media System. It is an alternative to the proprietary Emby and Plex.
 LICENSE  = GPLv2
 
-DOTNET_VERSION = 6.0
+DOTNET_VERSION = 8.0
 BUILD_DEPENDS = native/dotnet-sdk-$(DOTNET_VERSION)
 
 DOTNET_OUTPUT_PATH = share

--- a/cross/jellyfin/digests
+++ b/cross/jellyfin/digests
@@ -1,3 +1,3 @@
-jellyfin-10.8.13.tar.gz SHA1 96079e9aa4ff0a3101f5b650b7759a34b2cfd963
-jellyfin-10.8.13.tar.gz SHA256 aee70eacb9c72a64eb7b4413b1d4b55fea99863b8a54f5ccb552f0bf91152e36
-jellyfin-10.8.13.tar.gz MD5 174925eb730149a2e8ad4aa380fc85a0
+jellyfin-10.9.1.tar.gz SHA1 adfdbb14beba3c4b18c419e1d97b88963ee15a75
+jellyfin-10.9.1.tar.gz SHA256 f9fe7ab887ed944e43eb96d9d2933c13288974cb5a0b7a891f6099461d966ab0
+jellyfin-10.9.1.tar.gz MD5 f76b1da5e222941cda86f944852aead9

--- a/native/dotnet-sdk-8.0/Makefile
+++ b/native/dotnet-sdk-8.0/Makefile
@@ -1,0 +1,22 @@
+PKG_NAME = dotnet-sdk-8.0
+# Version 8.0.4, SDK 8.0.204
+# https://dotnet.microsoft.com/download/dotnet/8.0
+PKG_VERS = 8.0.204
+PKG_EXT = tar.gz
+PKG_DIST_NAME = dotnet-sdk-$(PKG_VERS)-linux-x64.$(PKG_EXT)
+PKG_DIST_SITE = https://dotnetcli.azureedge.net/dotnet/Sdk/${PKG_VERS}
+
+HOMEPAGE = https://dotnet.microsoft.com/
+COMMENT  = A developer platform for building apps.
+LICENSE  = MIT
+
+# just extract and create folder for nuget packages
+INSTALL_TARGET = dotnet_native_install
+
+NUGET_PACKAGES_DIR = $(DISTRIB_DIR)/nuget/packages
+
+include ../../mk/spksrc.native-install.mk
+
+.PHONY: dotnet_native_install
+dotnet_native_install:
+	mkdir -p $(NUGET_PACKAGES_DIR)

--- a/native/dotnet-sdk-8.0/digests
+++ b/native/dotnet-sdk-8.0/digests
@@ -1,0 +1,3 @@
+dotnet-sdk-8.0.204-linux-x64.tar.gz SHA1 7f31552610c9139db5be0ace78d3378242128720
+dotnet-sdk-8.0.204-linux-x64.tar.gz SHA256 0ec834dc0f11a994057cd05d84c6250db726457f2fe308091d50543a5285dd15
+dotnet-sdk-8.0.204-linux-x64.tar.gz MD5 e25e2727de72a7a076df7aa0f3d9c895

--- a/native/nodejs/Makefile
+++ b/native/nodejs/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = nodejs
 # https://nodejs.org/en/about/releases/
 # v18 is active LTS Version "Hydrogen" from 2022-10-25 to 2023-10-18 with EOL at 2025-04-30
-PKG_VERS = 18.20.0
+PKG_VERS = 20.0.0
 PKG_EXT = tar.xz
 PKG_DIST_NAME = node-v$(PKG_VERS)-linux-x64.$(PKG_EXT)
 PKG_DIST_SITE = https://nodejs.org/dist/v$(PKG_VERS)

--- a/native/nodejs/digests
+++ b/native/nodejs/digests
@@ -1,3 +1,3 @@
-node-v18.20.0-linux-x64.tar.xz SHA1 8d67b84fcf19a5830f0acc95873da8579019dead
-node-v18.20.0-linux-x64.tar.xz SHA256 03eea148e56785babb27930b05ed6bf311aaa3bc573c0399dd63cad2fe5713c7
-node-v18.20.0-linux-x64.tar.xz MD5 23ab56b824d15ffd1d022bb5e2abc7ec
+node-v20.0.0-linux-x64.tar.xz SHA1 b5e068605b4487bec1f5e43c28f4179db25c2cc2
+node-v20.0.0-linux-x64.tar.xz SHA256 9e512f1f1cadb3a5e37a10aa2d5e632f93aaf9f37165803e2ed981009970a3d7
+node-v20.0.0-linux-x64.tar.xz MD5 bdf5837f5503702e3c2b24fbe3b8d191

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -12,11 +12,11 @@ DEPENDS = cross/jellyfin cross/jellyfin-web
 # x64 and armv8 archs are supported only.
 UNSUPPORTED_ARCHS = $(32bit_ARCHS)
 
-MAINTAINER = SynoCommunity
+MAINTAINER = stevenliuit
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "1. Update jellyfin to 10.9.1<br/>2. Update dotnet to 8.0.4."
+CHANGELOG = "1. Update jellyfin to 10.9.1<br/>2. Update dotnet to 8.0.4.<br/>3.Update nodejs 20.0.0"
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
-SPK_VERS = 10.8.13
-SPK_REV = 13
+SPK_VERS = 10.9.1
+SPK_REV = 14
 SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
@@ -16,7 +16,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "1. Update jellyfin to 10.8.13<br/>2. Update dotnet to 6.0.25."
+CHANGELOG = "1. Update jellyfin to 10.9.1<br/>2. Update dotnet to 8.0.4."
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
1. Update jellyfin to 10.9.1
2. Update dotnet to 8.0.4.
3.Update nodejs 20.0.0

Jellyfin 10.9.1 needs to upgrade dotnet to 8.0.4 and nodejs requires a minimum version of 20.0.0. Please help with the upgrade or check whether other applications are affected.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
