### PR TITLE
Deluge: Pin setuptools to 81.0.0 to fix launch error

### DIFF
--- a/spk/deluge/Makefile
+++ b/spk/deluge/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = deluge
 SPK_VERS = 2.2.0
-SPK_REV = 26
+SPK_REV = 27
 SPK_ICON = src/deluge.png
 
 PYTHON_PACKAGE = python312
@@ -12,7 +12,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = Deluge is a cross platform BitTorrent client, based on libtorrent rasterbar. This package integrates both the deluge deamon \(deluged\), as well as its web counterpart \(deluge-web\), which serves the deluge web UI.
 DESCRIPTION_FRE = Deluge est un client BitTorrent multi-plateforme, basé sur libtorrent rasterbar. Ce paquet intègre à la fois le démon deluge \(deluged\) ainsi que son penchant web \(deluge-web\), desservant l\'interface utilisateur web deluge.
 STARTABLE = yes
-CHANGELOG = "1. Update libtorrent to 2.0.12.<br/>2. Update all other wheels."
+CHANGELOG = "1. Update libtorrent to 2.0.12. <br/>2. Update all other wheels. <br/>3. Pin setuptools to 81.0.0 to fix launch error."
 DISPLAY_NAME = Deluge
 
 HOMEPAGE = https://deluge-torrent.org

--- a/spk/deluge/src/requirements-pure.txt
+++ b/spk/deluge/src/requirements-pure.txt
@@ -17,6 +17,6 @@ pycparser==3.0
 pyopenssl==26.0.0
 pyxdg==0.28
 service_identity==24.2.0
-#setuptools               ==> python312
+setuptools==81.0.0        # pinned version to fix #7115
 twisted==25.5.0
 typing_extensions==4.15.0


### PR DESCRIPTION
## Description

This PR is a follow-on from #7073 and includes the following:

1. Pin setuptools to 81.0.0 to fix launch error

Fixes #7115

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
