### PR TITLE
native cmake fixes + add native llvm 14

### DIFF
--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -38,7 +38,7 @@ ifeq ($(strip $(CONFIGURE_TARGET)),)
 CONFIGURE_TARGET = cmake_configure_target
 endif
 
-# install
+# source directory
 ifeq ($(strip $(CMAKE_SOURCE_DIR)),)
 CMAKE_SOURCE_DIR = $(CMAKE_BASE_DIR)
 endif

--- a/mk/spksrc.cross-ninja.mk
+++ b/mk/spksrc.cross-ninja.mk
@@ -51,6 +51,8 @@ ifeq ($(strip $(INSTALL_TARGET)),)
 INSTALL_TARGET = ninja_install_target
 endif
 
+###
+
 .PHONY: ninja_compile_target
 
 # default ninja compile:

--- a/mk/spksrc.native-cmake-env.mk
+++ b/mk/spksrc.native-cmake-env.mk
@@ -12,7 +12,7 @@ endif
 
 # Use ninja to build
 ifeq ($(strip $(CMAKE_USE_NINJA)),)
-  CMAKE_USE_NINJA = 0
+  CMAKE_USE_NINJA = 1
 endif
 ifeq ($(strip $(CMAKE_USE_NINJA)),1)
   CMAKE_ARGS += -G Ninja

--- a/mk/spksrc.native-cmake.mk
+++ b/mk/spksrc.native-cmake.mk
@@ -35,7 +35,9 @@ ifeq ($(strip $(CMAKE_DIR)),)
 CMAKE_DIR = $(WORK_DIR)/$(PKG_DIR)
 endif
 
-ifneq ($(strip $(CMAKE_USE_NINJA)),1)
+ifeq ($(strip $(CMAKE_USE_NINJA)),1)
+include ../../mk/spksrc.cross-ninja.mk
+else
 # compile
 ifeq ($(strip $(COMPILE_TARGET)),)
 COMPILE_TARGET = cmake_compile_target
@@ -78,16 +80,14 @@ include ../../mk/spksrc.compile.mk
 install: compile
 include ../../mk/spksrc.install.mk
 
-.PHONY: cat_PLIST
-cat_PLIST:
-	@true
-
 all: install
 
 ###
 
-### Include common rules
-include ../../mk/spksrc.common-rules.mk
+# No PLIST to be processed for native
+.PHONY: cat_PLIST
+cat_PLIST:
+	@true
 
 ###
 
@@ -107,10 +107,6 @@ cmake_configure_target:
 
 .PHONY: cmake_compile_target
 
-ifeq ($(strip $(CMAKE_USE_NINJA)),1)
-include ../../mk/spksrc.cross-ninja.mk
-else
-
 # default compile:
 cmake_compile_target:
 	@$(MSG) - CMake compile
@@ -126,6 +122,10 @@ ifeq ($(strip $(CMAKE_USE_DESTDIR)),0)
 else
 	cd $(CMAKE_BUILD_DIR) && env $(ENV) $(MAKE) install DESTDIR=$(CMAKE_DESTDIR)
 endif
-endif
+
+###
+
+### Include common rules
+include ../../mk/spksrc.common-rules.mk
 
 ####

--- a/native/llvm-14.0-build/Makefile
+++ b/native/llvm-14.0-build/Makefile
@@ -1,0 +1,56 @@
+PKG_NAME = llvm
+PKG_VERS = 14.0.5
+PKG_EXT = tar.xz
+PKG_DIST_NAME = $(PKG_NAME)-project-$(PKG_VERS).src.$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/llvm/llvm-project/releases/download/llvmorg-$(PKG_VERS)
+#PKG_DIST_SITE = https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/llvm-project-14.0.5.src.tar.xz
+PKG_DIR = $(PKG_NAME)-project-$(PKG_VERS).src
+
+# REMARKS:
+# This was the original native/llvm-9.0/Makefile
+# Since it takes a huge amount of resources to build this, we started to host the 
+# output on https://github.com/SynoCommunity/spksrc/releases/tag/native%2Fllvm
+# 
+# This Makefile is kept to build it again
+# and has one additional target to build the archive (make build-archive)
+# 
+# The main reason to build llvm from source is, that other prebuilt packages
+# do not contain the binary "clang-tblgen" that is mandatory to build cross/llvm-9.0.
+# 
+
+DEPENDS =
+
+HOMEPAGE = https://llvm.org/
+COMMENT = The LLVM Project is a collection of modular and reusable compiler and toolchain technologies.
+LICENSE  = Apache License v2.0 with LLVM Exceptions
+
+POST_INSTALL_TARGET = llvm_post_install
+CMAKE_USE_NINJA = 1
+
+# Using LLVM project source need to change to llvm sub-directory
+CMAKE_DIR = $(WORK_DIR)/$(PKG_DIR)/llvm
+
+CMAKE_ARGS += -DCMAKE_BUILD_TYPE=MinSizeRel
+CMAKE_ARGS += -DLLVM_ENABLE_ASSERTIONS=ON
+CMAKE_ARGS += -DLLVM_BUILD_LLVM_DYLIB=ON
+CMAKE_ARGS += -DLLVM_LINK_LLVM_DYLIB=ON
+CMAKE_ARGS += -DBUILD_SHARED_LIBS=OFF
+CMAKE_ARGS += -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
+CMAKE_ARGS += -DLLVM_ENABLE_PROJECTS='clang'
+CMAKE_ARGS += -DLLVM_TARGETS_TO_BUILD=X86
+
+include ../../mk/spksrc.native-cmake.mk
+
+.PHONY: llvm_post_install
+llvm_post_install:
+	$(RUN) install -m 755 build/bin/llvm-config $(STAGING_INSTALL_PREFIX)/bin/llvm-config
+	$(RUN) install -m 755 build/bin/llvm-tblgen $(STAGING_INSTALL_PREFIX)/bin/llvm-tblgen
+	$(RUN) install -m 755 build/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
+
+.PHONY: build-archive
+build-archive:
+	@$(MSG) "Build archive of install folder"
+ifeq ($(wildcard work-native/install/usr/local/bin/*),)
+	$(error "Installation not found. Please call make first.")
+endif
+	cd work-native && tar -czf ../native-$(PKG_NAME)-$(PKG_VERS).tar.gz ./install/*

--- a/native/llvm-14.0-build/Makefile
+++ b/native/llvm-14.0-build/Makefile
@@ -1,5 +1,6 @@
 PKG_NAME = llvm
-PKG_VERS = 14.0.5
+PKG_VERS_MAJ = 14
+PKG_VERS = $(PKG_VERS_MAJ).0.5
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-project-$(PKG_VERS).src.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/llvm/llvm-project/releases/download/llvmorg-$(PKG_VERS)
@@ -44,8 +45,10 @@ include ../../mk/spksrc.native-cmake.mk
 .PHONY: llvm_post_install
 llvm_post_install:
 	$(RUN) install -m 755 build/bin/llvm-config $(STAGING_INSTALL_PREFIX)/bin/llvm-config
+	$(RUN) install -m 755 build/bin/llvm-link $(STAGING_INSTALL_PREFIX)/bin/llvm-link
 	$(RUN) install -m 755 build/bin/llvm-tblgen $(STAGING_INSTALL_PREFIX)/bin/llvm-tblgen
 	$(RUN) install -m 755 build/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
+	@cd $(STAGING_INSTALL_PREFIX)/bin && ln -sf clang-$(PKG_VERS_MAJ) clang-tool
 
 .PHONY: build-archive
 build-archive:

--- a/native/llvm-14.0-build/Makefile
+++ b/native/llvm-14.0-build/Makefile
@@ -44,11 +44,12 @@ include ../../mk/spksrc.native-cmake.mk
 
 .PHONY: llvm_post_install
 llvm_post_install:
+	$(RUN) install -m 755 build/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
+	@cd $(STAGING_INSTALL_PREFIX)/bin && ln -sf clang-$(PKG_VERS_MAJ) clang-tool
 	$(RUN) install -m 755 build/bin/llvm-config $(STAGING_INSTALL_PREFIX)/bin/llvm-config
 	$(RUN) install -m 755 build/bin/llvm-link $(STAGING_INSTALL_PREFIX)/bin/llvm-link
 	$(RUN) install -m 755 build/bin/llvm-tblgen $(STAGING_INSTALL_PREFIX)/bin/llvm-tblgen
-	$(RUN) install -m 755 build/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
-	@cd $(STAGING_INSTALL_PREFIX)/bin && ln -sf clang-$(PKG_VERS_MAJ) clang-tool
+	$(RUN) install -m 755 build/bin/opt $(STAGING_INSTALL_PREFIX)/bin/opt
 
 .PHONY: build-archive
 build-archive:

--- a/native/llvm-14.0-build/Makefile
+++ b/native/llvm-14.0-build/Makefile
@@ -1,29 +1,27 @@
 PKG_NAME = llvm
-PKG_VERS_MAJ = 14
-PKG_VERS = $(PKG_VERS_MAJ).0.5
+PKG_VERS = 14.0.5
+PKG_VERS_MAJ = $(firstword $(subst ., ,$(PKG_VERS)))
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-project-$(PKG_VERS).src.$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/llvm/llvm-project/releases/download/llvmorg-$(PKG_VERS)
-#PKG_DIST_SITE = https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/llvm-project-14.0.5.src.tar.xz
 PKG_DIR = $(PKG_NAME)-project-$(PKG_VERS).src
 
 # REMARKS:
-# This was the original native/llvm-9.0/Makefile
 # Since it takes a huge amount of resources to build this, we started to host the 
 # output on https://github.com/SynoCommunity/spksrc/releases/tag/native%2Fllvm
 # 
-# This Makefile is kept to build it again
+# This Makefile is to build the native llvm
 # and has one additional target to build the archive (make build-archive)
 # 
 # The main reason to build llvm from source is, that other prebuilt packages
-# do not contain the binary "clang-tblgen" that is mandatory to build cross/llvm-9.0.
+# do not contain the binary "clang-tblgen" that is mandatory to build cross/llvm-14.0.
 # 
 
 DEPENDS =
 
 HOMEPAGE = https://llvm.org/
 COMMENT = The LLVM Project is a collection of modular and reusable compiler and toolchain technologies.
-LICENSE  = Apache License v2.0 with LLVM Exceptions
+LICENSE = Apache v2.0 with LLVM Exceptions
 
 POST_INSTALL_TARGET = llvm_post_install
 CMAKE_USE_NINJA = 1

--- a/native/llvm-14.0-build/digests
+++ b/native/llvm-14.0-build/digests
@@ -1,0 +1,3 @@
+llvm-project-14.0.5.src.tar.xz SHA1 6f4fdf8bf943ab2ae362739e7c7e1524f3470c77
+llvm-project-14.0.5.src.tar.xz SHA256 c9d27903ba3883c476a83cd515e36e1e07b0585db55692835de11385d9e3c8fa
+llvm-project-14.0.5.src.tar.xz MD5 8fe06cfbec46c304f725db6beba18f35

--- a/native/llvm-14.0/Makefile
+++ b/native/llvm-14.0/Makefile
@@ -1,0 +1,28 @@
+PKG_NAME = llvm
+PKG_VERS = 14.0.5
+PKG_VERS_MAJ = $(firstword $(subst ., ,$(PKG_VERS)))
+PKG_EXT = tar.gz
+PKG_DIST_NAME = native-$(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/SynoCommunity/spksrc/releases/download/native%2Fllvm
+EXTRACT_PATH = $(WORK_DIR)
+
+# REMARKS:
+# Since it takes a huge amount of resources to build this, we started to host the 
+# output on https://github.com/SynoCommunity/spksrc/releases/tag/native%2Fllvm
+# 
+# This Makefile is to build the native llvm
+# and has one additional target to build the archive (make build-archive)
+# 
+# The main reason to build llvm from source is, that other prebuilt packages
+# do not contain the binary "clang-tblgen" that is mandatory to build cross/llvm-14.0.
+# 
+
+DEPENDS =
+
+HOMEPAGE = https://llvm.org/
+COMMENT = The LLVM Project is a collection of modular and reusable compiler and toolchain technologies.
+LICENSE = Apache v2.0 with LLVM Exceptions
+
+INSTALL_TARGET = nop
+
+include ../../mk/spksrc.native-install.mk

--- a/native/llvm-14.0/digests
+++ b/native/llvm-14.0/digests
@@ -1,0 +1,3 @@
+native-llvm-14.0.5.tar.gz SHA1 3896de59e6978678ec00cbc5db8ffaca4b02bafa
+native-llvm-14.0.5.tar.gz SHA256 9df2a307fc6582e90cf750daf9c475dd2307e76a5820ed3e2bb969300d49418f
+native-llvm-14.0.5.tar.gz MD5 ccee4d06c6e5fd94288d6e06b2bcd77a

--- a/native/llvm-9.0-build/Makefile
+++ b/native/llvm-9.0-build/Makefile
@@ -23,8 +23,8 @@ HOMEPAGE = https://llvm.org/
 COMMENT = The LLVM Project is a collection of modular and reusable compiler and toolchain technologies.
 LICENSE  = Apache License v2.0 with LLVM Exceptions
 
-CMAKE_USE_NINJA = 1
 POST_INSTALL_TARGET = llvm_post_install
+CMAKE_USE_NINJA = 1
 
 # Using LLVM project source need to change to llvm sub-directory
 CMAKE_DIR = $(WORK_DIR)/$(PKG_DIR)/llvm
@@ -38,6 +38,11 @@ CMAKE_ARGS += -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
 CMAKE_ARGS += -DLLVM_ENABLE_PROJECTS='clang'
 CMAKE_ARGS += -DLLVM_TARGETS_TO_BUILD=X86
 
+# For newer CMake compatibility
+CMAKE_ARGS += -DCMAKE_POLICY_DEFAULT_CMP0116='OLD'
+
+PATCHES_LEVEL = 1
+
 include ../../mk/spksrc.native-cmake.mk
 
 .PHONY: llvm_post_install
@@ -45,7 +50,6 @@ llvm_post_install:
 	$(RUN) install -m 755 build/bin/llvm-config $(STAGING_INSTALL_PREFIX)/bin/llvm-config
 	$(RUN) install -m 755 build/bin/llvm-tblgen $(STAGING_INSTALL_PREFIX)/bin/llvm-tblgen
 	$(RUN) install -m 755 build/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
-
 
 .PHONY: build-archive
 build-archive:

--- a/native/llvm-9.0-build/patches/001-fix-missing-header-limits.patch
+++ b/native/llvm-9.0-build/patches/001-fix-missing-header-limits.patch
@@ -1,0 +1,15 @@
+Related to this thread https://github.com/lifting-bits/cxx-common/issues/820
+Patch found at https://github.com/lifting-bits/cxx-common/commit/28e7561721d7e65eebbc3f349b77f5b5aefa8970
+-------
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"


### PR DESCRIPTION
## Description

1. Noticed issues with native cmake building
2. Adding native llvm 14 - This is to be used as pre-compiled released on spksrc for fastening the IGC build from https://github.com/SynoCommunity/spksrc/pull/6166

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
