### PR TITLE
armv5 rust fixes

### DIFF
--- a/cross/bottom/patches/88f6281/001-pin_dependencies_for_rust_1.77.patch
+++ b/cross/bottom/patches/88f6281/001-pin_dependencies_for_rust_1.77.patch
@@ -1,12 +1,22 @@
 --- Cargo.toml.orig	2024-08-06 00:28:17.000000000 +0000
-+++ Cargo.toml	2025-07-27 10:48:09.721653792 +0000
-@@ -80,7 +80,8 @@
++++ Cargo.toml	2025-08-25 13:39:32.812252177 +0000
+@@ -80,7 +80,6 @@
  
  [dependencies]
  anyhow = "1.0.86"
 -backtrace = "0.3.73"
-+# pinned for Rust 1.77.2
-+backtrace = "=0.3.74"
  cfg-if = "1.0.0"
  clap = { version = "4.5.13", features = ["default", "cargo", "wrap_help", "derive"] }
  concat-string = "1.0.1"
+@@ -103,6 +102,11 @@
+ unicode-segmentation = "1.11.0"
+ unicode-width = "0.1.13"
+ 
++# Dependencies pinned for Rust 1.77.2
++backtrace = "=0.3.74"
++rayon = "=1.10.0"
++rayon-core = "=1.12.1"
++
+ # Used for logging.
+ fern = { version = "0.6.2", optional = true }
+ log = { version = "0.4.22", optional = true }

--- a/cross/dua_2.30.0/patches/88f6281/001-pin_dependencies_for_rust_1.77.patch
+++ b/cross/dua_2.30.0/patches/88f6281/001-pin_dependencies_for_rust_1.77.patch
@@ -1,12 +1,14 @@
 --- Cargo.toml.orig	2025-01-27 08:53:38.000000000 +0000
-+++ Cargo.toml	2025-07-28 08:47:24.069857125 +0000
-@@ -62,6 +62,10 @@
++++ Cargo.toml	2025-08-25 13:55:36.790759321 +0000
+@@ -62,6 +62,12 @@
  log-panics = { version = "2", features = ["with-backtrace"] }
  crossbeam = "0.8"
  
 +# Dependencies pinned for Rust 1.77.2
 +home = "=0.5.9"
 +backtrace = "=0.3.74"
++rayon = "=1.10.0"
++rayon-core = "=1.12.1"
 +
  [[bin]]
  name = "dua"


### PR DESCRIPTION
## Description

- update patches for armv5 tools built with rust 1.77

pin dependencies for rust 1.77
recently updated dependencies are `rayon` and `rayon-core`

Other fixes for synocli-file tools are WIP in #6668

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
