### PR TITLE
tt-rss: Fix for MariaDB binaries

### DIFF
--- a/spk/tt-rss/Makefile
+++ b/spk/tt-rss/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = tt-rss
 SPK_VERS = 20230828
-SPK_REV = 19
+SPK_REV = 20
 SPK_ICON = src/tt-rss.png
 
 DEPENDS  = cross/tt-rss

--- a/spk/tt-rss/src/service-setup.sh
+++ b/spk/tt-rss/src/service-setup.sh
@@ -33,10 +33,8 @@ else
 fi
 JQ="/bin/jq"
 SYNOSVC="/usr/syno/sbin/synoservice"
-MARIADB_10_INSTALL_DIRECTORY="/var/packages/MariaDB10"
-MARIADB_10_BIN_DIRECTORY="${MARIADB_10_INSTALL_DIRECTORY}/target/usr/local/mariadb10/bin"
-MYSQL="${MARIADB_10_BIN_DIRECTORY}/mysql"
-MYSQLDUMP="${MARIADB_10_BIN_DIRECTORY}/mysqldump"
+MYSQL="/usr/local/mariadb10/bin/mysql"
+MYSQLDUMP="/usr/local/mariadb10/bin/mysqldump"
 MYSQL_USER="ttrss"
 MYSQL_DATABASE="ttrss"
 
@@ -175,6 +173,22 @@ validate_preinst ()
       exit 1
     fi
   fi
+
+  # Check database
+  if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
+    if ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
+      echo "Incorrect MariaDB 'root' password"
+      exit 1
+    fi
+    if ${MYSQL} -u root -p"${wizard_mysql_password_root}" mysql -e "SELECT User FROM user" | grep ^"${MYSQL_USER}"$ > /dev/null 2>&1; then
+      echo "MariaDB user '${MYSQL_USER}' already exists"
+      exit 1
+    fi
+    if ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e "SHOW DATABASES" | grep ^"${MYSQL_DATABASE}"$ > /dev/null 2>&1; then
+      echo "MariaDB database '${MYSQL_DATABASE}' already exists"
+      exit 1
+    fi
+  fi
 }
 
 validate_preuninst ()
@@ -182,7 +196,7 @@ validate_preuninst ()
   if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ]; then
     # Check database
     if ! ${MYSQL} -u root -p"${wizard_mysql_password_root}" -e quit > /dev/null 2>&1; then
-      echo "Incorrect MySQL root password"
+      echo "Incorrect MySQL 'root' password"
       exit 1
     fi
 


### PR DESCRIPTION
## Description

This is a follow-on from #6827 to fix the path for the MariaDB binaries on DSM 7.3. It also adds missing pre-install database checks.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
