### PR TITLE
Update noarch build

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -143,7 +143,6 @@ echo "arch_packages=${arch_packages}" >> $GITHUB_OUTPUT
 echo "noarch_packages=${noarch_packages}" >> $GITHUB_OUTPUT
 echo "has_arch_packages=${has_arch_packages}" >> $GITHUB_OUTPUT
 echo "has_noarch_packages=${has_noarch_packages}" >> $GITHUB_OUTPUT
-echo "min_dsm72_packages=${min_dsm72_packages}" >> $GITHUB_OUTPUT
 echo "has_min_dsm72_packages=${has_min_dsm72_packages}" >> $GITHUB_OUTPUT
 
 echo "::endgroup::"

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -122,10 +122,29 @@ do
     fi
 done
 
+# evaluate packages that require DSM 7.2
+min_dsm72_packages=
+has_min_dsm72_packages='false'
+for package in ${packages}
+do
+    if [ -f "./spk/${package}/Makefile" ]; then
+        if [ "$(grep REQUIRED_MIN_DSM ./spk/${package}/Makefile | cut -d= -f2 | xargs)" = "7.2" ]; then
+            min_dsm72_packages+="${package} "
+            has_min_dsm72_packages='true'
+        fi
+    fi
+done
+
+if [ "${has_min_dsm72_packages}" = "true" ]; then
+    echo "===> Min DSM 7.2 packages found: ${min_dsm72_packages}"
+fi
+
 echo "arch_packages=${arch_packages}" >> $GITHUB_OUTPUT
 echo "noarch_packages=${noarch_packages}" >> $GITHUB_OUTPUT
 echo "has_arch_packages=${has_arch_packages}" >> $GITHUB_OUTPUT
 echo "has_noarch_packages=${has_noarch_packages}" >> $GITHUB_OUTPUT
+echo "min_dsm72_packages=${min_dsm72_packages}" >> $GITHUB_OUTPUT
+echo "has_min_dsm72_packages=${has_min_dsm72_packages}" >> $GITHUB_OUTPUT
 
 echo "::endgroup::"
 

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -59,7 +59,7 @@ for i in {5..7}; do
     ffmpeg_dependent_packages=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "FFMPEG_PACKAGE = ffmpeg${i}" {} \; | grep -Po ".*spk/\K[^/]*" | sort | tr '\n' ' ')
 
     # If packages contain a package that depends on ffmpeg (or is ffmpeg),
-    # then ensure relevant ffmpeg5|ffmpeg6 is first in list
+    # then ensure relevant ffmpeg spk is first in list
     for package in ${packages}
     do
         if [ "$(echo ffmpeg${i} ${ffmpeg_dependent_packages} | grep -ow ${package})" != "" ]; then
@@ -107,19 +107,25 @@ all_noarch=$(find spk/ -maxdepth 2 -mindepth 2 -name "Makefile" -exec grep -Ho "
 # and filter out packages that are removed or do not exist (e.g. nzbdrone)
 arch_packages=
 noarch_packages=
+has_arch_packages='false'
+has_noarch_packages='false'
 for package in ${packages}
 do
     if [ -f "./spk/${package}/Makefile" ]; then
         if [ "$(echo ${all_noarch} | grep -ow ${package})" = "" ]; then
             arch_packages+="${package} "
+            has_arch_packages='true'
         else
             noarch_packages+="${package} "
+            has_noarch_packages='true'
         fi
     fi
 done
 
 echo "arch_packages=${arch_packages}" >> $GITHUB_OUTPUT
 echo "noarch_packages=${noarch_packages}" >> $GITHUB_OUTPUT
+echo "has_arch_packages=${has_arch_packages}" >> $GITHUB_OUTPUT
+echo "has_noarch_packages=${has_noarch_packages}" >> $GITHUB_OUTPUT
 
 echo "::endgroup::"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       package:
         description: 'Package to build'
         required: true
-        default: 'syno-magnet'
+        default: 'adminer'
       publish:
         description: 'Publish to repository'
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,14 @@ on:
         options:
           - 'true'
           - 'false'
+      add_noarch_builds:
+        description: 'Include noarch packages'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       add_dsm72_builds:
         description: 'Include DSM 7.2 archs'
         required: false
@@ -126,17 +134,25 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Start with the noarch architectures at the top
+          # Create a matrix as a JSON object
           matrix='{"include": ['
-          matrix+='{"arch": "noarch"},'
-          matrix+='{"arch": "noarch-6.1"},'
-          matrix+='{"arch": "noarch-7.0"},'
-
-          # Add other architectures based on input flags
-          if [ "${{ github.event.inputs.add_dsm52_builds }}" == "true" ]; then
-            matrix+='{"arch": "x86-5.2"},'
-            matrix+='{"arch": "88f6281-5.2"},'
-            matrix+='{"arch": "ppc853x-5.2"},'
+          
+          if [ "${{ github.event.inputs.add_noarch_builds }}" == "true" ]; then
+            matrix+='{"arch": "noarch-1.1"},'
+            matrix+='{"arch": "noarch-3.1"},'
+            matrix+='{"arch": "noarch-6.1"},'
+            matrix+='{"arch": "noarch-7.0"},'
+          fi
+          if [ "${{ github.event.inputs.add_dsm72_builds }}" == "true" ]; then
+            matrix+='{"arch": "x64-7.2"},'
+            matrix+='{"arch": "aarch64-7.2"},'
+          fi
+          if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" ]; then
+            matrix+='{"arch": "x64-7.1"},'
+            matrix+='{"arch": "aarch64-7.1"},'
+            matrix+='{"arch": "evansport-7.1"},'
+            matrix+='{"arch": "armv7-7.1"},'
+            matrix+='{"arch": "comcerto2k-7.1"},'
           fi
           if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" ]; then
             matrix+='{"arch": "x64-6.2.4"},'
@@ -147,16 +163,10 @@ jobs:
             matrix+='{"arch": "88f6281-6.2.4"},'
             matrix+='{"arch": "qoriq-6.2.4"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" ]; then
-            matrix+='{"arch": "x64-7.1"},'
-            matrix+='{"arch": "aarch64-7.1"},'
-            matrix+='{"arch": "evansport-7.1"},'
-            matrix+='{"arch": "armv7-7.1"},'
-            matrix+='{"arch": "comcerto2k-7.1"},'
-          fi
-          if [ "${{ github.event.inputs.add_dsm72_builds }}" == "true" ]; then
-            matrix+='{"arch": "x64-7.2"},'
-            matrix+='{"arch": "aarch64-7.2"},'
+          if [ "${{ github.event.inputs.add_dsm52_builds }}" == "true" ]; then
+            matrix+='{"arch": "x86-5.2"},'
+            matrix+='{"arch": "88f6281-5.2"},'
+            matrix+='{"arch": "ppc853x-5.2"},'
           fi
           if [ "${{ github.event.inputs.add_srm12_builds }}" == "true" ]; then
             matrix+='{"arch": "armv7-1.2"},'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
       - id: set-defaults
         run: |
           echo "add_noarch_builds=${{ github.event.inputs.add_noarch_builds || steps.dependencies.outputs.has_noarch_packages }}" >> $GITHUB_OUTPUT
-          echo "add_dsm72_builds=${{ github.event.inputs.add_dsm72_builds || 'false' }}" >> $GITHUB_OUTPUT
+          echo "add_dsm72_builds=${{ github.event.inputs.add_dsm72_builds || steps.dependencies.outputs.has_min_dsm72_packages }}" >> $GITHUB_OUTPUT
           echo "add_dsm71_builds=${{ github.event.inputs.add_dsm71_builds || steps.dependencies.outputs.has_arch_packages }}" >> $GITHUB_OUTPUT
           echo "add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || steps.dependencies.outputs.has_arch_packages }}" >> $GITHUB_OUTPUT
           echo "add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}" >> $GITHUB_OUTPUT
@@ -159,7 +159,7 @@ jobs:
           add_dsm52_builds=${{ needs.prepare.outputs.add_dsm52_builds }}
           add_srm12_builds=${{ needs.prepare.outputs.add_srm12_builds }}
 
-          # Create a matrix as a JSON object
+          # Create matrix as a JSON object
           matrix='{"include": ['
           
           if [ "$add_noarch_builds" == "true" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
           # Create a matrix as a JSON object
           matrix='{"include": ['
           
-          if [ "${{ github.event.inputs.add_noarch_builds }}" == "true" ]; then
+          if [ "${{ github.event.inputs.add_noarch_builds }}" == "true" -o "${{ github.event.inputs.add_noarch_builds }}" == "" ]; then
             matrix+='{"arch": "noarch-1.1"},'
             matrix+='{"arch": "noarch-3.1"},'
             matrix+='{"arch": "noarch-6.1"},'
@@ -147,14 +147,14 @@ jobs:
             matrix+='{"arch": "x64-7.2"},'
             matrix+='{"arch": "aarch64-7.2"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" ]; then
+          if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" -o "${{ github.event.inputs.add_dsm71_builds }}" == "" ]; then
             matrix+='{"arch": "x64-7.1"},'
             matrix+='{"arch": "aarch64-7.1"},'
             matrix+='{"arch": "evansport-7.1"},'
             matrix+='{"arch": "armv7-7.1"},'
             matrix+='{"arch": "comcerto2k-7.1"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" ]; then
+          if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" -o "${{ github.event.inputs.add_dsm62_builds }}" == "" ]; then
             matrix+='{"arch": "x64-6.2.4"},'
             matrix+='{"arch": "aarch64-6.2.4"},'
             matrix+='{"arch": "evansport-6.2.4"},'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
           NOARCH_PACKAGES: ${{ needs.prepare.outputs.noarch_packages }}
 
   generate_matrix:
-    name: Prepare Architectures
+    name: Generate Matrix
     needs: prepare
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,10 +121,10 @@ jobs:
       # Set default values for all builds (manual or automated)
       - id: set-defaults
         run: |
-          echo "add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'true' }}" >> $GITHUB_OUTPUT
+          echo "add_noarch_builds=${{ github.event.inputs.add_noarch_builds || steps.dependencies.outputs.has_noarch_packages }}" >> $GITHUB_OUTPUT
           echo "add_dsm72_builds=${{ github.event.inputs.add_dsm72_builds || 'false' }}" >> $GITHUB_OUTPUT
-          echo "add_dsm71_builds=${{ github.event.inputs.add_dsm71_builds || 'true' }}" >> $GITHUB_OUTPUT
-          echo "add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'true' }}" >> $GITHUB_OUTPUT
+          echo "add_dsm71_builds=${{ github.event.inputs.add_dsm71_builds || steps.dependencies.outputs.has_arch_packages }}" >> $GITHUB_OUTPUT
+          echo "add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || steps.dependencies.outputs.has_arch_packages }}" >> $GITHUB_OUTPUT
           echo "add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}" >> $GITHUB_OUTPUT
           echo "add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,8 @@ jobs:
           SPK_TO_BUILD: ${{ github.event.inputs.package }}
 
       # Set default values for all builds (manual or automated)
-      - id: set-defaults
+      - name: Set default values for generate matrix
+        id: set-defaults
         run: |
           echo "add_noarch_builds=${{ github.event.inputs.add_noarch_builds || steps.dependencies.outputs.has_noarch_packages }}" >> $GITHUB_OUTPUT
           echo "add_dsm72_builds=${{ github.event.inputs.add_dsm72_builds || steps.dependencies.outputs.has_min_dsm72_packages }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,12 @@ jobs:
     outputs:
       arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
       noarch_packages: ${{ steps.dependencies.outputs.noarch_packages }}
+      add_noarch_builds: ${{ steps.set-defaults.outputs.add_noarch_builds }}
+      add_dsm72_builds: ${{ steps.set-defaults.outputs.add_dsm72_builds }}
+      add_dsm71_builds: ${{ steps.set-defaults.outputs.add_dsm71_builds }}
+      add_dsm62_builds: ${{ steps.set-defaults.outputs.add_dsm62_builds }}
+      add_dsm52_builds: ${{ steps.set-defaults.outputs.add_dsm52_builds }}
+      add_srm12_builds: ${{ steps.set-defaults.outputs.add_srm12_builds }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -112,6 +118,16 @@ jobs:
           GH_FILES: ${{ steps.getfile.outputs.files }} ${{ steps.getfile_pr.outputs.files }}
           SPK_TO_BUILD: ${{ github.event.inputs.package }}
 
+      # Set default values for all builds (manual or automated)
+      - id: set-defaults
+        run: |
+          echo "add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'true' }}" >> $GITHUB_OUTPUT
+          echo "add_dsm72_builds=${{ github.event.inputs.add_dsm72_builds || 'false' }}" >> $GITHUB_OUTPUT
+          echo "add_dsm71_builds=${{ github.event.inputs.add_dsm71_builds || 'true' }}" >> $GITHUB_OUTPUT
+          echo "add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'true' }}" >> $GITHUB_OUTPUT
+          echo "add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}" >> $GITHUB_OUTPUT
+          echo "add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}" >> $GITHUB_OUTPUT
+
       - name: Cache downloaded files
         uses: actions/cache@v4
         with:
@@ -128,33 +144,42 @@ jobs:
 
   generate_matrix:
     name: Prepare Architectures
+    needs: prepare
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
         run: |
+          # Use the default values passed from the prepare step
+          add_noarch_builds=${{ needs.prepare.outputs.add_noarch_builds }}
+          add_dsm72_builds=${{ needs.prepare.outputs.add_dsm72_builds }}
+          add_dsm71_builds=${{ needs.prepare.outputs.add_dsm71_builds }}
+          add_dsm62_builds=${{ needs.prepare.outputs.add_dsm62_builds }}
+          add_dsm52_builds=${{ needs.prepare.outputs.add_dsm52_builds }}
+          add_srm12_builds=${{ needs.prepare.outputs.add_srm12_builds }}
+
           # Create a matrix as a JSON object
           matrix='{"include": ['
           
-          if [ "${{ github.event.inputs.add_noarch_builds }}" == "true" -o "${{ github.event.inputs.add_noarch_builds }}" == "" ]; then
+          if [ "$add_noarch_builds" == "true" ]; then
             matrix+='{"arch": "noarch-1.1"},'
             matrix+='{"arch": "noarch-3.1"},'
             matrix+='{"arch": "noarch-6.1"},'
             matrix+='{"arch": "noarch-7.0"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm72_builds }}" == "true" ]; then
+          if [ "$add_dsm72_builds" == "true" ]; then
             matrix+='{"arch": "x64-7.2"},'
             matrix+='{"arch": "aarch64-7.2"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm71_builds }}" == "true" -o "${{ github.event.inputs.add_dsm71_builds }}" == "" ]; then
+          if [ "$add_dsm71_builds" == "true" ]; then
             matrix+='{"arch": "x64-7.1"},'
             matrix+='{"arch": "aarch64-7.1"},'
             matrix+='{"arch": "evansport-7.1"},'
             matrix+='{"arch": "armv7-7.1"},'
             matrix+='{"arch": "comcerto2k-7.1"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm62_builds }}" == "true" -o "${{ github.event.inputs.add_dsm62_builds }}" == "" ]; then
+          if [ "$add_dsm62_builds" == "true" ]; then
             matrix+='{"arch": "x64-6.2.4"},'
             matrix+='{"arch": "aarch64-6.2.4"},'
             matrix+='{"arch": "evansport-6.2.4"},'
@@ -163,12 +188,12 @@ jobs:
             matrix+='{"arch": "88f6281-6.2.4"},'
             matrix+='{"arch": "qoriq-6.2.4"},'
           fi
-          if [ "${{ github.event.inputs.add_dsm52_builds }}" == "true" ]; then
+          if [ "$add_dsm52_builds" == "true" ]; then
             matrix+='{"arch": "x86-5.2"},'
             matrix+='{"arch": "88f6281-5.2"},'
             matrix+='{"arch": "ppc853x-5.2"},'
           fi
-          if [ "${{ github.event.inputs.add_srm12_builds }}" == "true" ]; then
+          if [ "$add_srm12_builds" == "true" ]; then
             matrix+='{"arch": "armv7-1.2"},'
           fi
 

--- a/cross/jellyfin/Makefile
+++ b/cross/jellyfin/Makefile
@@ -1,12 +1,10 @@
- PKG_NAME = jellyfin
+PKG_NAME = jellyfin
 PKG_VERS = 10.9.11
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
-
-# forced change
 
 HOMEPAGE = https://jellyfin.org
 COMMENT  = The Free Software Media System. It is an alternative to the proprietary Emby and Plex.

--- a/cross/jellyfin/Makefile
+++ b/cross/jellyfin/Makefile
@@ -1,10 +1,12 @@
-PKG_NAME = jellyfin
+ PKG_NAME = jellyfin
 PKG_VERS = 10.9.11
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jellyfin/jellyfin/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+# forced change
 
 HOMEPAGE = https://jellyfin.org
 COMMENT  = The Free Software Media System. It is an alternative to the proprietary Emby and Plex.

--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -18,8 +18,10 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 #####

--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -27,8 +27,10 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 ###

--- a/mk/spksrc.cross-dotnet.mk
+++ b/mk/spksrc.cross-dotnet.mk
@@ -30,8 +30,10 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 ##### dotnet specific configurations

--- a/mk/spksrc.cross-go.mk
+++ b/mk/spksrc.cross-go.mk
@@ -27,8 +27,10 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 ##### golang specific configurations

--- a/mk/spksrc.cross-rust-env.mk
+++ b/mk/spksrc.cross-rust-env.mk
@@ -23,7 +23,9 @@ endif
 # When calling directly from toolchain/syno-<arch>-<version>
 # ARCH variable is still unset thus using $(TC_ARCH) although
 # in generic archs we must rely on $(TC_NANE)
+ifneq ($(ARCH),noarch)
 RUST_ARCH = $(or $(ARCH),$(lastword $(subst -, ,$(TC_NAME))),$(TC_ARCH))
+endif
 
 # When building toolchain Tier-3 arch support
 #   While stage-2 is the truly current compiler, stage-1 suffice our needs

--- a/mk/spksrc.cross-rust.mk
+++ b/mk/spksrc.cross-rust.mk
@@ -26,8 +26,10 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 ##### rust specific configurations

--- a/mk/spksrc.install-resources.mk
+++ b/mk/spksrc.install-resources.mk
@@ -22,8 +22,10 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 

--- a/mk/spksrc.main-depends.mk
+++ b/mk/spksrc.main-depends.mk
@@ -10,8 +10,10 @@ NAME          = $(PKG_NAME)
 COOKIE_PREFIX = $(PKG_NAME)-
 
 ifneq ($(ARCH),)
+ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
+endif
 endif
 
 #####

--- a/mk/spksrc.supported.mk
+++ b/mk/spksrc.supported.mk
@@ -62,6 +62,9 @@ $(TARGET_TYPE)-arch-% &: pre-build-native
 arch-%:
 	$(PSTAT_TIME) $(MAKE) $(addprefix build-arch-, $(or $(filter $(addprefix %, $(DEFAULT_TC)), $(filter %$(word 2,$(subst -, ,$*)), $(filter $(firstword $(subst -, ,$*))%, $(AVAILABLE_TOOLCHAINS)))),$*)) | tee --append build-$*.log
 
+noarch-%:
+	$(PSTAT_TIME) $(MAKE) $(addprefix build-noarch-, $(filter $*, $(AVAILABLE_TCVERSIONS) 3.1)) | tee --append build-$@.log
+
 ####
 
 build-arch-%: SHELL:=/bin/bash
@@ -71,6 +74,14 @@ build-arch-%:
 	@MAKEFLAGS= GCC_DEBUG_INFO="$(GCC_DEBUG_INFO)" $(MAKE) ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*)) 2>&1 ; \
 	status=$${PIPESTATUS[0]} ; \
 	$(MSG) $$(date +%Y%m%d-%H%M%S) MAKELEVEL: $(MAKELEVEL), PARALLEL_MAKE: $(PARALLEL_MAKE), ARCH: $*, NAME: $(NAME) [END] >> $(PSTAT_LOG) ; \
+	[ $${status[0]} -eq 0 ] || false
+
+build-noarch-%: SHELL:=/bin/bash
+build-noarch-%: 
+	@$(MSG) BUILDING noarch package for TCVERSION $*
+	@MAKEFLAGS= $(MAKE) TCVERSION=$* 2>&1 ; \
+	status=$${PIPESTATUS[0]} ; \
+	$(MSG) $$(date +%Y%m%d-%H%M%S) MAKELEVEL: $(MAKELEVEL), PARALLEL_MAKE: $(PARALLEL_MAKE), TCVERSION: $*, NAME: $(NAME) [END] >> $(PSTAT_LOG) ; \
 	[ $${status[0]} -eq 0 ] || false
 
 ####

--- a/spk/adminer/Makefile
+++ b/spk/adminer/Makefile
@@ -40,8 +40,8 @@ WIZARDS_DIR = src/wizard/
 
 POST_STRIP_TARGET = adminer_extra_install
 
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/ariang/Makefile
+++ b/spk/ariang/Makefile
@@ -19,7 +19,7 @@ LICENSE  = MIT
 CONF_DIR = src/conf
 STARTABLE = no
 
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk

--- a/spk/bicbucstriim/Makefile
+++ b/spk/bicbucstriim/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 7
 SPK_ICON = src/bicbucstriim.png
 
 DEPENDS = cross/$(SPK_NAME)
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 REQUIRED_MIN_DSM = 7.0
 SPK_DEPENDS = WebStation:PHP8.2:Apache2.4

--- a/spk/cops/Makefile
+++ b/spk/cops/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 10
 SPK_ICON = src/cops.png
 
 DEPENDS  = cross/cops
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 REQUIRED_MIN_DSM = 7.0
 SPK_DEPENDS=WebStation:PHP8.2:Apache2.4

--- a/spk/couchpotatoserver-custom/Makefile
+++ b/spk/couchpotatoserver-custom/Makefile
@@ -29,8 +29,8 @@ ADMIN_PORT = $(SERVICE_PORT)
 COPY_TARGET = nop
 POST_STRIP_TARGET = couchpotatoserver-custom_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/couchpotatoserver/Makefile
+++ b/spk/couchpotatoserver/Makefile
@@ -30,8 +30,8 @@ ADMIN_PORT = $(SERVICE_PORT)
 COPY_TARGET = nop
 POST_STRIP_TARGET = couchpotatoserver_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/demoservice/Makefile
+++ b/spk/demoservice/Makefile
@@ -3,7 +3,7 @@ SPK_VERS = 1.2
 SPK_REV = 8
 SPK_ICON = src/demoservice.png
 
-override ARCH=
+override ARCH=noarch
 
 MAINTAINER = ymartin59
 DESCRIPTION = Demonstration package to show installer script capabilities when requiring non-root user for background service and show configuration/creation of shared folder for package user.

--- a/spk/demowebservice/Makefile
+++ b/spk/demowebservice/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/demowebservice.png
 
 DEPENDS =
 
-override ARCH=
+override ARCH=noarch
 
 MAINTAINER = hgy59
 DESCRIPTION = Demopackage to show how to create a web service \(web application\)

--- a/spk/fengoffice/Makefile
+++ b/spk/fengoffice/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 4
 SPK_ICON = src/fengoffice.png
 
 DEPENDS = cross/$(SPK_NAME)
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 # Due to not obvious WebStation handling requirements
 REQUIRED_MIN_DSM = 6.0

--- a/spk/full-text-rss/Makefile
+++ b/spk/full-text-rss/Makefile
@@ -26,8 +26,8 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 COPY_TARGET = nop
 POST_STRIP_TARGET = full-text-rss_extra_install
 
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/google-fonts/BROKEN
+++ b/spk/google-fonts/BROKEN
@@ -1,1 +1,0 @@
-temp. disabled

--- a/spk/google-fonts/BROKEN
+++ b/spk/google-fonts/BROKEN
@@ -1,0 +1,1 @@
+temp. disabled

--- a/spk/google-fonts/Makefile
+++ b/spk/google-fonts/Makefile
@@ -13,8 +13,8 @@ STARTABLE = no
 HOMEPAGE = http://fonts.google.com/
 LICENSE  = Most of the fonts in the collection use the SIL Open Font License, v1.1. Some fonts use the Apache 2 license. The Ubuntu fonts use the Ubuntu Font License v1.0.
 
-# Pure package, make sure ARCH is not defined
-override ARCH=
+# Pure package, make sure ARCH is noarch
+override ARCH=noarch
 
 WIZARDS_DIR = src/wizard
 SERVICE_SETUP = src/service-setup.sh

--- a/spk/headphones-custom/Makefile
+++ b/spk/headphones-custom/Makefile
@@ -31,8 +31,8 @@ WIZARDS_DIR = src/wizard/
 COPY_TARGET = nop
 POST_STRIP_TARGET = headphones-custom_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/headphones/Makefile
+++ b/spk/headphones/Makefile
@@ -30,8 +30,8 @@ WIZARDS_DIR = src/wizard/
 COPY_TARGET = nop
 POST_STRIP_TARGET = headphones_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/htpcmanager/Makefile
+++ b/spk/htpcmanager/Makefile
@@ -26,8 +26,8 @@ COPY_TARGET = nop
 
 POST_STRIP_TARGET = htpcmanager_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/jappix/Makefile
+++ b/spk/jappix/Makefile
@@ -27,8 +27,8 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
 POST_STRIP_TARGET = jappix_extra_install
 
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/lazylibrarian/Makefile
+++ b/spk/lazylibrarian/Makefile
@@ -28,8 +28,8 @@ WIZARDS_DIR = src/wizard/
 COPY_TARGET = nop
 POST_STRIP_TARGET = lazylibrarian_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/mantisbt/Makefile
+++ b/spk/mantisbt/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 6
 SPK_ICON = src/mantisbt.png
 
 DEPENDS  = cross/$(SPK_NAME)
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 # Due to not obvious WebStation handling requirements
 REQUIRED_MIN_DSM = 6.0

--- a/spk/maraschino/Makefile
+++ b/spk/maraschino/Makefile
@@ -27,8 +27,8 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 COPY_TARGET = nop
 POST_STRIP_TARGET = maraschino_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/mylar/Makefile
+++ b/spk/mylar/Makefile
@@ -29,8 +29,8 @@ WIZARDS_DIR = src/wizard/
 COPY_TARGET = nop
 POST_STRIP_TARGET = mylar_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/nzbget/Makefile
+++ b/spk/nzbget/Makefile
@@ -28,7 +28,7 @@ ADMIN_PORT = $(SERVICE_PORT)
 
 # Installer brings all the binaries
 COPY_TARGET = nop
-override ARCH=
+override ARCH=noarch
 
 POST_STRIP_TARGET = nzbget_extra_install
 

--- a/spk/nzbhydra/Makefile
+++ b/spk/nzbhydra/Makefile
@@ -27,8 +27,8 @@ ADMIN_PORT = $(SERVICE_PORT)
 COPY_TARGET = nop
 POST_STRIP_TARGET = nzbhydra_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/nzbmegasearch/Makefile
+++ b/spk/nzbmegasearch/Makefile
@@ -27,8 +27,8 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 COPY_TARGET = nop
 POST_STRIP_TARGET = nzbmegasearch_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/plexivity/BROKEN
+++ b/spk/plexivity/BROKEN
@@ -1,0 +1,3 @@
+plexivity requires installed python2 in the development environment
+
+not supported anymore since spksrc image was updated to debian 12

--- a/spk/plexivity/Makefile
+++ b/spk/plexivity/Makefile
@@ -27,8 +27,8 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
 POST_STRIP_TARGET = plexivity_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/plexpy-custom/Makefile
+++ b/spk/plexpy-custom/Makefile
@@ -29,8 +29,8 @@ ADMIN_PORT = $(SERVICE_PORT)
 COPY_TARGET = nop
 POST_STRIP_TARGET = plexpy-custom_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/roundcube/Makefile
+++ b/spk/roundcube/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 5
 SPK_ICON = src/roundcube.png
 
 DEPENDS  = cross/$(SPK_NAME)
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 # Due to not obvious WebStation handling requirements
 REQUIRED_MIN_DSM = 6.0

--- a/spk/rsnapshot/Makefile
+++ b/spk/rsnapshot/Makefile
@@ -17,8 +17,8 @@ LICENSE  = GPLv2
 
 SERVICE_SETUP = src/service-setup.sh
 
-# Pure Perl package, make sure ARCH is not defined
-override ARCH=
+# Pure Perl package, make sure ARCH is noarch
+override ARCH=noarch
 
 SPK_COMMANDS = bin/rsnapshot bin/rsnapshot-diff
 

--- a/spk/saltpad/BROKEN
+++ b/spk/saltpad/BROKEN
@@ -1,0 +1,3 @@
+saltpad requires installed python2 in the development environment
+
+not supported anymore since spksrc image was updated to debian 12

--- a/spk/saltpad/Makefile
+++ b/spk/saltpad/Makefile
@@ -26,8 +26,8 @@ CONF_DIR         = src/conf/
 
 POST_STRIP_TARGET = saltpad_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/selfoss/Makefile
+++ b/spk/selfoss/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 8
 SPK_ICON = src/selfoss.png
 
 DEPENDS  = cross/selfoss
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 REQUIRED_MIN_DSM = 6.0
 SPK_DEPENDS = WebStation:PHP7.4:Apache2.4

--- a/spk/sickbeard-custom/Makefile
+++ b/spk/sickbeard-custom/Makefile
@@ -29,8 +29,8 @@ WIZARDS_DIR = src/wizard/
 COPY_TARGET = nop
 POST_STRIP_TARGET = sickbeard-custom_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/sickrage/Makefile
+++ b/spk/sickrage/Makefile
@@ -27,8 +27,8 @@ WIZARDS_DIR = src/wizard/
 COPY_TARGET = nop
 POST_STRIP_TARGET = sickrage_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/subliminal/BROKEN
+++ b/spk/subliminal/BROKEN
@@ -1,0 +1,3 @@
+subliminal requires installed python2 in the development environment
+
+not supported anymore since spksrc image was updated to debian 12

--- a/spk/subliminal/Makefile
+++ b/spk/subliminal/Makefile
@@ -29,8 +29,8 @@ INSTALL_PREFIX = /usr/local/$(SPK_NAME)
 
 POST_STRIP_TARGET = subliminal_extra_install
 
-# Pure Python package, make sure ARCH is not defined
-override ARCH=
+# Pure Python package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/syno-magnet/Makefile
+++ b/spk/syno-magnet/Makefile
@@ -1,29 +1,29 @@
-PKG_NAME = syno-magnet
-PKG_VERS = 1.0
-PKG_EXT = tar.gz
-PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/neykov/$(PKG_NAME)/archive
-PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
-
-SPK_NAME = $(PKG_NAME)
-SPK_VERS = $(PKG_VERS)
+SPK_NAME = syno-magnet
+SPK_VERS = 1.0
 SPK_REV = 3
 SPK_ICON = src/magnet.png
+
+PKG_NAME = $(SPK_NAME)
+PKG_VERS = $(SPK_VERS)
+PKG_EXT = tar.gz
+PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/neykov/syno-magnet/archive
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 MAINTAINER = neykov
 DESCRIPTION = Download Station Magnet Handler. Register Download Station as the application to download magnet links from your browser. No plugins required.
 DISPLAY_NAME = Download Station Magnet
 CHANGELOG = "Initial Version"
 
-HOMEPAGE   = https://github.com/neykov/syno-magnet
-LICENSE    = Apache 2.0
+HOMEPAGE = https://github.com/neykov/syno-magnet
+LICENSE = Apache 2.0
 
 STARTABLE  = no
 DSM_UI_DIR = app
 SERVICE_TYPE = legacy
 SERVICE_URL = /webman/3rdparty/syno-magnet/index.html
-SERVICE_PORT_ALL_USERS=true
+SERVICE_PORT_ALL_USERS = true
 
 NAME          = $(PKG_NAME)
 COOKIE_PREFIX = $(PKG_NAME)-

--- a/spk/syno-magnet/Makefile
+++ b/spk/syno-magnet/Makefile
@@ -34,8 +34,8 @@ URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
 
 COPY_TARGET = syno_magnet_copy
 
-# Pure web package, make sure ARCH is not defined
-override ARCH =
+# Pure web package, make sure ARCH is noarch
+override ARCH=noarch
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/tt-rss/Makefile
+++ b/spk/tt-rss/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 18
 SPK_ICON = src/tt-rss.png
 
 DEPENDS  = cross/$(SPK_NAME)
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 # Due to not obvious WebStation handling requirements
 REQUIRED_MIN_DSM = 6.0

--- a/spk/wallabag/Makefile
+++ b/spk/wallabag/Makefile
@@ -4,8 +4,8 @@ SPK_REV = 4
 SPK_ICON = src/wallabag.png
 
 DEPENDS  = cross/$(SPK_NAME)
-# Pure PHP package, make sure ARCH is not defined
-override ARCH=
+# Pure PHP package, make sure ARCH is noarch
+override ARCH=noarch
 
 # Due to not obvious WebStation handling requirements
 REQUIRED_MIN_DSM = 6.0


### PR DESCRIPTION
## Description

redesign of noarch build.
- noarch packages should only be build for specific TCVERSION, otherwise REQUIRED_MIN_DSM is not evaluated
- noarch packages must now define `override ARCH=noarch` instead of `override ARCH=`

Replacement for #6249.
Contains a bugfix for #6247 that removed all arch specific builds in github build action.

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
