### PR TITLE
Update GitHub Download URLs in Cross Package Makefiles

### DIFF
--- a/cross/chromaprint/Makefile
+++ b/cross/chromaprint/Makefile
@@ -3,7 +3,6 @@ PKG_VERS = 1.5.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/acoustid/chromaprint/releases/download/v$(PKG_VERS)
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 #PKG_GIT_HASH = aa67c95b9e486884a6d3ee8b0c91207d8c2b0551

--- a/cross/chromaprint/Makefile
+++ b/cross/chromaprint/Makefile
@@ -1,8 +1,9 @@
 PKG_NAME = chromaprint
 PKG_VERS = 1.5.1
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/acoustid/chromaprint/releases/download/v$(PKG_VERS)
+PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/acoustid/chromaprint/archive/refs/tags
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 #PKG_GIT_HASH = aa67c95b9e486884a6d3ee8b0c91207d8c2b0551

--- a/cross/chromaprint/Makefile
+++ b/cross/chromaprint/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = chromaprint
 PKG_VERS = 1.5.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/acoustid/chromaprint/archive
+PKG_DIST_SITE = https://github.com/acoustid/chromaprint/releases/download/v$(PKG_VERS)
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 


### PR DESCRIPTION
## Description

This PR updates the GitHub download URLs in affected cross package Makefiles to conform to the new recommended formats. Legacy URLs that relied on the `/archive` endpoint have been revised so that the full download URL is constructed from an updated base URL (either using the releases/download or tag archive format).

An external script (provided separately) was used to perform the automated update. Only packages with GitHub-based PKG_DIST_SITE entries were processed; packages with non‑GitHub URLs were left unchanged. In this update, one package required modifications while all others already use working URLs.

All changes were verified via checksum comparison as part of the automated update process.

Fixes #6521

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
