### PR TITLE
ffmpeg56: Only make x64 dependent to synocli-videodriver

### DIFF
--- a/spk/ffmpeg5/Makefile
+++ b/spk/ffmpeg5/Makefile
@@ -1,10 +1,9 @@
 SPK_NAME = ffmpeg5
 SPK_VERS = 5.1.5
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/ffmpeg.png
 CHANGELOG = "1. Update to version 5.1.5<br/>2. Update Jellyfin upstream patches<br/>3. Update Intel Media Driver 2024Q2 Release (DSM7 only)<br/>4. Enable OpenCL on Intel platforms (DSM7 only)<br/>5. Update to latest version of x264 (fix for \#6176)<br/>6. Now using new synocli-videodriver package"
 
-SPK_DEPENDS = "synocli-videodriver"
 DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = th0ma7
@@ -29,8 +28,8 @@ VIDEODRIVER = on
 endif
 
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
+SPK_DEPENDS = "synocli-videodriver"
 SERVICE_SETUP = src/service-setup.sh
-SPK_COMMANDS += bin/vainfo
 endif
 
 include ../../mk/spksrc.videodriver.mk

--- a/spk/ffmpeg6/Makefile
+++ b/spk/ffmpeg6/Makefile
@@ -1,10 +1,9 @@
 SPK_NAME = ffmpeg6
 SPK_VERS = 6.0.1
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/ffmpeg.png
 CHANGELOG = "1. Update to version 6.0.1<br/>2. Update Jellyfin upstream patches<br/>3. Update Intel Media Driver 2024Q2 Release (DSM7 only)<br/>4. Revert DSM7 to MFX intead of Intel Video Processing Library (Intel-VPL) as unsupported by Jellyfin<br/>5. Enable OpenCL on Intel platforms (DSM7 only)<br/>6. Update to latest version of x264 (fix for \#6176)<br/>6. Now using new synocli-videodriver package"
 
-SPK_DEPENDS = "synocli-videodriver"
 DEPENDS = cross/$(SPK_NAME)
 
 MAINTAINER = th0ma7
@@ -29,8 +28,8 @@ VIDEODRIVER = on
 endif
 
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
+SPK_DEPENDS = "synocli-videodriver"
 SERVICE_SETUP = src/service-setup.sh
-SPK_COMMANDS += bin/vainfo
 endif
 
 include ../../mk/spksrc.videodriver.mk


### PR DESCRIPTION
## Description

ffmpeg56: Only make x64 dependent to synocli-videodriver

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
