### PR TITLE
cross/libsodium: use github to download source

### DIFF
--- a/cross/libsodium/Makefile
+++ b/cross/libsodium/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = libsodium
 PKG_VERS = 1.0.20
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://download.libsodium.org/libsodium/releases
+PKG_DIST_SITE = https://github.com/jedisct1/libsodium/releases/download/$(PKG_VERS)-RELEASE
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =


### PR DESCRIPTION
## Description

- libsodium.org is down atm.
Related to #6603

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Library source site update

