### PR TITLE
File Browser: Update to v2.59.0

### DIFF
--- a/cross/filebrowser/Makefile
+++ b/cross/filebrowser/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = filebrowser
-PKG_VERS = 2.55.0
+PKG_VERS = 2.59.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/filebrowser/filebrowser/archive

--- a/cross/filebrowser/digests
+++ b/cross/filebrowser/digests
@@ -1,3 +1,3 @@
-filebrowser-2.55.0.tar.gz SHA1 5914001b372420c2a1aa5acb8a7bfe897e2bf4be
-filebrowser-2.55.0.tar.gz SHA256 8a857d5ae7eac27c3a957610f0671943ba780ef947f15b83dfa7776f92495dbe
-filebrowser-2.55.0.tar.gz MD5 b36de975e5d218d3f450348f7a494598
+filebrowser-2.59.0.tar.gz SHA1 81e8386b6cba17fdb280e49ccd1933eab9f396cf
+filebrowser-2.59.0.tar.gz SHA256 fc311566b008be3796d6f27f0e9fb90b3bccb497c4e203bc53069f46e39f94f1
+filebrowser-2.59.0.tar.gz MD5 d06cd22007827b44d73e7c6beb33ee8a

--- a/spk/filebrowser/Makefile
+++ b/spk/filebrowser/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = filebrowser
-SPK_VERS = 2.55.0
-SPK_REV = 8
+SPK_VERS = 2.59.0
+SPK_REV = 9
 SPK_ICON = src/filebrowser.png
 
 DEPENDS = cross/filebrowser
@@ -9,11 +9,11 @@ UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 
 MAINTAINER = publicarray
 DISPLAY_NAME = File Browser
-DESCRIPTION = filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files. It allows the creation of multiple users and each user can have its own directory.
+DESCRIPTION = File Browser provides a file managing interface within a specified directory and it can be used to upload, delete, preview and edit your files.
 HOMEPAGE = https://filebrowser.org/
 HELPURL = https://github.com/filebrowser/filebrowser/issues
 LICENSE = Apache 2.0
-CHANGELOG = "1. Update File Browser to v2.55.0 <br/>2. Add wizard for admin credential configuration <br/>3. Built with go v1.25.4 and node v24.11.1."
+CHANGELOG = "1. Update File Browser to v2.59.0 <br/>2. Built with go v1.25.4 and node v24.11.1."
 
 GROUP = synocommunity
 


### PR DESCRIPTION
## Description

Update File Browser from v2.55.0 to v2.59.0. Upstream changelog highlights (v2.56.0 - v2.59.0):

- Render equations in markdown preview
- Add 'Open direct' button to images
- Various dependency updates and bug fixes

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
