### PR TITLE
Update node exporter to 1.8.1

### DIFF
--- a/cross/node-exporter/Makefile
+++ b/cross/node-exporter/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = node_exporter
-PKG_VERS = 1.3.1
+PKG_VERS = 1.8.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/prometheus/node_exporter/archive

--- a/cross/node-exporter/digests
+++ b/cross/node-exporter/digests
@@ -1,3 +1,3 @@
-node_exporter-1.3.1.tar.gz SHA1 b117f09fc0208af5e04a4533f3aa2ac150d56739
-node_exporter-1.3.1.tar.gz SHA256 66856b6b8953e094c46d7dd5aabd32801375cf4d13d9fe388e320cbaeaff573a
-node_exporter-1.3.1.tar.gz MD5 5b00f60341d34da5cd993853d099e0ce
+node_exporter-1.8.1.tar.gz SHA1 c6f6599152e86b692b2d302ea0aeb5c69a1743e4
+node_exporter-1.8.1.tar.gz SHA256 6a2dc6b0be27fa089574f2c32cee3673bbf4c6749c84f1d08f8c374e0908c0ad
+node_exporter-1.8.1.tar.gz MD5 2d5d6276a2fb8dc87b038b0a6b44cf83

--- a/spk/node-exporter/Makefile
+++ b/spk/node-exporter/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = node-exporter
-SPK_VERS = 1.3.1
-SPK_REV = 3
+SPK_VERS = 1.8.1
+SPK_REV = 4
 SPK_ICON = src/node-exporter.png
 
 DEPENDS = cross/$(SPK_NAME)
@@ -11,7 +11,7 @@ MAINTAINER = chiehmin
 DESCRIPTION = Prometheus exporter for hardware and OS metrics exposed by *NIX kernels.
 STARTABLE = yes
 DISPLAY_NAME = Node Exporter
-CHANGELOG = "1. Update to v1.3.1.<br/>2. Add 'parameters.txt' file to define custom parameters."
+CHANGELOG = "1. Update to v1.8.1."
 
 HOMEPAGE = https://github.com/prometheus/node_exporter
 LICENSE  = Apache License 2.0


### PR DESCRIPTION
## Description

Update node-exporter to latest current version (1.8.1). I successfully installed it on DS418 running DSM 7.2.1.

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [x] Package update
