### PR TITLE
libwebsockets: Enforce using CMake toolchain file build fix

### DIFF
--- a/cross/libwebsockets/Makefile
+++ b/cross/libwebsockets/Makefile
@@ -15,7 +15,6 @@ HOMEPAGE = https://libwebsockets.org/
 COMMENT  = Libwebsockets (LWS) is a flexible, lightweight pure C library for implementing modern network protocols easily with a tiny footprint, using a nonblocking event loop.
 LICENSE  = MIT
 
-CMAKE_USE_TOOLCHAIN_FILE = OFF
 CMAKE_ARGS += -DLWS_WITHOUT_TESTAPPS=ON
 CMAKE_ARGS += -DDISABLE_WERROR=ON
 CMAKE_ARGS += -DLWS_WITH_STATIC=OFF


### PR DESCRIPTION
## Description

libwebsockets: Enforce using CMake toolchain file build fix

Fixes https://github.com/SynoCommunity/spksrc/pull/7105#issuecomment-4297503012

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
