### PR TITLE
cross/libgcrypt: fix build with old gcc

### DIFF
--- a/cross/libgcrypt/patches/002-avoid-duplicate-declartions.patch
+++ b/cross/libgcrypt/patches/002-avoid-duplicate-declartions.patch
@@ -1,0 +1,18 @@
+# Remove typedefs for mpi_ptr_t and mpi_size_t
+# 
+# The definitions were moved to mpi.h in libgcrypt v1.11.1, but not removed in mpi-internal.h
+# - newer gcc do not complain about "duplicate typedefs with the same type"
+# - old gcc (< 4.4) fail to build without this patch
+# 
+--- mpi/mpi-internal.h.orig	2025-03-17 09:55:24.000000000 +0000
++++ mpi/mpi-internal.h	2025-07-26 19:20:46.298413009 +0000
+@@ -69,9 +69,6 @@
+ #endif
+ 
+ 
+-typedef mpi_limb_t *mpi_ptr_t; /* pointer to a limb */
+-typedef int mpi_size_t;        /* (must be a signed type) */
+-
+ #define ABS(x) (x >= 0 ? x : -x)
+ #define MIN(l,o) ((l) < (o) ? (l) : (o))
+ #define MAX(h,i) ((h) > (i) ? (h) : (i))


### PR DESCRIPTION
## Description

- add patch to fix build of libgcrypt with old gcc
- follow up to #6644 to fix build for ppc853x-5.2

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully (gnupg package)
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
