### PR TITLE
python31*: Fix msg realated to removing compiled files from __pycache__

### DIFF
--- a/spk/python310/Makefile
+++ b/spk/python310/Makefile
@@ -36,5 +36,5 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: python310_extra_install
 python310_extra_install:
-	@$(MSG) - Remove compiled files from __pycache__
-	find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete
+	@$(MSG) \($(SPK_NAME)\) Remove compiled files from __pycache__
+	@find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete

--- a/spk/python311/Makefile
+++ b/spk/python311/Makefile
@@ -41,5 +41,5 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: python311_extra_install
 python311_extra_install:
-	@$(MSG) - Remove compiled files from __pycache__
-	find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete
+	@$(MSG) \($(SPK_NAME)\) Remove compiled files from __pycache__
+	@find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete

--- a/spk/python312/Makefile
+++ b/spk/python312/Makefile
@@ -39,5 +39,5 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: python312_extra_install
 python312_extra_install:
-	@$(MSG) - Remove compiled files from __pycache__
-	find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete
+	@$(MSG) \($(SPK_NAME)\) Remove compiled files from __pycache__
+	@find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete

--- a/spk/python313/Makefile
+++ b/spk/python313/Makefile
@@ -39,5 +39,5 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: python313_extra_install
 python313_extra_install:
-	@$(MSG) - Remove compiled files from __pycache__
-	find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete
+	@$(MSG) \($(SPK_NAME)\) Remove compiled files from __pycache__
+	@find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete

--- a/spk/python314/Makefile
+++ b/spk/python314/Makefile
@@ -39,5 +39,5 @@ include ../../mk/spksrc.spk.mk
 
 .PHONY: python314_extra_install
 python314_extra_install:
-	@$(MSG) - Remove compiled files from __pycache__
-	find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete
+	@$(MSG) \($(SPK_NAME)\) Remove compiled files from __pycache__
+	@find $(STAGING_DIR)/$(PYTHON_LIB_DIR) -type f -regex '.*\.py[co]' -delete


### PR DESCRIPTION
## Description

python31*: Fix msg realated to removing compiled files from __pycache__

Discovered while working on https://github.com/SynoCommunity/spksrc/pull/6914

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
