### PR TITLE
Fix git for DSM 7

### DIFF
--- a/cross/git/Makefile
+++ b/cross/git/Makefile
@@ -24,18 +24,16 @@ CONFIGURE_ARGS += ac_cv_snprintf_returns_bogus=no
 ADDITIONAL_CPPFLAGS  = -std=gnu99
 ADDITIONAL_CPPFLAGS += -O
 
-# Version 2.50.0 uses CSPRNG_METHOD="getrandom" for all Linux targers,
+# Version 2.50.0 uses CSPRNG_METHOD="getrandom" for all Linux targets,
 # ignoring whether getrandom method (and sys/random.h) is available.
 # We could either patch "config.mak.uname" or overwrite CSPRNG_METHOD
-# Since getrandom is supported with DSM 7 toolchains (except for comcerto2k),
-# we use getrandom for those and set CSPRNG_METHOD="" for other toolchains
-# to use "/dev/urandom" that was the default for git < 2.50.0
+# getrandom is supported with DSM 7 toolchains (except for comcerto2k),
+# but at runtime we get 
+# "error: unable to get random bytes for temporary file: Function not implemented"
+# on DSM 7, so define CSPRNG_METHOD="" to use "/dev/urandom" as in git < 2.50.0
 include ../../mk/spksrc.common.mk
-ADDITIONAL_MAKE_OPTIONS =
-ifeq ($(call version_lt, $(TC_GCC), 5.0),1)
-# avoid CSPRNG_METHOD="getrandom" when sys/random.h is lacking in the toolchain
+# avoid CSPRNG_METHOD="getrandom"
 ADDITIONAL_MAKE_OPTIONS = CSPRNG_METHOD=""
-endif
 
 PRE_CONFIGURE_TARGET = git_pre_configure
 POST_INSTALL_TARGET = git_post_install

--- a/cross/git/Makefile
+++ b/cross/git/Makefile
@@ -24,22 +24,10 @@ CONFIGURE_ARGS += ac_cv_snprintf_returns_bogus=no
 ADDITIONAL_CPPFLAGS  = -std=gnu99
 ADDITIONAL_CPPFLAGS += -O
 
-# Version 2.50.0 uses CSPRNG_METHOD="getrandom" for all Linux targets,
-# ignoring whether getrandom method (and sys/random.h) is available.
-# We could either patch "config.mak.uname" or overwrite CSPRNG_METHOD
-# getrandom is supported with DSM 7 toolchains (except for comcerto2k),
-# but at runtime we get 
-# "error: unable to get random bytes for temporary file: Function not implemented"
-# on DSM 7, so define CSPRNG_METHOD="" to use "/dev/urandom" as in git < 2.50.0
-include ../../mk/spksrc.common.mk
-# avoid CSPRNG_METHOD="getrandom"
-ADDITIONAL_MAKE_OPTIONS = CSPRNG_METHOD=""
-
 PRE_CONFIGURE_TARGET = git_pre_configure
 POST_INSTALL_TARGET = git_post_install
 
-COMPILE_MAKE_OPTIONS = $(ADDITIONAL_MAKE_OPTIONS)
-INSTALL_MAKE_OPTIONS = install DESTDIR=$(INSTALL_DIR) prefix=$(INSTALL_PREFIX) $(ADDITIONAL_MAKE_OPTIONS)
+INSTALL_MAKE_OPTIONS = install DESTDIR=$(INSTALL_DIR) prefix=$(INSTALL_PREFIX)
 
 # compiling needs access to curl-config from cross/curl
 ENV += PATH=$$PATH:$(STAGING_INSTALL_PREFIX)/bin

--- a/cross/git/patches/001-avoid-use-of-getrandom.patch
+++ b/cross/git/patches/001-avoid-use-of-getrandom.patch
@@ -1,0 +1,20 @@
+# git version 2.50.0 uses CSPRNG_METHOD="getrandom" for all Linux targets,
+# ignoring whether getrandom method (and sys/random.h) is available.
+#
+# getrandom is supported with DSM 7 toolchains (except for comcerto2k),
+# but at runtime we get:
+# "error: unable to get random bytes for temporary file: Function not implemented" too.
+#
+# So define CSPRNG_METHOD="" to use "/dev/urandom" as in git < 2.50.0
+# 
+--- config.mak.uname.orig	2025-06-16 05:11:33.000000000 +0000
++++ config.mak.uname	2025-07-30 21:17:45.169947443 +0000
+@@ -50,7 +50,7 @@
+ 	HAVE_ALLOCA_H = YesPlease
+ 	# override in config.mak if you have glibc >= 2.38
+ 	NO_STRLCPY = YesPlease
+-	CSPRNG_METHOD = getrandom
++	CSPRNG_METHOD = 
+ 	HAVE_PATHS_H = YesPlease
+ 	LIBC_CONTAINS_LIBINTL = YesPlease
+ 	HAVE_DEV_TTY = YesPlease

--- a/spk/git/Makefile
+++ b/spk/git/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = git
 SPK_VERS = 2.50.1
-SPK_REV = 36
+SPK_REV = 37
 SPK_ICON = src/git.png
 
 DEPENDS = cross/git
@@ -11,7 +11,7 @@ DESCRIPTION = Git is a fast, scalable, distributed revision control system with 
 DESCRIPTION_FRE = Git est un système de gestion de révision rapide, extensible et distribué avec un ensemble de commandes inhabituellement riche qui fournit à la fois des opérations de haut niveau et un accès complet aux structures de bas niveau.
 STARTABLE = no
 DISPLAY_NAME = Git
-CHANGELOG = "1. Update git to v2.50.1. <br/>2. Update git-lfs to v3.7.0 (not supported for all archs)."
+CHANGELOG = "1. Update git to v2.50.1. <br/>2. Update git-lfs to v3.7.0 (not supported for all archs). <br/>3. Avoid use of getrandom on DSM 7."
 
 HOMEPAGE = https://git-scm.com
 LICENSE  = GPLv2


### PR DESCRIPTION
## Description

Avoid use of getrandom to fix git on DSM 7 too.

As reported in #6666, on DSM 7 getrandom is not available at runtime (despite it is defined in the toolchain).

Fixes #6666

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
