### PR TITLE
fix initialization of SHARE_PATH variable on DSM 7

### DIFF
--- a/mk/spksrc.service.installer.functions
+++ b/mk/spksrc.service.installer.functions
@@ -18,6 +18,8 @@ TAR="/bin/tar"
 
 INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
 INST_VARIABLES="${INST_ETC}/installer-variables"
+# DSM7 only
+INST_SHARES="/var/packages/${SYNOPKG_PKGNAME}/shares"
 
 if [ -z "${SYNOPKG_PKGVAR}" ]; then
     # define SYNOPKG_PKGVAR for compatibility with DSM7 (replaces former INST_VAR)
@@ -51,10 +53,20 @@ initialize_variables ()
         # this is required for installers without resource worker for file share (SRM 1, DSM 5, DSM 6 old packages)
         if [ "$(echo ${SHARE_PATH} | grep ^/)" != "${SHARE_PATH}" ]; then
             SHARE_NAME=${SHARE_PATH}
-            if synoshare --get "${SHARE_NAME}" &> /dev/null; then
-                SHARE_PATH=$(synoshare --get "${SHARE_NAME}" | awk 'NR==4' | cut -d] -f1 | cut -d[ -f2)
-                install_log "Path of existing share [${SHARE_NAME}] is [${SHARE_PATH}]"
+            if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
+                if synoshare --get "${SHARE_NAME}" &> /dev/null; then
+                    SHARE_PATH=$(synoshare --get "${SHARE_NAME}" | awk 'NR==4' | cut -d] -f1 | cut -d[ -f2)
+                    install_log "Path of existing share [${SHARE_NAME}] is [${SHARE_PATH}]"
+                fi
             else
+                # synoshare fails on DSM 7 (at least on 7.2.1) with "Permission denied"
+                # but DSM 7 links package specific shares to the package installation folder
+                if [ -d ${INST_SHARES}/${SHARE_NAME} ]; then
+                    SHARE_PATH=$(realpath ${INST_SHARES}/${SHARE_NAME})
+                    install_log "Path of existing share [${SHARE_NAME}] is [${SHARE_PATH}]"
+                fi
+            fi
+            if [ ! -d "${SHARE_PATH}" ]; then
                 install_log "SHARE_NAME is not an existing share [${SHARE_PATH}]."
             fi
         fi


### PR DESCRIPTION
## Description

- this is a leftover of shared folder redesign (#5649)
- DSM 7 does not allow to call synohare (Permission denied)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
