### PR TITLE
gh-action: fix intermittent CI failure due to toolchain cache

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -34,10 +34,11 @@ echo "===> TARGET: ${GH_ARCH}"
 echo "===> ARCH   packages: ${ARCH_PACKAGES}"
 echo "===> NOARCH packages: ${NOARCH_PACKAGES}"
 
-# Remove rust toolchain status file to enfore re-installing cargo/rust
-# This fixes isees on github-action where toolchain caching omits the
+# Remove toolchain status files to enforce re-building toolchain including cargo/rust
+# This fixes issues on github-action where toolchain caching omits the
 # actual installation state of cargo/rust within the distrib folder
 rm -f toolchain/syno-${GH_ARCH}/work/.rustc_done
+rm -f toolchain/syno-${GH_ARCH}/work/.toolchain_done
 
 if [ "${GH_ARCH%%-*}" = "noarch" ]; then
     build_packages=${NOARCH_PACKAGES}


### PR DESCRIPTION
## Description

Fixes intermittent CI build failures where rust/cargo is not installed, causing `ModuleNotFoundError: No module named 'puccinialin'` errors during Python wheel builds.

### Problem

The CI uses two separate caches:
- **Toolchain cache** - contains compiled toolchain and status cookies (`.toolchain_done`, `.rustc_done`)
- **Distrib cache** - contains downloaded/installed tools including rust/cargo

These caches have different keys and can get out of sync. When:
1. Toolchain cache is restored with `.toolchain_done` present
2. Distrib cache is restored **without** rust/cargo installed

The build fails because:
- The `toolchain` target sees `.toolchain_done` and skips entirely (`toolchain: ;`)
- The `rustc` target never executes (it's a dependency of `_all` which is never reached)
- Later, `maturin` tries to build wheels, can't find `cargo`, attempts auto-install via `puccinialin`, fails

### Solution

The existing workaround removed `.rustc_done` but this is ineffective because the parent `toolchain` target guards the entire dependency chain.

This PR adds removal of `.toolchain_done` to force re-evaluation of all toolchain dependencies including rust installation:

```bash
rm -f toolchain/syno-${GH_ARCH}/work/.rustc_done
rm -f toolchain/syno-${GH_ARCH}/work/.toolchain_done  # NEW
```

### Evidence

Comparing failed vs successful runs:

| Run | Distrib Cache Size | Rust Installed | Result |
|-----|-------------------|----------------|--------|
| Good | ~973 MB | Yes | ✅ Build succeeds |
| Failed | ~842 MB | No | ❌ `puccinialin` error |

Both runs had identical toolchain cache keys, confirming the issue is cache desync.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes gh-action changes
