### PR TITLE
readline: Fix readline.pc to depend on ncursesw

### DIFF
--- a/cross/readline/Makefile
+++ b/cross/readline/Makefile
@@ -14,6 +14,14 @@ LICENSE  = GPLv3
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --disable-static
 CONFIGURE_ARGS += --disable-install-examples
+CONFIGURE_ARGS += --with-curses=ncursesw
 ADDITIONAL_CFLAGS = -O
 
+POST_INSTALL_TARGET = readline_post_install
+
 include ../../mk/spksrc.cross-cc.mk
+
+.PHONY: readline_post_install
+readline_post_install:
+	$(RUN) sed -i 's/Requires.private: ncurses/Requires.private: ncursesw/' readline.pc
+	$(RUN) install -m 644 readline.pc $(STAGING_INSTALL_PREFIX)/lib/pkgconfig


### PR DESCRIPTION
## Description

readline: Fix readline.pc to depend on ncursesw

Fixes issue when compiling python 3.13.0 - relates to https://github.com/SynoCommunity/spksrc/pull/6282

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
