### PR TITLE
ntfs-3g_ntfsprogs: Fix download url using alternate download src

### DIFF
--- a/cross/ntfs-3g_ntfsprogs/Makefile
+++ b/cross/ntfs-3g_ntfsprogs/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = ntfs-3g_ntfsprogs
 PKG_VERS = 2022.10.3
 PKG_EXT = tgz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://tuxera.com/opensource
+PKG_DIST_SITE = https://download.tuxera.com/opensource
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =


### PR DESCRIPTION
## Description

ntfs-3g_ntfsprogs: Fix download url using alternate download src

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
