### PR TITLE
Beets: Revision for v2.2.0

### DIFF
--- a/spk/beets/Makefile
+++ b/spk/beets/Makefile
@@ -47,3 +47,8 @@ WHEELS_CFLAGS += [pycryptodomex] -std=c11
 else
 WHEELS_CFLAGS += [pycryptodomex] -std=c99
 endif
+
+# [pyppmd]
+ifeq ($(call version_lt, $(TC_GCC), 5.0),1)
+WHEELS_CFLAGS += [pyppmd] -std=gnu11
+endif

--- a/spk/beets/Makefile
+++ b/spk/beets/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = beets
 SPK_VERS = 2.2.0
-SPK_REV = 10
+SPK_REV = 11
 SPK_ICON = src/beets.png
 
 PYTHON_PACKAGE = python311
@@ -34,9 +34,16 @@ DEPENDS += cross/pillow
 DEPENDS += cross/libyaml
 
 # NOTE: Built with support for the following plugins:
-# aura, beatport, chroma, discogs, embedart, embyupdate, fetchart, kodiupdate, lastgenre, lastimport, lyrics, mpdstats, plexupdate, scrub, sonosupdate, thumbnails, web.
+# absubmit, aura, beatport, chroma, discogs, docs, embedart, embyupdate, fetchart, import, kodiupdate, lastgenre, lastimport, lyrics, mpdstats, plexupdate, reflink, scrub, sonosupdate, thumbnails, web.
 
 # NOTE: The following plugins are currently unsupported due to dependency issues:
 # autobpm, bpd, metasync, and replaygain.
 
 include ../../mk/spksrc.python.mk
+
+# [pycryptodomex]
+ifeq ($(call version_ge, $(TC_GCC), 4.9),1)
+WHEELS_CFLAGS += [pycryptodomex] -std=c11
+else
+WHEELS_CFLAGS += [pycryptodomex] -std=c99
+endif

--- a/spk/beets/src/requirements-crossenv.txt
+++ b/spk/beets/src/requirements-crossenv.txt
@@ -1,10 +1,17 @@
-# Generated using the requirements script on March 23, 2025
-# NOTE: The following plugins were excluded due to being broken or deprecated:
-# absubmit, docs, import, reflink
+# Generated using the requirements script on March 24, 2025
 
+Brotli==1.1.0
+cffi==1.17.1
 charset_normalizer==3.4.1
+inflate64==1.0.1
 jellyfish==1.1.3
 lxml==5.3.1
 MarkupSafe==3.0.2
 #pillow                         ==> cross/pillow
+psutil==7.0.0
+pybcj==1.0.3
+pycryptodomex==3.22.0
+pyppmd==1.1.1
 PyYAML==6.0.2
+pyzstd==0.16.2
+reflink==0.2.2

--- a/spk/beets/src/requirements-pure.txt
+++ b/spk/beets/src/requirements-pure.txt
@@ -1,16 +1,18 @@
-# Generated using the requirements script on March 23, 2025
-# NOTE: The following plugins were excluded due to being broken or deprecated:
-# absubmit, docs, import, reflink
+# Generated using the requirements script on March 24, 2025
 
+accessible_pygments==0.0.5
+alabaster==1.0.0
 anyio==4.9.0
 appdirs==1.4.4
 audioread==3.0.1
+babel==2.17.0
 beautifulsoup4==4.13.3
 beets==2.2.0
 blinker==1.9.0
 #certifi                        ==> python311
 click==8.1.8
 confuse==2.0.1
+docutils==0.21.2
 filetype==1.2.0
 flask==3.1.0
 flask_cors==5.0.1
@@ -19,29 +21,47 @@ httpcore==1.0.7
 httpx==0.28.1
 idna==3.10
 ifaddr==0.2.0
+imagesize==1.4.1
 itsdangerous==2.2.0
 jinja2==3.1.6
 langdetect==1.0.9
 mediafile==0.13.0
+multivolumefile==0.2.3
 munkres==1.1.4
 musicbrainzngs==0.7.1
 mutagen==1.47.0
 oauthlib==3.2.2
+packaging==24.2
 #pip                            ==> python311
 #platformdirs                   ==> python311
+py7zr==0.22.0
 pyacoustid==1.3.0
+pycparser==2.22
+pydata_sphinx_theme==0.16.1
+pygments==2.19.1
 pylast==5.5.0
 python3_discogs_client==2.8
 python_dateutil==2.9.0.post0
 python_mpd2==3.1.1
 pyxdg==0.28
+rarfile==4.2
 requests==2.32.3
 requests_oauthlib==2.0.0
+roman_numerals_py==3.1.0
 #setuptools                     ==> python311
 #six                            ==> python311
 sniffio==1.3.1
+snowballstemmer==2.2.0
 soco==0.30.9
 soupsieve==2.6
+sphinx==8.2.3
+sphinxcontrib_applehelp==2.0.0
+sphinxcontrib_devhelp==2.0.0
+sphinxcontrib_htmlhelp==2.1.0
+sphinxcontrib_jsmath==1.0.1
+sphinxcontrib_qthelp==2.0.0
+sphinxcontrib_serializinghtml==2.0.0
+texttable==1.7.0
 typing_extensions==4.12.2
 Unidecode==1.3.8
 urllib3==2.3.0


### PR DESCRIPTION
## Description

This PR builds on #6488 and re-enables previously excluded plugins—`absubmit`, `docs`, `import`, and `reflink`—which were disabled due to being broken or deprecated. They have since been reported as functional in current builds.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Package revision
