### PR TITLE
Jellyfin: Patch for v10.11.2

### DIFF
--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
 SPK_VERS = 10.11.2
-SPK_REV = 29
+SPK_REV = 30
 SPK_ICON = src/jellyfin.png
 
 DEPENDS = cross/jellyfin cross/jellyfin-web
@@ -40,6 +40,9 @@ SERVICE_PORT_TITLE = Jellyfin (HTTP)
 
 # Admin link
 ADMIN_PORT = $(SERVICE_PORT)
+
+# Use TMPDIR (insufficient space in /tmp/jellyfin)
+USE_ALTERNATE_TMPDIR = 1
 
 POST_STRIP_TARGET += jellyfin_extra_install
 


### PR DESCRIPTION
## Description

This follows up on #6771 and switches to using an alternate temporary directory to support systems with insufficient free space in the `/tmp/jellyfin` path.

Fixes #6777

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
