### PR TITLE
Build armv5 and armv7l rust 1.82.0 builds

### DIFF
--- a/mk/spksrc.cross-rust-env.mk
+++ b/mk/spksrc.cross-rust-env.mk
@@ -48,7 +48,7 @@ RUST_TARGET = armv7-unknown-linux-gnueabihf
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv7L_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = armv7-unknown-linux-gnueabi
-TC_RUSTUP_TOOLCHAIN = $(RUST_BUILD_VERSION)-$(RUST_TARGET)
+TC_RUSTUP_TOOLCHAIN = $(RUST_BUILD_VERSION)-armv7l-unknown-linux-gnueabi
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv8_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = aarch64-unknown-linux-gnu

--- a/mk/spksrc.cross-rust-env.mk
+++ b/mk/spksrc.cross-rust-env.mk
@@ -9,7 +9,7 @@ endif
 # source Tier-3 toolchains (qoriq)
 # ref: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 ifeq ($(RUST_BUILD_TOOLCHAIN),)
-RUST_BUILD_TOOLCHAIN = 0
+RUST_BUILD_TOOLCHAIN = 1
 endif
 
 # Versions available: https://releases.rs/docs/
@@ -40,15 +40,15 @@ RUSTUP_DEFAULT_TOOLCHAIN_STAGE = 2
 
 # map archs to rust targets
 ifeq ($(findstring $(RUST_ARCH), $(ARMv5_ARCHS)),$(RUST_ARCH))
-RUSTUP_DEFAULT_TOOLCHAIN = 1.77.2
 RUST_TARGET = armv5te-unknown-linux-gnueabi
+TC_RUSTUP_TOOLCHAIN = $(RUST_BUILD_VERSION)-$(RUST_TARGET)
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv7_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = armv7-unknown-linux-gnueabihf
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv7L_ARCHS)),$(RUST_ARCH))
-RUSTUP_DEFAULT_TOOLCHAIN = 1.77.2
 RUST_TARGET = armv7-unknown-linux-gnueabi
+TC_RUSTUP_TOOLCHAIN = $(RUST_BUILD_VERSION)-$(RUST_TARGET)
 endif
 ifeq ($(findstring $(RUST_ARCH), $(ARMv8_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = aarch64-unknown-linux-gnu

--- a/toolchain/syno-88f6281-6.2.4-rust/Makefile
+++ b/toolchain/syno-88f6281-6.2.4-rust/Makefile
@@ -1,0 +1,32 @@
+PKG_ARCH = 88f6281
+PKG_NAME = rust-$(PKG_ARCH)
+PKG_VERS = 1.82.0
+PKG_EXT = txz
+PKG_DIST_TARGET = $(PKG_VERS)-armv5te-unknown-linux-gnueabi
+PKG_DIST_NAME = $(PKG_DIST_TARGET).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/SynoCommunity/spksrc/releases/download/rust/88f6281
+EXTRACT_PATH = $(INSTALL_DIR)/$(INSTALL_PREFIX)
+
+DEPENDS = 
+
+HOMEPAGE = https://www.rust-lang.org/
+COMMENT = A language empowering everyone to build reliable and efficient software.
+LICENSE  = Apache-2.0, MIT licenses
+
+# extracted directly into install folder
+INSTALL_TARGET = nop
+POST_INSTALL_TARGET = rust-88f6281-postinstall
+
+CARGO_PATH=$(abspath $(BASE_DISTRIB_DIR)/cargo/bin)
+RUSTUP_HOME=$(abspath $(BASE_DISTRIB_DIR)/rustup)
+
+include ../../mk/spksrc.native-install.mk
+
+.PHONY: rust-88f6281-postinstall
+rust-88f6281-postinstall:
+	@$(MSG) "Rustup $(PKG_DIST_TARGET)"
+	@export PATH="$(CARGO_PATH):$${PATH}" ; \
+	export RUSTUP_HOME="$(RUSTUP_HOME)" ; \
+	which rustup ; \
+	rustup toolchain link $(PKG_DIST_TARGET) $(abspath $(INSTALL_DIR)/$(INSTALL_PREFIX)) ; \
+	rustup show

--- a/toolchain/syno-88f6281-6.2.4-rust/digests
+++ b/toolchain/syno-88f6281-6.2.4-rust/digests
@@ -1,0 +1,3 @@
+1.82.0-powerpc-unknown-linux-gnuspe.txz SHA1 2bb6a24ca736640e0cb1c7f6fa147fe93029beab
+1.82.0-powerpc-unknown-linux-gnuspe.txz SHA256 52eff1c1e0615ea084a81afba1548d0e085170981f339f3cec77df3790bb5758
+1.82.0-powerpc-unknown-linux-gnuspe.txz MD5 9b60c0a6bbf803290c388840b767989c

--- a/toolchain/syno-hi3535-6.2.4-rust/Makefile
+++ b/toolchain/syno-hi3535-6.2.4-rust/Makefile
@@ -1,0 +1,32 @@
+PKG_ARCH = hi3535
+PKG_NAME = rust-$(PKG_ARCH)
+PKG_VERS = 1.82.0
+PKG_EXT = txz
+PKG_DIST_TARGET = $(PKG_VERS)-armv7-unknown-linux-gnueabi
+PKG_DIST_NAME = $(PKG_DIST_TARGET).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/SynoCommunity/spksrc/releases/download/rust/hi3535
+EXTRACT_PATH = $(INSTALL_DIR)/$(INSTALL_PREFIX)
+
+DEPENDS = 
+
+HOMEPAGE = https://www.rust-lang.org/
+COMMENT = A language empowering everyone to build reliable and efficient software.
+LICENSE  = Apache-2.0, MIT licenses
+
+# extracted directly into install folder
+INSTALL_TARGET = nop
+POST_INSTALL_TARGET = rust-hi3535-postinstall
+
+CARGO_PATH=$(abspath $(BASE_DISTRIB_DIR)/cargo/bin)
+RUSTUP_HOME=$(abspath $(BASE_DISTRIB_DIR)/rustup)
+
+include ../../mk/spksrc.native-install.mk
+
+.PHONY: rust-hi3535-postinstall
+rust-hi3535-postinstall:
+	@$(MSG) "Rustup $(PKG_DIST_TARGET)"
+	@export PATH="$(CARGO_PATH):$${PATH}" ; \
+	export RUSTUP_HOME="$(RUSTUP_HOME)" ; \
+	which rustup ; \
+	rustup toolchain link $(PKG_DIST_TARGET) $(abspath $(INSTALL_DIR)/$(INSTALL_PREFIX)) ; \
+	rustup show

--- a/toolchain/syno-hi3535-6.2.4-rust/digests
+++ b/toolchain/syno-hi3535-6.2.4-rust/digests
@@ -1,0 +1,3 @@
+1.82.0-powerpc-unknown-linux-gnuspe.txz SHA1 2bb6a24ca736640e0cb1c7f6fa147fe93029beab
+1.82.0-powerpc-unknown-linux-gnuspe.txz SHA256 52eff1c1e0615ea084a81afba1548d0e085170981f339f3cec77df3790bb5758
+1.82.0-powerpc-unknown-linux-gnuspe.txz MD5 9b60c0a6bbf803290c388840b767989c


### PR DESCRIPTION
## Description

Build armv5 and armv7l rust 1.82.0 builds

Relates to https://github.com/SynoCommunity/spksrc/pull/6357

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)

### Testing
- [x] hi3535 (bat with a rust 1.82.0)
- [ ] 88f6281 - FAILS - glibc too old (2.15) - requires `getauxval` introduced with glibc >= 2.16