### PR TITLE
fix qoriq rust with github build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Cache toolchains
         uses: actions/cache@v4
         # Do not cache qoriq toolchain. It must be built every time to install custom rust toolchain
-        if: contains(${{ matrix.arch }}, 'qoriq') == false
+        if: ${{ contains(matrix.arch,'qoriq') == false }}
         with:
           path: toolchain/*/work
           key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles(format('toolchain/syno-{0}/digests',matrix.arch)) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: toolchain/syno-qoriq-*-rust/work-native
-          key: toolchain-${{ matrix.arch }}-rust-v3-${{format('toolchain/syno-{0}-rust/digests',matrix.arch)) }}
+          key: toolchain-${{ matrix.arch }}-rust-v3-${{ hashFiles(format('toolchain/syno-{0}-rust/digests',matrix.arch)) }}
 
       - name: Use cache of downloaded files
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: toolchain/syno-qoriq-*-rust/work-native
-          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles('toolchain/syno-qoriq-*-rust/digests') }}
+          key: toolchain-${{ matrix.arch }}-rust-v3-${{ hashFiles('toolchain/syno-qoriq-*-rust/digests') }}
 
       - name: Use cache of downloaded files
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,15 +91,11 @@ jobs:
 
       - name: Cache toolchains
         uses: actions/cache@v4
+        # Do not cache qoriq toolchain. It must be built every time to install custom rust toolchain
+        if: contains(${{ matrix.arch }}, 'qoriq') == false
         with:
           path: toolchain/*/work
           key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles(format('toolchain/syno-{0}/digests',matrix.arch)) }}
-
-      - name: Cache custom rust-qoriq
-        uses: actions/cache@v4
-        with:
-          path: toolchain/syno-qoriq-*-rust/work-native
-          key: toolchain-${{ matrix.arch }}-rust-v3-${{ hashFiles(format('toolchain/syno-{0}-rust/digests',matrix.arch)) }}
 
       - name: Use cache of downloaded files
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: toolchain/*/work
-          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles('toolchain/*/digests') }}
+          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles('toolchain/syno-${{ matrix.arch }}/digests') }}
 
       - name: Cache custom rust-qoriq
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,13 +93,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: toolchain/*/work
-          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles('toolchain/syno-${{ matrix.arch }}/digests') }}
+          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles(format('toolchain/syno-{0}/digests',matrix.arch)) }}
 
       - name: Cache custom rust-qoriq
         uses: actions/cache@v4
         with:
           path: toolchain/syno-qoriq-*-rust/work-native
-          key: toolchain-${{ matrix.arch }}-rust-v3-${{ hashFiles('toolchain/syno-qoriq-*-rust/digests') }}
+          key: toolchain-${{ matrix.arch }}-rust-v3-${{format('toolchain/syno-{0}-rust/digests',matrix.arch)) }}
 
       - name: Use cache of downloaded files
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,12 @@ jobs:
           path: toolchain/*/work
           key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles('toolchain/*/digests') }}
 
+      - name: Cache custom rust-qoriq
+        uses: actions/cache@v4
+        with:
+          path: toolchain/syno-qoriq-*-rust/work-native
+          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles('toolchain/syno-qoriq-*-rust/digests') }}
+
       - name: Use cache of downloaded files
         uses: actions/cache@v4
         with:

--- a/spk/synocli-monitor/Makefile
+++ b/spk/synocli-monitor/Makefile
@@ -3,8 +3,6 @@ SPK_VERS = 1.6
 SPK_REV = 8
 SPK_ICON = src/synocli-monitor.png
 
-# change to force build by github
-
 DEPENDS  = cross/nmon cross/njmon
 DEPENDS += cross/iperf2 cross/iperf3
 DEPENDS += cross/busybox

--- a/spk/synocli-monitor/Makefile
+++ b/spk/synocli-monitor/Makefile
@@ -3,6 +3,8 @@ SPK_VERS = 1.6
 SPK_REV = 8
 SPK_ICON = src/synocli-monitor.png
 
+# change to force build by github
+
 DEPENDS  = cross/nmon cross/njmon
 DEPENDS += cross/iperf2 cross/iperf3
 DEPENDS += cross/busybox


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
related to https://github.com/SynoCommunity/spksrc/pull/6123#issuecomment-2158070307

Disable the toolchain cache for qoriq to force the build of custom qoriq rust.

This PR updates the toolchain cache keys to include the related digests file only.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
