### PR TITLE
Framework: Skip toolchain build for noarch packages

### DIFF
--- a/mk/spksrc.cross-cc.mk
+++ b/mk/spksrc.cross-cc.mk
@@ -140,9 +140,13 @@ TCVARS_DONE := $(WORK_DIR)/.tcvars_done
 .PHONY: cross-stage1
 cross-stage1: $(TCVARS_DONE)
 
+ifneq ($(strip $(TC)),)
 $(TCVARS_DONE):
 	@$(MAKE) WORK_DIR=$(TC_WORK_DIR) --no-print-directory -C ../../toolchain/$(TC) toolchain
 	@$(MAKE) WORK_DIR=$(WORK_DIR) --no-print-directory -C ../../toolchain/$(TC) tcvars
+else
+$(TCVARS_DONE): ;
+endif
 
 # -----------------------------------------------------------------------------
 # Stage2: Package cross build


### PR DESCRIPTION
## Description

Fixes an issue where `cross/` packages using `spksrc.install-resources.mk` with `override ARCH = noarch` would fail to build because `spksrc.cross-cc.mk` attempted to include toolchain targets even when no toolchain is needed.

This mirrors the existing noarch handling already present in `spksrc.spk.mk` (lines 508-514).

**Affected packages**:

- `cross/mantisbt`
- others...

**Changes**:

- `mk/spksrc.cross-cc.mk` - Added guard to skip toolchain target when `TC` is empty (noarch builds)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
