### PR TITLE
kiwix: Support library auto reload

### DIFF
--- a/cross/kiwix-tools/Makefile
+++ b/cross/kiwix-tools/Makefile
@@ -17,4 +17,6 @@ LICENSE  = GPLv3
 
 GNU_CONFIGURE = 1
 
+CMAKE_USE_NINJA = 0
+
 include ../../mk/spksrc.cross-meson.mk

--- a/cross/libmicrohttpd/Makefile
+++ b/cross/libmicrohttpd/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libmicrohttpd
-PKG_VERS = 0.9.75
+PKG_VERS = 1.0.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://ftp.gnu.org/gnu/libmicrohttpd

--- a/cross/libmicrohttpd/PLIST
+++ b/cross/libmicrohttpd/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libmicrohttpd.so
 lnk:lib/libmicrohttpd.so.12
-lib:lib/libmicrohttpd.so.12.60.0
+lib:lib/libmicrohttpd.so.12.62.1

--- a/cross/libmicrohttpd/digests
+++ b/cross/libmicrohttpd/digests
@@ -1,3 +1,3 @@
-libmicrohttpd-0.9.75.tar.gz SHA1 9d5d42553b44b7c087f0746291ae98da27e13104
-libmicrohttpd-0.9.75.tar.gz SHA256 9278907a6f571b391aab9644fd646a5108ed97311ec66f6359cebbedb0a4e3bb
-libmicrohttpd-0.9.75.tar.gz MD5 aff64581937b53f3a23b05216ad2cd02
+libmicrohttpd-1.0.1.tar.gz SHA1 08e34fa5ec5b552e09ad98b08d8d7da2ba9496ca
+libmicrohttpd-1.0.1.tar.gz SHA256 a89e09fc9b4de34dde19f4fcb4faaa1ce10299b9908db1132bbfa1de47882b94
+libmicrohttpd-1.0.1.tar.gz MD5 b41c83799a478ea9c774e50ed22446bc

--- a/cross/libxapian/Makefile
+++ b/cross/libxapian/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = xapian-core
-PKG_VERS = 1.4.25
+PKG_VERS = 1.4.27
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://oligarchy.co.uk/xapian/$(PKG_VERS)

--- a/cross/libxapian/PLIST
+++ b/cross/libxapian/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libxapian.so
 lnk:lib/libxapian.so.30
-lib:lib/libxapian.so.30.12.6
+lib:lib/libxapian.so.30.13.1

--- a/cross/libxapian/digests
+++ b/cross/libxapian/digests
@@ -1,3 +1,3 @@
-xapian-core-1.4.25.tar.xz SHA1 e2b4b4cf6076873ec9402cab7b9a3b71dcf95e20
-xapian-core-1.4.25.tar.xz SHA256 0c99dfdd817571cb5689bc412a7e021407938313f38ea3a70fa3bf86410608ee
-xapian-core-1.4.25.tar.xz MD5 b570c2e47f157bee29584994657aafbb
+xapian-core-1.4.27.tar.xz SHA1 733763ae2e7d3da737a7e513e5c56686aa5dbb75
+xapian-core-1.4.27.tar.xz SHA256 bcbc99cfbf16080119c2571fc296794f539bd542ca3926f17c2999600830ab61
+xapian-core-1.4.27.tar.xz MD5 1b72c939a283c1e61ff6743e7d859041

--- a/cross/libzim/Makefile
+++ b/cross/libzim/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libzim
-PKG_VERS = 9.1.0
+PKG_VERS = 9.2.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/openzim/libzim/archive

--- a/cross/libzim/PLIST
+++ b/cross/libzim/PLIST
@@ -1,3 +1,3 @@
 lnk:lib/libzim.so
 lnk:lib/libzim.so.9
-lib:lib/libzim.so.9.1.0
+lib:lib/libzim.so.9.2.3

--- a/cross/libzim/digests
+++ b/cross/libzim/digests
@@ -1,3 +1,3 @@
-libzim-9.1.0.tar.gz SHA1 4d647f38053c219c6718de1649fda765daef6a4a
-libzim-9.1.0.tar.gz SHA256 faf19a35882415212d46a51aab45692ccfa1e2e36beb7261eec1ec53e29b9e6a
-libzim-9.1.0.tar.gz MD5 f5177e8caed56860444cee7c5c8e3dc6
+libzim-9.2.3.tar.gz SHA1 a23c31035c9938232270539f7a2b511a34b6a74c
+libzim-9.2.3.tar.gz SHA256 7c6e7fcaf5bc82447edb12c6c573779af6d77b3b79227da57586e81c4e13f1bf
+libzim-9.2.3.tar.gz MD5 3bef853bea1d0e71c1877f11c7bea4a9

--- a/spk/kiwix/Makefile
+++ b/spk/kiwix/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = kiwix
 SPK_VERS = 3.7.0
-SPK_REV  = 6
+SPK_REV  = 7
 SPK_ICON = src/kiwix.png
 
 DEPENDS = cross/kiwix-tools
@@ -15,7 +15,7 @@ LICENSE  = GPLv3
 
 MAINTAINER = hgy59
 DISPLAY_NAME = Kiwix
-CHANGELOG = "Update kiwix to v3.7.0."
+CHANGELOG = "1. Update kiwix to v3.7.0. <br/>2. Support library auto reload."
 
 SERVICE_USER = auto
 STARTABLE = yes

--- a/spk/kiwix/src/service-setup.sh
+++ b/spk/kiwix/src/service-setup.sh
@@ -11,7 +11,7 @@ if [ -r "${CONFIG_FILE}" ]; then
 fi
 
 LIBRARY_FILE="${SHARED_ZIM_FOLDER}/library.xml"
-SERVICE_COMMAND="${KIWIX_SERVE} --port=${SERVICE_PORT} --library ${LIBRARY_FILE}"
+SERVICE_COMMAND="${KIWIX_SERVE} --port=${SERVICE_PORT} --library ${LIBRARY_FILE} --monitorLibrary"
 
 service_prestart ()
 {


### PR DESCRIPTION
## Description

- add parameter --monitorLibrary to auto reload libraries (#6242)
- update libzim from v9.1.0 to v9.2.3
- update libxapian from v1.4.25 to v1.4.27
- update libmicrohttpd from v0.9.75 to v1.0.1

Fixes #6242

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
