### PR TITLE
fix memcached for OLD_PPC_ARCHS

### DIFF
--- a/cross/memcached/patches/ppc853x/000-remove-use-of_pthread_setname_np.patch
+++ b/cross/memcached/patches/ppc853x/000-remove-use-of_pthread_setname_np.patch
@@ -1,24 +1,24 @@
 # libthread of old ppc archs do not implement pthread_setname_np
 # 
---- thread.c.orig	2023-05-12 23:07:43.000000000 +0000
-+++ thread.c	2023-05-20 17:23:40.278542314 +0000
-@@ -635,9 +635,6 @@
+--- thread.c.orig	2025-02-04 21:32:28.000000000 +0000
++++ thread.c	2025-06-25 16:30:19.094177420 +0000
+@@ -678,9 +678,6 @@
  #define THR_NAME_MAXLEN 16
  void thread_setname(pthread_t thread, const char *name) {
  assert(strlen(name) < THR_NAME_MAXLEN);
--#if defined(__linux__)
+-#if defined(__linux__) && defined(HAVE_PTHREAD_SETNAME_NP)
 -pthread_setname_np(thread, name);
 -#endif
  }
  #undef THR_NAME_MAXLEN
  
---- extstore.c.orig	2023-01-11 06:10:10.000000000 +0000
-+++ extstore.c	2023-05-20 17:27:31.413889750 +0000
-@@ -119,9 +119,6 @@
+--- extstore.c.orig	2025-03-19 21:47:32.000000000 +0000
++++ extstore.c	2025-06-25 16:30:02.018402486 +0000
+@@ -118,9 +118,6 @@
  #define THR_NAME_MAXLEN 16
  static void thread_setname(pthread_t thread, const char *name) {
  assert(strlen(name) < THR_NAME_MAXLEN);
--#if defined(__linux__)
+-#if defined(__linux__) && defined(HAVE_PTHREAD_SETNAME_NP)
 -pthread_setname_np(thread, name);
 -#endif
  }

--- a/cross/memcached/patches/ppc853x/001-ajdust-typedefs-for-older-gcc.patch
+++ b/cross/memcached/patches/ppc853x/001-ajdust-typedefs-for-older-gcc.patch
@@ -1,0 +1,14 @@
+# Adjust typedef of io_queue_t to fix build with gcc 4.3.7 (gcc < 4.5)
+# 
+--- memcached.h.orig	2025-03-18 22:16:07.000000000 +0000
++++ memcached.h	2025-06-25 16:50:45.821775153 +0000
+@@ -691,8 +691,7 @@
+ 
+ typedef STAILQ_HEAD(iop_head_s, _io_pending_t) iop_head_t;
+ typedef struct _io_pending_t io_pending_t;
+-typedef struct io_queue_s io_queue_t;
+-typedef void (*io_queue_stack_cb)(io_queue_t *q);
++typedef void (*io_queue_stack_cb)(struct io_queue_s *q);
+ typedef void (*io_queue_cb)(io_pending_t *pending);
+ // IO pending objects are created and stacked into this structure. They are
+ // then sent off to remote threads.


### PR DESCRIPTION
## Description

- adjust existing patch
- add patch to fix typedef for older gcc

Fixes #6492

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
