### PR TITLE
toolchains: fix TC_GLIBC

### DIFF
--- a/toolchain/syno-alpine-7.0/Makefile
+++ b/toolchain/syno-alpine-7.0/Makefile
@@ -1,7 +1,7 @@
 TC_ARCH = alpine
 TC_VERS = 7.0
 TC_KERNEL = 3.10.108
-TC_GLIBC = 2.36
+TC_GLIBC = 2.26
 
 TC_DIST = alpine-gcc750_glibc226_hard-GPL
 TC_DIST_SITE_PATH = Annapurna%20Alpine%20Linux%203.10.108

--- a/toolchain/syno-alpine-7.1/Makefile
+++ b/toolchain/syno-alpine-7.1/Makefile
@@ -1,7 +1,7 @@
 TC_ARCH = alpine
 TC_VERS = 7.1
 TC_KERNEL = 3.10.108
-TC_GLIBC = 2.36
+TC_GLIBC = 2.26
 
 TC_DIST = alpine-gcc850_glibc226_hard-GPL
 TC_DIST_SITE_PATH = Annapurna%20Alpine%20Linux%203.10.108

--- a/toolchain/syno-alpine4k-7.0/Makefile
+++ b/toolchain/syno-alpine4k-7.0/Makefile
@@ -1,7 +1,7 @@
 TC_ARCH = alpine4k
 TC_VERS = 7.0
 TC_KERNEL = 3.10.108
-TC_GLIBC = 2.36
+TC_GLIBC = 2.26
 
 TC_DIST = alpine4k-gcc750_glibc226_hard-GPL
 TC_DIST_SITE_PATH = Annapurna%20Alpine%20Linux%203.10.108

--- a/toolchain/syno-alpine4k-7.1/Makefile
+++ b/toolchain/syno-alpine4k-7.1/Makefile
@@ -1,7 +1,7 @@
 TC_ARCH = alpine4k
 TC_VERS = 7.1
 TC_KERNEL = 3.10.108
-TC_GLIBC = 2.36
+TC_GLIBC = 2.26
 
 TC_DIST = alpine4k-gcc850_glibc226_hard-GPL
 TC_DIST_SITE_PATH = Annapurna%20Alpine%20Linux%203.10.108


### PR DESCRIPTION
## Description

- fix definition of TC_GLIBC of alpine and alpine4k toolchain

this popped up in the analysis of #6309

Since we prefere the generic archs (ARMv7 in this case) this is not an issue so far.

### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
