### PR TITLE
fix python wheel packages (312, 313)

### DIFF
--- a/spk/python312-wheels/Makefile
+++ b/spk/python312-wheels/Makefile
@@ -28,7 +28,7 @@ WHEELS  = src/requirements-abi3.txt
 WHEELS += src/requirements-crossenv.txt
 WHEELS += src/requirements-pure.txt
 
-include ../../mk/spksrc.common.mk
+include ../../mk/spksrc.python.mk
 
 # [borgbackup]
 # Use OpenSSL path as defined by either
@@ -149,5 +149,3 @@ endif
 ## unless WHEELS has been previously populated. This is due to
 ## the makefile analysis phase which discard ifeq instructions.
 ##
-
-include ../../mk/spksrc.python.mk

--- a/spk/python312-wheels/src/requirements-crossenv-numpy.txt
+++ b/spk/python312-wheels/src/requirements-crossenv-numpy.txt
@@ -9,7 +9,7 @@
 #   - Numpy >= 1.26.x requires:
 #           c++17, meson-python, scikit-build-core
 #   - Older version <= 1.25.x no longer supported
+numpy==1.26.4
 numpy==2.2.2
 numpy==2.1.3
 numpy==2.0.2
-numpy==1.26.4

--- a/spk/python313-wheels/Makefile
+++ b/spk/python313-wheels/Makefile
@@ -28,7 +28,7 @@ WHEELS  = src/requirements-abi3.txt
 WHEELS += src/requirements-crossenv.txt
 WHEELS += src/requirements-pure.txt
 
-include ../../mk/spksrc.python.mk
+include ../../mk/spksrc.common.mk
 
 # [borgbackup]
 # Use OpenSSL path as defined by either
@@ -146,3 +146,5 @@ endif
 ## unless WHEELS has been previously populated. This is due to
 ## the makefile analysis phase which discard ifeq instructions.
 ##
+
+include ../../mk/spksrc.python.mk

--- a/spk/python313-wheels/Makefile
+++ b/spk/python313-wheels/Makefile
@@ -28,7 +28,7 @@ WHEELS  = src/requirements-abi3.txt
 WHEELS += src/requirements-crossenv.txt
 WHEELS += src/requirements-pure.txt
 
-include ../../mk/spksrc.common.mk
+include ../../mk/spksrc.python.mk
 
 # [borgbackup]
 # Use OpenSSL path as defined by either
@@ -146,5 +146,3 @@ endif
 ## unless WHEELS has been previously populated. This is due to
 ## the makefile analysis phase which discard ifeq instructions.
 ##
-
-include ../../mk/spksrc.python.mk


### PR DESCRIPTION

## Description

- python312-wheels and python313-wheels did not include gcc version dependent wheels
- TC_GCC version checks must be used after include of spksrc.python.mk (or spksrc.spk.mk) to work

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
