### PR TITLE
mantisbt: tolerate alternative ip route output

### DIFF
--- a/spk/mantisbt/Makefile
+++ b/spk/mantisbt/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = mantisbt
 SPK_VERS = 2.27.3
-SPK_REV = 9
+SPK_REV = 10
 SPK_ICON = src/mantisbt.png
 
 DEPENDS  = cross/mantisbt

--- a/spk/mantisbt/src/wizard/install_uifile.sh
+++ b/spk/mantisbt/src/wizard/install_uifile.sh
@@ -4,7 +4,7 @@
 if [ -z "${SYNOPKG_PKGDEST_VOL}" ]; then
     SYNOPKG_PKGDEST_VOL="/volume1"
 fi
-INTERNAL_IP=$(ip -4 route get 8.8.8.8 | awk '/8.8.8.8/ && /src/ {print $NF}')
+INTERNAL_IP=$(ip -4 route get 8.8.8.8 | awk '/8.8.8.8/ {for (i=1; i<NF; i++) if ($i=="src") print $(i+1)}')
 
 quote_json ()
 {


### PR DESCRIPTION
## Description

This is a follow-on from #6804 to fix the wizard’s internal IP detection with DSM 7.2+ deployments.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
