### PR TITLE
dependency-tree: Allow using `ARCH=` `TCVERSION=`

### DIFF
--- a/mk/spksrc.common/stage0.mk
+++ b/mk/spksrc.common/stage0.mk
@@ -30,14 +30,18 @@ STAGE0_DONE := $(WORK_DIR)/.stage0-tcvars_done
 TC_VARS_MK := $(WORK_DIR)/tc_vars.mk
 
 # Load toolchain variables early (provides TC_GCC, TC_VERS, TC_ARCH etc.)
+# - if ARCH and TCVERSION are set and is not noarch
+# - if MAKECMDGOALS is empty, thus prior to stage1 or stage2 (unless called from dependency-* recipes)
 # - if TC does not exists then tc_vars.mk is not generated yet
-# - this occurs when MAKECMDGOALS is empty, thur prior to stage1 or stage2
-ifneq ($(ARCH),noarch)
-ifeq ($(MAKECMDGOALS),)
+# - do not print info msg if called from dependency-* recipes
+ifneq ($(filter-out noarch,$(ARCH))$(TCVERSION),)
+ifeq ($(filter-out dependency-%,$(MAKECMDGOALS)),)
 ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)
 ifeq ($(TC),)
 ifeq ($(wildcard $(STAGE0_DONE)),)
-  $(info ===> Generating $(TC_VARS_MK) (stage0))
+  ifeq ($(filter dependency-%,$(MAKECMDGOALS)),)
+    $(info ===> Generating $(TC_VARS_MK) (stage0))
+  endif
   $(shell mkdir -p $(WORK_DIR))
   $(shell $(MAKE) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) MSG= tc_vars > $(TC_VARS_MK) 2>/dev/null)
   $(shell touch $(STAGE0_DONE))

--- a/mk/spksrc.dependency-tree.mk
+++ b/mk/spksrc.dependency-tree.mk
@@ -89,12 +89,20 @@
 #  - Output interleaving is avoided to ensure safe parallel execution.
 ###############################################################################
 
+# Allows early access to stage0 environment
+include ../../mk/spksrc.common.mk
+
 # DEPENDS_TYPE filters output by dependency relation type.
 # Traversal always visits all dependency types regardless of this setting.
 # Values: DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS
 # Can be combined: "DEPENDS OPTIONAL_DEPENDS"
-# Default: all types included
-DEPENDS_TYPE ?= DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS
+# Default: all types included with exception of OPTIONAL_DEPEND if
+#          ARCH and TCVERSION exists
+_DEFAULT_DEPENDS_TYPE := DEPENDS BUILD_DEPENDS NATIVE_DEPENDS
+ifeq (,$(and $(ARCH),$(TCVERSION)))
+  _DEFAULT_DEPENDS_TYPE += OPTIONAL_DEPENDS
+endif
+DEPENDS_TYPE ?= $(_DEFAULT_DEPENDS_TYPE)
 
 # -------------------------------------------------------------------
 # ALL_DEPENDS: union of all dependency types — traversal is never filtered.
@@ -106,12 +114,14 @@ DEPENDS_TYPE ?= DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS
 # dep-flat-mk-% extracts the type and path from the target name and emits
 # "TYPE dep/path" so dependency-flat and dependency-list can filter by
 # DEPENDS_TYPE without re-traversing the graph.
+#
+# Also, if ARCH and TCVERSION are set then discard OPTIONAL_DEPENDS.
 # -------------------------------------------------------------------
 ALL_DEPENDS         := $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS))
 DEP_FLAT_TARGETS_MK := $(strip \
   $(addprefix dep-flat-mk-DEPENDS__,          $(subst /,__,$(DEPENDS))) \
   $(addprefix dep-flat-mk-BUILD_DEPENDS__,    $(subst /,__,$(BUILD_DEPENDS))) \
-  $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(OPTIONAL_DEPENDS))) \
+  $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))) \
   $(addprefix dep-flat-mk-NATIVE_DEPENDS__,   $(subst /,__,$(NATIVE_DEPENDS))))
 
 # -------------------------------------------------------------------

--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -60,7 +60,7 @@ $(eval $(1)_LIBS_DEFAULT := $(foreach f,$(wildcard $($(1)_STAGING_INSTALL_PREFIX
 $(eval $(1)_LIBS := $(if $(strip $($(1)_PC)),$(foreach f,$(wildcard $(addprefix $($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig/,$($(1)_PC))),$(realpath $(f))),$($(1)_LIBS_DEFAULT)))
 
 # Generate filtered dependency list (exclude all meta package deps)
-$(eval $(1)_DEPENDS_FILTERED := $(sort $(shell $(MAKE) -s dependency-list EXCLUDE_DEPENDS="$(META_DEPENDS)" | cut -f2 -d:)))
+$(eval $(1)_DEPENDS_FILTERED := $(sort $(shell $(MAKE) -s ARCH=$(ARCH) TCVERSION=$(TCVERSION) dependency-list EXCLUDE_DEPENDS="$(META_DEPENDS)" | cut -f2 -d:)))
 
 # From EXCLUDED_NAME, keep only those that are direct deps of this package
 $(eval $(1)_DIRECT_DEPENDS := $(filter $(addprefix cross/,$(EXCLUDED_NAME)),$($(1)_DEPENDS_FILTERED)))
@@ -72,7 +72,7 @@ $(eval DEPENDS := $(call uniq,$($(1)_DIRECT_DEPENDS) $(DEPENDS)))
 $(eval SPK_DEPENDS := $(call dedup,$($(1)_PACKAGE):$(SPK_DEPENDS),:))
 
 # Build list of status cookies to symlink (skip if $(1)_PC is set)
-$(eval $(1)_STATUS_COOKIES := $(sort $(if $(strip $($(1)_PC)),,$(foreach cross,$(filter-out $(EXCLUDED_NAME),$(foreach pkg_name,$(shell $(MAKE) dependency-list -C $(realpath $($(1)_PACKAGE_WORK_DIR)/../) 2>/dev/null | grep ^$($(1)_PACKAGE) | cut -f2 -d:),$(shell sed -n 's/^PKG_NAME = \(.*\)/\1/p' $(realpath $(CURDIR)/../../$(pkg_name)/Makefile)))),$(wildcard $($(1)_PACKAGE_WORK_DIR)/.$(cross)-*_done)))))
+$(eval $(1)_STATUS_COOKIES := $(sort $(if $(strip $($(1)_PC)),,$(foreach cross,$(filter-out $(EXCLUDED_NAME),$(foreach pkg_name,$(shell $(MAKE) ARCH=$(ARCH) TCVERSION=$(TCVERSION) dependency-list -C $(realpath $($(1)_PACKAGE_WORK_DIR)/../) 2>/dev/null | grep ^$($(1)_PACKAGE) | cut -f2 -d:),$(shell sed -n 's/^PKG_NAME = \(.*\)/\1/p' $(realpath $(CURDIR)/../../$(pkg_name)/Makefile)))),$(wildcard $($(1)_PACKAGE_WORK_DIR)/.$(cross)-*_done)))))
 
 # Register pre-depend hook so _links runs before dependency compilation
 $(eval PRE_DEPEND_TARGET += $(1)_meta_pre_depend)


### PR DESCRIPTION
## Description

dependency-tree: Allow using `ARCH=` `TCVERSION=`

In turn this also allows using updated `dependency-list|flat|tree` with `ARCH=<arch>` and `TCVERSION=<tcversion>` so we get the full dependency list of files for that specific target.

This also discard scanning through `OPTIONAL_DEPENDS` when `ARCH` and `TCVERSION` are set.

Relates and tested onto https://github.com/SynoCommunity/spksrc/pull/7035

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
