### PR TITLE
tt-rss: align PHP handling with DSM versions

### DIFF
--- a/spk/tt-rss/Makefile
+++ b/spk/tt-rss/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = tt-rss
 SPK_VERS = 20230828
-SPK_REV = 18
+SPK_REV = 19
 SPK_ICON = src/tt-rss.png
 
 DEPENDS  = cross/tt-rss
@@ -9,7 +9,6 @@ override ARCH=noarch
 
 # Due to not obvious WebStation handling requirements
 REQUIRED_MIN_DSM = 6.0
-SPK_DEPENDS = "WebStation:PHP7.4:MariaDB10:Apache2.4"
 # SRM is not supported due lacking webstation, php, mariadb and apache packages
 REQUIRED_MIN_SRM = 3.0
 
@@ -17,7 +16,7 @@ MAINTAINER = moneytoo
 DESCRIPTION = Tiny Tiny RSS is an open source web-based news feed \(RSS/Atom\) reader and aggregator, designed to allow you to read news from any location, while feeling as close to a real desktop application as possible.
 DESCRIPTION_FRE = Tiny Tiny RSS est un agrégateur et lecteur web de flux RSS et Atom open source conçu pour vous permettre de lire des nouvelles de n\'importe quel endroit, tout en se sentant aussi proche d\'une application de bureau que possible.
 DISPLAY_NAME = Tiny Tiny RSS
-CHANGELOG = "1. Update Tiny Tiny RSS to Git revision afd04d141c (20230828).<br/>2. Fix for DSM 6 app startup."
+CHANGELOG = "1. Align PHP dependency handling with DSM 6/7 (PHP 7.4/8.0/8.2) and harden service script."
 
 HOMEPAGE   = https://tt-rss.org/
 LICENSE    = GPL
@@ -33,16 +32,25 @@ SYSTEM_GROUP = http
 
 DSM_UI_DIR = app
 DSM_UI_CONFIG = src/app/config
-CONF_DIR = src/conf/
 
 include ../../mk/spksrc.common.mk
 
-# Alternate conf dir for DSM 6
-ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
+# DSM-specific PHP profiles
+ifeq ($(call version_ge, ${TCVERSION}, 7.2),1)
+SPK_DEPENDS = "WebStation:PHP8.2:MariaDB10:Apache2.4"
+CONF_DIR = src/conf_72/
+else ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+SPK_DEPENDS = "WebStation:PHP8.0:MariaDB10:Apache2.4"
+OS_MAX_VER = 7.1-59999
+CONF_DIR = src/conf_7/
+else
+SPK_DEPENDS = "WebStation:PHP7.4:MariaDB10:Apache2.4"
 CONF_DIR = src/conf_6/
 endif
 
+ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
 POST_STRIP_TARGET = tt-rss_extra_install
+endif
 
 include ../../mk/spksrc.spk.mk
 

--- a/spk/tt-rss/src/conf_7/resource
+++ b/spk/tt-rss/src/conf_7/resource
@@ -1,0 +1,86 @@
+{
+    "mariadb10-db": {
+        "admin-account-m10": "root",
+        "admin-account-m5": "root",
+        "admin-pw-m10": "{{wizard_mysql_password_root}}",
+        "admin-pw-m5": "{{wizard_mariadb5_password_root}}",
+        "create-db": {
+            "db-collision": "skip",
+            "db-name": "ttrss",
+            "flag": "{{wizard_create_db}}"
+        },
+        "drop-db-inst": {
+            "db-name": "ttrss",
+            "flag": "{{wizard_run_migration}}",
+            "ver": "m5"
+        },
+        "drop-db-uninst": true,
+        "drop-user-uninst": true,
+        "grant-user": {
+            "db-name": "ttrss",
+            "flag": "{{mysql_grant_user}}",
+            "host": "localhost",
+            "user-name": "ttrss",
+            "user-pw": "{{wizard_mysql_password_ttrss}}"
+        },
+        "migrate-db": {
+            "db-collision": "replace",
+            "flag": "{{wizard_run_migration}}",
+            "m10-db-name": "ttrss",
+            "m5-db-name": "ttrss"
+        }
+    },
+    "webservice": {
+        "migrate": {
+            "root": [
+                {
+                    "new": "tt-rss",
+                    "old": "tt-rss"
+                }
+            ]
+        },
+        "pkg_dir_prepare": [
+            {
+                "group": "http",
+                "mode": "0755",
+                "source": "/var/packages/tt-rss/target/share/tt-rss",
+                "target": "tt-rss",
+                "user": "sc-tt-rss"
+            }
+        ],
+        "portals": [
+            {
+                "alias": "tt-rss",
+                "app": "com.synocommunity.packages.tt-rss",
+                "name": "Tiny Tiny RSS",
+                "service": "tt-rss",
+                "type": "alias"
+            }
+        ],
+        "services": [
+            {
+                "backend": 2,
+                "display_name": "Tiny Tiny RSS",
+                "icon": "app/images/tt-rss-{0}.png",
+                "php": {
+                    "backend": 9,
+                    "extensions": [
+                        "curl",
+                        "gd",
+                        "intl",
+                        "mysqli",
+                        "pdo_mysql",
+                        "posix"
+                    ],
+                    "group": "http",
+                    "profile_desc": "PHP Profile for tt-rss",
+                    "profile_name": "tt-rss Profile",
+                    "user": "sc-tt-rss"
+                },
+                "root": "tt-rss",
+                "service": "tt-rss",
+                "type": "apache_php"
+            }
+        ]
+    }
+}

--- a/spk/tt-rss/src/conf_72/resource
+++ b/spk/tt-rss/src/conf_72/resource
@@ -63,7 +63,7 @@
                 "display_name": "Tiny Tiny RSS",
                 "icon": "app/images/tt-rss-{0}.png",
                 "php": {
-                    "backend": 8,
+                    "backend": 11,
                     "extensions": [
                         "curl",
                         "gd",

--- a/spk/tt-rss/src/service-setup.sh
+++ b/spk/tt-rss/src/service-setup.sh
@@ -17,12 +17,20 @@ LOGS_DIR="${WEB_DIR}/${PACKAGE}/logs"
 VERSION_FILE_DIRECTORY="var"
 VERSION_FILE="${VERSION_FILE_DIRECTORY}/version.txt"
 
-if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
+if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
     WEB_USER="http"
     WEB_GROUP="http"
 fi
 
-PHP="/usr/local/bin/php74"
+if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ]; then
+    if [ "${SYNOPKG_DSM_VERSION_MINOR}" -ge 2 ]; then
+        PHP="/usr/local/bin/php82"
+    else
+        PHP="/usr/local/bin/php80"
+    fi
+else
+    PHP="/usr/local/bin/php74"
+fi
 JQ="/bin/jq"
 SYNOSVC="/usr/syno/sbin/synoservice"
 MARIADB_10_INSTALL_DIRECTORY="/var/packages/MariaDB10"
@@ -33,25 +41,22 @@ MYSQL_USER="ttrss"
 MYSQL_DATABASE="ttrss"
 
 exec_update_schema() {
-  TTRSS="${WEB_DIR}/${PACKAGE}/update.php --update-schema=force-yes"
-  COMMAND="${PHP} ${TTRSS}"
-  if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
-      /bin/su "$WEB_USER" -s /bin/sh -c "${COMMAND}"
+  TTRSS="${WEB_DIR}/${PACKAGE}/update.php"
+  if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
+      /bin/su "$WEB_USER" -s /bin/sh -c "\"${PHP}\" \"${TTRSS}\" --update-schema=force-yes"
   else
-      $COMMAND
+      "${PHP}" "${TTRSS}" --update-schema=force-yes
   fi
-  return $?
 }
 
 service_prestart ()
 {
-  TTRSS="${WEB_DIR}/${PACKAGE}/update.php --daemon"
+  TTRSS="${WEB_DIR}/${PACKAGE}/update.php"
   LOG_FILE="${LOGS_DIR}/daemon.log"
-  COMMAND="${PHP} ${TTRSS}"
-  if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
-      /bin/su "$WEB_USER" -s /bin/sh -c "${COMMAND}" >> ${LOG_FILE} 2>&1 &
+  if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
+      /bin/su "$WEB_USER" -s /bin/sh -c "\"${PHP}\" \"${TTRSS}\" --daemon" >> "${LOG_FILE}" 2>&1 &
   else
-      $COMMAND >> ${LOG_FILE} 2>&1 &
+      "${PHP}" "${TTRSS}" --daemon >> "${LOG_FILE}" 2>&1 &
   fi
   echo "$!" > "${PID_FILE}"
 }
@@ -63,7 +68,7 @@ service_postinst ()
     ${CP} "${SYNOPKG_PKGDEST}/share/${PACKAGE}" ${WEB_DIR}
 
     TEMPDIR="${SYNOPKG_PKGTMP}/web"
-    ${MKDIR} ${TEMPDIR}
+    ${MKDIR} "${TEMPDIR}"
 
     WS_CFG_PATH="/usr/syno/etc/packages/WebStation"
     WS_CFG_FILE="WebStation.json"
@@ -81,6 +86,7 @@ service_postinst ()
     if [ ! "$WS_BACKEND" = "2" ]; then
         echo "Set Apache as the back-end server"
         ${JQ} '.default.backend = 2' "${FULL_WS_CFG_FILE}" > "${TEMP_WS_CFG_FILE}"
+        # shellcheck disable=SC2086  # RSYNC_ARCH_ARGS is intentionally a multi-word arg list
         rsync -aX ${RSYNC_ARCH_ARGS} "${TEMP_WS_CFG_FILE}" "${WS_CFG_PATH}/" 2>&1
         RESTART_APACHE="yes"
     fi
@@ -90,6 +96,7 @@ service_postinst ()
         # Locate default PHP profile
         PHP_PROF_ID=$(${JQ} -r '. | to_entries[] | select(.value | type == "object" and .profile_desc == "'"$PHP_PROF_NAME"'") | .key' "${FULL_PHP_CFG_FILE}")
         ${JQ} ".default.php = \"$PHP_PROF_ID\"" "${FULL_WS_CFG_FILE}" > "${TEMP_WS_CFG_FILE}"
+        # shellcheck disable=SC2086  # RSYNC_ARCH_ARGS is intentionally a multi-word arg list
         rsync -aX ${RSYNC_ARCH_ARGS} "${TEMP_WS_CFG_FILE}" "${WS_CFG_PATH}/" 2>&1
         RESTART_APACHE="yes"
     fi
@@ -97,13 +104,14 @@ service_postinst ()
     if ! ${JQ} -e '.["com-synocommunity-packages-tt-rss"]' "${FULL_PHP_CFG_FILE}" >/dev/null; then
         echo "Add PHP profile for tt-rss"
         ${JQ} --slurpfile ttRssNode "${SYNOPKG_PKGDEST}/web/tt-rss.json" '.["com-synocommunity-packages-tt-rss"] = $ttRssNode[0]' "${FULL_PHP_CFG_FILE}" > "${TEMP_PHP_CFG_FILE}"
+        # shellcheck disable=SC2086  # RSYNC_ARCH_ARGS is intentionally a multi-word arg list
         rsync -aX ${RSYNC_ARCH_ARGS} "${TEMP_PHP_CFG_FILE}" "${WS_CFG_PATH}/" 2>&1
         RESTART_APACHE="yes"
     fi
     # Check for tt-rss Apache config
     if [ ! -f "/usr/local/etc/apache24/sites-enabled/tt-rss.conf" ]; then
         echo "Add Apache config for tt-rss"
-        rsync -aX ${SYNOPKG_PKGDEST}/web/tt-rss.conf /usr/local/etc/apache24/sites-enabled/ 2>&1
+        rsync -aX "${SYNOPKG_PKGDEST}/web/tt-rss.conf" /usr/local/etc/apache24/sites-enabled/ 2>&1
         RESTART_APACHE="yes"
     fi
     # Restart Apache if configs have changed
@@ -119,7 +127,7 @@ service_postinst ()
     ${RM} "${TEMPDIR}"
   fi
 
-  mkdir "-p" "${LOGS_DIR}"
+  ${MKDIR} -p "${LOGS_DIR}"
 
   # Setup database and configuration file
   if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
@@ -157,7 +165,7 @@ service_postinst ()
 validate_preinst ()
 {
   # Check for modification to PHP template defaults on DSM 6
-  if [ ${SYNOPKG_DSM_VERSION_MAJOR} -lt 7 ]; then
+  if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
     WS_TMPL_PATH="/var/packages/WebStation/target/misc"
     WS_TMPL_FILE="php74_fpm.mustache"
     FULL_WS_TMPL_FILE="${WS_TMPL_PATH}/${WS_TMPL_FILE}"
@@ -171,17 +179,32 @@ validate_preinst ()
 
 validate_preuninst ()
 {
-  # Check database
-  if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ] && ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
-    echo "Incorrect MySQL root password"
-    exit 1
-  fi
-
-  # Check database export location
-  if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ] && [ -n "${wizard_dbexport_path}" ]; then
-    if [ -f "${wizard_dbexport_path}" ] || [ -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
-      echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+  if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ]; then
+    # Check database
+    if ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+      echo "Incorrect MySQL root password"
       exit 1
+    fi
+
+    # Check database export location
+    if [ -n "${wizard_dbexport_path}" ]; then
+      if [ -f "${wizard_dbexport_path}" ] || [ -e "${wizard_dbexport_path}/${MYSQL_DATABASE}.sql" ]; then
+        echo "File ${wizard_dbexport_path}/${MYSQL_DATABASE}.sql already exists. Please remove or choose a different location"
+        exit 1
+      fi
+
+      if [ -d "${wizard_dbexport_path}" ]; then
+        if [ ! -w "${wizard_dbexport_path}" ]; then
+          echo "Cannot write to ${wizard_dbexport_path}. Please choose a writable location"
+          exit 1
+        fi
+      else
+        parent_dir="$(dirname "${wizard_dbexport_path}")"
+        if [ ! -w "${parent_dir}" ]; then
+          echo "Cannot create ${wizard_dbexport_path}. Please choose a writable location"
+          exit 1
+        fi
+      fi
     fi
   fi
 }
@@ -205,7 +228,7 @@ service_postuninst ()
 
     # Remove web configurations
     TEMPDIR="${SYNOPKG_PKGTMP}/web"
-    ${MKDIR} ${TEMPDIR}
+    ${MKDIR} "${TEMPDIR}"
     WS_CFG_PATH="/usr/syno/etc/packages/WebStation"
     PHP_CFG_FILE="PHPSettings.json"
     FULL_PHP_CFG_FILE="${WS_CFG_PATH}/${PHP_CFG_FILE}"
@@ -215,8 +238,9 @@ service_postuninst ()
     # Check for tt-rss PHP profile
     if ${JQ} -e '.["com-synocommunity-packages-tt-rss"]' "${FULL_PHP_CFG_FILE}" >/dev/null; then
         echo "Removing PHP profile for tt-rss"
-        ${JQ} 'del(.["com-synocommunity-packages-tt-rss"])' ${FULL_PHP_CFG_FILE} > ${TEMP_PHP_CFG_FILE}
-        rsync -aX ${RSYNC_ARCH_ARGS} ${TEMP_PHP_CFG_FILE} ${WS_CFG_PATH}/ 2>&1
+        ${JQ} 'del(.["com-synocommunity-packages-tt-rss"])' "${FULL_PHP_CFG_FILE}" > "${TEMP_PHP_CFG_FILE}"
+        # shellcheck disable=SC2086  # RSYNC_ARCH_ARGS is intentionally a multi-word arg list
+        rsync -aX ${RSYNC_ARCH_ARGS} "${TEMP_PHP_CFG_FILE}" "${WS_CFG_PATH}/" 2>&1
         ${RM} "${WS_CFG_PATH}/php_profile/com-synocommunity-packages-tt-rss"
         RESTART_APACHE="yes"
     fi

--- a/spk/tt-rss/src/wizard_templates/install_uifile.sh
+++ b/spk/tt-rss/src/wizard_templates/install_uifile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-INTERNAL_IP=$(ip -4 route get 8.8.8.8 | awk '/8.8.8.8/ && /src/ {print $NF}')
+INTERNAL_IP=$(ip -4 route get 8.8.8.8 | awk '/8.8.8.8/ {for (i=1; i<NF; i++) if ($i=="src") print $(i+1)}')
 
 quote_json ()
 {


### PR DESCRIPTION
## Description

- Align tt-rss with DSM-specific PHP/WebStation dependencies (PHP 7.4 for DSM 6, PHP 8.0 for DSM 7.0/7.1, PHP 8.2 for DSM 7.2+).
- Harden `service-setup.sh`: consistent quoting, DSM-aware PHP selection, tidy legacy hooks, and ensure DB exports only target writable paths.
- Update wizard IP detection to handle alternate `ip route` formats.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package refresh
