### PR TITLE
update jellyfin 10.9.7

### DIFF
--- a/cross/jellyfin-web/Makefile
+++ b/cross/jellyfin-web/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin-web
-PKG_VERS = 10.9.6
+PKG_VERS = 10.9.7
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin-web/archive

--- a/cross/jellyfin-web/digests
+++ b/cross/jellyfin-web/digests
@@ -1,3 +1,3 @@
-jellyfin-web-10.9.6.tar.gz SHA1 aa7bb05eb47b6b305e6f259434a053e8b47fb961
-jellyfin-web-10.9.6.tar.gz SHA256 7095069abd46d692d9aaa6c9119ab84f177e13d34a719c25c37b769f98d13b46
-jellyfin-web-10.9.6.tar.gz MD5 a5dc1288f30a9f871add440d6895485f
+jellyfin-web-10.9.7.tar.gz SHA1 0911663e4f11214a69037bce81cc0382b6ae12ae
+jellyfin-web-10.9.7.tar.gz SHA256 de4a2b3e3894173484bdde66dd9ec2e66f1f4e734b9561a260b143ff6e983871
+jellyfin-web-10.9.7.tar.gz MD5 6db2d65c9baa0b01e627e91a05e6183b

--- a/cross/jellyfin/Makefile
+++ b/cross/jellyfin/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jellyfin
-PKG_VERS = 10.9.6
+PKG_VERS = 10.9.7
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin/archive

--- a/cross/jellyfin/digests
+++ b/cross/jellyfin/digests
@@ -1,3 +1,3 @@
-jellyfin-10.9.6.tar.gz SHA1 4c7c33a9d00f75cdae8a72b3bb41368374ff03e6
-jellyfin-10.9.6.tar.gz SHA256 183a114598347a3a5faebba04b524161c4424450fca4435b46b294d8088404ae
-jellyfin-10.9.6.tar.gz MD5 b27cc3a9abef63636a34598cbf1672b2
+jellyfin-10.9.7.tar.gz SHA1 73490dd3dd40f123d10df7899cf769b3183324c9
+jellyfin-10.9.7.tar.gz SHA256 dc8cd6c6d75600b14530d5660ee19505ccf45462ec3ac6a76b6ac1a761e55c25
+jellyfin-10.9.7.tar.gz MD5 4be677fab53ba17d0208cd9b3b336aca

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
-SPK_VERS = 10.9.6
-SPK_REV = 14
+SPK_VERS = 10.9.7
+SPK_REV = 15
 SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
@@ -18,7 +18,7 @@ MAINTAINER = stevenliuit
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "Update jellyfin to 10.9.6<br/>Built with dotnet 8 and nodejs 20."
+CHANGELOG = "Update jellyfin to 10.9.7"
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html


### PR DESCRIPTION
update jellyfin to 10.9.7 version

## Description

update jellyfin to 10.9.7 version

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
