### PR TITLE
native-cmake.mk: Fix build whereas install wouldn't be probed

### DIFF
--- a/mk/spksrc.native-cmake.mk
+++ b/mk/spksrc.native-cmake.mk
@@ -8,6 +8,9 @@
 include ../../mk/spksrc.common.mk
 include ../../mk/spksrc.directories.mk
 
+# cmake specific configurations
+include ../../mk/spksrc.native-cmake-env.mk
+
 # Force build in native tool directrory, not cross directory.
 WORK_DIR := $(CURDIR)/work-native
 
@@ -53,10 +56,8 @@ endif
 
 .NOTPARALLEL:
 
+# native specific environment
 include ../../mk/spksrc.native-env.mk
-
-# cmake specific configurations
-include ../../mk/spksrc.native-cmake-env.mk
 
 include ../../mk/spksrc.download.mk
 


### PR DESCRIPTION
## Description

native-cmake.mk: Fix build whereas install wouldn't be probed - When fixing `native/libmysql` to work with new debian image using legacy cmake, it was also converted to using ninja by default like cross-cmake.  An re-ordering of the rule files was missing for it to work.

Fixes https://github.com/SynoCommunity/spksrc/pull/6220#issuecomment-2353544515

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
