### PR TITLE
Enhance rust installation using flock also for the target toolchain

### DIFF
--- a/spk/python312-wheels/Makefile
+++ b/spk/python312-wheels/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python312-wheels
 SPK_VERS = 1.0
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 2
+SPK_REV = 1
 SPK_ICON = src/python3-pip.png
 
 # Compiler must support std=c++11


### PR DESCRIPTION
## Description

rustc: Enhance rust installation using flock also for the target toolchain
    
Currently there are case where, when using make all-supported, two instances of rust target arch could be installed at the same time breaking-up rust toolchain installation.

Proposed fix brings the toolchain target under the same flock use to install rust default compiler, avoiding collision all-together.

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Found while working on #7032

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
