### PR TITLE
adminer: cap DSM 7.0/7.1 builds at 7.1-59999

### DIFF
--- a/spk/adminer/Makefile
+++ b/spk/adminer/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = adminer
 SPK_VERS = 5.4.1
-SPK_REV = 7
+SPK_REV = 8
 SPK_ICON = src/adminer.png
 DSM_UI_DIR = app
 
@@ -33,7 +33,7 @@ CONF_DIR = src/conf_dsm72
 else ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 SPK_DEPENDS = "WebStation:PHP8.0:Apache2.4"
 # DSM >= 7.3 does not support PHP8.0
-OS_MAX_VER = 7.2-81180
+OS_MAX_VER = 7.1-59999
 # DSM 7.0 and 7.1
 CONF_DIR = src/conf_dsm7
 else


### PR DESCRIPTION
## Description

This is a follow-on from #6740 to correct the `OS_MAX_VER` in alignment with https://github.com/SynoCommunity/spkrepo/pull/159.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
