### PR TITLE
gh-action consolidated diagnostics

### DIFF
--- a/spk/jellyfin/Makefile
+++ b/spk/jellyfin/Makefile
@@ -1,7 +1,7 @@
 # Remember to also update jellyfin-web
 SPK_NAME = jellyfin
 SPK_VERS = 10.11.7
-SPK_REV = 36
+SPK_REV = 35
 SPK_ICON = src/jellyfin.png
 
 DEPENDS = cross/jellyfin cross/jellyfin-web


### PR DESCRIPTION
## Description
This PR does the following:
- Renames architecture-specific diagnostics artifacts as `diagnostics-<arch>-<tcversion>`.
- Creates a consolidated `Diagnostics` artifact.
- Sets the lifetime of arch-specific artifacts to 1 day.
- Retains the 30-day lifetime for the consolidated diagnostics artifact.

## Note
It is not possible to delete individual diagnostic files or to use a cache. Since we are using a matrix, there is a one-to-many relationship, which prevents creating a true many-to-one consolidated artifact within the same workflow run. Therefore, both individual and consolidated artifacts must exist concurrently. Reducing the lifetime of the arch-specific artifacts to 1 day mitigates storage accumulation.

Relates to https://github.com/SynoCommunity/spksrc/issues/6892

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
