### PR TITLE
Wallabag: Update PHP extensions

### DIFF
--- a/spk/wallabag/Makefile
+++ b/spk/wallabag/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = wallabag
 SPK_VERS = 2.6.9
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/wallabag.png
 
 DEPENDS  = cross/$(SPK_NAME)

--- a/spk/wallabag/src/conf/resource
+++ b/spk/wallabag/src/conf/resource
@@ -69,6 +69,10 @@
                         "zlib"
                     ],
                     "group": "http",
+                    "php_settings": {
+                        "error_log": "/var/services/web_packages/wallabag/php_errors.log",
+                        "pdo_mysql.default_socket": "/run/mysqld/mysqld10.sock"
+                    },    
                     "profile_desc": "PHP Profile for wallabag",
                     "profile_name": "wallabag Profile",
                     "user": "sc-wallabag"

--- a/spk/wallabag/src/conf/resource
+++ b/spk/wallabag/src/conf/resource
@@ -64,7 +64,9 @@
                         "iconv",
                         "imagick",
                         "intl",
-                        "pdo_mysql"
+                        "openssl",
+                        "pdo_mysql",
+                        "zlib"
                     ],
                     "group": "http",
                     "profile_desc": "PHP Profile for wallabag",

--- a/spk/wallabag/src/service-setup.sh
+++ b/spk/wallabag/src/service-setup.sh
@@ -33,9 +33,9 @@ exec_php ()
     else
         PHP_SETTINGS=""
     fi
-    # Fix for mysqli default socket on DSM 6
+    # Fix for pdo_mysql default socket on DSM 6
     if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
-        PHP_SETTINGS="${PHP_SETTINGS} -d mysqli.default_socket=/run/mysqld/mysqld10.sock"
+        PHP_SETTINGS="${PHP_SETTINGS} -d pdo_mysql.default_socket=/run/mysqld/mysqld10.sock"
     fi
     COMMAND="${PHP} ${PHP_SETTINGS} $*"
     if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then

--- a/spk/wallabag/src/web/wallabag.json
+++ b/spk/wallabag/src/web/wallabag.json
@@ -12,7 +12,9 @@
         "iconv",
         "imagick",
         "intl",
-        "pdo_mysql"
+        "openssl",
+        "pdo_mysql",
+        "zlib"
     ],
     "fpm_settings": {
         "max_children": 20,

--- a/spk/wallabag/src/web/wallabag.json
+++ b/spk/wallabag/src/web/wallabag.json
@@ -25,7 +25,8 @@
     },
     "open_basedir": "",
     "php_settings": {
-        "mysqli.default_socket": "/run/mysqld/mysqld10.sock"
+        "error_log": "/var/services/web/wallabag/php_errors.log",
+        "pdo_mysql.default_socket": "/run/mysqld/mysqld10.sock"
     },
     "profile_desc": "PHP Profile for wallabag",
     "profile_name": "wallabag Profile"


### PR DESCRIPTION
## Description

This follow-up to #6232 addresses missing PHP extensions in the default installation and refines certain PHP settings. Special thanks to @j4w0r for their help in identifying the missing extensions not included in the [documentation](https://doc.wallabag.org/en/admin/installation/requirements).

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
