### PR TITLE
kernel-modules.mk: Re-order loop to output proper kernel build error

### DIFF
--- a/mk/spksrc.kernel-modules.mk
+++ b/mk/spksrc.kernel-modules.mk
@@ -9,26 +9,26 @@ kernel-modules:
 	@bash -e -o pipefail -c ' \
 	{ \
 	  $(MSG) "kernel-modules archs to be processed: $(KERNEL_DEPEND)" ; \
-	    rsync -ah --mkpath work$(ARCH_SUFFIX)/tc_vars* work$(ARCH_SUFFIX)/tc_vars-backup ; \
-	    for depend in $(KERNEL_DEPEND); \
-	    do \
+	  rsync -ah --mkpath work$(ARCH_SUFFIX)/tc_vars* work$(ARCH_SUFFIX)/tc_vars-backup ; \
+	  for depend in $(KERNEL_DEPEND); \
+	  do \
 	    { \
 	      $(MAKE) spkclean ; \
 	      $(MSG) "Building kernel-modules for $${depend} ARCH" ; \
-	      $(MAKE) LOGGING_ENABLED=1 \
+	      if ! $(MAKE) LOGGING_ENABLED=1 \
 	          WORK_DIR=$(CURDIR)/work$(ARCH_SUFFIX) \
 	          REQUIRE_KERNEL_MODULE="$(REQUIRE_KERNEL_MODULE)" \
 	          ARCH=$$(echo $${depend} | cut -f1 -d-) \
 	          TCVERSION=$$(echo $${depend} | cut -f2 -d-) \
-	          -C ../../kernel/syno-$$depend ; \
+	          -C ../../kernel/syno-$${depend} ; then \
+	        $(MSG) $$(printf "%s MAKELEVEL: %02d, PARALLEL_MAKE: %s, DEPEND: %s, NAME: %s - FAILED\n" \
+	          "$$(date +%Y%m%d-%H%M%S)" $(MAKELEVEL) "$(PARALLEL_MAKE)" "$${depend}" "kernel-modules") | tee --append $(STATUS_LOG) ; \
+	        exit 1 ; \
+	      fi ; \
 	      rm -fr $(CURDIR)/work$(ARCH_SUFFIX)/linux-$${depend} ; \
 	    } > >(tee --append build-$${depend}.log) 2>&1 ; \
-	    done ; \
-	    rsync -ah work$(ARCH_SUFFIX)/tc_vars-backup/tc_vars* work$(ARCH_SUFFIX)/. ; \
-	} > >(tee --append $(DEFAULT_LOG)) 2>&1 \
-	' || { \
-	  $(MSG) $$(printf "%s MAKELEVEL: %02d, PARALLEL_MAKE: %s, ARCH: %s, NAME: %s - FAILED\n" "$$(date +%Y%m%d-%H%M%S)" $(MAKELEVEL) "$(PARALLEL_MAKE)" "$(ARCH)-$(TCVERSION)" "kernel-modules-$${depend}") | tee --append $(STATUS_LOG) ; \
-	  exit 1 ; \
-	}
+	  done ; \
+	  rsync -ah work$(ARCH_SUFFIX)/tc_vars-backup/tc_vars* work$(ARCH_SUFFIX)/. ; \
+	}'
 
 ###


### PR DESCRIPTION
## Description

kernel-modules.mk: Re-order loop to output proper kernel build error

Follows-up https://github.com/SynoCommunity/spksrc/pull/6775

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
