### PR TITLE
Update kernel digests for denverton 7.2

### DIFF
--- a/kernel/syno-denverton-7.2/digests
+++ b/kernel/syno-denverton-7.2/digests
@@ -1,3 +1,3 @@
-denverton-linux-4.4.x.txz SHA1 a2d94dc276cb757d356caafa3828da152988ab5a
-denverton-linux-4.4.x.txz SHA256 5fbec4ccbfcba050f9fa67e4fd3913ec9ffd9669a0a904b85cc523182dd7a53b
-denverton-linux-4.4.x.txz MD5 fa5606798b0dabf4094adb0896e7e1f7
+denverton-linux-4.4.x.txz SHA1 979640d91d584e80a1082d85baa13da8699b4185
+denverton-linux-4.4.x.txz SHA256 a20bef031194f9283ed413b95f54a39d1c0666574a75b3d99083401d017eef19
+denverton-linux-4.4.x.txz MD5 3a19887cb910a69baf47275a4b511026


### PR DESCRIPTION
## Description

Something seems to have changed the checksums for the Denverton 7.2 kernel sources on the Synology site (https://global.download.synology.com/download/ToolChain/Synology%20NAS%20GPL%20Source/7.2-64570/denverton/linux-4.4.x.txz), which was causing 7.2 builds to fail.  This may be a wider issue with 7.2 builds, but can only attest for Denverton.

Fixes #6314 

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
