### PR TITLE
framework: fix arch-suffix for noarch builds

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -17,8 +17,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -23,8 +23,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.cross-dotnet.mk
+++ b/mk/spksrc.cross-dotnet.mk
@@ -29,8 +29,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.cross-go.mk
+++ b/mk/spksrc.cross-go.mk
@@ -26,8 +26,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.cross-meson.mk
+++ b/mk/spksrc.cross-meson.mk
@@ -20,8 +20,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.cross-rust.mk
+++ b/mk/spksrc.cross-rust.mk
@@ -25,8 +25,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.install-resources.mk
+++ b/mk/spksrc.install-resources.mk
@@ -21,8 +21,8 @@ DIST_FILE     = $(DISTRIB_DIR)/$(LOCAL_FILE)
 DIST_EXT      = $(PKG_EXT)
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.main-depends.mk
+++ b/mk/spksrc.main-depends.mk
@@ -14,8 +14,8 @@ NAME          = $(PKG_NAME)
 COOKIE_PREFIX = $(PKG_NAME)-
 
 ifneq ($(ARCH),)
-ifneq ($(ARCH),noarch)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
+ifneq ($(ARCH),noarch)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -33,6 +33,7 @@ include ../../mk/spksrc.common.mk
 NAME = $(SPK_NAME)
 
 ifneq ($(ARCH),)
+ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 ifneq ($(ARCH),noarch)
 # arch specific packages
 ifneq ($(SPK_PACKAGE_ARCHS),)
@@ -48,7 +49,6 @@ ifeq ($(SPK_NAME_ARCH),)
 SPK_NAME_ARCH = $(ARCH)
 endif
 SPK_TCVERS = $(TCVERSION)
-ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 TC = syno$(ARCH_SUFFIX)
 endif
 endif
@@ -79,7 +79,6 @@ else
 SPK_TCVERS = srm
 TC_OS_MIN_VER = 1.1-6931
 endif
-ARCH_SUFFIX = -$(SPK_TCVERS)
 endif
 endif
 


### PR DESCRIPTION
## Description

- fix work folders for noarch packages
- define ARCH_SUFFIX before include of spksrc.directories.mk for noarch packages too

follow up to #6627, similar to #6673

Without this fix, builds for noarch packages WORK_DIR = work instead of work-noarch-$(TCVERSION) and builds were lacking build*.log files.
This behaviour fix fixed for builds in cross and spk folders.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes

