### PR TITLE
Cloudflare Tunnel: Update to v2026.3.0

### DIFF
--- a/cross/cloudflared/Makefile
+++ b/cross/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = cloudflared
-PKG_VERS = 2026.1.1
+PKG_VERS = 2026.3.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/cloudflare/cloudflared/archive

--- a/cross/cloudflared/digests
+++ b/cross/cloudflared/digests
@@ -1,3 +1,3 @@
-cloudflared-2026.1.1.tar.gz SHA1 b7d604f938e68787ac6ba5f1d267fa6d409a77d3
-cloudflared-2026.1.1.tar.gz SHA256 9f10dc955023c4d471ffa1d202bda994094f073066d81ccb69ab7c27801f2fab
-cloudflared-2026.1.1.tar.gz MD5 715d4a889b850abd6c015e498fd26195
+cloudflared-2026.3.0.tar.gz SHA1 31bff5c702569e81e516ef0a0f515d1de6a73913
+cloudflared-2026.3.0.tar.gz SHA256 1c9e88653f091d3085975e50c2cf7308923c88ed5c82afe7fb98938d3f9c93ad
+cloudflared-2026.3.0.tar.gz MD5 1360e8a19b0c9ec5b7b4cd05fd1d791d

--- a/spk/cloudflared/Makefile
+++ b/spk/cloudflared/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = cloudflared
-SPK_VERS = 2026.1.1
-SPK_REV = 21
+SPK_VERS = 2026.3.0
+SPK_REV = 22
 SPK_ICON = src/cloudflared.png
 
 DEPENDS = cross/cloudflared
@@ -12,7 +12,7 @@ DISPLAY_NAME = Cloudflare Tunnel
 DESCRIPTION = "Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address. With Tunnel, you do not send traffic to an external IP - instead, a lightweight daemon in your infrastructure \('cloudflared'\) creates outbound-only connections to Cloudflare\'s global network. Cloudflare Tunnel can connect HTTP web servers, SSH servers, remote desktops, and other protocols safely to Cloudflare. This way, your origins can serve traffic through Cloudflare without being vulnerable to attacks that bypass Cloudflare."
 HOMEPAGE = https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
 LICENSE = Apache-2.0
-CHANGELOG = "Update to v2026.1.1."
+CHANGELOG = "Update to v2026.3.0."
 
 WIZARDS_DIR = src/wizard/
 


### PR DESCRIPTION
## Description

- Update Cloudflare Tunnel to v2026.3.0 (fixes multiple CVEs)
### Upstream changelog
2026.3.0
- 2026-03-05 TUN-10292: Add cloudflared management token command
- 2026-03-03 chore: Addressing small fixes and typos
- 2026-03-03 fix: Update go-sentry and go-oidc to address CVE's
- 2026-02-24 TUN-10258: add agents.md
- 2026-02-23 TUN-10267: Update mods to fix CVE GO-2026-4394
- 2026-02-20 TUN-10247: Update tail command to use /management/logs endpoint
- 2026-02-11 TUN-9858: Add more information to proxy-dns removal message

2026.2.0
- 2026-02-06 TUN-10216: TUN fix cloudflare vulnerabilities GO-2026-4340 and GO-2026-4341
- 2026-02-02 TUN-9858: Remove proxy-dns feature from cloudflared

2026.1.2
- 2026-01-23 Revert "TUN-9863: Update pipelines to use cloudflared EV Certificate"
- 2026-01-21 Revert "TUN-9886 notarize cloudflared"
- 2025-12-12 TUN-9886 notarize cloudflared
## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

- [x] Package update
