### PR TITLE
fossil-scm: Fix LLONG_MIN/MAX for ppc853x-5.2 build

### DIFF
--- a/cross/fossil-scm/patches/ppc853x/001-fix-llong-min.patch
+++ b/cross/fossil-scm/patches/ppc853x/001-fix-llong-min.patch
@@ -1,0 +1,17 @@
+--- extsrc/shell.c.orig	2024-01-01 00:00:00.000000000 +0000
++++ extsrc/shell.c	2024-01-01 00:00:00.000000000 +0000
+@@ -105,6 +105,14 @@
+ # define _LARGEFILE_SOURCE 1
+ #endif
+ 
++/* Define LLONG_MIN if not available (for old PPC toolchains) */
++#ifndef LLONG_MIN
++# define LLONG_MIN (-9223372036854775807LL - 1)
++#endif
++#ifndef LLONG_MAX
++# define LLONG_MAX 9223372036854775807LL
++#endif
++
+ #if defined(SQLITE_SHELL_FIDDLE) && !defined(_POSIX_SOURCE)
+ /*
+ ** emcc requires _POSIX_SOURCE (or one of several similar defines)


### PR DESCRIPTION
## Description

This is a follow-on from #6887:
- Add arch-specific patch to define LLONG_MIN/MAX macros for ppc853x-5.2 architecture where these are missing in the old toolchain headers.

Fixes https://github.com/SynoCommunity/spksrc/pull/6887#issuecomment-3717979702

- This fixes the compilation error at extsrc/shell.c:6287 when building for ppc853x-5.2. Only targeting ppc853x as it's the only OLD_PPC_ARCH actually built in GitHub Actions CI.

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
