### PR TITLE
fix libraries: lcms2, jemalloc

### DIFF
--- a/cross/bind_9.16/Makefile
+++ b/cross/bind_9.16/Makefile
@@ -15,7 +15,6 @@ DEPENDS += cross/libxml2
 
 OPTIONAL_DEPENDS = cross/libcap cross/libcap_2.51
 
-# by cross/libuv
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
 include ../../mk/spksrc.archs.mk

--- a/cross/jemalloc/Makefile
+++ b/cross/jemalloc/Makefile
@@ -7,6 +7,8 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 
+UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+
 # jemalloc is a development tool, replacing standard allocator to diagnose memory leaks.
 # It is not included in any package, except to produce test packages for troubleshooting.
 

--- a/cross/lcms2/Makefile
+++ b/cross/lcms2/Makefile
@@ -13,4 +13,10 @@ LICENSE  = MIT
 
 ADDITIONAL_CFLAGS = -O
 
+include ../../mk/spksrc.archs.mk
+ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
+# meson/ninja build does not evaluate this (while regular build with configure does).
+ADDITIONAL_CFLAGS += -std=gnu99
+endif
+
 include ../../mk/spksrc.cross-meson.mk


### PR DESCRIPTION
## Description

- fix cross/lcms2 for OLD_PPC_ARCHS
- jemalloc 5.3.0 is not supported for OLD_PPC_ARCHS

Follow up to #6699 and #6697
In preparation for the update of the imagemagick package.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
