### PR TITLE
add arch icelaked

### DIFF
--- a/toolchain/syno-x64-7.1/Makefile
+++ b/toolchain/syno-x64-7.1/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 geminilake geminilakenk grantley kvmx64 purley r1000 r1000nk v1000 v1000nk
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow cedarview denverton epyc7002 geminilake geminilakenk grantley icelaked kvmx64 purley r1000 r1000nk v1000 v1000nk
 TC_VERS = 7.1
 TC_KERNEL = 4.4.180
 TC_GLIBC = 2.26

--- a/toolchain/syno-x64-7.2/Makefile
+++ b/toolchain/syno-x64-7.2/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow denverton epyc7002 geminilake geminilakenk grantley kvmx64 purley r1000 r1000nk v1000 v1000nk
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow denverton epyc7002 geminilake geminilakenk grantley icelaked kvmx64 purley r1000 r1000nk v1000 v1000nk
 TC_VERS = 7.2
 # kernel is "4.4.302+"; despite TC_DIST_SITE_PATH is "Intel x86 Linux 4.4.180 (Apollolake)"
 TC_KERNEL = 4.4.302

--- a/toolchain/syno-x64-7.3/Makefile
+++ b/toolchain/syno-x64-7.3/Makefile
@@ -1,6 +1,6 @@
 TC_NAME = syno-x64
 
-TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow denverton epyc7002 geminilake geminilakenk grantley kvmx64 purley r1000 r1000nk v1000 v1000nk
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk broadwellnkv2 broadwellntbap bromolow denverton epyc7002 geminilake geminilakenk grantley icelaked kvmx64 purley r1000 r1000nk v1000 v1000nk
 TC_VERS = 7.3
 # kernel is "4.4.302+"; despite TC_DIST_SITE_PATH is "Intel x86 Linux 4.4.180 (Apollolake)"
 TC_KERNEL = 4.4.302


### PR DESCRIPTION
## Description

- add icelaked to generic x64 archs for upcoming RS1626xs+
- toolchain is not available yet

Even without the related toolchain we can add icelaked to the generic x64 archs to support this model.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
