### PR TITLE
framework: add standardized boolean parsing helper

### DIFF
--- a/mk/spksrc.bool.mk
+++ b/mk/spksrc.bool.mk
@@ -1,0 +1,36 @@
+# Standardized boolean parsing helper
+#
+# This file provides consistent boolean evaluation across the build system.
+# It normalizes various boolean representations (yes/no, true/false, 1/0, y/n)
+# into a consistent format for Make conditionals.
+#
+# Usage:
+#   include ../../mk/spksrc.bool.mk
+#   ifeq ($(call bool,$(MY_VAR)),true)
+#     # do something when MY_VAR is truthy
+#   endif
+#
+# Truthy values: yes, true, 1, y, YES, TRUE, Y (case insensitive)
+# Falsy values:  no, false, 0, n, NO, FALSE, N, empty (case insensitive)
+#
+
+# Convert any boolean-like value to lowercase 'true' or 'false'
+# Empty values are considered false
+define bool
+$(strip \
+  $(if $(1), \
+    $(if $(filter yes YES Yes true TRUE True 1 y Y,$(1)),true,false), \
+    false))
+endef
+
+# Check if a value is truthy
+# Returns non-empty string if true, empty if false
+define is_true
+$(strip $(filter true,$(call bool,$(1))))
+endef
+
+# Check if a value is falsy
+# Returns non-empty string if false, empty if true
+define is_false
+$(strip $(if $(call is_true,$(1)),,false))
+endef

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -85,6 +85,9 @@ AVAILABLE_KERNEL_VERSIONS = $(sort $(foreach arch,$(AVAILABLE_KERNEL),$(shell ec
 # Global arch definitions
 include $(BASEDIR)mk/spksrc.archs.mk
 
+# Standardized boolean parsing helpers
+include $(BASEDIR)mk/spksrc.bool.mk
+
 # Load local configuration
 LOCAL_CONFIG_MK = $(BASEDIR)local.mk
 ifneq ($(wildcard $(LOCAL_CONFIG_MK)),)

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -256,7 +256,7 @@ ifneq ($(strip $(SPK_USR_LOCAL_LINKS)),)
 endif
 ifneq ($(strip $(SERVICE_WIZARD_SHARE)),)
 # e.g. SERVICE_WIZARD_SHARE=wizard_download_dir, for DSM 6 with USE_DATA_SHARE_WORKER = yes
-ifeq ($(strip $(USE_DATA_SHARE_WORKER)),yes)
+ifeq ($(call is_true,$(USE_DATA_SHARE_WORKER)),true)
 	@jq --arg share "{{${SERVICE_WIZARD_SHARE}}}" --arg user sc-${SPK_USER} \
 		'."data-share" = {"shares": [{"name": $$share, "permission":{"rw":[$$user]}} ] }' $@ | sponge $@
 endif
@@ -436,7 +436,7 @@ endif
 #     - SERVICE_TYPE
 # default values are documentent at the top of this file
 ifneq ($(strip $(SPK_ICON)),)
-ifeq ($(strip $(NO_SERVICE_SHORTCUT)),)
+ifeq ($(call is_true,$(NO_SERVICE_SHORTCUT)),)
 ifneq ($(wildcard $(DSM_UI_CONFIG)),)
 $(STAGING_DIR)/$(DSM_UI_DIR)/config:
 	$(create_target_dir)


### PR DESCRIPTION
## Description

**Changes**

- `mk/spksrc.bool.mk` - New helper with `bool()`, `is_true()`, `is_false()` functions
- `mk/spksrc.common.mk` - Includes the new helper
- `mk/spksrc.service.mk` - Updated `NO_SERVICE_SHORTCUT` and `USE_DATA_SHARE_WORKER` checks

**Analysis Findings**

- 35 boolean checks in mk files use `,1)` pattern
- All packages consistently use 1 for those variables
- Only `NO_SERVICE_SHORTCUT` has mixed usage (`yes`, `true`, `y`)
- Phase 2 can extend usage to other variables if needed

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
