### PR TITLE
ffsync: Update to v0.18.3 and migrate to Python 3.12

### DIFF
--- a/cross/syncstorage-rs/Makefile
+++ b/cross/syncstorage-rs/Makefile
@@ -5,8 +5,6 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/mozilla-services/$(PKG_NAME)/archive/${PKG_VERS}
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-# only required for build in cross/syncstorage-rs folder (not when using prebuilt spk/python311)
-#BUILD_DEPENDS = cross/python311
 # for openssl-sys
 DEPENDS = cross/openssl3
 # for mysqlclient-sys
@@ -36,17 +34,6 @@ CARGO_BUILD_ARGS += --locked
 # we must define the mysql db socket, since the rust binaries (mysqlclient-sys)
 # do not read settings from bin/mysql_conf
 export MYSQL_DB_SOCKET=/run/mysqld/mysqld10.sock
-
-# To find libpython in prebuilt or local built python
-ifneq ($(PYTHON_STAGING_PREFIX),)
-# use prebuilt python
-ENV += PYO3_CROSS_LIB_DIR=$(PYTHON_STAGING_PREFIX)/lib/
-ENV += PYO3_CROSS_INCLUDE_DIR=$(PYTHON_STAGING_PREFIX)/include/
-else
-# use local python (together with "BUILD_DEPENDS = cross/python311" above)
-ENV += PYO3_CROSS_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib/
-ENV += PYO3_CROSS_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/
-endif
 
 # mysqlclient-sys: to find libmysqlclient
 ENV += MYSQLCLIENT_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib

--- a/cross/syncstorage-rs/Makefile
+++ b/cross/syncstorage-rs/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncstorage-rs
-PKG_VERS = 0.18.2
+PKG_VERS = 0.18.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/mozilla-services/$(PKG_NAME)/archive/${PKG_VERS}

--- a/cross/syncstorage-rs/digests
+++ b/cross/syncstorage-rs/digests
@@ -1,3 +1,3 @@
-syncstorage-rs-0.18.2.tar.gz SHA1 b5eda7e8d2168ece628336d2a2e321916a048c41
-syncstorage-rs-0.18.2.tar.gz SHA256 901c3ef6296ba36300f44d56317769c81c87f756ab0f8e5c2ebb7049135a5f4c
-syncstorage-rs-0.18.2.tar.gz MD5 fc6e691358a468ab1f4f2567ea78b1cf
+syncstorage-rs-0.18.3.tar.gz SHA1 3b38d1acd98f18378c63f093b0e7dcf21cde983b
+syncstorage-rs-0.18.3.tar.gz SHA256 496555d4fd4059b9b33b8c20d2742c6eb3a0592188dd0f2da77624ac9856d1b5
+syncstorage-rs-0.18.3.tar.gz MD5 516d56ac1b24e51db5669d4de21d8b6d

--- a/cross/syncstorage-rs/patches/001-update-ring.patch
+++ b/cross/syncstorage-rs/patches/001-update-ring.patch
@@ -1,0 +1,14 @@
+--- Cargo.lock.orig	2025-05-14 19:36:30
++++ Cargo.lock	2025-05-17 12:30:33
+@@ -2488,9 +2488,9 @@
+ 
+ [[package]]
+ name = "ring"
+-version = "0.17.13"
++version = "0.17.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
++checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+ dependencies = [
+  "cc",
+  "cfg-if",

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = ffsync
-SPK_VERS = 0.18.2
+SPK_VERS = 0.18.3
 SPK_REV = 5
 SPK_ICON = src/ffsync.png
 
@@ -16,7 +16,7 @@ SPK_DEPENDS = MariaDB10:$(PYTHON_PACKAGE)
 MAINTAINER = SynoCommunity
 DESCRIPTION = An implementation of the Mozilla Sync-1.5 Server protocol used by the sync service in Firefox 29 and later. You can use Mozilla Sync Server to exchange browser data \(bookmarks, history, open tabs, passwords, add-ons, and the like\) between \'clients\' in a manner that respects a user\'s security and privacy. The service runs on port 8132.
 DISPLAY_NAME = Mozilla Sync Server
-CHANGELOG = "1. Update Mozilla Sync Server package to v0.18.2.<br/>2. Migrate to Python 3.12."
+CHANGELOG = "1. Update Mozilla Sync Server package to v0.18.3.<br/>2. Migrate to Python 3.12."
 
 HOMEPAGE = https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html
 LICENSE = MPL 2.0

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -8,7 +8,7 @@ DEPENDS = cross/syncstorage-rs cross/diesel
 PYTHON_PACKAGE = python312
 WHEELS = src/requirements-crossenv.txt src/requirements-pure.txt
 
-UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(PPC_ARCHS)
+UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(PPC_ARCHS) $(ARMv7L_ARCHS)
 
 REQUIRED_MIN_DSM = 6.0
 SPK_DEPENDS = MariaDB10:$(PYTHON_PACKAGE)
@@ -46,11 +46,9 @@ include ../../mk/spksrc.python.mk
 # [greenlet]
 ifeq ($(call version_ge, $(TC_GCC), 5.0),1)
 WHEELS += src/requirements-crossenv-greenlet-v3.txt
-else ifeq ($(call version_ge, $(TC_GCC), 4.9)$(call version_lt, $(TC_GCC), 5.0),11)
+else
 WHEELS += src/requirements-crossenv-greenlet-v3-gcc4.txt
 WHEELS_CPPFLAGS += [greenlet] -std=c++11 -fpermissive
-else
-WHEELS += src/requirements-crossenv-greenlet-v1.txt
 endif
 
 

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ffsync
 SPK_VERS = 0.18.3
-SPK_REV = 5
+SPK_REV = 6
 SPK_ICON = src/ffsync.png
 
 DEPENDS = cross/syncstorage-rs cross/diesel

--- a/spk/ffsync/Makefile
+++ b/spk/ffsync/Makefile
@@ -5,7 +5,7 @@ SPK_ICON = src/ffsync.png
 
 DEPENDS = cross/syncstorage-rs cross/diesel
 
-PYTHON_PACKAGE = python311
+PYTHON_PACKAGE = python312
 WHEELS = src/requirements-crossenv.txt src/requirements-pure.txt
 
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(PPC_ARCHS)
@@ -16,7 +16,7 @@ SPK_DEPENDS = MariaDB10:$(PYTHON_PACKAGE)
 MAINTAINER = SynoCommunity
 DESCRIPTION = An implementation of the Mozilla Sync-1.5 Server protocol used by the sync service in Firefox 29 and later. You can use Mozilla Sync Server to exchange browser data \(bookmarks, history, open tabs, passwords, add-ons, and the like\) between \'clients\' in a manner that respects a user\'s security and privacy. The service runs on port 8132.
 DISPLAY_NAME = Mozilla Sync Server
-CHANGELOG = "Update Mozilla Sync Server package to v0.18.2."
+CHANGELOG = "1. Update Mozilla Sync Server package to v0.18.2.<br/>2. Migrate to Python 3.12."
 
 HOMEPAGE = https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html
 LICENSE = MPL 2.0

--- a/spk/ffsync/src/requirements-crossenv-greenlet-v1.txt
+++ b/spk/ffsync/src/requirements-crossenv-greenlet-v1.txt
@@ -1,9 +1,0 @@
-##
-## All configurations below are optional and
-## are provided to demonstrate how to build
-## various wheels.  Uncoment to enable.
-##
-
-# [greenlet]
-#   - gcc < 5.0 (DSM6) Last known working version
-greenlet==1.1.3

--- a/spk/ffsync/src/requirements-crossenv.txt
+++ b/spk/ffsync/src/requirements-crossenv.txt
@@ -1,8 +1,8 @@
-# Generated using the requirements script on February 22, 2025
+# Generated using the requirements script on May 15, 2025
 
 cffi==1.17.1
-charset_normalizer==3.4.1
-cryptography==42.0.8
+charset_normalizer==3.4.2
+cryptography==44.0.2
 #greenlet                   ==> supported version depends on gcc version
 mysqlclient==2.1.1
 SQLAlchemy==1.4.46

--- a/spk/ffsync/src/requirements-pure.txt
+++ b/spk/ffsync/src/requirements-pure.txt
@@ -1,4 +1,4 @@
-# Generated using the requirements script on February 22, 2025
+# Generated using the requirements script on May 15, 2025
 
 backoff==2.2.1
 boto==2.49.0
@@ -7,22 +7,25 @@ datadog==0.51.0
 hawkauthlib==2.0.0
 hupper==1.12.1
 idna==3.10
+iniconfig==2.1.0
+packaging==25.0
 PasteDeploy==3.1.0
 #pip                        ==> python312
 plaster==1.1.2
 plaster_pastedeploy==1.0.1
+pluggy==1.6.0
 PyBrowserID==0.14.0
 pycparser==2.22
-PyFxA==0.7.7
+pyfxa==0.8.1
 PyJWT==2.10.1
 pyramid==2.0.2
+pytest==8.3.5
 requests==2.32.3
 #setuptools                 ==> python312
-#six                        ==> python312
 testfixtures==8.3.0
 tokenlib==2.0.0
 translationstring==1.4
-urllib3==2.3.0
+urllib3==2.4.0
 venusian==3.1.1
 WebOb==1.8.9
 zope.deprecation==5.1

--- a/spk/ffsync/src/requirements-pure.txt
+++ b/spk/ffsync/src/requirements-pure.txt
@@ -2,13 +2,13 @@
 
 backoff==2.2.1
 boto==2.49.0
-#certifi                    ==> python311
+#certifi                    ==> python312
 datadog==0.51.0
 hawkauthlib==2.0.0
 hupper==1.12.1
 idna==3.10
 PasteDeploy==3.1.0
-#pip                        ==> python311
+#pip                        ==> python312
 plaster==1.1.2
 plaster_pastedeploy==1.0.1
 PyBrowserID==0.14.0
@@ -17,8 +17,8 @@ PyFxA==0.7.7
 PyJWT==2.10.1
 pyramid==2.0.2
 requests==2.32.3
-#setuptools                 ==> python311
-#six                        ==> python311
+#setuptools                 ==> python312
+#six                        ==> python312
 testfixtures==8.3.0
 tokenlib==2.0.0
 translationstring==1.4

--- a/spk/ffsync/src/service-setup.sh
+++ b/spk/ffsync/src/service-setup.sh
@@ -1,6 +1,6 @@
 
 # ffsync service setup
-PYTHON_DIR="/var/packages/python311/target/bin"
+PYTHON_DIR="/var/packages/python312/target/bin"
 PATH="${SYNOPKG_PKGDEST}/env/bin:${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}:${PATH}"
 
 MARIADB_10_INSTALL_DIRECTORY="/var/packages/MariaDB10"

--- a/spk/ffsync/src/service-setup.sh
+++ b/spk/ffsync/src/service-setup.sh
@@ -44,19 +44,19 @@ percent_encode ()
 
 validate_preinst ()
 {
-    # Check MySQL database
+    # Check database
     if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
         if [ -n "${wizard_mysql_password_root}" ]; then
             if ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
-                echo "Incorrect MySQL root password"
+                echo "Incorrect MariaDB root password"
                 exit 1
             fi
             if ${MYSQL} -u root -p"${wizard_mysql_password_root}" mysql -e "SELECT User FROM user" | grep ^${DBUSER}$ > /dev/null 2>&1; then
-                echo "MySQL user ${DBUSER} already exists"
+                echo "MariaDB user ${DBUSER} already exists"
                 exit 1
             fi
             if ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "SHOW DATABASES" | grep -E '^(syncstorage_rs|tokenserver_rs)$' > /dev/null 2>&1; then
-                echo "MySQL database(s) for ${DBUSER} already exist(s)"
+                echo "MariaDB database(s) for ${DBUSER} already exist(s)"
                 exit 1
             fi
         fi
@@ -143,7 +143,7 @@ validate_preuninst ()
 {
     # Check database
     if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
-        echo "Incorrect MySQL root password"
+        echo "Incorrect MariaDB root password"
         exit 1
     fi
     # Check if database export path is specified


### PR DESCRIPTION
## Description

This PR includes the following:

1. Update syncstorage-rs to v0.18.3
2. Migrate to Python 3.12
3. Update MariaDB references

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
