### PR TITLE
synokernel-cdrom|usbserial: Add DSM-7.3 support

### DIFF
--- a/spk/synokernel-cdrom/Makefile
+++ b/spk/synokernel-cdrom/Makefile
@@ -11,7 +11,7 @@ REQUIRE_KERNEL_MODULE += CONFIG_BLK_DEV_SR:drivers/scsi:sr_mod
 
 MAINTAINER = th0ma7
 DESCRIPTION = "Provides Synology kernel CD-ROM drivers cdrom.ko and sr_mod.ko."
-CHANGELOG = "Add support for Linux 5.x kernels."
+CHANGELOG = "Add DSM-7.3 support."
 
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 # we only have ipq806x for SRM 1.2, but this fails with:

--- a/spk/synokernel-usbserial/Makefile
+++ b/spk/synokernel-usbserial/Makefile
@@ -16,7 +16,7 @@ REQUIRE_KERNEL_MODULE += CONFIG_USB_SERIAL_TI:drivers/usb/serial:ti_usb_3410_505
 
 MAINTAINER = th0ma7
 DESCRIPTION = "Provides usbserial.ko ch341.ko cp210x.ko pl2303.ko ti_usb3410_5052.ko and ftdi_sio.ko."
-CHANGELOG = "Add support for Linux 5.x kernels."
+CHANGELOG = "Add DSM-7.3 support."
 
 UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 # we only have ipq806x for SRM 1.2, but this fails with:


### PR DESCRIPTION
## Description

synokernel-cdrom|usbserial: Add DSM-7.3 support

Relates to #7007

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
