### PR TITLE
GnuPG: Update to v2.4.9

### DIFF
--- a/cross/gnupg/Makefile
+++ b/cross/gnupg/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = gnupg
-PKG_VERS = 2.4.8
+PKG_VERS = 2.4.9
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://gnupg.org/ftp/gcrypt/gnupg

--- a/cross/gnupg/digests
+++ b/cross/gnupg/digests
@@ -1,3 +1,3 @@
-gnupg-2.4.8.tar.bz2 SHA1 c704085aa7cc131a67edd0b7c0c90e5c35ee4adb
-gnupg-2.4.8.tar.bz2 SHA256 b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616
-gnupg-2.4.8.tar.bz2 MD5 a165b60aeaac0bb4d251117a45199c5f
+gnupg-2.4.9.tar.bz2 SHA1 d4b76a8de78631b64b8c6f3725ed28dede40bdb4
+gnupg-2.4.9.tar.bz2 SHA256 dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964
+gnupg-2.4.9.tar.bz2 MD5 21a5a83bd7fae40c8c9c3f79c6d0358b

--- a/cross/npth/PLIST
+++ b/cross/npth/PLIST
@@ -1,4 +1,3 @@
-rsc:bin/npth-config
 lnk:lib/libnpth.so
 lnk:lib/libnpth.so.0
 lib:lib/libnpth.so.0.3.0

--- a/spk/gnupg/Makefile
+++ b/spk/gnupg/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = gnupg
-SPK_VERS = 2.4.8
-SPK_REV = 7
+SPK_VERS = 2.4.9
+SPK_REV = 8
 SPK_ICON = src/gnupg.png
 
 DEPENDS = cross/gnupg
@@ -9,7 +9,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = GnuPG allows to encrypt and sign your data and communication, features a versatile key management system as well as access modules for all kinds of public key directories.
 STARTABLE = no
 DISPLAY_NAME = GnuPG
-CHANGELOG = "1. Update gnupg to 2.4.8<br/>2. Update shared libraries."
+CHANGELOG = "Update GnuPG to 2.4.9."
 
 HOMEPAGE = https://www.gnupg.org/
 LICENSE  = GPLv3


### PR DESCRIPTION
## Description

This PR includes the following changes:

- Update GnuPG from 2.4.8 to 2.4.9
- Remove obsolete npth-config from npth PLIST (no longer installed by upstream)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
