### PR TITLE
kernel-modules.mk: Ensure exit on error and output proper msg

### DIFF
--- a/mk/spksrc.kernel-modules.mk
+++ b/mk/spksrc.kernel-modules.mk
@@ -6,7 +6,7 @@ include $(BASEDIR)mk/spksrc.kernel-env.mk
 ###
 
 kernel-modules:
-	@bash -o pipefail -c ' \
+	@bash -e -o pipefail -c ' \
 	{ \
 	  $(MSG) "kernel-modules archs to be processed: $(KERNEL_DEPEND)" ; \
 	    rsync -ah --mkpath work$(ARCH_SUFFIX)/tc_vars* work$(ARCH_SUFFIX)/tc_vars-backup ; \


### PR DESCRIPTION
## Description

kernel-modules.mk: Ensure exit on error and output proper msg

Relates to : https://github.com/SynoCommunity/spksrc/issues/6773

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
