### PR TITLE
x265: Fix for PPC/qoriq symbol `pthread_mutex_init' out of range

### DIFF
--- a/cross/x265/Makefile
+++ b/cross/x265/Makefile
@@ -40,6 +40,13 @@ ifeq ($(findstring $(ARCH),$(ARM_ARCHS) $(PPC_ARCHS)),$(ARCH))
 CMAKE_ARGS += -DENABLE_ASSEMBLY=OFF
 endif
 
+# Fixes:
+#    https://github.com/SynoCommunity/spksrc/issues/5314
+#    https://github.com/SynoCommunity/spksrc/issues/6597
+ifeq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
+CMAKE_ARGS += -DENABLE_PIC=ON
+endif
+
 ifeq ($(findstring $(ARCH),$(i686_ARCHS) $(x64_ARCHS)),$(ARCH))
 CMAKE_ARGS += -DCMAKE_ASM_NASM_FLAGS=-w-macro-params-legacy
 endif


### PR DESCRIPTION
## Description

x265: Fix for PPC/qoriq symbol `pthread_mutex_init' out of range

Fixes #6597

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
