### PR TITLE
github action: omit broken packages in dependency-list

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -31,7 +31,9 @@ echo "Building dependency list..."
 DEPENDENCY_LIST=
 for package in $(find spk/ -maxdepth 1 -type d | cut -c 5- | sort)
 do
-    DEPENDENCY_LIST+=$(DEPENDENCY_WALK=1 make -s -C spk/${package} dependency-list 2> /dev/null)$'\n'
+    if [ ! -f "./spk/${package}/BROKEN" ]; then
+        DEPENDENCY_LIST+=$(DEPENDENCY_WALK=1 make -s -C spk/${package} dependency-list 2> /dev/null)$'\n'
+    fi
 done
 
 # search for dependent spk packages


### PR DESCRIPTION
## Description

- do not evaluate dependencies for broken packages

This is a small optimization to avoid the download of packages that will not be built.

This will be fixed by #6255, but since some more packages are declared broken, it will safe some cpu cycles until #6255 is merged.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
