### PR TITLE
Framework: Fix POSIX Compliance in Service Start-Stop-Status Script

### DIFF
--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -91,7 +91,7 @@ stop_daemon()
         do
             if [ -z "${SVC_QUIET}" ]; then
                 date >> "${LOG_FILE}"
-                echo "Stopping ${DNAME} service : $(ps -p"${pid}" -o comm=) (${pid})" >> "${LOG_FILE}"
+                echo "Stopping ${DNAME} service : $(ps -p "${pid}" -o comm=) (${pid})" >> "${LOG_FILE}"
             fi
             kill -TERM "${pid}" >> "${LOG_FILE}" 2>&1
             wait_for_status 1 "${SVC_WAIT_TIMEOUT:=20}" "${pid}" || kill -KILL "${pid}" >> "${LOG_FILE}" 2>&1


### PR DESCRIPTION
## Description

Fixes POSIX compliance issues in `mk/spksrc.service.start-stop-status` that caused service startup failures on older Synology devices with minimal POSIX shells (e.g., DS216se with kernel 3.2.101).

### Changes

- Replace obsolete `-a` test operator with `&&`
- Replace bash-specific `let` with POSIX `$(())`
- Replace `echo -ne` with `printf`
- Add proper variable quoting
- Remove dead code (redundant DSM version check)
- Fix formatting inconsistencies


Fixes #6996

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
