### PR TITLE
cross/readline: update and fix

### DIFF
--- a/cross/readline/Makefile
+++ b/cross/readline/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = readline
-PKG_VERS = 8.2
+PKG_VERS = 8.2.13
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://ftp.gnu.org/gnu/readline
@@ -15,13 +15,17 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS  = --disable-static
 CONFIGURE_ARGS += --disable-install-examples
 CONFIGURE_ARGS += --with-curses=ncursesw
+CONFIGURE_ARGS += --with-shared-termcap-library=-lncursesw
 ADDITIONAL_CFLAGS = -O
 
-POST_INSTALL_TARGET = readline_post_install
+POST_COMPILE_TARGET = readline_post_compile
 
 include ../../mk/spksrc.cross-cc.mk
 
-.PHONY: readline_post_install
-readline_post_install:
-	$(RUN) sed -i 's/Requires.private: ncurses/Requires.private: ncursesw/' readline.pc
-	$(RUN) install -m 644 readline.pc $(STAGING_INSTALL_PREFIX)/lib/pkgconfig
+.PHONY: readline_post_compile
+# The configure script does not handle ncursesw correctly
+# - it adds ncurses dependency to the pkgconfig file even when statically linked (the default)
+# - the dependency in the pkgconfig file is ncurses instead of ncursesw 
+# we could patch the configure file but it is easier to patch the created pkgconfig file.
+readline_post_compile:
+	@$(RUN) sed 's/Requires.private: ncurses/Requires.private: ncursesw/' -i readline.pc

--- a/cross/readline/digests
+++ b/cross/readline/digests
@@ -1,3 +1,3 @@
-readline-8.2.tar.gz SHA1 97ad98be243a857b639c0f3da2fe7d81c6d1d36e
-readline-8.2.tar.gz SHA256 3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35
-readline-8.2.tar.gz MD5 4aa1b31be779e6b84f9a96cb66bc50f6
+readline-8.2.13.tar.gz SHA1 5ffb6a334c2422acbe8f4d2cb11e345265c8d930
+readline-8.2.13.tar.gz SHA256 0e5be4d2937e8bd9b7cd60d46721ce79f88a33415dd68c2d738fb5924638f656
+readline-8.2.13.tar.gz MD5 05080bf3801e6874bb115cd6700b708f


### PR DESCRIPTION
## Description

- update cross/readline from v8.2 to v8.2.13
- configure to use shared ncursesw library
- adjust patch of readline.pc introduced with #6283


This fixes the build of cross/bind for synocli-net that popped up in #6220 after #6283 was merged.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Library update

