### PR TITLE
Framework: Add Configurable Build Architectures and Input Flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,22 +11,38 @@ on:
         description: 'Publish to repository'
         required: false
         default: 'false'
-      include_optional_arch:
-        description: 'Include dsm 7.2 archs'
+      add_srm12_builds:
+        description: 'Include SRM 1.2 archs'
+        required: false
+        default: 'false'
+      add_dsm52_builds:
+        description: 'Include DSM 5.2 archs'
+        required: false
+        default: 'false'
+      add_dsm62_builds:
+        description: 'Include DSM 6.2 archs'
+        required: false
+        default: 'true'
+      add_dsm71_builds:
+        description: 'Include DSM 7.1 archs'
+        required: false
+        default: 'true'
+      add_dsm72_builds:
+        description: 'Include DSM 7.2 archs'
         required: false
         default: 'false'
   pull_request:
     paths:
-    - 'spk/**'
-    - 'cross/**'
-    - 'native/**'
+      - 'spk/**'
+      - 'cross/**'
+      - 'native/**'
   push:
     branches:
       - "**"
     paths:
-    - 'spk/**'
-    - 'cross/**'
-    - 'native/**'
+      - 'spk/**'
+      - 'cross/**'
+      - 'native/**'
 
 jobs:
   prepare:
@@ -34,14 +50,14 @@ jobs:
     runs-on: ubuntu-latest
     # provide results to other jobs
     outputs:
-        arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
-        noarch_packages: ${{ steps.dependencies.outputs.noarch_packages }}
+      arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
+      noarch_packages: ${{ steps.dependencies.outputs.noarch_packages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
-            persist-credentials: false
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Get changed files for pull request
         if: github.event_name == 'pull_request'
@@ -78,36 +94,62 @@ jobs:
           ARCH_PACKAGES: ${{ needs.prepare.outputs.arch_packages }}
           NOARCH_PACKAGES: ${{ needs.prepare.outputs.noarch_packages }}
 
+  generate_matrix:
+    name: Prepare Architectures
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          # Start with the noarch architectures at the top
+          matrix='{"include": ['
+          matrix+='{"arch": "noarch"},'
+          matrix+='{"arch": "noarch-6.1"},'
+          matrix+='{"arch": "noarch-7.0"},'
+
+          # Add other architectures based on input flags
+          if [ "${{ github.event.inputs.add_dsm52_builds }}" == "true" ]; then
+            matrix+='{"arch": "x86-5.2"},'
+            matrix+='{"arch": "88f6281-5.2"},'
+            matrix+='{"arch": "ppc853x-5.2"},'
+          fi
+          if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" ]; then
+            matrix+='{"arch": "x64-6.2.4"},'
+            matrix+='{"arch": "aarch64-6.2.4"},'
+            matrix+='{"arch": "evansport-6.2.4"},'
+            matrix+='{"arch": "armv7-6.2.4"},'
+            matrix+='{"arch": "hi3535-6.2.4"},'
+            matrix+='{"arch": "88f6281-6.2.4"},'
+            matrix+='{"arch": "qoriq-6.2.4"},'
+          fi
+          if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" ]; then
+            matrix+='{"arch": "x64-7.1"},'
+            matrix+='{"arch": "aarch64-7.1"},'
+            matrix+='{"arch": "evansport-7.1"},'
+            matrix+='{"arch": "armv7-7.1"},'
+            matrix+='{"arch": "comcerto2k-7.1"},'
+          fi
+          if [ "${{ github.event.inputs.add_dsm72_builds }}" == "true" ]; then
+            matrix+='{"arch": "x64-7.2"},'
+            matrix+='{"arch": "aarch64-7.2"},'
+          fi
+          if [ "${{ github.event.inputs.add_srm12_builds }}" == "true" ]; then
+            matrix+='{"arch": "armv7-1.2"},'
+          fi
+
+          # Remove trailing comma and close the matrix
+          matrix=$(echo $matrix | sed 's/,$//')
+          matrix+=']}'
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   build:
     name: Build
-    needs: prepare
+    needs: [prepare, generate_matrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        # x64=x86_64, evansport=i686, aarch64=armv8, armv7, hi3535=armv7l, 88f6281=armv5, qoriq=ppc
-        # https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures
-        include:
-          - arch: noarch
-          - arch: noarch-6.1
-          - arch: noarch-7.0
-          - arch: x64-6.2.4
-          - arch: x64-7.1
-          - arch: x64-7.2
-            optional: ${{ github.event.inputs.include_optional_arch == 'true' }}
-          - arch: aarch64-6.2.4
-          - arch: aarch64-7.1
-          - arch: aarch64-7.2
-            optional: ${{ github.event.inputs.include_optional_arch == 'true' }}
-          - arch: evansport-6.2.4
-          - arch: evansport-7.1
-          - arch: armv7-6.2.4
-          - arch: armv7-7.1
-          - arch: hi3535-6.2.4
-          - arch: 88f6281-6.2.4
-          - arch: qoriq-6.2.4
-          - arch: comcerto2k-7.1
-
+      matrix: ${{ fromJSON(needs.generate_matrix.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -145,7 +187,6 @@ jobs:
           BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
-          INCLUDE_OPTIONAL_ARCH: ${{ github.event.inputs.include_optional_arch }}
 
       - name: Build Status
         id: build_status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,26 +15,10 @@ on:
         options:
           - 'true'
           - 'false'
-      add_srm12_builds:
-        description: 'Include SRM 1.2 archs'
+      add_dsm72_builds:
+        description: 'Include DSM 7.2 archs'
         required: false
         default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
-      add_dsm52_builds:
-        description: 'Include DSM 5.2 archs'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
-      add_dsm62_builds:
-        description: 'Include DSM 6.2 archs'
-        required: false
-        default: 'true'
         type: choice
         options:
           - 'true'
@@ -47,8 +31,24 @@ on:
         options:
           - 'true'
           - 'false'
-      add_dsm72_builds:
-        description: 'Include DSM 7.2 archs'
+      add_dsm62_builds:
+        description: 'Include DSM 6.2 archs'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      add_dsm52_builds:
+        description: 'Include DSM 5.2 archs'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      add_srm12_builds:
+        description: 'Include SRM 1.2 archs'
         required: false
         default: 'false'
         type: choice

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ on:
         options:
           - 'true'
           - 'false'
-      add_dsm624_builds:
-        description: 'Include DSM 6.2.4 archs'
+      add_dsm62_builds:
+        description: 'Include DSM 6.2 archs'
         required: false
         default: 'true'
         type: choice
@@ -138,7 +138,7 @@ jobs:
             matrix+='{"arch": "88f6281-5.2"},'
             matrix+='{"arch": "ppc853x-5.2"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm624_builds }}" == "true" ]; then
+          if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" ]; then
             matrix+='{"arch": "x64-6.2.4"},'
             matrix+='{"arch": "aarch64-6.2.4"},'
             matrix+='{"arch": "evansport-6.2.4"},'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,26 +11,50 @@ on:
         description: 'Publish to repository'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       add_srm12_builds:
         description: 'Include SRM 1.2 archs'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       add_dsm52_builds:
         description: 'Include DSM 5.2 archs'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       add_dsm62_builds:
         description: 'Include DSM 6.2 archs'
         required: false
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       add_dsm71_builds:
         description: 'Include DSM 7.1 archs'
         required: false
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       add_dsm72_builds:
         description: 'Include DSM 7.2 archs'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
   pull_request:
     paths:
       - 'spk/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ on:
         options:
           - 'true'
           - 'false'
-      add_dsm62_builds:
-        description: 'Include DSM 6.2 archs'
+      add_dsm624_builds:
+        description: 'Include DSM 6.2.4 archs'
         required: false
         default: 'true'
         type: choice
@@ -138,7 +138,7 @@ jobs:
             matrix+='{"arch": "88f6281-5.2"},'
             matrix+='{"arch": "ppc853x-5.2"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" ]; then
+          if [ "${{ github.event.inputs.add_dsm624_builds }}" == "true" ]; then
             matrix+='{"arch": "x64-6.2.4"},'
             matrix+='{"arch": "aarch64-6.2.4"},'
             matrix+='{"arch": "evansport-6.2.4"},'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
         description: 'Publish to repository'
         required: false
         default: 'false'
+      include_optional_arch:
+        description: 'Include dsm 7.2 archs'
+        required: false
+        default: 'false'
   pull_request:
     paths:
     - 'spk/**'
@@ -83,7 +87,26 @@ jobs:
       matrix:
         # x64=x86_64, evansport=i686, aarch64=armv8, armv7, hi3535=armv7l, 88f6281=armv5, qoriq=ppc
         # https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures
-        arch: [noarch, noarch-6.1, noarch-7.0, x64-6.2.4, x64-7.1, evansport-6.2.4, evansport-7.1, aarch64-6.2.4, aarch64-7.1, armv7-6.2.4, armv7-7.1, hi3535-6.2.4, 88f6281-6.2.4, qoriq-6.2.4, comcerto2k-7.1]
+        include:
+          - arch: noarch
+          - arch: noarch-6.1
+          - arch: noarch-7.0
+          - arch: x64-6.2.4
+          - arch: x64-7.1
+          - arch: x64-7.2
+            optional: ${{ github.event.inputs.include_optional_arch == 'true' }}
+          - arch: aarch64-6.2.4
+          - arch: aarch64-7.1
+          - arch: aarch64-7.2
+            optional: ${{ github.event.inputs.include_optional_arch == 'true' }}
+          - arch: evansport-6.2.4
+          - arch: evansport-7.1
+          - arch: armv7-6.2.4
+          - arch: armv7-7.1
+          - arch: hi3535-6.2.4
+          - arch: 88f6281-6.2.4
+          - arch: qoriq-6.2.4
+          - arch: comcerto2k-7.1
 
     steps:
       - name: Checkout repository
@@ -122,6 +145,7 @@ jobs:
           BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
+          INCLUDE_OPTIONAL_ARCH: ${{ github.event.inputs.include_optional_arch }}
 
       - name: Build Status
         id: build_status


### PR DESCRIPTION
## Description

This PR introduces several updates to the build workflow, including:

- Added new input flags to optionally include specific architectures for SRM 1.2, DSM 5.2, DSM 6.2, DSM 7.1, and DSM 7.2 (required for Jellyfin).
- Introduced logic to generate a dynamic matrix of architectures based on user input (noarch architectures included by default).
- Made adjustments to conditionally include older DSM architectures, improving build flexibility and reducing unnecessary builds.

These changes optimise the build process, allowing more control over which architectures are built and improving workflow performance by excluding unused architectures.

Related to #6101

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
