### PR TITLE
Forgejo: update to v15.0.0 LTS

### DIFF
--- a/cross/forgejo/Makefile
+++ b/cross/forgejo/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = forgejo
-PKG_VERS = 14.0.4
+PKG_VERS = 15.0.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-src-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://codeberg.org/forgejo/forgejo/releases/download/v$(PKG_VERS)

--- a/cross/forgejo/Makefile
+++ b/cross/forgejo/Makefile
@@ -18,15 +18,14 @@ ENV += NPM_CONFIG_USER=root
 
 CGO_ENABLED = 1
 COMPILE_TARGET = forgejo_compile_target
-# forgejo fork from gitea and keep binary name as gitea
-GO_BIN_DIR = $(WORK_DIR)/$(PKG_DIR)/gitea
+GO_BIN_DIR = $(WORK_DIR)/$(PKG_DIR)/$(PKG_NAME)
 
 export EXTRA_GOFLAGS=-buildvcs=false
 
 include ../../mk/spksrc.cross-go.mk
 
 # PATH must be defined after include of spksrc.cross-go.mk,
-# otherwise WORK_DIR is not defined when building in cross/gitea folder
+# otherwise WORK_DIR is not defined when building in cross/forgejo folder
 PATH := $(WORK_DIR)/../../../native/nodejs/work-native/node/bin:$(PATH)
 
 SYNOPKG_PKGVAR = /var/packages/$(PKG_NAME)/var

--- a/cross/forgejo/PLIST
+++ b/cross/forgejo/PLIST
@@ -1,1 +1,1 @@
-bin:bin/gitea
+bin:bin/forgejo

--- a/cross/forgejo/digests
+++ b/cross/forgejo/digests
@@ -1,3 +1,3 @@
-forgejo-src-14.0.4.tar.gz SHA1 46d67bc162f526c93b1bf030817787e2b4efe783
-forgejo-src-14.0.4.tar.gz SHA256 34326eb230015f12f2a6610b0f4559447e62b4730b3d2607c31342ec8fb65556
-forgejo-src-14.0.4.tar.gz MD5 7201bd811cf7eda9831df794e926f66b
+forgejo-src-15.0.0.tar.gz SHA1 e4bdb6e7039e6861c24c954caa1ef487b98081f0
+forgejo-src-15.0.0.tar.gz SHA256 deb9daa0aa72a95d44d871f5e79dfdb6ab080f83b47fc7f53965059429fc45ac
+forgejo-src-15.0.0.tar.gz MD5 c77fcf8cab5ed1c367ccfd79e2a773f2

--- a/spk/forgejo/Makefile
+++ b/spk/forgejo/Makefile
@@ -1,12 +1,12 @@
 SPK_NAME = forgejo
-SPK_VERS = 14.0.4
-SPK_REV = 2
+SPK_VERS = 15.0.0
+SPK_REV = 3
 SPK_ICON = src/forgejo.png
 
 MAINTAINER = nhymxu
 DESCRIPTION  = Forgejo is a self-hosted lightweight software forge.
 DISPLAY_NAME = Forgejo
-CHANGELOG = "Update to v14.0.4"
+CHANGELOG = "Update to v15.0.0 LTS"
 
 LICENSE = GPLv3
 

--- a/spk/forgejo/src/service-setup.sh
+++ b/spk/forgejo/src/service-setup.sh
@@ -1,4 +1,4 @@
-GITEA="${SYNOPKG_PKGDEST}/bin/gitea"
+FORGEJO="${SYNOPKG_PKGDEST}/bin/forgejo"
 CFG_FILE="${SYNOPKG_PKGVAR}/conf.ini"
 PATH="/var/packages/git/target/bin:${PATH}"
 
@@ -8,7 +8,7 @@ fi
 
 ENV="PATH=${PATH} HOME=${SYNOPKG_PKGHOME}"
 
-SERVICE_COMMAND="env ${ENV} ${GITEA} web --port ${SERVICE_PORT} --pid ${PID_FILE}"
+SERVICE_COMMAND="env ${ENV} ${FORGEJO} web --port ${SERVICE_PORT} --pid ${PID_FILE}"
 SVC_BACKGROUND=y
 
 service_postinst ()


### PR DESCRIPTION
## Description

- Forgejo update to [v15.0.0](https://forgejo.org/2026-04-release-v15-0/) LTS
- Move back binary name from `gitea` to `forgejo` because not need [backward compatibility](https://forgejo.org/compare-to-gitea/#why-must-i-keep-the-binary-name-gitea-on-upgrade) with gitea

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
