### PR TITLE
gh-action: Fix missing builds for standard packages on higher DSM toolchains

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -7,8 +7,11 @@
 # Functions:
 # - Build all packages depending on files defined in ${ARCH_PACKAGES} or ${NOARCH_PACKAGES}.
 # - Build for arch defined by ${GH_ARCH} (e.g. x64-6.1, noarch, ...).
-# - For DSM versions above the default builds, only packages declared for that
-#   minimum DSM version are built (driven by MIN_DSM<V>_PACKAGES env vars).
+# - For DSM versions above the default builds, packages declared for that minimum
+#   DSM version are built (driven by MIN_DSM<V>_PACKAGES env vars). If no
+#   DSM-restricted packages are present, standard packages are built instead,
+#   allowing packages that behave differently per DSM version (but declare no
+#   minimum) to be built on all selected toolchains.
 # - Successfully built packages are logged to ${BUILD_SUCCESS_FILE}.
 # - Failed builds are logged to ${BUILD_ERROR_FILE} and annotated as error.
 # - For failed builds, the make command and the latest 15 lines of the build output are written to ${BUILD_ERROR_LOGFILE}.
@@ -81,6 +84,7 @@ if [ "${GH_ARCH%%-*}" = "noarch" ]; then
         if [ "${DSM_VERSION}" = "${version}" ]; then
             v=${version//.}
             var="NOARCH_MIN_DSM${v^^}_PACKAGES"
+            # No DSM-restricted packages — fall back to standard noarch packages
             build_packages="${!var:-${NOARCH_PACKAGES}}"
             break
         fi
@@ -91,6 +95,7 @@ else
         if [ "${DSM_VERSION}" = "${version}" ]; then
             v=${version//.}
             var="ARCH_MIN_DSM${v^^}_PACKAGES"
+            # No DSM-restricted packages — fall back to standard arch packages
             build_packages="${!var:-${ARCH_PACKAGES}}"
             break
         fi


### PR DESCRIPTION
## Description

This is a follow-on from #7040

### Problem

Packages that build differently depending on DSM version but do not declare `REQUIRED_MIN_DSM` (e.g. `radarr`) were not being built when a higher DSM toolchain (e.g. `x64-7.2`) was selected.

In `build.sh`, when `GH_ARCH` matches a versioned toolchain like `x64-7.2`, `build_packages` is replaced with the DSM-restricted package list (`ARCH_MIN_DSM72_PACKAGES`). Since `radarr` is not a restricted package it never appears in that list, leaving `build_packages` empty and causing the build to exit early with "No packages to build."

### Fix

Use Bash parameter expansion to fall back to the standard package list when the DSM-version-specific list is empty, in both the arch and noarch branches of `build.sh`:

```bash
build_packages="${!var:-${ARCH_PACKAGES}}"
```

and:

```bash
build_packages="${!var:-${NOARCH_PACKAGES}}"
```

This ensures that standard packages are built on all selected toolchains, while DSM-restricted packages continue to be built only on their designated toolchain.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes gh-action changes
