### PR TITLE
Misc fixes

### DIFF
--- a/cross/freetype/Makefile
+++ b/cross/freetype/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = freetype
 PKG_VERS = 2.13.2
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://de.freedif.org/savannah/freetype
+PKG_DIST_SITE = https://download.savannah.gnu.org/releases/freetype
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib cross/libpng

--- a/cross/llvm-latest/Makefile
+++ b/cross/llvm-latest/Makefile
@@ -37,7 +37,7 @@ CMAKE_ARGS += -DLLVM_ENABLE_ZLIB=ON
 # linked with the Foreign Function Interface library
 # (libffi) in order to enable calling external functions.
 DEPENDS += cross/libffi
-CMAKE_ARGS += LLVM_ENABLE_FFI=ON
+CMAKE_ARGS += -DLLVM_ENABLE_FFI=ON
 
 DEPENDS += cross/ncursesw
 CMAKE_ARGS += -DLLVM_ENABLE_TERMINFO=ON

--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -147,7 +147,7 @@ cmake_configure_target: $(CMAKE_TOOLCHAIN_PKG)
 	@$(MSG)    - Path BUILD_DIR = $(CMAKE_BUILD_DIR)
 	@$(MSG)    - Path CMAKE_SOURCE_DIR = $(CMAKE_SOURCE_DIR)
 	$(RUN) rm -rf CMakeCache.txt CMakeFiles
-	$(RUN) cmake -S $(CMAKE_SOURCE_DIR) -B $(CMAKE_BUILD_DIR) $(CMAKE_ARGS) $(ADDITIONAL_CMAKE_ARGS)
+	$(RUN) cmake -S $(CMAKE_SOURCE_DIR) -B $(CMAKE_BUILD_DIR) $(CMAKE_ARGS) $(ADDITIONAL_CMAKE_ARGS) $(CMAKE_DIR)
 
 .PHONY: cmake_compile_target
 

--- a/mk/spksrc.kernel.mk
+++ b/mk/spksrc.kernel.mk
@@ -4,7 +4,6 @@ default: all
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.common-rules.mk
 include ../../mk/spksrc.directories.mk
 
 # Common kernel variables
@@ -78,11 +77,11 @@ include ../../mk/spksrc.install.mk
 plist: install
 include ../../mk/spksrc.plist.mk
 
-### For make digests
-include ../../mk/spksrc.generate-digests.mk
-
 .PHONY: kernel_post_extract_target
 kernel_post_extract_target:
 	mv $(WORK_DIR)/$(KERNEL_DIST) $(WORK_DIR)/$(PKG_DIR)
 
 all: install plist
+
+# Common rules makefiles
+include ../../mk/spksrc.common-rules.mk


### PR DESCRIPTION
## Description

Misc fixes:
1. freetype URL change
2. missing `CMAKE` argument at configure (needed for `llvm`)
3. `llvm` fix due to missing `-D` for ffi configure call
4. remove duplicate `digests` call in `kernel.mk`

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
