### PR TITLE
c-ares: update and fix download link

### DIFF
--- a/cross/c-ares-1.28/Makefile
+++ b/cross/c-ares-1.28/Makefile
@@ -1,0 +1,23 @@
+PKG_NAME = c-ares
+PKG_VERS = 1.28.1
+PKG_EXT = tar.gz
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/c-ares/c-ares/releases/download/cares-$(subst .,_,$(PKG_VERS))
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+DEPENDS =
+
+HOMEPAGE = https://c-ares.org/
+COMMENT  = c-ares is a C library for asynchronous DNS requests (including name resolves).
+LICENSE  = MIT
+
+POST_CONFIGURE_TARGET = cares_post_configure
+
+CMAKE_ARGS += -DCARES_BUILD_TOOLS=OFF
+
+include ../../mk/spksrc.cross-cmake.mk
+
+.PHONY: cares_post_configure
+cares_post_configure:
+	@$(MSG) Create target include folder to suppress ignorable error logs
+	@$(RUN) install -d $(INSTALL_DIR)$(INSTALL_PREFIX)/include

--- a/cross/c-ares-1.28/PLIST
+++ b/cross/c-ares-1.28/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libcares.so
 lnk:lib/libcares.so.2
-lib:lib/libcares.so.2.12.0
+lib:lib/libcares.so.2.13.1

--- a/cross/c-ares-1.28/digests
+++ b/cross/c-ares-1.28/digests
@@ -1,0 +1,3 @@
+c-ares-1.28.1.tar.gz SHA1 3a55cc7d21a4eff683bfb03c12067c44c0c43698
+c-ares-1.28.1.tar.gz SHA256 675a69fc54ddbf42e6830bc671eeb6cd89eeca43828eb413243fd2c0a760809d
+c-ares-1.28.1.tar.gz MD5 2b0f0df7491538a0d10f3310e13d4b5f

--- a/cross/c-ares-latest/Makefile
+++ b/cross/c-ares-latest/Makefile
@@ -1,0 +1,26 @@
+PKG_NAME = c-ares
+PKG_VERS = 1.29.0
+PKG_EXT = tar.gz
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/c-ares/c-ares/releases/download/cares-$(subst .,_,$(PKG_VERS))
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+DEPENDS =
+
+# ares_event_configchg.c:140: error: 'IN_NONBLOCK' undeclared (first use in this function)
+UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+
+HOMEPAGE = https://c-ares.org/
+COMMENT  = c-ares is a C library for asynchronous DNS requests (including name resolves).
+LICENSE  = MIT
+
+POST_CONFIGURE_TARGET = cares_post_configure
+
+CMAKE_ARGS += -DCARES_BUILD_TOOLS=OFF
+
+include ../../mk/spksrc.cross-cmake.mk
+
+.PHONY: cares_post_configure
+cares_post_configure:
+	@$(MSG) Create target include folder to suppress ignorable error logs
+	@$(RUN) install -d $(INSTALL_DIR)$(INSTALL_PREFIX)/include

--- a/cross/c-ares-latest/PLIST
+++ b/cross/c-ares-latest/PLIST
@@ -1,0 +1,3 @@
+lnk:lib/libcares.so
+lnk:lib/libcares.so.2
+lib:lib/libcares.so.2.14.0

--- a/cross/c-ares-latest/digests
+++ b/cross/c-ares-latest/digests
@@ -1,0 +1,3 @@
+c-ares-1.29.0.tar.gz SHA1 69d14a6ea7e414a290e3e3f058210ef02d469c0b
+c-ares-1.29.0.tar.gz SHA256 0b89fa425b825c4c7bc708494f374ae69340e4d1fdc64523bdbb2750bfc02ea7
+c-ares-1.29.0.tar.gz MD5 0768b7b8a7318be4576a68a7c31db6fb

--- a/cross/c-ares/Makefile
+++ b/cross/c-ares/Makefile
@@ -1,16 +1,12 @@
-PKG_NAME = c-ares
-PKG_VERS = 1.27.0
-PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://c-ares.org/download
-PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+PKG_NAME = c-ares-main
 
-DEPENDS =
+OPTIONAL_DEPENDS  = cross/c-ares-latest
+OPTIONAL_DEPENDS += cross/c-ares-1.28
 
-HOMEPAGE = https://c-ares.org/
-COMMENT  = c-ares is a C library for asynchronous DNS requests (including name resolves).
-LICENSE  = MIT
+include ../../mk/spksrc.main-depends.mk
 
-CMAKE_ARGS += -DCARES_BUILD_TOOLS=OFF
-
-include ../../mk/spksrc.cross-cmake.mk
+ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
+DEPENDS = cross/c-ares-1.28
+else
+DEPENDS = cross/c-ares-latest
+endif

--- a/cross/c-ares/digests
+++ b/cross/c-ares/digests
@@ -1,3 +1,0 @@
-c-ares-1.27.0.tar.gz SHA1 839f67cfb067b35e040b6fd3dd1bcf5c72af4277
-c-ares-1.27.0.tar.gz SHA256 0a72be66959955c43e2af2fbd03418e82a2bd5464604ec9a62147e37aceb420b
-c-ares-1.27.0.tar.gz MD5 e69ed15d01d1824a0241946b283abf79


### PR DESCRIPTION
## Description

c-ares has removed source from former location
- update c-ares to v1.29.0
- limit c-ares to v1.28.1 for OLD_PPC_ARCHS
- c-ares sources are now available on github only

related to #6126 and #6127

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Library update
