### PR TITLE
fix publish

### DIFF
--- a/mk/spksrc.publish.mk
+++ b/mk/spksrc.publish.mk
@@ -57,7 +57,7 @@ endif
 ifeq ($(PUBLISH_API_KEY),)
 	$(error Set PUBLISH_API_KEY in local.mk)
 endif
-	@response=$$(http --verify=no --ignore-stdin --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME) --print=hb) ; \
+	@response=$$(PYTHONPATH= http --verify=no --ignore-stdin --auth $(PUBLISH_API_KEY): POST $(PUBLISH_URL)/packages @$(SPK_FILE_NAME) --print=hb) ; \
 	response_code=$$(echo "$$response" | grep -Fi "HTTP/1.1" | awk '{print $$2}') ; \
 	if [ "$$response_code" = "201" ] ; then \
 		output=$$(echo "$$response" | awk '/^[[:space:]]*$$/ {p=1;next} p') ; \


### PR DESCRIPTION

## Description

related to https://github.com/SynoCommunity/spksrc/pull/6406#issuecomment-2613837511

This is a hotfix since publish python311 and related packages is broken

- avoid PYTHONPATH definition for http tool
- PYTHONPATH is defined spksrc.crossenv.mk and was introduced with #6282

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
