### PR TITLE
RabbitMQ: Fix for Erlang version dependency

### DIFF
--- a/spk/rabbitmq/Makefile
+++ b/spk/rabbitmq/Makefile
@@ -1,11 +1,11 @@
 SPK_NAME = rabbitmq
 SPK_VERS = 3.12.13
-SPK_REV = 10
+SPK_REV = 11
 SPK_ICON = src/rabbitmq.png
 DSM_UI_DIR = app
 
 DEPENDS = cross/rabbitmq
-SPK_DEPENDS = "erlang>=25.0:erlang<=26.2"
+SPK_DEPENDS = "erlang>=25.0:erlang<26.3"
 
 MAINTAINER = DigitalBox98
 DESCRIPTION = RabbitMQ is one of the most popular open source message brokers. From T-Mobile to Runtastic, RabbitMQ is used worldwide at small startups and large enterprises. RabbitMQ is lightweight and easy to deploy on premises and in the cloud. It supports multiple messaging protocols. RabbitMQ can be deployed in distributed and federated configurations to meet high-scale, high-availability requirements.


### PR DESCRIPTION
## Description

This is a follow-on from #7085 to fix the Erlang dependency to include versions up to 26.2.x inclusive.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
