### PR TITLE
patch.mk: Allow md5sum deduplication of patches to be applied

### DIFF
--- a/mk/spksrc.common/macros.mk
+++ b/mk/spksrc.common/macros.mk
@@ -16,6 +16,7 @@
 #
 #  uniq        : removes duplicate words while preserving order
 #  dedup       : de-duplicates delimiter-separated strings
+#  dedup-files : removes duplicate files while preserving order (via md5sum)
 #  merge       : merges environment variable values from input
 #
 # LOG_WRAPPED  : generic macro to call recipe execution using logging
@@ -57,6 +58,32 @@ dedup = $(shell /bin/bash -c '\
     tr "\n" "$$delimiter" | \
     sed "s/$$delimiter$$//" \
 ')
+
+# Macro: dedup-files
+#        Removes duplicate files from a list by comparing their content (md5sum),
+#        preserving the order of first occurrences and silently discarding
+#        subsequent files whose content has already been seen.
+#        Useful when the same patch may exist under multiple directories.
+#
+# Usage: $(call dedup-files,$(PATCHES))
+#
+# Note:  _seen_md5s and _deduped are reset at each call to avoid
+#        accumulation across multiple invocations.
+define dedup-files
+$(strip \
+  $(eval _seen_md5s :=) \
+  $(eval _deduped :=) \
+  $(foreach file,$(1), \
+    $(eval _md5 := $(shell md5sum $(file) | cut -d' ' -f1)) \
+    $(if $(filter $(_md5),$(_seen_md5s)), \
+      $(info ===> [DEDUP] Skipping duplicate content: $(file)), \
+      $(eval _seen_md5s += $(_md5)) \
+      $(eval _deduped += $(file)) \
+    ) \
+  ) \
+  $(_deduped) \
+)
+endef
 
 # Macro: merge
 #        merges multiple environment variable values from a given input string,

--- a/mk/spksrc.patch.mk
+++ b/mk/spksrc.patch.mk
@@ -36,7 +36,7 @@ PATCHES += $(sort $(foreach group,ARM_ARCHS ARMv5_ARCHS ARMv7_ARCHS ARMv7L_ARCHS
 	   $(wildcard patches/$(shell echo $(group) | cut -f1 -d '_' | tr 'A-Z' 'a-z')/*.patch \
 	              patches/$(shell echo $(group) | cut -f1 -d '_' | tr 'A-Z' 'a-z')-$(TCVERSION)/*.patch))))
 endif
-PATCHES := $(call uniq,$(realpath $(PATCHES)))
+PATCHES := $(call dedup-files,$(call uniq,$(realpath $(PATCHES))))
 
 PATCH_COOKIE = $(WORK_DIR)/.$(COOKIE_PREFIX)patch_done
 


### PR DESCRIPTION
## Description

patch.mk: Allow md5sum deduplication of patches to be applied

Fixes https://github.com/SynoCommunity/spksrc/pull/7098#issuecomment-4276737014

Shows in the logs:
```
make[3]: Leaving directory '/home/spksrc/patch-md5sum/spksrc/cross/libvpx'
make[3]: Entering directory '/home/spksrc/patch-md5sum/spksrc/cross/libvpx'
===> [DEDUP] Skipping duplicate content: /home/spksrc/patch-md5sum/spksrc/cross/libvpx/patches/88f6281/001-gcc-over-ld-configure-fix.patch
===>  Downloading files for libvpx
```

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
