### PR TITLE
Ensure valid custom toolchain name for qoriq-6.2.4 (powerpc-unknown-linux-gnuspe)

### DIFF
--- a/cross/ripgrep/Makefile
+++ b/cross/ripgrep/Makefile
@@ -6,6 +6,8 @@ PKG_DIST_SITE = https://github.com/BurntSushi/ripgrep/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
+# changed to trigger build
+
 DEPENDS = cross/pcre
 
 # powerpc archs (except qoriq) are not supported

--- a/cross/ripgrep/Makefile
+++ b/cross/ripgrep/Makefile
@@ -6,8 +6,6 @@ PKG_DIST_SITE = https://github.com/BurntSushi/ripgrep/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-# changed to trigger build
-
 DEPENDS = cross/pcre
 
 # powerpc archs (except qoriq) are not supported

--- a/mk/spksrc.cross-rust-env.mk
+++ b/mk/spksrc.cross-rust-env.mk
@@ -1,6 +1,8 @@
 # Configuration for rust compiler
 #
 
+RUSTUP_QORIQ_TOOLCHAIN = 1.82.0
+
 ifeq ($(RUSTUP_DEFAULT_TOOLCHAIN),)
 RUSTUP_DEFAULT_TOOLCHAIN = stable
 endif
@@ -14,7 +16,7 @@ endif
 
 # Versions available: https://releases.rs/docs/
 ifeq ($(RUST_BUILD_VERSION),)
-RUST_BUILD_VERSION = 1.82.0
+RUST_BUILD_VERSION = $(RUSTUP_QORIQ_TOOLCHAIN)
 endif
 
 # Enforce using newer cmake when building Tier-3 toolchains
@@ -54,7 +56,7 @@ RUST_TARGET = aarch64-unknown-linux-gnu
 endif
 ifeq ($(findstring $(RUST_ARCH), $(PPC_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = powerpc-unknown-linux-gnuspe
-TC_RUSTUP_TOOLCHAIN = $(RUST_BUILD_VERSION)-$(RUST_TARGET)
+TC_RUSTUP_TOOLCHAIN = stable-$(RUSTUP_QORIQ_TOOLCHAIN)-$(RUST_TARGET)
 endif
 ifeq ($(findstring $(RUST_ARCH), $(x64_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = x86_64-unknown-linux-gnu

--- a/toolchain/syno-qoriq-6.2.4-rust/Makefile
+++ b/toolchain/syno-qoriq-6.2.4-rust/Makefile
@@ -24,9 +24,9 @@ include ../../mk/spksrc.native-install.mk
 
 .PHONY: rust-qoriq-postinstall
 rust-qoriq-postinstall:
-	@$(MSG) "Rustup $(PKG_DIST_TARGET)"
+	@$(MSG) "Rustup stable-$(PKG_DIST_TARGET)"
 	@export PATH="$(CARGO_PATH):$${PATH}" ; \
 	export RUSTUP_HOME="$(RUSTUP_HOME)" ; \
 	which rustup ; \
-	rustup toolchain link $(PKG_DIST_TARGET) $(abspath $(INSTALL_DIR)/$(INSTALL_PREFIX)) ; \
+	rustup toolchain link stable-$(PKG_DIST_TARGET) $(abspath $(INSTALL_DIR)/$(INSTALL_PREFIX)) ; \
 	rustup show

--- a/toolchain/syno-qoriq-6.2.4-rust/Makefile
+++ b/toolchain/syno-qoriq-6.2.4-rust/Makefile
@@ -2,18 +2,18 @@ PKG_ARCH = qoriq
 PKG_NAME = rust-$(PKG_ARCH)
 PKG_VERS = 1.82.0
 PKG_EXT = txz
-PKG_DIST_TARGET = $(PKG_VERS)-powerpc-unknown-linux-gnuspe
+PKG_DIST_TARGET = stable-$(PKG_VERS)-powerpc-unknown-linux-gnuspe
 PKG_DIST_NAME = $(PKG_DIST_TARGET).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/SynoCommunity/spksrc/releases/download/rust/qoriq
 EXTRACT_PATH = $(INSTALL_DIR)/$(INSTALL_PREFIX)
 
-DEPENDS = 
+DEPENDS =
 
 HOMEPAGE = https://www.rust-lang.org/
 COMMENT = A language empowering everyone to build reliable and efficient software.
-LICENSE  = Apache-2.0, MIT licenses
+LICENSE = Apache-2.0, MIT licenses
 
-# extracted directly into install folder
+# Extracted directly into install folder
 INSTALL_TARGET = nop
 POST_INSTALL_TARGET = rust-qoriq-postinstall
 
@@ -24,9 +24,10 @@ include ../../mk/spksrc.native-install.mk
 
 .PHONY: rust-qoriq-postinstall
 rust-qoriq-postinstall:
-	@$(MSG) "Rustup stable-$(PKG_DIST_TARGET)"
+	@$(MSG) "Rustup $(PKG_DIST_TARGET)"
 	@export PATH="$(CARGO_PATH):$${PATH}" ; \
 	export RUSTUP_HOME="$(RUSTUP_HOME)" ; \
 	which rustup ; \
-	rustup toolchain link stable-$(PKG_DIST_TARGET) $(abspath $(INSTALL_DIR)/$(INSTALL_PREFIX)) ; \
+	rustup --version ; \
+	rustup toolchain link $(PKG_DIST_TARGET) $(abspath $(INSTALL_DIR)/$(INSTALL_PREFIX)) ; \
 	rustup show

--- a/toolchain/syno-qoriq-6.2.4-rust/digests
+++ b/toolchain/syno-qoriq-6.2.4-rust/digests
@@ -1,3 +1,3 @@
-1.82.0-powerpc-unknown-linux-gnuspe.txz SHA1 2bb6a24ca736640e0cb1c7f6fa147fe93029beab
-1.82.0-powerpc-unknown-linux-gnuspe.txz SHA256 52eff1c1e0615ea084a81afba1548d0e085170981f339f3cec77df3790bb5758
-1.82.0-powerpc-unknown-linux-gnuspe.txz MD5 9b60c0a6bbf803290c388840b767989c
+stable-1.82.0-powerpc-unknown-linux-gnuspe.txz SHA1 2f32d9100663bf26ddf3b193da5902a5b4a36642
+stable-1.82.0-powerpc-unknown-linux-gnuspe.txz SHA256 91ed5f963399a45150bfdca99cbbaa0dd03480d8350355678757885cbe5379a9
+stable-1.82.0-powerpc-unknown-linux-gnuspe.txz MD5 fb57d6ef3b16c9ca5f3aea0d4b2178b3

--- a/toolchain/syno-qoriq-6.2.4/Makefile
+++ b/toolchain/syno-qoriq-6.2.4/Makefile
@@ -13,8 +13,6 @@ TC_RUSTFLAGS = -C target-cpu=e500
 
 include ../../mk/spksrc.tc.mk
 
-OPTIONAL_DEPENDS = toolchain/syno-$(TC_ARCH)-$(TC_VERS)-rust
-
 ifneq ($(RUST_BUILD_TOOLCHAIN),1)
 DEPENDS = toolchain/syno-$(TC_ARCH)-$(TC_VERS)-rust
 else


### PR DESCRIPTION
## Description

This resolves recent build failures in #6454 and #6471 when building `qoriq-6.2.4` packages, which reported an "invalid custom toolchain name" after a recent Rust update. The fix applies a custom toolchain channel prefix aligned with the [documented standard](https://rust-lang.github.io/rustup/overrides.html#toolchain-file-settings) for toolchain files.

Follow-on from #5879.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
