### PR TITLE
github build action: set specific title for manual builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,16 @@
 name: Build
 
+# Add package name and optional publish for manual builds
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch' &&
+      format(
+        '{0} ({1})',
+        (inputs.publish && 'Build and Publish' || 'Build'),
+        inputs.package
+      )
+      || '' }}
+
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description

add package name to title of manual build actions
show the publish option in the title

Better distinction of manual builds in Actions history.