### PR TITLE
spksrc: Fix subtile bug at stage0

### DIFF
--- a/mk/spksrc.common/stage0.mk
+++ b/mk/spksrc.common/stage0.mk
@@ -18,6 +18,8 @@
 # Notes:
 #  - Generation is guarded by MAKECMDGOALS == "" to avoid re-running
 #    during explicit sub-targets (stage1, stage2, clean, …)
+#  - Also guarded against running in toolchain directory which actually
+#    means we're in stage1 and could comtaminate resulting toolchain install
 #  - The -include directive makes the file optional; a missing tc_vars.mk
 #    is silently ignored (TC not yet built)
 #  - STAGE0_DONE sentinel file is touched after generation
@@ -25,18 +27,22 @@
 ###############################################################################
 
 STAGE0_DONE := $(WORK_DIR)/.stage0-tcvars_done
+TC_VARS_MK := $(WORK_DIR)/tc_vars.mk
 
 # Load toolchain variables early (provides TC_GCC, TC_VERS, TC_ARCH etc.)
 # - if TC does not exists then tc_vars.mk is not generated yet
 # - this occurs when MAKECMDGOALS is empty, thur prior to stage1 or stage2
 ifneq ($(ARCH),noarch)
 ifeq ($(MAKECMDGOALS),)
+ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)
 ifeq ($(TC),)
 ifeq ($(wildcard $(STAGE0_DONE)),)
-  $(info ===> Generating $(WORK_DIR)/tc_vars.mk (stage0))
+  $(info ===> Generating $(TC_VARS_MK) (stage0))
   $(shell mkdir -p $(WORK_DIR))
-  $(shell $(MAKE) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) MSG= tc_vars > $(WORK_DIR)/tc_vars.mk 2>/dev/null)
+  $(shell $(MAKE) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) MSG= tc_vars > $(TC_VARS_MK) 2>/dev/null)
   $(shell touch $(STAGE0_DONE))
+  $(eval -include $(TC_VARS_MK))
+endif
 endif
 endif
 endif

--- a/mk/spksrc.cross-env.mk
+++ b/mk/spksrc.cross-env.mk
@@ -105,7 +105,7 @@ DEFAULT_ENV ?= autotools flags rust
 # Map DEFAULT_ENV definitions to filenames
 TC_VARS_FILES := $(wildcard $(foreach b,$(DEFAULT_ENV),$(WORK_DIR)/tc_vars.$(b).mk))
 
-# Load full toolchain environment ONLY after tc_vars have been generated
+# Load full toolchain environment ONLY after tc_vars have been generated at stage1
 ifeq ($(wildcard $(TCVARS_DONE)),$(TCVARS_DONE))
   ENV += TC=$(TC)
   $(eval -include $(TC_VARS_MK))

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -26,9 +26,6 @@
 #  DSM_SCRIPT_FILES             List of script files that are in the scripts folder within the spk file.
 #
 
-# Common makefiles
-include ../../mk/spksrc.common.mk
-
 # Configure the included makefiles
 NAME = $(SPK_NAME)
 
@@ -58,6 +55,9 @@ endif
 
 # Common directories (must be set after ARCH_SUFFIX)
 include ../../mk/spksrc.directories.mk
+
+# Common makefiles
+include ../../mk/spksrc.common.mk
 
 ifeq ($(ARCH),noarch)
 ifneq ($(strip $(TCVERSION)),)


### PR DESCRIPTION
## Description

Also found and fixed a subtile bug where:
1. under certain conditions `stage0` could contaminate the toolchain environment (e.g. `spksrc/toolchain/syno*`)
2. under spk builds `spksrc.common.mk` was loaded too early prior to `spksrc.directory.mk`

To fix those:
1. an extra `ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)` was added to stage0.mk to skip `stage0` at toolchain time (e.g. when really being at `stage1`)
2. forced include with no fail within `spksrc.common/stage0.mk` such as `$(eval -include $(TC_VARS_MK))` to ensure `stage0` environment is loaded as early as possible
3. move `spksrc.common.mk` in `spksrc.spk.mk` after directories have been set through `spksrc.directories.mk`

Relates to #7077 where the issue was first found.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
