### PR TITLE
Framework: Prevent noarch builds without DSM 5.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,19 +126,18 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Start with the noarch architectures at the top
+          # Create a matrix as a JSON object
           matrix='{"include": ['
-          matrix+='{"arch": "noarch"},'
-          matrix+='{"arch": "noarch-6.1"},'
-          matrix+='{"arch": "noarch-7.0"},'
 
-          # Add other architectures based on input flags
+          # Add architectures based on input flags
           if [ "${{ github.event.inputs.add_dsm52_builds }}" == "true" ]; then
+            matrix+='{"arch": "noarch"},'
             matrix+='{"arch": "x86-5.2"},'
             matrix+='{"arch": "88f6281-5.2"},'
             matrix+='{"arch": "ppc853x-5.2"},'
           fi
           if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" ]; then
+            matrix+='{"arch": "noarch-6.1"},'
             matrix+='{"arch": "x64-6.2.4"},'
             matrix+='{"arch": "aarch64-6.2.4"},'
             matrix+='{"arch": "evansport-6.2.4"},'
@@ -148,6 +147,7 @@ jobs:
             matrix+='{"arch": "qoriq-6.2.4"},'
           fi
           if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" ]; then
+            matrix+='{"arch": "noarch-7.0"},'
             matrix+='{"arch": "x64-7.1"},'
             matrix+='{"arch": "aarch64-7.1"},'
             matrix+='{"arch": "evansport-7.1"},'
@@ -155,6 +155,7 @@ jobs:
             matrix+='{"arch": "comcerto2k-7.1"},'
           fi
           if [ "${{ github.event.inputs.add_dsm72_builds }}" == "true" ]; then
+            matrix+='{"arch": "noarch-7.0"},'
             matrix+='{"arch": "x64-7.2"},'
             matrix+='{"arch": "aarch64-7.2"},'
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,7 @@ jobs:
         run: |
           # Start with the noarch architectures at the top
           matrix='{"include": ['
+          matrix+='{"arch": "noarch"},'
           matrix+='{"arch": "noarch-6.1"},'
           matrix+='{"arch": "noarch-7.0"},'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,6 @@ jobs:
         run: |
           # Start with the noarch architectures at the top
           matrix='{"include": ['
-          matrix+='{"arch": "noarch"},'
           matrix+='{"arch": "noarch-6.1"},'
           matrix+='{"arch": "noarch-7.0"},'
 

--- a/mk/spksrc.pre-check.mk
+++ b/mk/spksrc.pre-check.mk
@@ -82,6 +82,13 @@ endif
 
 # Check minimum DSM requirements of package
 ifneq ($(REQUIRED_MIN_DSM),)
+  # Check if ARCH is noarch and TCVERSION is empty
+  ifeq ($(ARCH),noarch)
+    ifeq ($(TCVERSION),)
+      TCVERSION=3.1
+    endif
+  endif
+
   ifeq (,$(findstring $(ARCH),$(SRM_ARCHS)))
     ifneq ($(REQUIRED_MIN_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_DSM))))
       ifneq (,$(BUILD_UNSUPPORTED_FILE))

--- a/mk/spksrc.pre-check.mk
+++ b/mk/spksrc.pre-check.mk
@@ -82,13 +82,6 @@ endif
 
 # Check minimum DSM requirements of package
 ifneq ($(REQUIRED_MIN_DSM),)
-  # Check if ARCH is noarch and TCVERSION is empty
-  ifeq ($(ARCH),noarch)
-    ifeq ($(TCVERSION),)
-      TCVERSION=3.1
-    endif
-  endif
-
   ifeq (,$(findstring $(ARCH),$(SRM_ARCHS)))
     ifneq ($(REQUIRED_MIN_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_DSM))))
       ifneq (,$(BUILD_UNSUPPORTED_FILE))


### PR DESCRIPTION
## Description

This update ensures `noarch` builds only occur when DSM 5.2 is selected. Previously, `noarch` builds were triggered even when DSM 5.2 wasn't chosen. Now, `noarch`, `noarch-6.1` and `noarch-7.0` are properly tied to DSM 5.2, DSM 6.2 and DSM 7.x, respectively, improving build accuracy.

Follow-up on #6247 and https://github.com/SynoCommunity/spksrc/pull/6229#issuecomment-2351049498.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
