### PR TITLE
framework: normalize ARCH when resolving patch directories

### DIFF
--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -25,15 +25,24 @@ endif
 #    patches/$(arch)-$(TCVERSION)/*.patch
 # supported groups: arm, armv5, armv7, armv7l, armv8, ppc, i686, x64
 ifeq ($(strip $(PATCHES)),)
-ifeq ($(strip $(ARCH)),)
+PATCH_ARCH = $(strip $(ARCH))
+ifneq ($(PATCH_ARCH),)
+PATCH_ARCH := $(firstword $(subst -, ,$(PATCH_ARCH)))
+endif
+
+ifeq ($(PATCH_ARCH),)
 PATCHES = $(wildcard patches/*.patch)
 else ifneq ($(filter cross diyspk python spk,$(shell basename $(dir $(abspath $(dir $$PWD))))),)
 PATCHES = $(sort $(foreach group,ARM_ARCHS ARMv5_ARCHS ARMv7_ARCHS ARMv7L_ARCHS ARMv8_ARCHS PPC_ARCHS i686_ARCHS x64_ARCHS, \
 	$(foreach arch,$($(group)), \
-	$(if $(filter $(ARCH),$(arch)),$(sort $(wildcard patches/*.patch patches/kernel-$(subst +,,$(TC_KERNEL))/*.patch patches/DSM-$(TCVERSION)/*.patch patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch  patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')-$(TCVERSION)/*.patch patches/$(arch)/*.patch patches/$(arch)-$(TCVERSION)/*.patch)),))))
+	$(if $(filter $(PATCH_ARCH),$(arch)),$(sort $(wildcard patches/*.patch patches/kernel-$(subst +,,$(TC_KERNEL))/*.patch patches/DSM-$(TCVERSION)/*.patch patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')/*.patch  patches/$(shell echo ${group} | cut -f1 -d'_'| tr '[:upper:]' '[:lower:]')-$(TCVERSION)/*.patch patches/$(arch)/*.patch patches/$(arch)-$(TCVERSION)/*.patch)),))))
 else
 PATCHES = $(sort $(wildcard patches/*.patch))
 endif  
+
+ifeq ($(strip $(PATCHES)),)
+PATCHES = $(wildcard patches/*.patch)
+endif
 endif
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done


### PR DESCRIPTION
## Description

- strip the toolchain suffix from ARCH before selecting patch directories so builds such as x64-7.0 and noarch-7.0 reuse the expected patch buckets
- keeps the original lookup order and generic fallback intact; no other framework changes required

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [x] Includes small framework changes
