### PR TITLE
github build status: avoid duplicates in list of unsupported builds

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -9,6 +9,7 @@
 # - Build for arch defined by ${GH_ARCH} (e.g. x64-6.1, noarch, ...).
 # - Successfully built packages are logged to $BUILD_SUCCESS_FILE.
 # - Failed builds are logged to ${BUILD_ERROR_FILE} and annotated as error.
+# - For failed builds, the make command and the latest 15 lines of the build output are written to ${BUILD_ERROR_LOGFILE}
 # - The build output is structured into log groups by package.
 # - As the disk space in the workflow environment is limitted, we clean the
 #   work folder of each package after build. At 2020.06 this limit is 14GB.

--- a/.github/actions/build_status.sh
+++ b/.github/actions/build_status.sh
@@ -15,6 +15,7 @@
 # BUILD_SUCCESS_FILE        defines the name of the file with built packages
 # BUILD_UNSUPPORTED_FILE    defines the name of the file with unsupported packages
 # BUILD_ERROR_FILE          defines the name of the file with build errors
+# BUILD_ERROR_LOGFILE       defines the name of the file with last 15 lines of build output for failed packages
 #
 
 echo ""
@@ -38,7 +39,7 @@ fi
 echo ""
 echo "UNSUPPORTED (skipped):"
 if [ -f "${BUILD_UNSUPPORTED_FILE}" ]; then
-    cat "${BUILD_UNSUPPORTED_FILE}"
+    cat "${BUILD_UNSUPPORTED_FILE}" | awk '!seen[$0]++'
     if [ -f "${BUILD_ERROR_FILE}" ]; then
         # remove unsupported packages from errors:
         unsupported_packages=$(cat "${BUILD_UNSUPPORTED_FILE}" | grep -Po "\- \K.*:" | sort -u | tr '\n' '|' | sed -e 's/|$//')


### PR DESCRIPTION
## Description

duplicate entries exist for broken packages and packages with definition of UNSUPPORTED_ARCHS or REQUIRED_MIN_DSM in cross and spk Makefile.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes

