### PR TITLE
cross/dbus: set Expat paths for pre-compiled Python

### DIFF
--- a/cross/dbus/Makefile
+++ b/cross/dbus/Makefile
@@ -14,4 +14,9 @@ LICENSE = Academic Free License v2.1 or GPLv2
 CMAKE_ARGS += -DDBUS_BUILD_TESTS=OFF
 CMAKE_ARGS += -DDBUS_ENABLE_XML_DOCS=OFF
 
+ifneq ($(strip $(PYTHON_PACKAGE)),)
+CMAKE_ARGS += -DEXPAT_INCLUDE_DIR=$(PYTHON_STAGING_INSTALL_PREFIX)/include
+CMAKE_ARGS += -DEXPAT_LIBRARY=$(PYTHON_STAGING_INSTALL_PREFIX)/lib/libexpat.so
+endif
+
 include ../../mk/spksrc.cross-cmake.mk


### PR DESCRIPTION
## Description

Adds conditional CMake arguments that point to Expat’s headers and library whenever a pre-compiled Python is used (PYTHON_PACKAGE set). This ensures consistent Expat detection in that build configuration. The change is a prerequisite for PR #6447.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
