### PR TITLE
fix ffmpeg build dependency

### DIFF
--- a/mk/spksrc.ffmpeg.mk
+++ b/mk/spksrc.ffmpeg.mk
@@ -45,7 +45,7 @@ endif
 PRE_DEPEND_TARGET = ffmpeg_pre_depend
 
 else
-BUILD_DEPENDS += cross/$(PYTHON_PACKAGE)
+BUILD_DEPENDS += cross/$(FFMPEG_PACKAGE)
 CMAKE_RPATH =
 endif
 


### PR DESCRIPTION

## Description

- fix for build of ffmpeg dependent packages when ffmpeg is not prebuilt

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
