### PR TITLE
Ombi: Patch for v4.44.1 (Min DSM 7.2)

### DIFF
--- a/spk/ombi/Makefile
+++ b/spk/ombi/Makefile
@@ -1,19 +1,20 @@
 SPK_NAME = ombi
 SPK_VERS = 4.44.1
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/ombi.png
+
+REQUIRED_MIN_DSM = 7.2
 
 # Arch exclusions for dotnet 6.0
 DOTNET_CORE_ARCHS = 1
 
 DEPENDS = cross/ombi
-OPTIONAL_DEPENDS = cross/libstdc++
 
 MAINTAINER = hgy59
 DISPLAY_NAME = Ombi
 HOMEPAGE = https://ombi.io/
 DESCRIPTION = Ombi is a self-hosted web application that automatically gives your shared Plex or Emby users the ability to request content by themselves! Ombi can be linked to multiple TV Show and Movie DVR tools to create a seamless end-to-end experience for your users.
-CHANGELOG = "Update Ombi to v4.44.1."
+CHANGELOG = "Update Ombi to v4.44.1. (Requires DSM 7.2)"
 LICENSE  = GPLv2
 
 SERVICE_USER = auto
@@ -21,19 +22,4 @@ SERVICE_PORT = 8822
 STARTABLE = yes
 SERVICE_SETUP = src/service-setup.sh
 
-include ../../mk/spksrc.common.mk
-
-ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
-# we do not only need the updated libstdc++ library, we also need to
-# adjust the library search path in ombi executables to use this version.
-DEPENDS += cross/libstdc++
-POST_STRIP_TARGET = ombi_patch_target
-endif
-
 include ../../mk/spksrc.spk.mk
-
-.PHONY: ombi_patch_target
-# Set library path to use libstdc++ of dotnet-runtime package.
-ombi_patch_target:
-	@$(MSG) "Set library runpath in ombi executables."
-	@patchelf --set-rpath /var/packages/$(SPK_NAME)/target/lib $(STAGING_DIR)/shared/Ombi


### PR DESCRIPTION
## Description

This is a follow-on from #6323 to set the minimum DSM version to 7.2 for compatibility with Sqlite 8.0.5.

Fixes #6346

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
