### PR TITLE
Build fixes: glibc, java-17|21-openjdk, jasper

### DIFF
--- a/cross/giflib/Makefile
+++ b/cross/giflib/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = giflib
 PKG_VERS = 5.2.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://downloads.sourceforge.net/project/giflib
+PKG_DIST_SITE = https://downloads.sourceforge.net/project/giflib/giflib-5.x
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/jasper/Makefile
+++ b/cross/jasper/Makefile
@@ -18,10 +18,9 @@ CMAKE_ARGS += -DJAS_ENABLE_PROGRAMS=OFF
 CMAKE_ARGS += -DJAS_STDC_VERSION=199901L
 CMAKE_ARGS += -DCMAKE_C_FLAGS_RELEASE="-O"
 
-include ../../mk/spksrc.cross-cmake.mk
-
 # Avoid build dir within source:
 # The useof an in-source build is not officially supported and is 
 # therefore disallowed by default. 
-CMAKE_BUILD_DIR = $(CMAKE_BASE_DIR)/../jasper.build
-CMAKE_ARGS += -B$(CMAKE_BUILD_DIR)
+CMAKE_BUILD_DIR = $(abspath $(CMAKE_BASE_DIR)/../jasper.build)
+
+include ../../mk/spksrc.cross-cmake.mk

--- a/cross/java-17-openjdk/Makefile
+++ b/cross/java-17-openjdk/Makefile
@@ -75,12 +75,12 @@ CONFIGURE_ARGS += --with-vendor-bug-url=https://github.com/SynoCommunity/spksrc/
 CONFIGURE_ARGS += --with-vendor-vm-bug-url=https://github.com/SynoCommunity/spksrc/issues
 
 # arguments not taken from environment
-CONFIGURE_ARGS += READELF=$(READELF)
-CONFIGURE_ARGS += AR=$(AR)
-CONFIGURE_ARGS += STRIP=$(STRIP)
-CONFIGURE_ARGS += NM=$(NM)
-CONFIGURE_ARGS += OBJCOPY=$(OBJCOPY)
-CONFIGURE_ARGS += OBJDUMP=$(OBJDUMP)
+CONFIGURE_ARGS += READELF=$(TC_PATH)/$(TC_PREFIX)readelf
+CONFIGURE_ARGS += AR=$(TC_PATH)/$(TC_PREFIX)ar
+CONFIGURE_ARGS += STRIP=$(TC_PATH)/$(TC_PREFIX)strip
+CONFIGURE_ARGS += NM=$(TC_PATH)/$(TC_PREFIX)nm
+CONFIGURE_ARGS += OBJCOPY=$(TC_PATH)/$(TC_PREFIX)objcopy
+CONFIGURE_ARGS += OBJDUMP=$(TC_PATH)/$(TC_PREFIX)objdump
 
 # Build images twice, second time with newly built JDK
 COMPILE_MAKE_OPTIONS += product-images

--- a/cross/java-17-openjdk/Makefile
+++ b/cross/java-17-openjdk/Makefile
@@ -22,7 +22,6 @@ BUILD_DEPENDS += cross/libXrender
 # Dependencies used as system dependencies:
 DEPENDS  = cross/alsa-lib
 DEPENDS += cross/fontconfig
-DEPENDS += cross/libffi
 DEPENDS += cross/zlib
 DEPENDS += cross/libpng
 DEPENDS += cross/libjpeg
@@ -33,8 +32,8 @@ HOMEPAGE = https://openjdk.org/projects/jdk/17/
 COMMENT  = OpenJDK 17 is the open-source reference implementation of version 17 of the Java SE Platform as specified by JSR 390 in the Java Community Process.
 LICENSE  = GPLv2 with the Classpath Exception
 
-# Use our own configure since the one supplied by openjdk has no shebang
-CONFIGURE_TARGET = java-17-openjdk_configure
+# Make configure script executable
+PRE_CONFIGURE_TARGET = java-17-openjdk_pre_configure
 
 # Force openjdk to install into the package install folder
 PRE_COMPILE_TARGET = java-17-openjdk_pre_compile
@@ -63,10 +62,9 @@ CONFIGURE_ARGS += --with-fontconfig=$(INSTALL_DIR)/$(INSTALL_PREFIX)
 CONFIGURE_ARGS += --with-freetype=system
 CONFIGURE_ARGS += --with-freetype-include=$(INSTALL_DIR)/$(INSTALL_PREFIX)/include/freetype2
 CONFIGURE_ARGS += --with-freetype-lib=$(INSTALL_DIR)/$(INSTALL_PREFIX)/lib
-CONFIGURE_ARGS += --with-extra-cflags="$(CFLAGS) -fno-stack-protector -Wno-deprecated-declarations"
-CONFIGURE_ARGS += --with-extra-cxxflags="$(CPPFLAGS) -fno-stack-protector -Wno-deprecated-declarations"
-CONFIGURE_ARGS += --with-extra-ldflags="$(LDFLAGS) -Xlinker -z -Xlinker relro -Xlinker -Bsymbolic-functions"
-CONFIGURE_ARGS += --with-libffi=$(INSTALL_DIR)/$(INSTALL_PREFIX)
+CONFIGURE_ARGS += --with-extra-cflags="$(CFLAGS) $(ADDITIONAL_CFLAGS) -fno-stack-protector -Wno-deprecated-declarations"
+CONFIGURE_ARGS += --with-extra-cxxflags="$(CPPFLAGS) $(ADDITIONAL_CPPFLAGS) -fno-stack-protector -Wno-deprecated-declarations"
+CONFIGURE_ARGS += --with-extra-ldflags="$(LDFLAGS) $(ADDITIONAL_LDFLAGS) -ljpeg -Xlinker -z -Xlinker relro -Xlinker -Bsymbolic-functions"
 CONFIGURE_ARGS += --disable-manpages
 # Disable all GUI related
 CONFIGURE_ARGS += --enable-headless-only
@@ -103,12 +101,10 @@ ifneq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
 PLIST_TRANSFORM = sed -e '/lib\/libjsvml.so/d'
 endif
 
-.PHONY: java-17-openjdk_configure
-# Use CONFIGURE_ARGS instead of REAL_CONFIGURE_ARGS to ignore TC_CONFIGURE_ARGS
-# Disable the normal host build target triplets since openjdk uses its own openjdk-target
-# Avoid the use of $(RUN) since configure complains about env variables
-java-17-openjdk_configure:
-	cd $(WORK_DIR)/$(PKG_DIR) && bash ./configure $(CONFIGURE_ARGS)
+.PHONY: java-17-openjdk_pre_configure
+java-17-openjdk_pre_configure:
+	@$(MSG) "- Make configure script executable"
+	@cd $(WORK_DIR)/$(PKG_DIR) && chmod +x ./configure
 
 .PHONY: java-17-openjdk_pre_compile
 # As DESTDIR is not supported we must patch the make file for make install.

--- a/cross/java-21-openjdk/Makefile
+++ b/cross/java-21-openjdk/Makefile
@@ -78,12 +78,12 @@ CONFIGURE_ARGS += --with-vendor-bug-url=https://github.com/SynoCommunity/spksrc/
 CONFIGURE_ARGS += --with-vendor-vm-bug-url=https://github.com/SynoCommunity/spksrc/issues
 
 # arguments not taken from environment
-CONFIGURE_ARGS += READELF=$(READELF)
-CONFIGURE_ARGS += AR=$(AR)
-CONFIGURE_ARGS += STRIP=$(STRIP)
+CONFIGURE_ARGS += READELF=$(TC_PATH)/$(TC_PREFIX)readelf
+CONFIGURE_ARGS += AR=$(TC_PATH)/$(TC_PREFIX)ar
+CONFIGURE_ARGS += STRIP=$(TC_PATH)/$(TC_PREFIX)strip
 CONFIGURE_ARGS += NM=$(TC_PATH)/$(TC_PREFIX)nm
-CONFIGURE_ARGS += OBJCOPY=$(OBJCOPY)
-CONFIGURE_ARGS += OBJDUMP=$(OBJDUMP)
+CONFIGURE_ARGS += OBJCOPY=$(TC_PATH)/$(TC_PREFIX)objcopy
+CONFIGURE_ARGS += OBJDUMP=$(TC_PATH)/$(TC_PREFIX)objdump
 
 # Build images twice, second time with newly built JDK
 COMPILE_MAKE_OPTIONS += product-images


### PR DESCRIPTION
## Description

Changes:
- `cross/giflib`: Update URL to new download directory tree
- `cross/java-17|21-openjdk`: Fix build issue caused by missing variable in build environment
- `cross/jasper`: Ensure cmake variables are before `include ../../mk/spksrc.cross-cmake.mk`

Relates to #7028 where build issues where found.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
