### PR TITLE
toolchain SYSROOT definition bug fix (2)

### DIFF
--- a/cross/glibc-2.28/Makefile
+++ b/cross/glibc-2.28/Makefile
@@ -27,7 +27,7 @@ CONFIGURE_ARGS += --disable-build-nscd
 CONFIGURE_ARGS += --disable-nscd
 CONFIGURE_ARGS += --disable-werror
 CONFIGURE_ARGS += --enable-stack-protector=strong
-CONFIGURE_ARGS += --with-headers=$(TC_SYSROOT)/usr/include
+CONFIGURE_ARGS += --with-headers=$(TC_WORK_DIR)/$(TC_TARGET)/$(TC_INCLUDE)
 CONFIGURE_ARGS += ac_cv_prog_MAKEINFO=false
 
 ADDITIONAL_CFLAGS = -O2

--- a/cross/glibc-latest/Makefile
+++ b/cross/glibc-latest/Makefile
@@ -27,7 +27,7 @@ CONFIGURE_ARGS += --disable-build-nscd
 CONFIGURE_ARGS += --disable-nscd
 CONFIGURE_ARGS += --disable-werror
 CONFIGURE_ARGS += --enable-stack-protector=strong
-CONFIGURE_ARGS += --with-headers=$(TC_SYSROOT)/usr/include
+CONFIGURE_ARGS += --with-headers=$(TC_WORK_DIR)/$(TC_TARGET)/$(TC_INCLUDE)
 CONFIGURE_ARGS += ac_cv_prog_MAKEINFO=false
 
 ADDITIONAL_CFLAGS = -O2

--- a/cross/glibc/Makefile
+++ b/cross/glibc/Makefile
@@ -5,8 +5,13 @@ OPTIONAL_DEPENDS += cross/glibc-2.28
 
 include ../../mk/spksrc.main-depends.mk
 
-ifeq ($(call version_ge, $(TC_GCC), 5.1),1)
+###
+### In theory the version should be an exact match such as:
+###      DEPENDS = cross/glibc-$(TC_GLIBC)
+###
+
+ifeq ($(call version_ge, $(TC_KERNEL), 4)$(call version_ge, $(TC_GCC), 5),11)
 DEPENDS = cross/glibc-latest
-else
+else ifeq ($(call version_ge, $(TC_KERNEL), 3.10),1)
 DEPENDS = cross/glibc-2.28
 endif

--- a/mk/spksrc.toolchain/tc_vars.mk
+++ b/mk/spksrc.toolchain/tc_vars.mk
@@ -368,7 +368,7 @@ tc_flags:
 tc_vars:
 	@echo TC_TYPE := $(TC_TYPE) ; \
 	echo TC_WORK_DIR := $(TC_WORK_DIR) ; \
-	echo TC_SYSROOT := $(TC_WORK_DIR)/$(TC_TARGET)/$(TC_SYSROOT) ; \
+	echo TC_SYSROOT := $(TC_SYSROOT) ; \
 	echo TC_TARGET := $(TC_TARGET) ; \
 	echo TC_PREFIX := $(TC_PREFIX) ; \
 	echo TC_PATH := $(TC_WORK_DIR)/$(TC_TARGET)/bin/ ; \


### PR DESCRIPTION
## Description

THIS PR REPLACES https://github.com/SynoCommunity/spksrc/pull/7105 ACCIDENTLY CLOSED.

toolchain `SYSROOT` definition bug fix.

The default `tc_vars.mk` (re)defines `TC_SYSROOT` so that variable comming from the toolchain's makefile ends-up being available.  Issue is that it is re-defining it with it's full path rather than limiting it to the original scope of the variable being related to the toolchain specific directory.  Later-on one the autotools `SYSROOT` gets defined for the `ENV` environment, it adds-up the remainder of the path prefix to the TC_SYSROOT variable to generate a resulting SYSROOT which ends-up double-couting the prefix.

Fixes: https://github.com/SynoCommunity/spksrc/pull/7103#issuecomment-4288253057

Confirmed that meson and cmake do not make use of TC_SYSROOT for their toolchain files.  Although was found that `glibc` uses `TC_SYSROOT` and now converted to `$(TC_WORK_DIR)/$(TC_TARGET)/$(TC_INCLUDE)`.

Important to note: `glibc` was added in hope to be able to eventually provide a functional target `gcc` as well as ability to update the default Synology cross-compilers.  I noticed that current `glibc` meta definition should be using the exact same `glibc` as the destination DSM which isn't the case currently and thus fails to build for many archs.  I've added a comment in that sense if we ever want to consider pursuing this.... Alternate option is to remove the `cross/glibc*` entirely as git repo history will still be available.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
