### PR TITLE
Update libraries: libpng, libtiff

### DIFF
--- a/cross/libpng/Makefile
+++ b/cross/libpng/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libpng
-PKG_VERS = 1.6.44
+PKG_VERS = 1.6.50
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://download.sourceforge.net/libpng

--- a/cross/libpng/PLIST
+++ b/cross/libpng/PLIST
@@ -1,4 +1,4 @@
 lnk:lib/libpng.so
 lnk:lib/libpng16.so
 lnk:lib/libpng16.so.16
-lib:lib/libpng16.so.16.44.0
+lib:lib/libpng16.so.16.50.0

--- a/cross/libpng/digests
+++ b/cross/libpng/digests
@@ -1,3 +1,3 @@
-libpng-1.6.44.tar.xz SHA1 3aaea393b33f9cd3b36661ffb0c56b443f643c42
-libpng-1.6.44.tar.xz SHA256 60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e
-libpng-1.6.44.tar.xz MD5 e40b61660dcc807e1bcc4df9de8389ce
+libpng-1.6.50.tar.xz SHA1 ecd92ba84628a8ace430706c85fd2fb26ba0882c
+libpng-1.6.50.tar.xz SHA256 4df396518620a7aa3651443e87d1b2862e4e88cad135a8b93423e01706232307
+libpng-1.6.50.tar.xz MD5 e583e61455c4f40d565d85c0e9a2fbf9

--- a/cross/libtiff/Makefile
+++ b/cross/libtiff/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = tiff
-PKG_VERS = 4.6.0
+PKG_VERS = 4.7.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://download.osgeo.org/libtiff
@@ -12,7 +12,12 @@ COMMENT  = LibTIFF provides support for the Tag Image File Format (TIFF), a wide
 LICENSE  = No license. All rights reserved.
 
 GNU_CONFIGURE = 1
-CONFIGURE_ARGS = --enable-rpath --disable-static
+CONFIGURE_ARGS  = --enable-rpath
+CONFIGURE_ARGS += --disable-static
+CONFIGURE_ARGS += --disable-tools
+CONFIGURE_ARGS += --disable-tests
+CONFIGURE_ARGS += --disable-docs
+
 ADDITIONAL_CFLAGS = -O
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/libtiff/PLIST
+++ b/cross/libtiff/PLIST
@@ -1,6 +1,6 @@
 lnk:lib/libtiff.so
 lnk:lib/libtiff.so.6
-lib:lib/libtiff.so.6.0.2
+lib:lib/libtiff.so.6.1.0
 lnk:lib/libtiffxx.so
 lnk:lib/libtiffxx.so.6
-lib:lib/libtiffxx.so.6.0.2
+lib:lib/libtiffxx.so.6.1.0

--- a/cross/libtiff/digests
+++ b/cross/libtiff/digests
@@ -1,3 +1,3 @@
-tiff-4.6.0.tar.gz SHA1 5eda840cc24e1c74c6a9d92faa86a0851f7de7d5
-tiff-4.6.0.tar.gz SHA256 88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a
-tiff-4.6.0.tar.gz MD5 fc7d49a9348b890b29f91a4ecadd5b49
+tiff-4.7.0.tar.gz SHA1 c32bc600f82bb8a09b83ce59a0abbee7f3dc2603
+tiff-4.7.0.tar.gz SHA256 67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976
+tiff-4.7.0.tar.gz MD5 3a0fa4a270a4a192b08913f88d0cfbdd


### PR DESCRIPTION
## Description

- update cross/libpng from v1.6.44 to v1.6.50
- update cross/libtiff from v4.6.0 to v4.7.0

Libraries with common dependencies.
Separated from next update of imagemagick.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Library update
