### PR TITLE
cloudflared: update to 2025.6.1

### DIFF
--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2025.4.0
+PKG_VERS = 2025.6.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive
@@ -18,13 +18,7 @@ COMPILE_TARGET = cloudflared_compile
 
 include ../../mk/spksrc.cross-go.mk
 
-GOROOT_BOOTSTRAP=$(WORK_DIR)/../../../native/go/work-native/go/
-
 .PHONY: cloudflared_compile
 cloudflared_compile:
-ifeq (,$(wildcard /tmp/go))
-	@$(MSG) "- Install cloudflare go toolchain"
-	@$(RUN) GOARCH= GOOS= GOROOT_BOOTSTRAP=$(GOROOT_BOOTSTRAP) .teamcity/install-cloudflare-go.sh
-endif
 	@$(MSG) "- Build cloudflared"
-	@$(RUN) $(MAKE) PATH="/tmp/go/bin:${PATH}" VERSION=$(PKG_VERS) LINK_FLAGS="-s -w" cloudflared
+	@$(RUN) $(MAKE) VERSION=$(PKG_VERS) LINK_FLAGS="-s -w" cloudflared

--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2025.6.0
+PKG_VERS = 2025.6.1
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2025.4.0.tar.gz SHA1 28219500e7b5d096db63121eebde49d8212b7198
-cloudflared-2025.4.0.tar.gz SHA256 731694e178c7671ee9210cc7aca87aa35a5f0114e834c4e83f49dbb97b2b2b0f
-cloudflared-2025.4.0.tar.gz MD5 fb05d564c68eb20600713f1a00bc5a8a
+cloudflared-2025.6.0.tar.gz SHA1 02de934d5f8ac0fd66dc37ecfedc13930fba05e1
+cloudflared-2025.6.0.tar.gz SHA256 5d1dc902930bca96b4d97d7204f6472c53ae04f523f55f2803e8115c99310912
+cloudflared-2025.6.0.tar.gz MD5 46d22a051bd36b5eca6b3defc0fdcbb1

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2025.6.0.tar.gz SHA1 02de934d5f8ac0fd66dc37ecfedc13930fba05e1
-cloudflared-2025.6.0.tar.gz SHA256 5d1dc902930bca96b4d97d7204f6472c53ae04f523f55f2803e8115c99310912
-cloudflared-2025.6.0.tar.gz MD5 46d22a051bd36b5eca6b3defc0fdcbb1
+cloudflared-2025.6.1.tar.gz SHA1 0b66457c3001f936430690cf0cd45a5e3d9b0c43
+cloudflared-2025.6.1.tar.gz SHA256 73b402abb8519b70a889eeb1c47c7c5fa58e0092e9859e4001ebb15e95b8043b
+cloudflared-2025.6.1.tar.gz MD5 b8b6c493aa71c6bbdf4d2d3c155fe4e1

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2025.6.0
+SPK_VERS = 2025.6.1
 SPK_REV = 19
 SPK_ICON = src/cloudflared.png
 
@@ -11,7 +11,7 @@ DISPLAY_NAME = Cloudflare Tunnel
 DESCRIPTION = "Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address. With Tunnel, you do not send traffic to an external IP - instead, a lightweight daemon in your infrastructure \('cloudflared'\) creates outbound-only connections to Cloudflare\'s global network. Cloudflare Tunnel can connect HTTP web servers, SSH servers, remote desktops, and other protocols safely to Cloudflare. This way, your origins can serve traffic through Cloudflare without being vulnerable to attacks that bypass Cloudflare."
 HOMEPAGE = https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
 LICENSE = Apache-2.0
-CHANGELOG = "Update to v2025.6.0"
+CHANGELOG = "Update to v2025.6.1"
 
 WIZARDS_DIR = src/wizard/
 

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2025.4.0
-SPK_REV = 18
+SPK_VERS = 2025.6.0
+SPK_REV = 19
 SPK_ICON = src/cloudflared.png
 
 DEPENDS = cross/cloudflared
@@ -11,7 +11,7 @@ DISPLAY_NAME = Cloudflare Tunnel
 DESCRIPTION = "Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address. With Tunnel, you do not send traffic to an external IP - instead, a lightweight daemon in your infrastructure \('cloudflared'\) creates outbound-only connections to Cloudflare\'s global network. Cloudflare Tunnel can connect HTTP web servers, SSH servers, remote desktops, and other protocols safely to Cloudflare. This way, your origins can serve traffic through Cloudflare without being vulnerable to attacks that bypass Cloudflare."
 HOMEPAGE = https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
 LICENSE = Apache-2.0
-CHANGELOG = "Update to v2025.4.0"
+CHANGELOG = "Update to v2025.6.0"
 
 WIZARDS_DIR = src/wizard/
 


### PR DESCRIPTION
## Description

1. Update to 2025.6.1
2. Switch back to regular go since https://github.com/cloudflare/cloudflared/commit/96ce66bd302872c41605f167775f7abe0681cb95 removed the requirement for cloudflare-go in favor of go >= 1.24

### Upstream changelog
2025.6.1
- 2025-06-16 TUN-9467: add vulncheck to cloudflared
- 2025-06-16 TUN-9495: Remove references to cloudflare-go
- 2025-06-16 TUN-9371: Add logging format as JSON
- 2025-06-12 TUN-9467: bump coredns to solve CVE
- 
2025.6.0
- 2025-06-06 TUN-9016: update go to 1.24
- 2025-06-05 TUN-9171: Use `is_default_network` instead of `is_default` to create vnet's

2025.5.0
- 2025-05-14 TUN-9319: Add dynamic loading of features to connections via ConnectionOptionsSnapshot
- 2025-05-13 TUN-9322: Add metric for unsupported RPC commands for datagram v3
- 2025-05-07 TUN-9291: Remove dynamic reloading of features for datagram v3

2025.4.2
- 2025-04-30 chore: Do not use gitlab merge request pipelines
- 2025-04-30 DEVTOOLS-16383: Create GitlabCI pipeline to release Mac builds
- 2025-04-24 TUN-9255: Improve flush on write conditions in http2 tunnel type to match what is done on the edge
- 2025-04-10 SDLC-3727 - Adding FIPS status to backstage

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [X] Package update
