### PR TITLE
Fix WORK_DIR for toolchain configuration file location

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -3,7 +3,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # Configure the included makefiles
 URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
@@ -23,6 +22,9 @@ ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
+
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 #####
 

--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -9,10 +9,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
-
-# cmake specific configurations
-include ../../mk/spksrc.cross-cmake-env.mk
 
 # Configure the included makefiles
 URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
@@ -33,7 +29,13 @@ TC = syno$(ARCH_SUFFIX)
 endif
 endif
 
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
+
 ###
+
+# cmake specific configurations
+include ../../mk/spksrc.cross-cmake-env.mk
 
 # configure using cmake
 ifeq ($(strip $(CONFIGURE_TARGET)),)

--- a/mk/spksrc.cross-dotnet.mk
+++ b/mk/spksrc.cross-dotnet.mk
@@ -15,7 +15,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # Configure the included makefiles
 URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
@@ -35,6 +34,9 @@ ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
+
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 ##### dotnet specific configurations
 include ../../mk/spksrc.cross-dotnet-env.mk

--- a/mk/spksrc.cross-go.mk
+++ b/mk/spksrc.cross-go.mk
@@ -12,7 +12,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # Configure the included makefiles
 URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
@@ -32,6 +31,9 @@ ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
+
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 ##### golang specific configurations
 include ../../mk/spksrc.cross-go-env.mk

--- a/mk/spksrc.cross-rust.mk
+++ b/mk/spksrc.cross-rust.mk
@@ -11,7 +11,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # Configure the included makefiles
 URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
@@ -31,6 +30,9 @@ ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
+
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 ##### rust specific configurations
 include ../../mk/spksrc.cross-rust-env.mk

--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -22,7 +22,7 @@ DISTRIB_DIR = $(BASE_DISTRIB_DIR)
 endif
 
 ifndef WORK_DIR
-WORK_DIR = $(CURDIR)/work$(ARCH_SUFFIX)
+WORK_DIR := $(CURDIR)/work$(ARCH_SUFFIX)
 endif
 
 ifndef INSTALL_DIR

--- a/mk/spksrc.install-resources.mk
+++ b/mk/spksrc.install-resources.mk
@@ -7,7 +7,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # Configure the included makefiles
 URLS          = $(PKG_DIST_SITE)/$(PKG_DIST_NAME)
@@ -28,6 +27,8 @@ TC = syno$(ARCH_SUFFIX)
 endif
 endif
 
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 #####
 

--- a/mk/spksrc.main-depends.mk
+++ b/mk/spksrc.main-depends.mk
@@ -3,7 +3,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # nothing to download
 download:
@@ -20,6 +19,9 @@ ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
+
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 #####
 

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -28,7 +28,6 @@
 
 # Common makefiles
 include ../../mk/spksrc.common.mk
-include ../../mk/spksrc.directories.mk
 
 # Configure the included makefiles
 NAME = $(SPK_NAME)
@@ -53,6 +52,9 @@ ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
+
+# Common directories (must be set after ARCH_SUFFIX)
+include ../../mk/spksrc.directories.mk
 
 ifeq ($(ARCH),noarch)
 ifneq ($(strip $(TCVERSION)),)


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Since a while when invoking a build it hapens that all dependencies ends-up also with a `work-<arch>-<version>/tc_vars.cmake|meson*|mk`. Expected behavior is for the location to be unique under the current directory from where the build was invoked.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
