### PR TITLE
framework: Add CC/CXX and other build tools as Make variables in tc_flags

### DIFF
--- a/mk/spksrc.tc.mk
+++ b/mk/spksrc.tc.mk
@@ -332,7 +332,15 @@ autotools_vars:
 
 .PHONY: tc_flags
 tc_flags:
-	@echo CFLAGS := $(CFLAGS) $$\(GCC_DEBUG_FLAGS\) $$\(ADDITIONAL_CFLAGS\) ; \
+	@echo CC := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)gcc ; \
+	echo CXX := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)g++ ; \
+	echo LD := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)ld ; \
+	echo AR := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)ar ; \
+	echo AS := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)as ; \
+	echo NM := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)nm ; \
+	echo RANLIB := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)ranlib ; \
+	echo STRIP := $(WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)strip ; \
+	echo CFLAGS := $(CFLAGS) $$\(GCC_DEBUG_FLAGS\) $$\(ADDITIONAL_CFLAGS\) ; \
 	echo CPPFLAGS := $(CPPFLAGS) $$\(GCC_DEBUG_FLAGS\) $$\(ADDITIONAL_CPPFLAGS\) ; \
 	echo CXXFLAGS := $(CXXFLAGS) $$\(GCC_DEBUG_FLAGS\) $$\(ADDITIONAL_CXXFLAGS\) ; \
 	if [ -n "$(TC_HAS_FORTRAN)" ]; then \


### PR DESCRIPTION
## Description

This is a follow-on from #6877 to address a regression in 1ebe52b affecting the cross-compilation of boost libraries.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
