### PR TITLE
add more x25 models

### DIFF
--- a/mk/spksrc.archs.mk
+++ b/mk/spksrc.archs.mk
@@ -42,7 +42,7 @@ ARM_ARCHS = $(ARMv5_ARCHS) $(ARMv7_ARCHS) $(ARMv7L_ARCHS) $(ARMv8_ARCHS)
 PPC_ARCHS = powerpc ppc824x ppc853x ppc854x qoriq
 
 i686_ARCHS = evansport
-x64_ARCHS = $(GENERIC_x64_ARCH) apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton dockerx64 epyc7002 geminilake grantley purley kvmx64 v1000 v1000nk r1000 x86 x86_64
+x64_ARCHS = $(GENERIC_x64_ARCH) apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton dockerx64 epyc7002 geminilake geminilakenk grantley purley kvmx64 v1000 v1000nk r1000 r1000nk x86 x86_64
 
 32bit_ARCHS = $(ARMv5_ARCHS) $(ARMv7_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) $(PPC_ARCHS)
 64bit_ARCHS = $(ARMv8_ARCHS) $(x64_ARCHS)

--- a/toolchain/syno-x64-7.1/Makefile
+++ b/toolchain/syno-x64-7.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 geminilake grantley kvmx64 purley r1000 v1000 v1000nk
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 geminilake geminilakenk grantley kvmx64 purley r1000 r1000nk v1000 v1000nk
 TC_VERS = 7.1
 TC_KERNEL = 4.4.180
 TC_GLIBC = 2.26

--- a/toolchain/syno-x64-7.2/Makefile
+++ b/toolchain/syno-x64-7.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow denverton epyc7002 geminilake grantley kvmx64 purley r1000 v1000 v1000nk
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow denverton epyc7002 geminilake geminilakenk grantley kvmx64 purley r1000 r1000nk v1000 v1000nk
 TC_VERS = 7.2
 TC_KERNEL = 4.4.302
 TC_GLIBC = 2.36


### PR DESCRIPTION
## Description

follow up to #6574 
- add arch r1000nk for DS725+
- add arch geminilakenk for DS425+ (and maybe for DS225+, DS625slim)
- still no toolchains and kernel sources available for x25 models

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
