### PR TITLE
version bump libgcrypt to v1.10.3

### DIFF
--- a/cross/libgcrypt/Makefile
+++ b/cross/libgcrypt/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libgcrypt
-PKG_VERS = 1.10.2
+PKG_VERS = 1.10.3
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://gnupg.org/ftp/gcrypt/libgcrypt

--- a/cross/libgcrypt/digests
+++ b/cross/libgcrypt/digests
@@ -1,3 +1,3 @@
-libgcrypt-1.10.2.tar.bz2 SHA1 0b9555960d84a09ea14e52360808f2e02e9c12d2
-libgcrypt-1.10.2.tar.bz2 SHA256 3b9c02a004b68c256add99701de00b383accccf37177e0d6c58289664cce0c03
-libgcrypt-1.10.2.tar.bz2 MD5 663abb395452750522d6797967e2f442
+libgcrypt-1.10.3.tar.bz2 SHA1 359e1d01ad2eb9cd2db964ea96ef3712d0c2c649
+libgcrypt-1.10.3.tar.bz2 SHA256 8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa
+libgcrypt-1.10.3.tar.bz2 MD5 a8cada0b343e10dbee51c9e92d856a94


### PR DESCRIPTION
## Description

Updated libgcrypt from v1.10.2 to v1.10.3

For changes, see official release notes: https://github.com/gpg/libgcrypt/releases/tag/libgcrypt-1.10.3

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
