### PR TITLE
Use mirror to download GNU sources

### DIFF
--- a/cross/bc/Makefile
+++ b/cross/bc/Makefile
@@ -2,9 +2,7 @@ PKG_NAME = bc
 PKG_VERS = 1.08.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-# original dist site is https://ftp.gnu.org/gnu/bc
-# but we are encouraged to use a mirror like this:
-PKG_DIST_SITE = https://www.artfiles.org/gnu.org/bc
+PKG_DIST_SITE = https://ftp.gnu.org/gnu/bc
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/libiconv/Makefile
+++ b/cross/libiconv/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = libiconv
 PKG_VERS = 1.17
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://ftp.gnu.org/pub/gnu/libiconv
+PKG_DIST_SITE = https://ftp.gnu.org/gnu/libiconv
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/ncursesw/Makefile
+++ b/cross/ncursesw/Makefile
@@ -3,7 +3,7 @@ DIST_NAME = ncurses
 PKG_VERS = 6.5
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(DIST_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://ftp.gnu.org/pub/gnu/ncurses
+PKG_DIST_SITE = https://ftp.gnu.org/gnu/ncurses
 PKG_DIR = $(DIST_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/mk/spksrc.download.mk
+++ b/mk/spksrc.download.mk
@@ -152,7 +152,7 @@ download_target: $(PRE_DOWNLOAD_TARGET)
 	      if [ -z "$${localFile}" ]; then \
 	        localFile=$$(basename $${url}) ; \
 	      fi ; \
-	      url=$$(echo $${url} | sed -e '#^\(http://sourceforge\.net/.*\)$#\1?use_mirror=autoselect#') ; \
+	      url=$$(echo $${url} | sed -e 's#//ftp.gnu.org/#//ftpmirror.gnu.org/#g') ; \
 	      exec 9> /tmp/wget.$${localFile}.lock ; \
 	      flock --timeout $(FLOCK_TIMEOUT) --exclusive 9 || exit 1 ; \
 	      pid=$$$$ ; \


### PR DESCRIPTION
## Description

- on https://www.gnu.org/prep/ftp.html we are encouraged to use a mirror to download gnu source code and while we ignored this, we frequently experienced timeouts.
- globally patch the url in spksrc.download.mk to use the mirror (packages can still use https://ftp.gnu.org/gnu)
- /pub/gnu/ is not supported by mirrors but /gnu is (cross/libiconv and cross/ncursesw needed adjustment)
- avoid use a specific mirror in cross/bc
- remove patch of sourceforge urls (patch didn't work and most packages use https anyway)

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
