### PR TITLE
xz: Update from version 5.6.1+really5.4.5 to 5.6.2

### DIFF
--- a/cross/fd/Makefile
+++ b/cross/fd/Makefile
@@ -8,6 +8,7 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 # PKG_VERS = 8.7.1 fails to build for RUST_TARGET = armv7-unknown-linux-gnueabi $(ARMv7L_ARCHS)
 # PKG_VERS >= 9 still fails for$(ARMv7L_ARCHS)
+# PKG_VERS <= 8.7.0 fails with newer rustc 1.80.1
 # see: https://github.com/sharkdp/fd/issues/1428
 UNSUPPORTED_ARCHS = $(ARMv7L_ARCHS)
 # powerpc archs (except qoriq) are not supported

--- a/cross/fd_8.7.0/Makefile
+++ b/cross/fd_8.7.0/Makefile
@@ -7,6 +7,7 @@ PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 # PKG_VERS = 8.7.1 fails to build for RUST_TARGET = armv7-unknown-linux-gnueabi $(ARMv7L_ARCHS)
+# PKG_VERS <= 8.7.0 fails with newer rustc 1.80.1 - rust version to 1.77.2 for hi3535
 # see: https://github.com/sharkdp/fd/issues/1428
 
 # powerpc archs (except qoriq) are not supported

--- a/cross/python310/Makefile
+++ b/cross/python310/Makefile
@@ -27,6 +27,7 @@ CONFIGURE_ARGS += --enable-ipv6
 CONFIGURE_ARGS += --without-ensurepip
 CONFIGURE_ARGS += --enable-loadable-sqlite-extensions
 CONFIGURE_ARGS += --with-computed-gotos=yes
+CONFIGURE_ARGS += --with-build-python
 
 include ../../mk/spksrc.archs.mk
 
@@ -35,6 +36,9 @@ ifeq ($(strip $(PYTHON_OPTIMIZE)),1)
 CONFIGURE_ARGS += --enable-optimizations
 # old compilers fail with unrecognized command line options: -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none
 ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
+# Some tests (like test_base64) must find libpython shared library at runtime.
+# python: error while loading shared libraries: libpython3.10.so.1.0: cannot open shared object file: No such file or directory
+ENV += LD_LIBRARY_PATH=$(WORK_DIR)/$(PKG_DIR)
 # Enable Link-Time Optimization
 CONFIGURE_ARGS += --with-lto
 endif
@@ -43,8 +47,8 @@ else
 CONFIGURE_ARGS += --disable-test-modules
 endif
 
-ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 # older gcc does not know -Wno-unused-result
+ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 CONFIGURE_ARGS += ac_cv_disable_unused_result_warning=no
 endif
 
@@ -131,11 +135,8 @@ python310_install:
 	@install -m 644 src/mime.types $(STAGING_INSTALL_PREFIX)/etc/
 	$(RUN) _PYTHON_HOST_PLATFORM=$(TC_TARGET) $(MAKE) install prefix=$(STAGING_INSTALL_PREFIX)
 
-
-# wheels to install in crossenv
-CROSSENV_WHEELS  = setuptools-rust==1.7.0
-CROSSENV_WHEELS += setuptools-scm==7.1.0
-CROSSENV_WHEELS += cffi==1.15.1
+# default wheels to install in crossenv
+CROSSENV_WHEELS  = cffi==1.17.0
 #
 # Cython version >= 3.x breaks PyYAML wheel
 # https://github.com/yaml/pyyaml/issues/601
@@ -146,12 +147,16 @@ CROSSENV_WHEELS += cffi==1.15.1
 #CROSSENV_WHEELS += Cython==3.0.2
 CROSSENV_WHEELS += Cython==0.29.36
 CROSSENV_WHEELS += flit==3.9.0
+CROSSENV_WHEELS += scikit-build==0.17.6
+CROSSENV_WHEELS += setuptools-rust==1.7.0
+CROSSENV_WHEELS += setuptools-scm==7.1.0
+# For future use when building numpy >= 1.26
+#CROSSENV_WHEELS += meson-python==0.13.2
+#CROSSENV_WHEELS += scikit-build-core==0.5.0
 ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 CROSSENV_WHEELS += cryptography==41.0.3
-CROSSENV_WHEELS += poetry==1.6.1
-endif
-ifneq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(OLD_PPC_ARCHS)),$(ARCH))
 CROSSENV_WHEELS += maturin==1.2.3
+CROSSENV_WHEELS += poetry==1.6.1
 endif
 
 # Create the crossenv in preparation for
@@ -162,12 +167,30 @@ python310_post_install: $(WORK_DIR)/python-cc.mk
 	cp -R $(HOSTPYTHON_LIB_NATIVE) $(PYTHON_LIB_CROSS)/../
 	@$(RUN) $(PYTHON_NATIVE) -m crossenv $(STAGING_INSTALL_PREFIX)/bin/python$(PKG_VERS_MAJOR_MINOR) --cc $(TC_PATH)$(TC_PREFIX)gcc --cxx $(TC_PATH)$(TC_PREFIX)c++ --ar $(TC_PATH)$(TC_PREFIX)ar --sysroot $(TC_SYSROOT) --env LIBRARY_PATH= --manylinux manylinux2014 $(WORK_DIR)/crossenv/
 	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) wget --no-verbose https://bootstrap.pypa.io/get-pip.py
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-python get-pip.py "pip==23.2.1" --no-setuptools --no-wheel --disable-pip-version-check
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) python get-pip.py "pip==23.2.1" --no-setuptools --no-wheel --disable-pip-version-check
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==68.1.2" "wheel==0.41.2"
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==68.1.2" "wheel==0.41.2"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-python get-pip.py "pip==24.2" --no-setuptools --no-wheel --disable-pip-version-check
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) python get-pip.py "pip==24.2" --no-setuptools --no-wheel --disable-pip-version-check
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==74.0.0" "wheel==0.44.0" "pip-tools==7.4.1"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==74.0.0" "wheel==0.44.0" "pip-tools==7.4.1"
 	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install $(CROSSENV_WHEELS)
 	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install $(CROSSENV_WHEELS)
+# [numpy] <= 1.2x.y Must be installed using setuptools < 70.0
+# [numpy] <= 1.21.6 (armv5)  - gcc-4.6.4 - unsupported
+# [numpy] <= 1.22.4 (armv7l) - gcc-4.8.3 - unsupported
+ifneq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==69.5.1"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==69.5.1"
+# [numpy] <= 1.24.4 last working version with gcc-4.9
+ifeq ($(call version_le, $(TC_GCC), 5.0),1)
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "numpy==1.24.4"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "numpy==1.24.4"
+# [numpy] >= 1.25.0 requires c++17
+else ifeq ($(call version_gt, $(TC_GCC), 5.0),1)
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "numpy==1.25.2"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "numpy==1.25.2"
+endif
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==74.0.0"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==74.0.0"
+endif
 ifneq ($(PYTHON_LIB_NATIVE),$(PYTHON_LIB_CROSS))
 	cp $(PYTHON_LIB_CROSS)/_sysconfigdata_*.py $(PYTHON_LIB_NATIVE)/_sysconfigdata.py
 endif

--- a/cross/python311/Makefile
+++ b/cross/python311/Makefile
@@ -133,7 +133,7 @@ python311_install:
 	$(RUN) _PYTHON_HOST_PLATFORM=$(TC_TARGET) $(MAKE) install prefix=$(STAGING_INSTALL_PREFIX)
 
 # default wheels to install in crossenv
-CROSSENV_WHEELS  = cffi==1.15.1
+CROSSENV_WHEELS  = cffi==1.17.0
 CROSSENV_WHEELS += cryptography==41.0.3
 #
 # Cython version >= 3.x breaks PyYAML wheel
@@ -145,6 +145,7 @@ CROSSENV_WHEELS += cryptography==41.0.3
 #CROSSENV_WHEELS += Cython==3.0.2
 CROSSENV_WHEELS += Cython==0.29.36
 CROSSENV_WHEELS += flit==3.9.0
+CROSSENV_WHEELS += maturin==1.2.3
 CROSSENV_WHEELS += poetry==1.6.1
 CROSSENV_WHEELS += scikit-build==0.17.6
 CROSSENV_WHEELS += setuptools-rust==1.7.0
@@ -153,20 +154,6 @@ CROSSENV_WHEELS += setuptools-scm==7.1.0
 #CROSSENV_WHEELS += meson-python==0.13.2
 #CROSSENV_WHEELS += scikit-build-core==0.5.0
 
-# [numpy] <= 1.21.6 (armv5)  - gcc-4.6.4 - unsupported
-# [numpy] <= 1.22.4 (armv7l) - gcc-4.8.3 - unsupported
-ifneq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
-# [numpy] <= 1.24.4 last working version with gcc-4.9
-ifeq ($(call version_le, $(TC_GCC), 5.0),1)
-CROSSENV_WHEELS += numpy==1.24.4
-# [numpy] >= 1.25.0 requires c++17
-else ifeq ($(call version_gt, $(TC_GCC), 5.0),1)
-CROSSENV_WHEELS += numpy==1.25.2
-endif
-endif
-
-# [maturin]
-CROSSENV_WHEELS += maturin==1.2.3
 
 # Create the crossenv in preparation for
 # cross-compiling all the necessary wheels
@@ -176,12 +163,30 @@ python311_post_install: $(WORK_DIR)/python-cc.mk
 	cp -R $(HOSTPYTHON_LIB_NATIVE) $(PYTHON_LIB_CROSS)/../
 	@$(RUN) $(PYTHON_NATIVE) -m crossenv $(STAGING_INSTALL_PREFIX)/bin/python$(PKG_VERS_MAJOR_MINOR) --cc $(TC_PATH)$(TC_PREFIX)gcc --cxx $(TC_PATH)$(TC_PREFIX)c++ --ar $(TC_PATH)$(TC_PREFIX)ar --sysroot $(TC_SYSROOT) --env LIBRARY_PATH= --manylinux manylinux2014 $(WORK_DIR)/crossenv/
 	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) wget --no-verbose https://bootstrap.pypa.io/get-pip.py
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-python get-pip.py "pip==23.2.1" --no-setuptools --no-wheel --disable-pip-version-check
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) python get-pip.py "pip==23.2.1" --no-setuptools --no-wheel --disable-pip-version-check
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==63.4.3" "wheel==0.41.2"
-	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==63.4.3" "wheel==0.41.2"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-python get-pip.py "pip==24.2" --no-setuptools --no-wheel --disable-pip-version-check
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) python get-pip.py "pip==24.2" --no-setuptools --no-wheel --disable-pip-version-check
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==74.0.0" "wheel==0.44.0" "pip-tools==7.4.1"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==74.0.0" "wheel==0.44.0" "pip-tools==7.4.1"
 	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install $(CROSSENV_WHEELS)
 	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install $(CROSSENV_WHEELS)
+# [numpy] <= 1.2x.y Must be installed using setuptools < 70.0
+# [numpy] <= 1.21.6 (armv5)  - gcc-4.6.4 - unsupported
+# [numpy] <= 1.22.4 (armv7l) - gcc-4.8.3 - unsupported
+ifneq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==69.5.1"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==69.5.1"
+# [numpy] <= 1.24.4 last working version with gcc-4.9
+ifeq ($(call version_le, $(TC_GCC), 5.0),1)
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "numpy==1.24.4"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "numpy==1.24.4"
+# [numpy] >= 1.25.0 requires c++17
+else ifeq ($(call version_gt, $(TC_GCC), 5.0),1)
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "numpy==1.25.2"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "numpy==1.25.2"
+endif
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) build-pip --disable-pip-version-check install "setuptools==74.0.0"
+	. $(WORK_DIR)/crossenv/bin/activate && $(RUN) pip --disable-pip-version-check install "setuptools==74.0.0"
+endif
 ifneq ($(PYTHON_LIB_NATIVE),$(PYTHON_LIB_CROSS))
 	cp $(PYTHON_LIB_CROSS)/_sysconfigdata_*.py $(PYTHON_LIB_NATIVE)/_sysconfigdata.py
 endif

--- a/cross/xz/Makefile
+++ b/cross/xz/Makefile
@@ -1,10 +1,9 @@
 PKG_NAME = xz
-PKG_VERS = 5.6.1+really5.4.5
+PKG_VERS = 5.6.2
 PKG_EXT = tar.xz
-PKG_DIST_NAME = $(PKG_NAME)-utils_$(PKG_VERS).orig.$(PKG_EXT)
-PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = http://deb.debian.org/debian/pool/main/x/xz-utils/
-PKG_DIR = $(PKG_NAME)-5.4.5
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/tukaani-project/xz/releases/download/v$(PKG_VERS)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 

--- a/cross/xz/PLIST
+++ b/cross/xz/PLIST
@@ -9,4 +9,4 @@ lnk:bin/xzcat
 bin:bin/xzdec
 lnk:lib/liblzma.so
 lnk:lib/liblzma.so.5
-lib:lib/liblzma.so.5.4.5
+lib:lib/liblzma.so.5.6.2

--- a/cross/xz/digests
+++ b/cross/xz/digests
@@ -1,3 +1,3 @@
-xz-5.6.1+really5.4.5.tar.xz SHA1 37ee68951814c3565f10ab92629d1d5173215fe0
-xz-5.6.1+really5.4.5.tar.xz SHA256 da9dec6c12cf2ecf269c31ab65b5de18e8e52b96f35d5bcd08c12b43e6878803
-xz-5.6.1+really5.4.5.tar.xz MD5 1d33e0be05c53e7a5641acf5c8b35fdd
+xz-5.6.2.tar.xz SHA1 340fb0e4e814edbed726e32f0d1e8e3a0dc85092
+xz-5.6.2.tar.xz SHA256 a9db3bb3d64e248a0fae963f8fb6ba851a26ba1822e504dc0efd18a80c626caf
+xz-5.6.2.tar.xz MD5 bbf73fb28425cebb854328599f85c4cf

--- a/cross/xz/patches/001-liblzma_fix_movzw_compatibility.patch
+++ b/cross/xz/patches/001-liblzma_fix_movzw_compatibility.patch
@@ -1,0 +1,84 @@
+github issue: https://github.com/tukaani-project/xz/issues/121
+github PR: https://github.com/tukaani-project/xz/pull/136
+
+--- src/liblzma/rangecoder/range_decoder.h-orig	2024-05-29 15:16:04.000000000 +0000
++++ src/liblzma/rangecoder/range_decoder.h	2024-08-26 11:54:33.092252300 +0000
+@@ -592,13 +592,13 @@ do { \
+ // *_only = rc_asm_y or _n to include or exclude code marked with them
+ #define rc_asm_bittree(a, b, first_only, middle_only, last_only) \
+ 	first_only( \
+-		"movzw	2(%[probs_base]), %[prob" #a "]\n\t" \
++		"movzwl	2(%[probs_base]), %[prob" #a "]\n\t" \
+ 		"mov	$2, %[symbol]\n\t" \
+-		"movzw	4(%[probs_base]), %[prob" #b "]\n\t" \
++		"movzwl	4(%[probs_base]), %[prob" #b "]\n\t" \
+ 	) \
+ 	middle_only( \
+ 		/* Note the scaling of 4 instead of 2: */ \
+-		"movzw	(%[probs_base], %q[symbol], 4), %[prob" #b "]\n\t" \
++		"movzwl	(%[probs_base], %q[symbol], 4), %[prob" #b "]\n\t" \
+ 	) \
+ 	last_only( \
+ 		"add	%[symbol], %[symbol]\n\t" \
+@@ -610,11 +610,11 @@ do { \
+ 		"cmovae	%[t0], %[range]\n\t" \
+ 		\
+ 	first_only( \
+-		"movzw	6(%[probs_base]), %[t0]\n\t" \
++		"movzwl	6(%[probs_base]), %[t0]\n\t" \
+ 		"cmovae	%[t0], %[prob" #b "]\n\t" \
+ 	) \
+ 	middle_only( \
+-		"movzw	2(%[probs_base], %q[symbol], 4), %[t0]\n\t" \
++		"movzwl	2(%[probs_base], %q[symbol], 4), %[t0]\n\t" \
+ 		"lea	(%q[symbol], %q[symbol]), %[symbol]\n\t" \
+ 		"cmovae	%[t0], %[prob" #b "]\n\t" \
+ 	) \
+@@ -716,12 +716,12 @@ do { \
+ #define rc_asm_bittree_rev(a, b, add, dcur, dnext0, dnext1, \
+ 		first_only, middle_only, last_only) \
+ 	first_only( \
+-		"movzw	2(%[probs_base]), %[prob" #a "]\n\t" \
++		"movzwl	2(%[probs_base]), %[prob" #a "]\n\t" \
+ 		"xor	%[symbol], %[symbol]\n\t" \
+-		"movzw	4(%[probs_base]), %[prob" #b "]\n\t" \
++		"movzwl	4(%[probs_base]), %[prob" #b "]\n\t" \
+ 	) \
+ 	middle_only( \
+-		"movzw	" #dnext0 "(%[probs_base], %q[symbol], 2), " \
++		"movzwl	" #dnext0 "(%[probs_base], %q[symbol], 2), " \
+ 			"%[prob" #b "]\n\t" \
+ 	) \
+ 		\
+@@ -731,11 +731,11 @@ do { \
+ 		"cmovae	%[t0], %[range]\n\t" \
+ 		\
+ 	first_only( \
+-		"movzw	6(%[probs_base]), %[t0]\n\t" \
++		"movzwl	6(%[probs_base]), %[t0]\n\t" \
+ 		"cmovae	%[t0], %[prob" #b "]\n\t" \
+ 	) \
+ 	middle_only( \
+-		"movzw	" #dnext1 "(%[probs_base], %q[symbol], 2), %[t0]\n\t" \
++		"movzwl	" #dnext1 "(%[probs_base], %q[symbol], 2), %[t0]\n\t" \
+ 		"cmovae	%[t0], %[prob" #b "]\n\t" \
+ 	) \
+ 		\
+@@ -788,7 +788,7 @@ do { \
+ 	uint32_t t_index; \
+ 	\
+ 	__asm__( \
+-		"movzw	(%[probs_base], %q[symbol], 2), %[prob]\n\t" \
++		"movzwl	(%[probs_base], %q[symbol], 2), %[prob]\n\t" \
+ 		"mov	%[symbol], %[index]\n\t" \
+ 		\
+ 		"add	%[dest], %[t2]\n\t" \
+@@ -844,7 +844,7 @@ do { \
+ 		"and	%[offset], %[match_bit]\n\t" \
+ 		"add	%[match_bit], %[symbol]\n\t" \
+ 		\
+-		"movzw	(%[probs_base], %q[symbol], 2), %[prob]\n\t" \
++		"movzwl	(%[probs_base], %q[symbol], 2), %[prob]\n\t" \
+ 		\
+ 		"add	%[symbol], %[symbol]\n\t" \
+ 		\

--- a/mk/spksrc.cross-rust-env.mk
+++ b/mk/spksrc.cross-rust-env.mk
@@ -39,6 +39,7 @@ ifeq ($(findstring $(RUST_ARCH), $(ARMv7_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = armv7-unknown-linux-gnueabihf
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv7L_ARCHS)),$(RUST_ARCH))
+RUSTUP_DEFAULT_TOOLCHAIN = 1.77.2
 RUST_TARGET = armv7-unknown-linux-gnueabi
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv8_ARCHS)),$(RUST_ARCH))


### PR DESCRIPTION
## Description

1. `xz`: Update from version 5.6.1+really5.4.5 to 5.6.2
2. Fix python 3.10-3.11 builds.
3. Fix build issue for hi3535 related to fd-8.7.0 with newer rustc >= 1.80.1 (now version fixed to 1.77.2 like ARMv5)

Superseeds part of https://github.com/SynoCommunity/spksrc/pull/6200

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)

### TODO
- [ ] publish `jackett` https://github.com/SynoCommunity/spksrc/pull/6211
- [ ] publish `rutorrent` https://github.com/SynoCommunity/spksrc/pull/6215
