### PR TITLE
update cloudflared to 2025.1.0 (2nd try)

### DIFF
--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2024.10.1
+PKG_VERS = 2025.1.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2024.10.1.tar.gz SHA1 64a76aa90b6b37592a953f75848fb4fd440cffbf
-cloudflared-2024.10.1.tar.gz SHA256 7e35e3e57a65f8914c5b53896cfa3711153af78b95d971791602c6624d53a1e1
-cloudflared-2024.10.1.tar.gz MD5 364287f2daf356aa54e5da8af2cbcafc
+cloudflared-2025.1.0.tar.gz SHA1 754e85783eab60a3f7644b0ea7f6501066c781c7
+cloudflared-2025.1.0.tar.gz SHA256 f9223cdefaa4b75aa1c49638936af9d5007b6c7bd943ab70203bb75bf32467da
+cloudflared-2025.1.0.tar.gz MD5 0fd57ebebeadd3dd44fc2c1d6069ca15

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2024.10.1
-SPK_REV = 15
+SPK_VERS = 2025.1.0
+SPK_REV = 16
 SPK_ICON = src/cloudflared.png
 
 DEPENDS = cross/cloudflared
@@ -11,7 +11,7 @@ DISPLAY_NAME = Cloudflare Tunnel
 DESCRIPTION = "Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address. With Tunnel, you do not send traffic to an external IP - instead, a lightweight daemon in your infrastructure \('cloudflared'\) creates outbound-only connections to Cloudflare\'s global network. Cloudflare Tunnel can connect HTTP web servers, SSH servers, remote desktops, and other protocols safely to Cloudflare. This way, your origins can serve traffic through Cloudflare without being vulnerable to attacks that bypass Cloudflare."
 HOMEPAGE = https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
 LICENSE = Apache-2.0
-CHANGELOG = "Update to v2024.10.1"
+CHANGELOG = "Update to v2025.1.0"
 
 WIZARDS_DIR = src/wizard/
 


### PR DESCRIPTION
⚠️ This is the 2nd try for this PR, [first one](https://github.com/SynoCommunity/spksrc/pull/6390) was closed because I wrongly submitted it against the `master` branch. Oops.

## Description

Updates cloudflared package to 2025.1.0 version

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created

### Type of change

- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)

I only tested the `arch-v1000-7.2` toolchain build because that's what I have (DS1621). I don't think there is any issue for other architectures. But others can test & confirm.