### PR TITLE
ruTorrent: Patch for v5.2.10

### DIFF
--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = rutorrent
 SPK_VERS = 5.2.10
-SPK_REV = 19
+SPK_REV = 20
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
@@ -65,7 +65,6 @@ ifeq ($(call version_ge, ${TCVERSION}, 7.2),1)
 # Default to PHP 8.2 on DSM 7.2+ (PHP 8.0 not supported)
 SPK_DEPENDS = "WebStation:PHP8.2:Apache2.4:${PYTHON_PACKAGE}:mediainfo"
 CONF_DIR = src/conf_72
-OS_MAX_VER = 7.2-79999
 else
 # Default to PHP 8.0 on DSM 7.0/7.1
 SPK_DEPENDS = "WebStation:PHP8.0:Apache2.4:${PYTHON_PACKAGE}:mediainfo"


### PR DESCRIPTION
## Description

This is a follow-on from #6810 that enables support for DSM 7.3 (drop the `OS_MAX_VER` cap).

- during install, detect the actual download share with a case-insensitive lookup and use that canonical path when templating `config.php` and `rtorrent.rc`, fixing plugins when the share already exists with different casing

Fixes #6724

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
