### PR TITLE
syncstorage-rs, diesel: Fix MYSQLCLIENT_VERSION timing issue

### DIFF
--- a/cross/diesel/Makefile
+++ b/cross/diesel/Makefile
@@ -29,11 +29,15 @@ export MYSQL_DB_SOCKET=/run/mysqld/mysqld10.sock
 ENV += MYSQLCLIENT_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib
 ENV += MYSQLCLIENT_INCLUDE_DIR=$(STAGING_INSTALL_PREFIX)/include/mariadb
 
-# pass mysql client version (needed by mysqlclient-sys crate)
-# Read from mariadb-connector-c-latest Makefile which exists at parse time
-ENV += MYSQLCLIENT_VERSION=$(shell sed -n 's/^PKG_VERS = //p' $(BASEDIR)cross/mariadb-connector-c-latest/Makefile)
-
 # let ./configure find mysql_config (it is a script and works for cross compile)
 ENV += "PATH=$(PATH):$(STAGING_INSTALL_PREFIX)/bin"
 
 include ../../mk/spksrc.cross-rust.mk
+
+# pass mysql client version (needed by mysqlclient-sys crate)
+# Use same conditional as mariadb-connector-c to select correct version
+ifeq ($(call version_ge, $(TC_GCC), 5),1)
+ENV += MYSQLCLIENT_VERSION=$(shell sed -n 's/^PKG_VERS = //p' $(BASEDIR)cross/mariadb-connector-c-latest/Makefile)
+else
+ENV += MYSQLCLIENT_VERSION=$(shell sed -n 's/^PKG_VERS = //p' $(BASEDIR)cross/mariadb-connector-c-3.3.11/Makefile)
+endif

--- a/cross/syncstorage-rs/Makefile
+++ b/cross/syncstorage-rs/Makefile
@@ -33,13 +33,17 @@ ENV += MYSQLCLIENT_LIB_DIR=$(STAGING_INSTALL_PREFIX)/lib
 # to find dependencies of libmysqlclient (libz)
 ENV += RUSTFLAGS="-Clink-arg=-Wl,--rpath,$(INSTALL_PREFIX)/lib -Clink-arg=-Wl,--rpath-link,$(STAGING_INSTALL_PREFIX)/lib"
 
-# pass mysql client version (needed by mysqlclient-sys crate)
-# Read from mariadb-connector-c-latest Makefile which exists at parse time
-ENV += MYSQLCLIENT_VERSION=$(shell sed -n 's/^PKG_VERS = //p' $(BASEDIR)cross/mariadb-connector-c-latest/Makefile)
-
 POST_INSTALL_TARGET = syncstorage-rs_post_install
 
 include ../../mk/spksrc.cross-rust.mk
+
+# pass mysql client version (needed by mysqlclient-sys crate)
+# Use same conditional as mariadb-connector-c to select correct version
+ifeq ($(call version_ge, $(TC_GCC), 5),1)
+ENV += MYSQLCLIENT_VERSION=$(shell sed -n 's/^PKG_VERS = //p' $(BASEDIR)cross/mariadb-connector-c-latest/Makefile)
+else
+ENV += MYSQLCLIENT_VERSION=$(shell sed -n 's/^PKG_VERS = //p' $(BASEDIR)cross/mariadb-connector-c-3.3.11/Makefile)
+endif
 
 .PHONY: syncstorage-rs_post_install
 syncstorage-rs_post_install:


### PR DESCRIPTION
## Description

Fixes `MYSQLCLIENT_VERSION` being empty when building `syncstorage-rs` and `diesel` for cross-compilation targets (e.g., `aarch64-7.1`), which caused the `mysqlclient-sys` crate to fail with `"" is not supported`.

**Two issues addressed**:
1. **Wildcard timing**: The original `$(wildcard $(WORK_DIR)/mariadb-connector-c-[0-9]*)` evaluated before the dependency directory exists. Moving it after the include was tested but did not resolve the issue.
2. **TC_GCC availability**: The version selection needs `TC_GCC` to choose between `mariadb-connector-c-latest` (GCC ≥ 5) and `mariadb-connector-c-3.3.11` (GCC < 5), but `TC_GCC` isn't defined until after `spksrc.cross-rust.mk` is processed.

**Solution**: Move the assignment after the include and use `$(shell sed ...)` to read the version directly from the source Makefiles, which always exist on disk. The `TC_GCC` conditional mirrors the logic in `cross/mariadb-connector-c/Makefile` to select the correct version.

Fixes https://github.com/SynoCommunity/spksrc/pull/6877#issuecomment-3734884542

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
