### PR TITLE
common.mk: Migrate remaining spksrc.archs.mk to spksrc.common.mk

### DIFF
--- a/cross/qbittorrent/Makefile
+++ b/cross/qbittorrent/Makefile
@@ -17,7 +17,7 @@ INSTALL_TARGET = qbittorrent_install
 # Available: x86_64, aarch64, armv7, x86
 PKG_DIST_ARCH_LIST = x86_64 aarch64 armv7 x86
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
 PKG_DIST_ARCH = x86_64

--- a/cross/rustdesk-server/Makefile
+++ b/cross/rustdesk-server/Makefile
@@ -13,7 +13,7 @@ LICENSE  = AGPL-3.0
 
 INSTALL_TARGET = rustdesk-server_install
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 
 # Map spksrc architectures to RustDesk binary architectures
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))

--- a/diyspk/bat/Makefile
+++ b/diyspk/bat/Makefile
@@ -6,7 +6,7 @@ UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
 DEPENDS = cross/bat
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(PPC_ARCHS)),$(ARCH))
 SPK_VERS = 0.25.0
 endif

--- a/diyspk/bottom/Makefile
+++ b/diyspk/bottom/Makefile
@@ -4,7 +4,7 @@ SPK_REV = 1
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/bottom_0.10
 SPK_VERS = 0.10.2

--- a/diyspk/eza/Makefile
+++ b/diyspk/eza/Makefile
@@ -6,7 +6,7 @@ UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
 DEPENDS = cross/eza
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
 SPK_VERS = 0.20.18
 endif

--- a/diyspk/image-optim/Makefile
+++ b/diyspk/image-optim/Makefile
@@ -4,7 +4,7 @@ SPK_REV = 1
 
 # pngquant (pngquant3) must be built first
 OPTIONAL_DEPENDS = cross/pngquant
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifneq ($(findstring $(ARCH), $(OLD_PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/pngquant
 endif

--- a/diyspk/lsd/Makefile
+++ b/diyspk/lsd/Makefile
@@ -6,7 +6,7 @@ UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
 DEPENDS = cross/lsd
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(PPC_ARCHS)),$(ARCH))
 SPK_VERS = 1.1.5
 endif

--- a/diyspk/nmap/Makefile
+++ b/diyspk/nmap/Makefile
@@ -13,7 +13,7 @@ STARTABLE = no
 HOMEPAGE = https://nmap.org/
 LICENSE  = https://svn.nmap.org/nmap/LICENSE
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/nmap_7.92
 SPK_VERS = 7.92

--- a/diyspk/pngquant/Makefile
+++ b/diyspk/pngquant/Makefile
@@ -11,7 +11,7 @@ STARTABLE = no
 HOMEPAGE = https://pngquant.org/
 LICENSE = GPL
 
-include ../../mk/spksrc.archs.mk
+include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5_ARCHS)),$(ARCH))
 # std=c11 not fully supported
 DEPENDS = cross/pngquant2


### PR DESCRIPTION
## Description

common.mk: Migrate remaining spksrc.archs.mk to spksrc.common.mk

Follows-up #6906 where a few left-over `spksrc.archs.mk` where still in used, in particular in the `diyspk` folder.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
