### PR TITLE
videodrv.mk: Standardize VIDEODRV_*INSTALL_PREFIX variable names

### DIFF
--- a/cross/ffmpeg7/Makefile
+++ b/cross/ffmpeg7/Makefile
@@ -251,7 +251,7 @@ endif
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
 # Dependencies provided by synocli-videodriver
 # If built outside spksrc.videodriver.mk
-ifeq ($(wildcard $(VIDEODRV_STAGING_PREFIX)),)
+ifeq ($(wildcard $(VIDEODRV_STAGING_INSTALL_PREFIX)),)
 DEPENDS += cross/libva cross/libva-utils
 DEPENDS += cross/intel-vaapi-driver
 DEPENDS += cross/intel-media-driver cross/intel-mediasdk

--- a/mk/spksrc.videodriver.mk
+++ b/mk/spksrc.videodriver.mk
@@ -15,19 +15,19 @@ include ../../mk/spksrc.common.mk
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
 
 # Set videodriver installtion prefix directory variables
-ifeq ($(strip $(VIDEODRV_STAGING_PREFIX)),)
-export VIDEODRV_PREFIX = /var/packages/$(VIDEODRV_PACKAGE)/target
-export VIDEODRV_STAGING_PREFIX = $(realpath $(VIDEODRV_PACKAGE_ROOT)/install/$(VIDEODRV_PREFIX))
+ifeq ($(strip $(VIDEODRV_STAGING_INSTALL_PREFIX)),)
+export VIDEODRV_INSTALL_PREFIX = /var/packages/$(VIDEODRV_PACKAGE)/target
+export VIDEODRV_STAGING_INSTALL_PREFIX = $(realpath $(VIDEODRV_PACKAGE_ROOT)/install/$(VIDEODRV_INSTALL_PREFIX))
 endif
 
 # set build flags including ld to rewrite for the library path
 # used to access videodrv package provide libraries at destination
-ifneq ($(strip $(VIDEODRV_STAGING_PREFIX)),)
-export ADDITIONAL_CFLAGS   += -I$(VIDEODRV_STAGING_PREFIX)/include
-export ADDITIONAL_CPPFLAGS += -I$(VIDEODRV_STAGING_PREFIX)/include
-export ADDITIONAL_CXXFLAGS += -I$(VIDEODRV_STAGING_PREFIX)/include
-export ADDITIONAL_LDFLAGS  += -L$(VIDEODRV_STAGING_PREFIX)/lib
-export ADDITIONAL_LDFLAGS  += -Wl,--rpath-link,$(VIDEODRV_STAGING_PREFIX)/lib -Wl,--rpath,$(VIDEODRV_PREFIX)/lib
+ifneq ($(strip $(VIDEODRV_STAGING_INSTALL_PREFIX)),)
+export ADDITIONAL_CFLAGS   += -I$(VIDEODRV_STAGING_INSTALL_PREFIX)/include
+export ADDITIONAL_CPPFLAGS += -I$(VIDEODRV_STAGING_INSTALL_PREFIX)/include
+export ADDITIONAL_CXXFLAGS += -I$(VIDEODRV_STAGING_INSTALL_PREFIX)/include
+export ADDITIONAL_LDFLAGS  += -L$(VIDEODRV_STAGING_INSTALL_PREFIX)/lib
+export ADDITIONAL_LDFLAGS  += -Wl,--rpath-link,$(VIDEODRV_STAGING_INSTALL_PREFIX)/lib -Wl,--rpath,$(VIDEODRV_INSTALL_PREFIX)/lib
 
 # videodrv library to share with other packages
 VIDEODRV_PKGCFG  = igc-opencl.pc
@@ -53,8 +53,8 @@ VIDEODRV_PKGCFG += vpl.pc
 
 # Re-use a default subset of videodrv mandatory libraries
 # This avoids sharing other built-in such as zlib and al
-# To share everything: $(wildcard $(VIDEODRV_STAGING_PREFIX)/lib/pkgconfig/*.pc)
-VIDEODRV_LIBS := $(wildcard $(patsubst %.pc,$(VIDEODRV_STAGING_PREFIX)/lib/pkgconfig/%.pc, $(VIDEODRV_PKGCFG)))
+# To share everything: $(wildcard $(VIDEODRV_STAGING_INSTALL_PREFIX)/lib/pkgconfig/*.pc)
+VIDEODRV_LIBS := $(wildcard $(patsubst %.pc,$(VIDEODRV_STAGING_INSTALL_PREFIX)/lib/pkgconfig/%.pc, $(VIDEODRV_PKGCFG)))
 endif
 
 # call-up pre-depend to prepare the shared videodrv build environment


### PR DESCRIPTION
## Description

videodrv.mk: Standardize VIDEODRV_*INSTALL_PREFIX variable names

`spksrc` normal variable names includes:
- `INSTALL_PREFIX` installation path relative to `$(WORK_DIR)/install` directory
- `STAGING_INSTSALL_PREFIX` full installation path including `$(WORK_DIR)/install/$(INSTALL_PREFIX)`

The "meta" environments to reuse `videodriver` libraries are not standardized.  They now obey the same guiding principles such as:
- `VIDEODRV_INSTALL_PREFIX`
- `VIDEODRV_STAGING_INSTALL_PREFIX`

Relates to #7041 in order to sub-divide overall gh-action build

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
