### PR TITLE
Avoid downloading dependencies for broken pacjages

### DIFF
--- a/spk/ffmpeg6/Makefile
+++ b/spk/ffmpeg6/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = ffmpeg6
 SPK_VERS = 6.0.1
-SPK_REV = 6
+SPK_REV = 5
 SPK_ICON = src/ffmpeg.png
 CHANGELOG = "1. Update to version 6.0.1<br/>2. Update Jellyfin upstream patches<br/>3. Update Intel Media Driver 2024Q2 Release (DSM7 only)<br/>4. Revert DSM7 to MFX intead of Intel Video Processing Library (Intel-VPL) as unsupported by Jellyfin<br/>5. Enable OpenCL on Intel platforms (DSM7 only)<br/>6. Update to latest version of x264 (fix for \#6176)<br/>6. Now using new synocli-videodriver package"
 


### PR DESCRIPTION
## Description

This PR fixes an issue when `BROKEN` packages ends-up being update it triggers a build process that fails such as:
```
  -> spk/ffmpeg6: download-wheels
make: Entering directory '/home/runner/work/spksrc/spksrc/spk/ffmpeg6'
../../mk/spksrc.pre-check.mk:25: *** ffmpeg6: Broken package.  Stop.
make: Leaving directory '/home/runner/work/spksrc/spksrc/spk/ffmpeg6'
Error: Error on line 84 while processing spk/ffmpeg6
Error: Process completed with exit code 1.
```
Fix here filters out packages at `prepare.sh` time.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
