### PR TITLE
intel-compute-runtime: Fix to use OCL_ICD_VENDORDIR cmake variable

### DIFF
--- a/cross/intel-compute-runtime/Makefile
+++ b/cross/intel-compute-runtime/Makefile
@@ -14,7 +14,6 @@ COMMENT = The Intel(R) Graphics Compute Runtime for oneAPI Level Zero and OpenCL
 LICENSE = MIT license
 
 POST_EXTRACT_TARGET = intel-compute-runtime_post_extract_target
-POST_INSTALL_TARGET = intel-compute-runtime_post_install_target
 CMAKE_USE_NINJA = 0
 CMAKE_USE_DESTDIR = 1
 
@@ -31,6 +30,7 @@ BUILD_DEPENDS += cross/Khronos-SPIRV-Headers
 CMAKE_ARGS += -DIGC_DIR=$(STAGING_INSTALL_PREFIX)
 CMAKE_ARGS += -DNEO_DISABLE_LD_GOLD:BOOL='ON'
 CMAKE_ARGS += -DSKIP_UNIT_TESTS=1
+CMAKE_ARGS += -DOCL_ICD_VENDORDIR=$(INSTALL_PREFIX)/etc/OpenCL/vendors/
 
 include ../../mk/spksrc.cross-cmake.mk
 
@@ -39,8 +39,3 @@ ENV += LD_LIBRARY_PATH=$(STAGING_INSTALL_PREFIX)/lib
 .PHONY: intel-compute-runtime_post_extract_target
 intel-compute-runtime_post_extract_target:
 	@cd $(WORK_DIR) && ln -s $(PKG_DIR) $(PKG_NAME)
-
-.PHONY: intel-compute-runtime_post_install_target
-intel-compute-runtime_post_install_target:
-	@install -m 755 -d $(STAGING_INSTALL_PREFIX)/etc/OpenCL/vendors/
-	@install -m 644 $(INSTALL_DIR)/etc/OpenCL/vendors/intel.icd $(STAGING_INSTALL_PREFIX)/etc/OpenCL/vendors/

--- a/cross/intel-compute-runtime/Makefile
+++ b/cross/intel-compute-runtime/Makefile
@@ -15,7 +15,6 @@ LICENSE = MIT license
 
 POST_EXTRACT_TARGET = intel-compute-runtime_post_extract_target
 CMAKE_USE_NINJA = 0
-CMAKE_USE_DESTDIR = 1
 
 DEPENDS  = cross/intel-gmmlib
 DEPENDS += cross/intel-graphics-compiler


### PR DESCRIPTION
## Description

intel-compute-runtime: Fix to use OCL_ICD_VENDORDIR cmake variable

Fixes https://github.com/intel/compute-runtime/issues/758

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
