### PR TITLE
Update libraries: jmalloc, libtool

### DIFF
--- a/cross/jemalloc/Makefile
+++ b/cross/jemalloc/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = jemalloc
-PKG_VERS = 5.2.1
+PKG_VERS = 5.3.0
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/jemalloc/jemalloc/releases/download/$(PKG_VERS)

--- a/cross/jemalloc/digests
+++ b/cross/jemalloc/digests
@@ -1,3 +1,3 @@
-jemalloc-5.2.1.tar.bz2 SHA1 9e06b5cc57fd185379d007696da153893cf73e30
-jemalloc-5.2.1.tar.bz2 SHA256 34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6
-jemalloc-5.2.1.tar.bz2 MD5 3d41fbf006e6ebffd489bdb304d009ae
+jemalloc-5.3.0.tar.bz2 SHA1 1c8f2d0dfbf39fa8cd86363bf3314351ab21f8d4
+jemalloc-5.3.0.tar.bz2 SHA256 2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
+jemalloc-5.3.0.tar.bz2 MD5 09a8328574dab22a7df848eae6dbbf53

--- a/cross/libtool/Makefile
+++ b/cross/libtool/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libtool
-PKG_VERS = 2.4.7
+PKG_VERS = 2.5.4
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://ftp.gnu.org/gnu/libtool

--- a/cross/libtool/PLIST
+++ b/cross/libtool/PLIST
@@ -2,4 +2,4 @@ rsc:bin/libtool
 rsc:bin/libtoolize
 lnk:lib/libltdl.so
 lnk:lib/libltdl.so.7
-lib:lib/libltdl.so.7.3.2
+lib:lib/libltdl.so.7.3.3

--- a/cross/libtool/digests
+++ b/cross/libtool/digests
@@ -1,3 +1,3 @@
-libtool-2.4.7.tar.xz SHA1 0c90f1b046ea9cd7b32a4b5a6a9df4b46ddb637a
-libtool-2.4.7.tar.xz SHA256 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
-libtool-2.4.7.tar.xz MD5 2fc0b6ddcd66a89ed6e45db28fa44232
+libtool-2.5.4.tar.xz SHA1 9781a113fe6af1b150571410b29d3eee2e792516
+libtool-2.5.4.tar.xz SHA256 f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675
+libtool-2.5.4.tar.xz MD5 22e0a29df8af5fdde276ea3a7d351d30


### PR DESCRIPTION
## Description

- update cross/jemalloc from v5.2.1 to v5.3.0
- update cross/libtool from v2.4.7 to v2.5.4

Libraries with common dependencies.
Separated from next update of imagemagick.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Library update
