### PR TITLE
make dsm7 uninstall less verbose

### DIFF
--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -186,16 +186,16 @@ postuninst ()
     if [ "$wizard_delete_data" = "true" ]; then
         echo "Removing files..." | install_log
         if [ "$(ls -A ${SYNOPKG_PKGHOME})" != "" ]; then
-            find ${SYNOPKG_PKGHOME} -mindepth 1 -delete -print | install_log
+            find ${SYNOPKG_PKGHOME} -mindepth 1 -delete | install_log
         fi
 
         if [ "$(ls -A ${SYNOPKG_PKGVAR})" != "" ]; then
-            find ${SYNOPKG_PKGVAR} -mindepth 1 -delete -print | install_log
+            find ${SYNOPKG_PKGVAR} -mindepth 1 -delete | install_log
         fi
 
         _etc_path=$(realpath /var/packages/${SYNOPKG_PKGNAME}/etc)
         if [ "$(ls -A ${_etc_path})" != "" ]; then
-            find ${_etc_path} -mindepth 1 -delete -print | install_log
+            find ${_etc_path} -mindepth 1 -delete | install_log
         fi
     fi
 


### PR DESCRIPTION
## Description

- do not print deleted files to installer log when removing all files on uninstall

### Motivation
The generic uninstall function on dsm7 supports the removal of all installed data.
When removing all files, every file is logged to the installer log of the packag.

This floods the installer log with (IMHO) unimportant information.
When a python package is uninstalled with this option, all files in the pip cache (in the var folder) are printed to the installer log For Home Assistant with a lot of wheels and package data there are > 60'000 lines printed and the log file gets immediatly rotated.


## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
