### PR TITLE
Jellyfin: Update v10.9.11 to include .NET v8.0.8

### DIFF
--- a/native/dotnet-sdk-8.0/Makefile
+++ b/native/dotnet-sdk-8.0/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = dotnet-sdk-8.0
-# Version 8.0.6, 8.0.301
+# Version 8.0.8, SDK 8.0.402
 # https://dotnet.microsoft.com/download/dotnet/8.0
-PKG_VERS = 8.0.301
+PKG_VERS = 8.0.402
 PKG_EXT = tar.gz
 PKG_DIST_NAME = dotnet-sdk-$(PKG_VERS)-linux-x64.$(PKG_EXT)
 PKG_DIST_SITE = https://dotnetcli.azureedge.net/dotnet/Sdk/${PKG_VERS}

--- a/native/dotnet-sdk-8.0/digests
+++ b/native/dotnet-sdk-8.0/digests
@@ -1,3 +1,3 @@
-dotnet-sdk-8.0.301-linux-x64.tar.gz SHA1 c6a978b16e2462ce91446d987cca349c875db5d3
-dotnet-sdk-8.0.301-linux-x64.tar.gz SHA256 d237cf0e8865f51eb9634df32a8bcfb1dd95dac95c0d16b5d599df867ab16c27
-dotnet-sdk-8.0.301-linux-x64.tar.gz MD5 d91e94323d8db5551c9a5179162f2532
+dotnet-sdk-8.0.402-linux-x64.tar.gz SHA1 806325e920feec4f243b87d67e03ce34b893594f
+dotnet-sdk-8.0.402-linux-x64.tar.gz SHA256 10910e098161a0461b93f4f08d0c310b452b1a7f56b43378f547fd765d6f68bc
+dotnet-sdk-8.0.402-linux-x64.tar.gz MD5 517a234e43182fd5c1fda9a6394f8b7f

--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
 SPK_VERS = 10.9.11
-SPK_REV = 16
+SPK_REV = 17
 SPK_ICON = src/jellyfin.png
 WIZARDS_DIR = src/wizard/
 DSM_UI_DIR = app
@@ -18,7 +18,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = "The Free Software Media System. It is an alternative to the proprietary Emby and Plex."
 DISPLAY_NAME = Jellyfin
 STARTABLE = yes
-CHANGELOG = "1. Update jellyfin to 10.9.11<br/>2. Migrate to ffmpeg7"
+CHANGELOG = "1. Update jellyfin to 10.9.11<br/>2. Update dotnet to 8.0.8<br/>3. Migrate to ffmpeg7"
 HOMEPAGE = https://jellyfin.org
 HELPURL = https://jellyfin.org/docs/general/server/settings.html
 SUPPORTURL = https://jellyfin.org/docs/general/getting-help.html


### PR DESCRIPTION
## Description

This is a follow-on from #6201 to include the current version of .NET v8.0.8.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
