### PR TITLE
Erlang: Update to v25.3.2.21

### DIFF
--- a/spk/erlang/Makefile
+++ b/spk/erlang/Makefile
@@ -1,19 +1,19 @@
 SPK_NAME = erlang
-SPK_VERS = 25.3.2.5
-SPK_REV = 5
+SPK_VERS = 25.3.2.21
+SPK_REV = 6
 SPK_ICON = src/erlang.png
 
 DEPENDS = cross/erlang
 
 MAINTAINER = DigitalBox98
 DESCRIPTION = Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability. Some of its uses are in telecoms, banking, e-commerce, computer telephony and instant messaging. Erlang's runtime system has built-in support for concurrency, distribution and fault tolerance.
-CHANGELOG = "1. Update Erlang to v25.3.2.5<br/>2. Update OpenSSL to v3.1.2."
+CHANGELOG = "1. Update Erlang to v25.3.2.21 <br/>2. Update OpenSSL to v3.1.2"
 STARTABLE = no
 DISPLAY_NAME = Erlang
 
 HOMEPAGE = https://www.erlang.org
 LICENSE  = Apache 2.0
 
-SPK_COMMANDS = bin/erl bin/erlc
+SPK_COMMANDS = bin/erl bin/erlc bin/escript
 
 include ../../mk/spksrc.spk.mk


### PR DESCRIPTION
## Description

This is a follow-on from #5829 with a minor version correction to match the `cross/erlang` version. Also adds the command `bin/escript` which is a pre-requisite to #7085.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
