### PR TITLE
framework: fix version_ge dependency in directories.mk

### DIFF
--- a/mk/spksrc.directories.mk
+++ b/mk/spksrc.directories.mk
@@ -61,7 +61,8 @@ endif
 # when invoking make from under spk/*.  Setting var when
 # test-building dependencies from under cross/* is unecessary.
 #
-ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
+# Using inline shell comparison to avoid dependency on version_ge from spksrc.common.mk
+ifeq ($(shell if printf '%s\n' "$(TCVERSION)" "7.0" | sort -VCr ; then echo 1; fi),1)
 ifeq ($(lastword $(subst /, ,$(INSTALL_PREFIX))),target)
 INSTALL_PREFIX_VAR = $(shell dirname $(INSTALL_PREFIX))/var
 endif


### PR DESCRIPTION
## Description

Fixes the circular dependency issue in `mk/spksrc.directories.mk` where `version_ge` is called before it's defined.

### Problem

In files like `spksrc.cross-cc.mk`, the include order is:

1. Line 25: `include ../../mk/spksrc.directories.mk`
2. Line 28: `include ../../mk/spksrc.common.mk`

The `version_ge` function is defined in `spksrc.common.mk` (line 160), but `spksrc.directories.mk` tries to use it at line 64 to determine `INSTALL_PREFIX_VAR`. This causes the conditional to silently fail, resulting in incorrect var directory paths for DSM 7+ builds.

### Solution

Replace the `$(call version_ge, ${TCVERSION}, 7.0)` with an inline shell comparison using the same logic that `version_ge` uses internally:
```
$(shell if printf '%s\n' "$(TCVERSION)" "7.0" | sort -VCr ; then echo 1; fi)
```
This is the simplest fix because:

- Single-line change with minimal footprint
- Preserves exact DSM 6 vs 7 behavior
- No include reordering or new files required
- Uses identical shell logic to `version_ge`

### Testing

| DSM Version | INSTALL_PREFIX_VAR | Expected | Status |
|------------|-------------------|----------|--------|
| 7.1 | /var/packages/demoservice/var | /var/packages/SPK_NAME/var | ✅ |
| 6.2.4 | /var/packages/demoservice/target/var | /var/packages/SPK_NAME/target/var | ✅ |

### Related

- Ref: PR #5829 discussion
- Alternative to commit e0bcf980 which removed the conditional entirely

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
