### PR TITLE
local.mk: add option to disable github api call for maintainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,9 @@ local.mk:
 	@echo "DISTRIBUTOR_URL =" >> $@
 	@echo "REPORT_URL =" >> $@
 	@echo "DEFAULT_TC =" >> $@
+	@echo "# Option to disable the use of github API to get the real name and url of the maintainer" >> $@
+	@echo "# define it for local builds when you reach the API rate limit" >> $@
+	@echo "DISABLE_GITHUB_MAINTAINER =" >> $@
 	@echo "#PSTAT = on" >> $@
 	@echo "#PARALLEL_MAKE = max" >> $@
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -151,8 +151,13 @@ ifeq ($(strip $(MAINTAINER)),)
 $(error Add MAINTAINER for '$(SPK_NAME)' in spk Makefile or set default MAINTAINER in local.mk.)
 endif
 
+ifeq ($(strip $(DISABLE_GITHUB_MAINTAINER)),)
 get_github_maintainer_url = $(shell wget --quiet --spider https://github.com/$(1) && echo "https://github.com/$(1)" || echo "")
 get_github_maintainer_name = $(shell curl -s -H application/vnd.github.v3+json https://api.github.com/users/$(1) | jq -r '.name' | sed -e 's|null||g' | sed -e 's|^$$|$(1)|g' )
+else
+get_github_maintainer_url = "https://github.com/SynoCommunity"
+get_github_maintainer_name = $(MAINTAINER)
+endif
 
 $(WORK_DIR)/INFO:
 	$(create_target_dir)


### PR DESCRIPTION
## Description

- spksrc.spk.mk uses the github api to get the realname and the url of the package maintainer
- if you build packages too often (e.g. small diyspk packages) you can reach the api rate limit and the build fails
- for this case you can define DISABLE_GITHUB_MAINTAINER with any non empty value (1, true, ...) to avoid the api call
- if DISABLE_GITHUB_MAINTAINER is defined the MAINTAINER is used as defined and the MAINTERNER_URL is set to "https://github.com/SynoCommunity" if not defined in the package


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
- [x] This change requires a documentation update (e.g. Wiki)
