### PR TITLE
libuuid: update util-linux to v2.41.4

### DIFF
--- a/cross/libuuid/Makefile
+++ b/cross/libuuid/Makefile
@@ -1,14 +1,16 @@
 PKG_NAME = libuuid
 PKG_REAL_NAME = util-linux
-PKG_VERS = 2.38.1
+PKG_VERS = 2.41.4
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_REAL_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.kernel.org/pub/linux/utils/util-linux/v$(word 1,$(subst ., ,$(PKG_VERS))).$(word 2,$(subst ., ,$(PKG_VERS)))
-PKG_DIR = $(PKG_REAL_NAME)-$(PKG_VERS)
+# use dedicated folder to build independent of other libraries built from util-linux (i.e. ionice, libblkid, libmount, libuuid, misc-util-linux)
+PKG_DIR = $(PKG_NAME)/$(PKG_REAL_NAME)-$(PKG_VERS)
+EXTRACT_PATH = $(WORK_DIR)/$(PKG_NAME)
 
 DEPENDS =
 
-HOMEPAGE = https://github.com/karelzak/util-linux
+HOMEPAGE = https://github.com/util-linux/util-linux/
 COMMENT  = Random collection of Linux utilities. We use this only to build libuuid out of util-linux.
 LICENSE  = GPLv2
 
@@ -19,6 +21,19 @@ CONFIGURE_ARGS += --disable-static
 # We use libuuid only
 CONFIGURE_ARGS += --disable-all-programs --enable-libuuid
 
+include ../../mk/spksrc.common.mk
+ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(OLD_PPC_ARCHS)),$(ARCH))
+# optimization "-O" fails with older toolchains 
+# assembler Error: invalid operands (.text and *UND* sections)
+ADDITIONAL_CFLAGS = -O2
+else
 ADDITIONAL_CFLAGS = -O
+endif
+
+ifeq ($(findstring $(ARCH),$(32bit_ARCHS)),$(ARCH))
+ifeq ($(call version_lt, $(TCVERSION), 7.2),1) 
+CONFIGURE_ARGS += --disable-year2038
+endif
+endif
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/libuuid/digests
+++ b/cross/libuuid/digests
@@ -1,3 +1,3 @@
-util-linux-2.38.1.tar.xz SHA1 f62a7b6fe64ce7f4569b57d7d2d0875b39f79836
-util-linux-2.38.1.tar.xz SHA256 60492a19b44e6cf9a3ddff68325b333b8b52b6c59ce3ebd6a0ecaa4c5117e84f
-util-linux-2.38.1.tar.xz MD5 cd11456f4ddd31f7fbfdd9488c0c0d02
+util-linux-2.41.4.tar.xz SHA1 0e61178c68875f33be327a7606429904d1663867
+util-linux-2.41.4.tar.xz SHA256 a8c213cc06048862602a42b2d299b340001f6d05c4407b549f3e03521df83688
+util-linux-2.41.4.tar.xz MD5 3a9cb8f3e1957c867d80b77b3daeb311


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully (java-17-openjdk and java-21-openjdk fail, but not related to this PR, fixed in #7105)
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Library update
