### PR TITLE
patch.mk: Avoid duplicate patches to be applied

### DIFF
--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -36,7 +36,7 @@ PATCHES += $(sort $(foreach group,ARM_ARCHS ARMv5_ARCHS ARMv7_ARCHS ARMv7L_ARCHS
 	   $(wildcard patches/$(shell echo $(group) | cut -f1 -d '_' | tr 'A-Z' 'a-z')/*.patch \
 	              patches/$(shell echo $(group) | cut -f1 -d '_' | tr 'A-Z' 'a-z')-$(TCVERSION)/*.patch))))
 endif
-PATCHES := $(realpath $(PATCHES))
+PATCHES := $(call uniq,$(realpath $(PATCHES)))
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done
 


### PR DESCRIPTION
## Description

patch.mk: Avoid duplicate patches to be applied

In rare case armv7 and x64 patches could be double counted as they are both an 'arch' and a 'group'.  This fix ensure evey patch are unique within the PATCHES variable.

Fixes https://github.com/SynoCommunity/spksrc/pull/6839#issuecomment-4274576828

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
