### PR TITLE
cross-cc.mk: Fix pseudo-TTY script to return exit status of child

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -72,19 +72,19 @@ _all: install plist
 
 all:
 	@mkdir -p $(WORK_DIR)
-	@if [ -z "$$LOGGING_ENABLED" ]; then \
-		export LOGGING_ENABLED=1 ; \
-		bash -o pipefail -c '\
-			script -q -c "$(MAKE) -f $(firstword $(MAKEFILE_LIST)) _all" /dev/null \
-				| tee >(sed -r "s/\x1B\[[0-9;]*[mK]//g" >> "$(DEFAULT_LOG)") \
-		' ; \
-	else \
-		$(MAKE) -f $(firstword $(MAKEFILE_LIST)) _all ; \
-	fi || { \
-		$(MSG) $$(printf "%s MAKELEVEL: %02d, PARALLEL_MAKE: %s, ARCH: %s, NAME: %s - FAILED\n" \
-		"$$(date +%Y%m%d-%H%M%S)" $(MAKELEVEL) "$(PARALLEL_MAKE)" "$(ARCH)-$(TCVERSION)" "$(NAME)") \
-		| tee --append $(STATUS_LOG) ; \
-		exit 1 ; \
+	@bash -o pipefail -c ' \
+	    if [ -z "$$LOGGING_ENABLED" ]; then \
+	        export LOGGING_ENABLED=1 ; \
+	        script -q -e -c "$(MAKE) -f $(firstword $(MAKEFILE_LIST)) _all" /dev/null \
+	            | tee >(sed -r "s/\x1B\[[0-9;]*[mK]//g; s/\\r//g" >> "$(DEFAULT_LOG)") ; \
+	    else \
+	        $(MAKE) -f $(firstword $(MAKEFILE_LIST)) _all ; \
+	    fi \
+	' || { \
+	    $(MSG) $$(printf "%s MAKELEVEL: %02d, PARALLEL_MAKE: %s, ARCH: %s, NAME: %s - FAILED\n" \
+	    "$$(date +%Y%m%d-%H%M%S)" $(MAKELEVEL) "$(PARALLEL_MAKE)" "$(ARCH)-$(TCVERSION)" "$(NAME)") \
+	    | tee --append $(STATUS_LOG) ; \
+	    exit 1 ; \
 	}
 
 ####


### PR DESCRIPTION
## Description

cross-cc.mk: Fix pseudo-TTY script to return exit status of child

Follow-up fix to https://github.com/SynoCommunity/spksrc/pull/6797

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
