### PR TITLE
chromaprint: Use same download for chromaprint and -fftw

### DIFF
--- a/cross/chromaprint-fftw/digests
+++ b/cross/chromaprint-fftw/digests
@@ -1,3 +1,3 @@
-chromaprint-1.6.0.tar.gz SHA1 240bfee1b77d4403234f8583fb42871e5eee584f
-chromaprint-1.6.0.tar.gz SHA256 65bfce4a35b2e673dbcda917b6aa577e2f145cf805243d19e6a50fea2a520c2a
-chromaprint-1.6.0.tar.gz MD5 bc4f344ad275767de951d6a0a756aa31
+chromaprint-1.6.0.tar.gz SHA1 34cc6188bdaa898f6e014757960c272754039a84
+chromaprint-1.6.0.tar.gz SHA256 9d33482e56a1389a37a0d6742c376139fa43e3b8a63d29003222b93db2cb40da
+chromaprint-1.6.0.tar.gz MD5 291575b0a2d41cc8603514378bbc4235

--- a/cross/chromaprint/Makefile
+++ b/cross/chromaprint/Makefile
@@ -1,9 +1,8 @@
 PKG_NAME = chromaprint
 PKG_VERS = 1.6.0
 PKG_EXT = tar.gz
-PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://github.com/acoustid/chromaprint/archive/refs/tags
-PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/acoustid/chromaprint/releases/download/v$(PKG_VERS)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 #PKG_GIT_HASH = aa67c95b9e486884a6d3ee8b0c91207d8c2b0551

--- a/cross/chromaprint/digests
+++ b/cross/chromaprint/digests
@@ -1,3 +1,3 @@
-chromaprint-1.6.0.tar.gz SHA1 240bfee1b77d4403234f8583fb42871e5eee584f
-chromaprint-1.6.0.tar.gz SHA256 65bfce4a35b2e673dbcda917b6aa577e2f145cf805243d19e6a50fea2a520c2a
-chromaprint-1.6.0.tar.gz MD5 bc4f344ad275767de951d6a0a756aa31
+chromaprint-1.6.0.tar.gz SHA1 34cc6188bdaa898f6e014757960c272754039a84
+chromaprint-1.6.0.tar.gz SHA256 9d33482e56a1389a37a0d6742c376139fa43e3b8a63d29003222b93db2cb40da
+chromaprint-1.6.0.tar.gz MD5 291575b0a2d41cc8603514378bbc4235


### PR DESCRIPTION
## Description

chromaprint: Use same download for chromaprint and -fftw

Same package being downloaded between `chromaprint` vs `chromaprint-fftw` but using a different download string:
```
-PKG_DIST_SITE = https://github.com/acoustid/chromaprint/archive/refs/tags
+PKG_DIST_SITE = https://github.com/acoustid/chromaprint/releases/download/v$(PKG_VERS)
```
Resulting in a different digests depending of who initiated the download.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
