### PR TITLE
bzip2: Add bzip2.pc pkgconfig file

### DIFF
--- a/cross/bzip2/Makefile
+++ b/cross/bzip2/Makefile
@@ -31,3 +31,7 @@ bzip2_post_install:
 	ln -sf bzmore $(STAGING_INSTALL_PREFIX)/bin/bzless
 	@$(RUN) cp libbz2.so.$(PKG_VERS) $(STAGING_INSTALL_PREFIX)/lib/
 	ln -sf libbz2.so.$(PKG_VERS) $(STAGING_INSTALL_PREFIX)/lib/libbz2.so.1.0
+	@install -m 755 -d $(STAGING_INSTALL_PREFIX)/lib/pkgconfig
+	@install -m 644 src/bzip2.pc $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/
+	@sed -ie 's%@PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/bzip2.pc
+	@sed -ie 's%@VERSION@%$(PKG_VERS)%g' $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/bzip2.pc

--- a/cross/bzip2/src/bzip2.pc
+++ b/cross/bzip2/src/bzip2.pc
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: A file compression library
+Version: @VERSION@
+Libs: -L${libdir} -lbz2
+Cflags: -I${includedir}


### PR DESCRIPTION
## Description

bzip2: Add bzip2.pc pkgconfig file as missing by default

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
