### PR TITLE
lz4: Migrate to using meson and fix Debug build with gcc <= 4.9.x

### DIFF
--- a/cross/lz4/Makefile
+++ b/cross/lz4/Makefile
@@ -4,7 +4,7 @@ PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/lz4/lz4/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIR = $(PKG_NAME)-$(PKG_VERS)/build/cmake
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 
@@ -12,9 +12,18 @@ HOMEPAGE = https://github.com/lz4/lz4
 COMMENT  = LZ4 is lossless compression algorithm, providing compression speed at 400 MB/s per core, scalable with multi-cores CPU.
 LICENSE  = BSD
 
-include ../../mk/spksrc.cross-cmake.mk
+MESON_BASE_DIR = $(WORK_DIR)/$(PKG_DIR)/build/meson
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
+
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(OLD_PPC_ARCHS)),$(ARCH))
 ADDITIONAL_LDFLAGS += -lrt
 endif
+
+ifeq ($(GCC_DEBUG_INFO),1)
+ifeq ($(call version_lt, $(TC_GCC), 5.0),1)
+ADDITIONAL_CFLAGS = -std=c99
+endif
+endif
+
+include ../../mk/spksrc.cross-meson.mk


### PR DESCRIPTION
## Description

lz4: Migrate to using meson and fix Debug build with gcc <= 4.9.x

Relates to https://github.com/SynoCommunity/spksrc/pull/6719

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
