### PR TITLE
Fix Python build errors from PR #6868

### DIFF
--- a/mk/spksrc.crossenv.mk
+++ b/mk/spksrc.crossenv.mk
@@ -124,9 +124,11 @@ crossenv-%:
 
 ####
 
-# Defined using current install prefix by replacing package name using
-# PYTHON_PACKAGE from spksrc.python.mk, else use local install prefix
-ifneq ($(PYTHON_PACKAGE),)
+# Determine the correct Python install prefix:
+# - If PYTHON_PACKAGE_WORK_DIR exists (pre-built python package available),
+#   use the python package's install prefix by replacing SPK_NAME with PYTHON_PACKAGE
+# - Otherwise (python is built as a dependency), use the current package's install prefix
+ifneq ($(wildcard $(PYTHON_PACKAGE_WORK_DIR)),)
 PYTHON_INSTALL_PREFIX = $(subst $(SPK_NAME),$(PYTHON_PACKAGE),$(INSTALL_PREFIX))
 else
 PYTHON_INSTALL_PREFIX = $(INSTALL_PREFIX)

--- a/mk/spksrc.python.mk
+++ b/mk/spksrc.python.mk
@@ -6,7 +6,7 @@
 
 # set default spk/python* path to use
 PYTHON_PACKAGE_DIR = $(realpath $(CURDIR)/../../spk/$(PYTHON_PACKAGE))
-PYTHON_PACKAGE_WORK_DIR = $(PYTHON_PACKAGE_DIR)/work-$(ARCH)-$(TCVERSION))
+PYTHON_PACKAGE_WORK_DIR = $(PYTHON_PACKAGE_DIR)/work-$(ARCH)-$(TCVERSION)
 
 include ../../mk/spksrc.common.mk
 


### PR DESCRIPTION
## Description
Fixes syntax and logic errors introduced in PR #6868 that broke Python-dependent package builds.

### Issues Fixed
- Removed extra closing parenthesis in `mk/spksrc.python.mk:9`
- Fixed Python install prefix detection in `mk/spksrc.crossenv.mk` when python312 isn't pre-built

### Testing
- Tested `ffsync` build without pre-built python312
- Tested with pre-built python312 (backward compatible)

### Impact
Completes PR #6868's goal: packages can now build without pre-building python312 first.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
