### PR TITLE
Python: Rename numpy package and correct spelling errors for 312/313-wheels

### DIFF
--- a/python/numpy/Makefile
+++ b/python/numpy/Makefile
@@ -1,10 +1,9 @@
-PKG_NAME = numpy_v2
-PKG_SHORT_NAME = $(firstword $(subst _, ,$(PKG_NAME)))
+PKG_NAME = numpy
 PKG_VERS = 2.2.4
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_SHORT_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://files.pythonhosted.org/packages/source/n/numpy
-PKG_DIR = $(PKG_SHORT_NAME)-$(PKG_VERS)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS  = cross/openblas
 CONFIGURE_ARGS += -Dblas=OpenBLAS

--- a/spk/python312-wheels/Makefile
+++ b/spk/python312-wheels/Makefile
@@ -21,7 +21,7 @@ CHANGELOG = "1. Initial package"
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF
 
-# Enable debug_info symgols
+# Enable debug_info symbols
 #GCC_DEBUG_INFO := 1
 
 # IMPORTANT: WHEELS must be initialized before include of spksrc.python.mk
@@ -137,7 +137,7 @@ endif
 
 # [numpy]
 # gcc-8.4 is the minimal version to build numpy
-# gcc-8.5 hapens to be the default version for DSM-7.1
+# gcc-8.5 happens to be the default version for DSM-7.1
 ifeq ($(call version_gt, $(TC_GCC), 8.4),1)
 DEPENDS += python/numpy_1.26
 DEPENDS += python/numpy_ha

--- a/spk/python313-wheels/Makefile
+++ b/spk/python313-wheels/Makefile
@@ -21,7 +21,7 @@ CHANGELOG = "1. Initial package"
 HOMEPAGE = https://www.python.org
 LICENSE  = PSF
 
-# Enable debug_info symgols
+# Enable debug_info symbols
 #GCC_DEBUG_INFO := 1
 
 # IMPORTANT: WHEELS must be initialized before include of spksrc.python.mk
@@ -134,7 +134,7 @@ endif
 
 # [numpy]
 # gcc-8.4 is the minimal version to build numpy
-# gcc-8.5 hapens to be the default version for DSM-7.1
+# gcc-8.5 happens to be the default version for DSM-7.1
 ifeq ($(call version_gt, $(TC_GCC), 8.4),1)
 DEPENDS += python/numpy_1.26
 DEPENDS += python/numpy_ha


### PR DESCRIPTION
## Description

This PR introduces the following changes:

1. Renames the package `numpy_v2` to `numpy` to enable direct inclusion in Python builds.  
2. Fixes minor spelling errors in `python31[2,3]-wheels` to ensure build validation.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Includes small framework changes
