### PR TITLE
syncthing: update to disable auto updates for ARMv5 archs

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -6,7 +6,7 @@ PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_
 PKG_DIR = src/github.com/$(PKG_NAME)
 EXTRACT_PATH = $(WORK_DIR)/$(PKG_DIR)
 
-BUILD_DEPENDS = native/go
+BUILD_DEPENDS = native/go_1.23
 
 HOMEPAGE = https://www.syncthing.net/
 COMMENT  = Syncthing is a continuous file synchronization program. It synchronizes files between two or more computers.
@@ -24,4 +24,4 @@ BUILD_ARGS = -goos=$(GOOS) -goarch=$(GO_ARCH) -version=v$(PKG_VERS)
 .PHONY: syncthing_compile
 # use custom build to remove GOARCH from ENV and for custom BUILD_ARGS
 syncthing_compile:
-	cd $(GO_SRC_DIR) && env $(filter-out GOARCH=%, $(ENV)) go run build.go $(BUILD_ARGS) build
+	cd $(GO_SRC_DIR) && PATH=$(WORK_DIR)/../../../native/go_1.23/work-native/go/bin/:$$PATH && env $(filter-out GOARCH=%, $(ENV)) go run build.go $(BUILD_ARGS) build

--- a/native/go_1.23/Makefile
+++ b/native/go_1.23/Makefile
@@ -1,0 +1,17 @@
+PKG_NAME = go
+PKG_VERS = 1.23.12
+PKG_EXT = tar.gz
+PKG_DIST_NAME = $(PKG_NAME)$(PKG_VERS).linux-amd64.$(PKG_EXT)
+PKG_DIST_SITE = https://go.dev/dl
+PKG_DIR = $(PKG_NAME)
+
+# Version 1.23 is required to build syncthing for ARMv5 ARCHS
+
+HOMEPAGE = https://golang.org/
+COMMENT  = Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+LICENSE  = BSD-style
+
+# extract only to $(WORK_DIR)
+INSTALL_TARGET = nop
+
+include ../../mk/spksrc.native-install.mk

--- a/native/go_1.23/digests
+++ b/native/go_1.23/digests
@@ -1,0 +1,3 @@
+go1.23.12.linux-amd64.tar.gz SHA1 c63be4049001152b6055c8a4741eb8db0b49e7f4
+go1.23.12.linux-amd64.tar.gz SHA256 d3847fef834e9db11bf64e3fb34db9c04db14e068eeb064f49af747010454f90
+go1.23.12.linux-amd64.tar.gz MD5 8ae5e950f873ef4d3c4d60d1a92c792d

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,10 +1,10 @@
 SPK_NAME = syncthing
 SPK_VERS = 1.30.0
-SPK_REV = 31
+SPK_REV = 32
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
-DEPENDS  = cross/syncthing
+DEPENDS = cross/syncthing
 
 # archs not supported by go
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
@@ -13,7 +13,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update syncthing to v1.30.0 to support new DSM models released in 2025.<br/>2. Remove tech-ui as not supported anymore.<br/><br/>REMARKS: New packages are rarely created because syncthing's automatic package updater is used."
+CHANGELOG = "Build syncthing v1.30.0 with go v1.23 for final ARMv5 compatibility. <br/><br/>REMARKS: New packages are rarely created because syncthing's automatic package updater is used. <br/>On ARMv5 archs (i.e. DS213air, DS213, DS413j, DS112, DS112+, DS212, DS212+, RS212, RS812, DS212j, DS112j, DS111, DS211, DS211+, DS411slim, DS411, RS411, DS211j and DS411j) the automatic update is disabled. Further updates will not work, and manual use of the internal updater will result in a broken installation."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes


### PR DESCRIPTION
## Description

- create a final syncthing v1.30 package with disabled auto upgrade for ARMv5 archs (#6725)
- syncthing built with go >= 1.24 fails to run on ARMv5 archs
- add native/go_1.23 to limit go for this syncthing release
- update options.conf file to disable auto update on ARMv5 archs at package installation/update
- 
Fixes #6725

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Package update
