### PR TITLE
chore: do not systematically build python spk when building python dependent modules

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -76,7 +76,7 @@ done
 for py in python310 python311; do
       if [ "$(echo ${packages} | grep -ow ${py})" != "" ]; then
           python_dependent_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "PYTHON_PACKAGE = ${py}" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
-          
+
           # If packages contain a package that depends on python (or is python), then ensure    
           # relevant python spk is first in list
           for package in ${packages}

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Part of github build action
 # 
@@ -74,18 +74,20 @@ done
 
 # for python (310, 311) find all packages that depend on them
 for py in python310 python311; do
-    python_dependent_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "PYTHON_PACKAGE = ${py}" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
-
-    # If packages contain a package that depends on python (or is python), then ensure
-    # relevant python spk is first in list
-    for package in ${packages}
-    do
-        if [ "$(echo ${py} ${python_dependent_packages} | grep -ow ${package})" != "" ]; then
-            packages_without_python=$(echo "${packages}" | tr ' ' '\n' | grep -v "${py}" | tr '\n' ' ')
-            packages="${py} ${packages_without_python}"
-            break
-        fi
-    done
+      if [ "$(echo ${packages} | grep -ow ${py})" != "" ]; then
+          python_dependent_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "PYTHON_PACKAGE = ${py}" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
+          
+          # If packages contain a package that depends on python (or is python), then ensure    
+          # relevant python spk is first in list
+          for package in ${packages}
+          do
+              if [ "$(echo ${py} ${python_dependent_packages} | grep -ow ${package})" != "" ]; then
+                  packages_without_python=$(echo "${packages}" | tr ' ' '\n' | grep -v "${py}" | tr '\n' ' ')
+                  packages="${py} ${packages_without_python}"
+                  break
+              fi
+          done
+      fi
 done
 
 # find all noarch packages

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Part of github build action
 # 


### PR DESCRIPTION
## Description

Fixes issue where, when trying to update a python depending module (let's say "Bazaar"), Python's spk would systematically be built.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [x] Includes small framework changes