### PR TITLE
Add wheel top-level status cookie and mark armv5 as unsupported >= python 3.12

### DIFF
--- a/mk/spksrc.python.mk
+++ b/mk/spksrc.python.mk
@@ -7,7 +7,12 @@
 # set default spk/python* path to use
 PYTHON_PACKAGE_WORK_DIR = $(realpath $(CURDIR)/../../spk/$(PYTHON_PACKAGE)/work-$(ARCH)-$(TCVERSION))
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
+
+# armv5 no longer supported with python >= 3.12
+ifeq ($(call version_ge, $(subst python,,$(PYTHON_PACKAGE)), 312), 1)
+UNSUPPORTED_ARCHS += $(ARMv5_ARCHS)
+endif
 
 ifneq ($(wildcard $(PYTHON_PACKAGE_WORK_DIR)),)
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -525,6 +525,7 @@ spkclean:
 	       work-*/.depend_done \
 	       work-*/.icon_done \
 	       work-*/.strip_done \
+	       work-*/.wheel_done \
 	       work-*/conf \
 	       work-*/scripts \
 	       work-*/staging \

--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -18,6 +18,9 @@
 #          make download-wheels : MAKECMDGOALS is download-wheels
 WHEEL_GOAL := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),wheel)
 
+# Completion status file
+WHEEL_COOKIE = $(WORK_DIR)/.wheel_done
+
 ## python wheel specific configurations
 include ../../mk/spksrc.wheel-env.mk
 
@@ -149,7 +152,16 @@ download-wheels: $(WHEEL_TARGET)
 
 post_wheel_target: $(WHEEL_TARGET) install_python_wheel
 
-wheel: post_wheel_target
+ifeq ($(wildcard $(WHEEL_COOKIE)),)
+wheel: $(WHEEL_COOKIE)
+
+$(WHEEL_COOKIE): $(POST_WHEEL_TARGET)
+	$(create_target_dir)
+	@touch -f $@
+
+else
+wheel: ;
+endif
 
 # endif REQUIREMENT non-empty
 endif


### PR DESCRIPTION
## Description

Add wheel top-level status cookie and mark armv5 as unsupported >= python 3.12

Relates to comments:
- Mark armv5 as unsupported: https://github.com/SynoCommunity/spksrc/pull/6422#issuecomment-2614601077
- Add top-level wheel status cookie https://github.com/SynoCommunity/spksrc/pull/6409#issuecomment-2614492794

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
