### PR TITLE
vc-intrinsics: Update to v0.20.1 and remove unused USE_NATIVE_CMAKE

### DIFF
--- a/cross/intel-opencl-clang-140/Makefile
+++ b/cross/intel-opencl-clang-140/Makefile
@@ -17,6 +17,15 @@ PKG_DIR = $(PKG_NAME)-$(PKG_GIT_HASH)
 #PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 #PKG_DIR = $(PKG_NAME)-$(PKG_GIT_BRANCH)
 
+###
+### This serves as test the sub-component builds
+### needed in order to compile in-tree IGC needed
+### dependencies.
+###
+### Optionally next iteration may use out-of-tree
+### builds of IGC for easier management of dependendices
+###
+
 REQUIRED_MIN_DSM = 7
 UNSUPPORTED_ARCHS = $(ARM_ARCHS) $(PPC_ARCHS) $(i686_ARCHS)
 
@@ -24,7 +33,6 @@ BUILD_DEPENDS  = cross/llvm-project-140.src
 BUILD_DEPENDS += cross/Khronos-SPIRV-LLVM-Translator-140.src
 BUILD_DEPENDS += cross/Khronos-SPIRV-Headers
 BUILD_DEPENDS += cross/Khronos-OpenCL-Headers
-BUILD_DEPENDS += cross/intel-vc-intrinsics.src
 # Cannot be built in-tree:
 #     SPIRV-Tools requires C++17 or later, but is configured for C++14
 DEPENDS += cross/Khronos-SPIRV-Tools
@@ -74,11 +82,21 @@ include ../../mk/spksrc.common.mk
 #
 CMAKE_ARGS += -DLLVM_TARGETS_TO_BUILD=X86
 CMAKE_ARGS += -DLLVM_ENABLE_PROJECTS='clang;lld'
-CMAKE_ARGS += -DLLVM_EXTERNAL_PROJECTS='llvm-spirv;opencl-clang;vc-intrinsics'
 CMAKE_ARGS += -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=$(STAGING_INSTALL_PREFIX)/include
 CMAKE_ARGS += -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=$(WORK_DIR)/SPIRV-LLVM-Translator
-CMAKE_ARGS += -DLLVM_EXTERNAL_VC_INTRINSICS_SOURCE_DIR=$(WORK_DIR)/vc-intrinsics
 CMAKE_ARGS += -DLLVM_EXTERNAL_OPENCL_CLANG_SOURCE_DIR=$(WORK_DIR)/$(PKG_NAME)
+
+# Allow vc-intrinsics to be built out-of-tree from intel-opencl-clang
+ifeq ($(strip $(VC_INTRINSICS_IN_TREE_INSTALL)),FALSE)
+CMAKE_ARGS += -DLLVM_EXTERNAL_PROJECTS='llvm-spirv;opencl-clang'
+
+# Allow vc-intrinsics to be built in-tree from intel-opencl-clang
+else
+BUILD_DEPENDS += cross/intel-vc-intrinsics.src
+CMAKE_ARGS += -DLLVM_EXTERNAL_VC_INTRINSICS_SOURCE_DIR=$(WORK_DIR)/vc-intrinsics
+CMAKE_ARGS += -DLLVM_EXTERNAL_PROJECTS='llvm-spirv;opencl-clang;vc-intrinsics'
+CMAKE_ARGS += -DLLVM_GENX_INTRINSICS_IN_TREE_INSTALL=TRUE
+endif
 
 # Contrary to IGC does not fail to access in NATIVE/bin/llvm-tblgen but reduces built time and size
 BUILD_DEPENDS += native/llvm-14.0

--- a/cross/intel-vc-intrinsics.src/Makefile
+++ b/cross/intel-vc-intrinsics.src/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = vc-intrinsics
-PKG_VERS = 0.20.0
+PKG_VERS = 0.20.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_FILE = vc-intrinsics-$(PKG_VERS).$(PKG_EXT)

--- a/cross/intel-vc-intrinsics.src/digests
+++ b/cross/intel-vc-intrinsics.src/digests
@@ -1,3 +1,3 @@
-vc-intrinsics-0.20.0.tar.gz SHA1 2e8926b0ce90e0c206dd5f04f874662a90ec20cb
-vc-intrinsics-0.20.0.tar.gz SHA256 2ef1e668e128e87ac9bd4c93c1fc7ee0f7fb478a9bd0c7fdd684ce93a4524f96
-vc-intrinsics-0.20.0.tar.gz MD5 4aef42825204cc35d1f115b8569a4110
+vc-intrinsics-0.20.1.tar.gz SHA1 830ed0ab293c64da1e55d1a1c28be0210655a2fc
+vc-intrinsics-0.20.1.tar.gz SHA256 01a68a3c8299075ad2b094264bef5109d660f1d53faf614f4f95745ad05f4e3e
+vc-intrinsics-0.20.1.tar.gz MD5 f26e206f30c07c4b77dcbbac4ce47267

--- a/cross/intel-vc-intrinsics/Makefile
+++ b/cross/intel-vc-intrinsics/Makefile
@@ -1,10 +1,19 @@
 PKG_NAME = vc-intrinsics
-PKG_VERS = 0.20.0
+PKG_VERS = 0.20.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_FILE = vc-intrinsics-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/intel/vc-intrinsics/archive/refs/tags
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+###
+### This serves as test the sub-component builds
+### needed in order to compile in-tree IGC needed
+### dependencies.
+###
+### Optionally next iteration may use out-of-tree
+### builds of IGC for easier management of dependendices
+###
 
 HOMEPAGE = https://github.com/intel/vc-intrinsics
 COMMENT = Contains a set of new intrinsics on top of core LLVM IR instructions that represent SIMD semantics of a program targeting GPU.
@@ -12,8 +21,10 @@ LICENSE = MIT
 
 DEPENDS = cross/intel-opencl-clang-140
 
+# Allow vc-intrinsics to be built out-of-tree from intel-opencl-clang
+export VC_INTRINSICS_IN_TREE_INSTALL=FALSE
+
 POST_EXTRACT_TARGET = vc-intrinsics_post_extract_target
-USE_NATIVE_CMAKE = 1
 
 # External build: To configure VC Intrinsics with prebuilt LLVM
 CMAKE_ARGS += -DLLVM_DIR=$(STAGING_INSTALL_PREFIX)/lib/cmake/llvm

--- a/cross/intel-vc-intrinsics/digests
+++ b/cross/intel-vc-intrinsics/digests
@@ -1,3 +1,3 @@
-vc-intrinsics-0.20.0.tar.gz SHA1 2e8926b0ce90e0c206dd5f04f874662a90ec20cb
-vc-intrinsics-0.20.0.tar.gz SHA256 2ef1e668e128e87ac9bd4c93c1fc7ee0f7fb478a9bd0c7fdd684ce93a4524f96
-vc-intrinsics-0.20.0.tar.gz MD5 4aef42825204cc35d1f115b8569a4110
+vc-intrinsics-0.20.1.tar.gz SHA1 830ed0ab293c64da1e55d1a1c28be0210655a2fc
+vc-intrinsics-0.20.1.tar.gz SHA256 01a68a3c8299075ad2b094264bef5109d660f1d53faf614f4f95745ad05f4e3e
+vc-intrinsics-0.20.1.tar.gz MD5 f26e206f30c07c4b77dcbbac4ce47267


### PR DESCRIPTION
## Description

vc-intrinsics: Update to v0.20.1 and remove unecessary `USE_NATIVE_CMAKE` since docker image update to Debian 12.

Refers to https://github.com/SynoCommunity/spksrc/pull/6255

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
