### PR TITLE
Memcached: Update to v1.6.34

### DIFF
--- a/cross/memcached/Makefile
+++ b/cross/memcached/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = memcached
-PKG_VERS = 1.6.23
+PKG_VERS = 1.6.34
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://www.memcached.org/files

--- a/cross/memcached/digests
+++ b/cross/memcached/digests
@@ -1,3 +1,3 @@
-memcached-1.6.23.tar.gz SHA1 d5490856170453b15a782ad55ffdea188c2eade0
-memcached-1.6.23.tar.gz SHA256 85b0334904f440296a685ccfda75f0f4517bf8922ab8efa6d0c4b3c92c354d4c
-memcached-1.6.23.tar.gz MD5 fa12c58ff124d97b5b4150123623865d
+memcached-1.6.34.tar.gz SHA1 d2a0a65b3c69147e1a4fe0b3c20308c40cc0027e
+memcached-1.6.34.tar.gz SHA256 0d5380e2e0a5b4fcef1d89a368a11c4f06686c6017c1fff778b3b4578f0674ec
+memcached-1.6.34.tar.gz MD5 6fdf1dca74eaaff02b65338d7bcfad23

--- a/spk/memcached/Makefile
+++ b/spk/memcached/Makefile
@@ -1,19 +1,19 @@
 SPK_NAME = memcached
-SPK_VERS = 1.6.23
-SPK_REV = 6
+SPK_VERS = 1.6.34
+SPK_REV = 7
 SPK_ICON = src/memcached.png
 DSM_UI_DIR = app
 
 DEPENDS = cross/phpmemcachedadmin cross/memcached
 
 REQUIRED_MIN_DSM = 6.0
-SPK_DEPENDS = WebStation:PHP7.4
+SPK_DEPENDS = WebStation:PHP7.4:Apache2.4
 
 MAINTAINER = Diaoul
 DESCRIPTION = Free \& open source, high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load. It comes with phpMemcachedAdmin, a graphic stand-alone administration for memcached to monitor and debug purpose.
 ADMIN_URL = /phpMemcachedAdmin/
 DISPLAY_NAME = Memcached
-CHANGELOG = "1. Update Memcached to v1.6.23<br/>2. Update to PHP 7.4 to fix DSM 7 installation."
+CHANGELOG = "1. Update Memcached to v1.6.34<br/>2. Fix Apache 2.4 dependency."
 
 HOMEPAGE = https://memcached.org/
 LICENSE  = 3-Clause BSD
@@ -27,9 +27,6 @@ DSM_UI_CONFIG = src/app/config
 # SERVICE_COMMAND is defined in service setup script
 STARTABLE = yes
 SERVICE_SETUP = src/service-setup.sh
-
-INSTALL_DEP_SERVICES = apache-web
-START_DEP_SERVICES = apache-web
 
 POST_STRIP_TARGET = memcached_extra_install
 


### PR DESCRIPTION
## Description

This PR contains the following:

1. Update Memcached to version 1.6.34
2. Fix Apache 2.4 dependency (follow-on from #6005)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Package update
