### PR TITLE
homeassistant: adjust numpy to fix build

### DIFF
--- a/spk/homeassistant/src/requirements-crossenv.txt
+++ b/spk/homeassistant/src/requirements-crossenv.txt
@@ -28,7 +28,7 @@ miniaudio==1.59
 msgpack==1.0.5
 multidict==6.0.4
 netifaces==0.11.0
-numpy==1.23.2
+numpy==1.24.4
 orjson==3.9.1
 # pandas==2.0.3         # depends on installed numpy wheel ?...
 Pillow==9.5.0


### PR DESCRIPTION
## Description

- update numpy to v1.24.4 to fix build with python311

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
