### PR TITLE
mympd: fix build

### DIFF
--- a/cross/mympd/Makefile
+++ b/cross/mympd/Makefile
@@ -17,6 +17,7 @@ LICENSE  = GPLv3
 # myMPD was originally a fork of ympd, but it has evolved into a much more comprehensive MPD client.
 
 CMAKE_USE_TOOLCHAIN_FILE = NO
+CMAKE_USE_NINJA = 0
 
 POST_INSTALL_TARGET = mympd_post_install
 

--- a/mk/spksrc.cross-meson.mk
+++ b/mk/spksrc.cross-meson.mk
@@ -25,7 +25,7 @@ include ../../mk/spksrc.cross-ninja.mk
 meson_configure_target:
 	@$(MSG) - Meson configure
 	@$(MSG)    - Dependencies = $(DEPENDS)
-	@$(MSG)    - Build path = $(WORK_DIR)/$(PKG_DIR)/$(MESON_BUILD_DIR)
+	@$(MSG)    - Build path = $(MESON_BUILD_DIR)
 	@$(MSG)    - Configure ARGS = $(CONFIGURE_ARGS)
 	@$(MSG)    - Install prefix = $(INSTALL_PREFIX)
 	cd $(MESON_BASE_DIR) && env $(ENV) meson setup $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS)

--- a/mk/spksrc.native-meson.mk
+++ b/mk/spksrc.native-meson.mk
@@ -83,7 +83,7 @@ include ../../mk/spksrc.common-rules.mk
 meson_configure_target:
 	@$(MSG) - Meson configure
 	@$(MSG)    - Dependencies = $(DEPENDS)
-	@$(MSG)    - Build path = $(WORK_DIR)/$(PKG_DIR)/$(MESON_BUILD_DIR)
+	@$(MSG)    - Build path = $(MESON_BUILD_DIR)
 	@$(MSG)    - Configure ARGS = $(CONFIGURE_ARGS)
 	@$(MSG)    - Install prefix = $(INSTALL_PREFIX)
 	cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV) meson $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS)


### PR DESCRIPTION
## Description

In #6274 the build of mympd fails and some research was needed to find the problem ⛑️ 

- build mympd with CMake (disable ninja)
- mympd build was broken since CMAKE_USE_NINJA default value changed from 0 to 1 in #6002

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
