### PR TITLE
python313 hi3535 arch freetype fix

### DIFF
--- a/cross/bzip2/Makefile
+++ b/cross/bzip2/Makefile
@@ -33,5 +33,5 @@ bzip2_post_install:
 	ln -sf libbz2.so.$(PKG_VERS) $(STAGING_INSTALL_PREFIX)/lib/libbz2.so.1.0
 	@install -m 755 -d $(STAGING_INSTALL_PREFIX)/lib/pkgconfig
 	@install -m 644 src/bzip2.pc $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/
-	@sed -ie 's%@PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/bzip2.pc
-	@sed -ie 's%@VERSION@%$(PKG_VERS)%g' $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/bzip2.pc
+	@sed -i 's%@PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/bzip2.pc
+	@sed -i 's%@VERSION@%$(PKG_VERS)%g' $(STAGING_INSTALL_PREFIX)/lib/pkgconfig/bzip2.pc

--- a/cross/freetype/Makefile
+++ b/cross/freetype/Makefile
@@ -5,7 +5,7 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://download.savannah.gnu.org/releases/freetype
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-DEPENDS = cross/zlib cross/libpng
+DEPENDS = cross/bzip2 cross/libpng cross/zlib
 
 HOMEPAGE = https://www.freetype.org
 COMMENT  = FreeType is a freely available software library to render fonts.

--- a/mk/spksrc.python.mk
+++ b/mk/spksrc.python.mk
@@ -42,12 +42,12 @@ export ADDITIONAL_LDFLAGS  += -L$(OPENSSL_STAGING_PREFIX)/lib
 export ADDITIONAL_LDFLAGS  += -Wl,--rpath-link,$(OPENSSL_STAGING_PREFIX)/lib -Wl,--rpath,$(OPENSSL_PREFIX)/lib
 endif
 
-# Re-use all default python mandatory libraries (with exception of xz, zlib)
-PYTHON_LIBS_EXCLUDE = %lzma.pc %zlib.pc
+# Re-use all default python mandatory libraries (with exception of bzip2, xz, zlib)
+PYTHON_LIBS_EXCLUDE = %bzip2.pc %lzma.pc %zlib.pc
 PYTHON_LIBS := $(filter-out $(PYTHON_LIBS_EXCLUDE),$(wildcard $(PYTHON_STAGING_INSTALL_PREFIX)/lib/pkgconfig/*.pc))
 
-# Re-use all python dependencies and mark as already done (with exceltion of xz, zlib)
-PYTHON_DEPENDS_EXCLUDE = xz zlib
+# Re-use all python dependencies and mark as already done (with exceltion of bzip2, xz, zlib)
+PYTHON_DEPENDS_EXCLUDE = bzip2 xz zlib
 PYTHON_DEPENDS := $(foreach cross,$(filter-out $(PYTHON_DEPENDS_EXCLUDE),$(foreach pkg_name,$(shell $(MAKE) dependency-list -C $(realpath $(PYTHON_PACKAGE_WORK_DIR)/../) 2>/dev/null | grep ^$(PYTHON_PACKAGE) | cut -f2 -d:),$(shell sed -n 's/^PKG_NAME = \(.*\)/\1/p' $(realpath $(CURDIR)/../../$(pkg_name)/Makefile)))),$(wildcard $(PYTHON_PACKAGE_WORK_DIR)/.$(cross)-*_done))
 
 # call-up pre-depend to prepare the shared python build environment


### PR DESCRIPTION
## Description

python313 hi3535 arch freetype fix - error in bzip2.pc pkgconfig file creation and freetype build error due to missing dependency.

Relates to https://github.com/SynoCommunity/spksrc/pull/6409

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
