### PR TITLE
wheel.mk: Avoid processing when WHEELS variable is empty

### DIFF
--- a/mk/spksrc.wheel.mk
+++ b/mk/spksrc.wheel.mk
@@ -100,7 +100,13 @@ post_wheel_target: $(WHEEL_TARGET) install_python_wheel
 ifeq ($(wildcard $(WHEEL_COOKIE)),)
 wheel: $(WHEEL_COOKIE)
 
+# If WHEELS is empty then skip processing and
+# mark as completed using status cookie
+ifeq ($(strip $(WHEELS)),)
+$(WHEEL_COOKIE):
+else
 $(WHEEL_COOKIE): $(POST_WHEEL_TARGET)
+endif
 	$(create_target_dir)
 	@touch -f $@
 


### PR DESCRIPTION
## Description

wheel.mk: Avoid processing when WHEELS variable is empty

Fixes :
- https://github.com/SynoCommunity/spksrc/pull/6456#issuecomment-2663677717
- https://github.com/SynoCommunity/spksrc/pull/6437#issuecomment-2663022414

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
