### PR TITLE
Further refine dependency-tree using ARCH and TCVERSION

### DIFF
--- a/cross/bat/Makefile
+++ b/cross/bat/Makefile
@@ -5,10 +5,12 @@ OPTIONAL_DEPENDS += cross/bat-0.25
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/bat-0.25
 else
 DEPENDS = cross/bat-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/binutils/Makefile
+++ b/cross/binutils/Makefile
@@ -4,7 +4,7 @@ OPTIONAL_DEPENDS  = cross/binutils-latest
 OPTIONAL_DEPENDS += cross/binutils-2.41
 OPTIONAL_DEPENDS += cross/binutils-2.32
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_lt, $(TC_GCC), 4.4),1)
 DEPENDS = cross/binutils-2.32
@@ -15,3 +15,5 @@ DEPENDS = cross/binutils-2.41
 else
 DEPENDS = cross/binutils-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/c-ares/Makefile
+++ b/cross/c-ares/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = c-ares-main
 OPTIONAL_DEPENDS  = cross/c-ares-latest
 OPTIONAL_DEPENDS += cross/c-ares-1.28
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/c-ares-1.28
 else
 DEPENDS = cross/c-ares-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/cairo/Makefile
+++ b/cross/cairo/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = cairo-main
 OPTIONAL_DEPENDS  = cross/cairo-latest
 OPTIONAL_DEPENDS += cross/cairo-1.16
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5-ARCHS)),$(ARCH))
 DEPENDS = cross/cairo-1.16
 else
 DEPENDS = cross/cairo-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/eza/Makefile
+++ b/cross/eza/Makefile
@@ -5,10 +5,12 @@ OPTIONAL_DEPENDS += cross/eza-0.20.18
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
 DEPENDS = cross/eza-0.20.18
 else
 DEPENDS = cross/eza-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/gdb/Makefile
+++ b/cross/gdb/Makefile
@@ -4,7 +4,7 @@ OPTIONAL_DEPENDS  = cross/gdb-latest
 OPTIONAL_DEPENDS += cross/gdb-7.12
 OPTIONAL_DEPENDS += cross/gdb-14.2
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_lt, $(TC_GCC), 4.8.1),1)
 DEPENDS += cross/gdb-7.12
@@ -13,3 +13,5 @@ DEPENDS += cross/gdb-14.2
 else
 DEPENDS += cross/gdb-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/glib/Makefile
+++ b/cross/glib/Makefile
@@ -4,7 +4,7 @@ OPTIONAL_DEPENDS  = cross/glib-latest
 OPTIONAL_DEPENDS += cross/glib-2.66
 OPTIONAL_DEPENDS += cross/glib-2.58
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 # If kernel >= 3.2 && gcc >= 7.5
 ifeq ($(call version_ge, $(TC_KERNEL), 3.2)$(call version_ge, $(TC_GCC), 7.5),11)
@@ -17,3 +17,5 @@ else
 DEPENDS = cross/glib-2.58
 endif
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/glibc/Makefile
+++ b/cross/glibc/Makefile
@@ -3,15 +3,17 @@ PKG_NAME = glibc-main
 OPTIONAL_DEPENDS  = cross/glibc-latest
 OPTIONAL_DEPENDS += cross/glibc-2.28
 
-include ../../mk/spksrc.main-depends.mk
-
 ###
 ### In theory the version should be an exact match such as:
 ###      DEPENDS = cross/glibc-$(TC_GLIBC)
 ###
+
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, $(TC_KERNEL), 4)$(call version_ge, $(TC_GCC), 5),11)
 DEPENDS = cross/glibc-latest
 else ifeq ($(call version_ge, $(TC_KERNEL), 3.10),1)
 DEPENDS = cross/glibc-2.28
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/glibmm/Makefile
+++ b/cross/glibmm/Makefile
@@ -3,7 +3,7 @@ PKG_NAME = glibmm-main
 OPTIONAL_DEPENDS  = cross/glibmm-latest
 OPTIONAL_DEPENDS += cross/glibmm-2.66
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, $(TC_GCC), 7.5),1)
 # Requires libsigc++ >= 3.x
@@ -12,3 +12,5 @@ else
 # Last version require libsigc++ 2.x
 DEPENDS += cross/glibmm-2.66
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/intel-gmmlib/Makefile
+++ b/cross/intel-gmmlib/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = intel-gmmlib-main
 OPTIONAL_DEPENDS  = cross/intel-gmmlib-latest
 OPTIONAL_DEPENDS += cross/intel-gmmlib-22.3
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 DEPENDS = cross/intel-gmmlib-latest
 else
 DEPENDS = cross/intel-gmmlib-22.3
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/intel-media-driver/Makefile
+++ b/cross/intel-media-driver/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = intel-media-main
 OPTIONAL_DEPENDS  = cross/intel-media-driver-latest
 OPTIONAL_DEPENDS += cross/intel-media-driver-22.5
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 DEPENDS = cross/intel-media-driver-latest
 else
 DEPENDS = cross/intel-media-driver-22.5
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/intel-mediasdk/Makefile
+++ b/cross/intel-mediasdk/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = intel-mediasdk-main
 OPTIONAL_DEPENDS  = cross/intel-mediasdk-latest
 OPTIONAL_DEPENDS += cross/intel-mediasdk-22.5
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 DEPENDS = cross/intel-mediasdk-latest
 else
 DEPENDS = cross/intel-mediasdk-22.5
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/iperf3/Makefile
+++ b/cross/iperf3/Makefile
@@ -4,7 +4,7 @@ PKG_NAME = iperf3-main
 OPTIONAL_DEPENDS  = cross/iperf3-latest
 OPTIONAL_DEPENDS += cross/iperf3-3.15
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_lt, ${TCVERSION}, 6.0)$(call version_ge, ${TCVERSION}, 3.0),11)
 DEPENDS = cross/iperf3-3.15
@@ -13,3 +13,5 @@ DEPENDS = cross/iperf3-3.15
 else
 DEPENDS = cross/iperf3-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libaom/Makefile
+++ b/cross/libaom/Makefile
@@ -5,7 +5,7 @@ OPTIONAL_DEPENDS += cross/libaom-3.8
 
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 # gcc >= 7.5
 ifeq ($(call version_ge, $(TC_GCC), 7.5),1)
@@ -13,3 +13,5 @@ DEPENDS = cross/libaom-latest
 else
 DEPENDS = cross/libaom-3.8
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libheif/Makefile
+++ b/cross/libheif/Makefile
@@ -5,7 +5,7 @@ OPTIONAL_DEPENDS += cross/libheif-1.18
 
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 # support for C++20
 ifeq ($(call version_ge, $(TC_GCC), 8.5),1)
@@ -13,3 +13,5 @@ DEPENDS = cross/libheif-latest
 else
 DEPENDS = cross/libheif-1.18
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libicu/Makefile
+++ b/cross/libicu/Makefile
@@ -3,7 +3,7 @@ PKG_NAME = libicu-main
 OPTIONAL_DEPENDS  = cross/libicu-latest
 OPTIONAL_DEPENDS += cross/libicu-74.2
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 # If gcc >= 5 (i.e. DSM >= 7.0)
 ifeq ($(call version_ge, $(TC_GCC), 5),1)
@@ -11,3 +11,5 @@ DEPENDS = cross/libicu-latest
 else
 DEPENDS = cross/libicu-74.2
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libmediainfo/Makefile
+++ b/cross/libmediainfo/Makefile
@@ -5,7 +5,7 @@ OPTIONAL_DEPENDS += cross/libmediainfo-25.04
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 # GCC >= 5 (DSM >= 7.0)
 ifeq ($(call version_ge, $(TC_GCC), 5),1)
@@ -13,3 +13,5 @@ DEPENDS = cross/libmediainfo-latest
 else
 DEPENDS = cross/libmediainfo-25.04
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libpcap/Makefile
+++ b/cross/libpcap/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = libpcap-main
 OPTIONAL_DEPENDS  = cross/libpcap-latest
 OPTIONAL_DEPENDS += cross/libpcap-1.9
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
 DEPENDS = cross/libpcap-1.9
 else
 DEPENDS = cross/libpcap-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libsigc++/Makefile
+++ b/cross/libsigc++/Makefile
@@ -6,10 +6,12 @@ UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 OPTIONAL_DEPENDS  = cross/libsigc++-latest
 OPTIONAL_DEPENDS += cross/libsigc++-2.12
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, $(TC_GCC), 7.5),1)
 DEPENDS = cross/libsigc++-latest
 else
 DEPENDS = cross/libsigc++-2.12
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libva-utils/Makefile
+++ b/cross/libva-utils/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = libva-utils-main
 OPTIONAL_DEPENDS  = cross/libva-utils-latest
 OPTIONAL_DEPENDS += cross/libva-utils-2.17
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 DEPENDS = cross/libva-utils-latest
 else
 DEPENDS = cross/libva-utils-2.17
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/libva/Makefile
+++ b/cross/libva/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = libva-main
 OPTIONAL_DEPENDS  = cross/libva-latest
 OPTIONAL_DEPENDS += cross/libva-2.17
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, ${TCVERSION}, 7.0),1)
 DEPENDS = cross/libva-latest
 else
 DEPENDS = cross/libva-2.17
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/llvm/Makefile
+++ b/cross/llvm/Makefile
@@ -5,10 +5,12 @@ UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 OPTIONAL_DEPENDS  = cross/llvm-latest
 OPTIONAL_DEPENDS += cross/llvm-9.0
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, $(TC_GCC), 5.1),1)
 DEPENDS = cross/llvm-latest
 else
 DEPENDS = cross/llvm-9.0
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/lsd/Makefile
+++ b/cross/lsd/Makefile
@@ -5,10 +5,12 @@ OPTIONAL_DEPENDS += cross/lsd-1.1
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/lsd-1.1
 else
 DEPENDS = cross/lsd-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/mariadb-connector-c/Makefile
+++ b/cross/mariadb-connector-c/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = mariadb-connector-c-main
 OPTIONAL_DEPENDS  = cross/mariadb-connector-c-latest
 OPTIONAL_DEPENDS += cross/mariadb-connector-c-3.3.11
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, ${TC_GCC}, 5),1)
 DEPENDS = cross/mariadb-connector-c-latest
 else
 DEPENDS = cross/mariadb-connector-c-3.3.11
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/mediainfo/Makefile
+++ b/cross/mediainfo/Makefile
@@ -5,7 +5,7 @@ OPTIONAL_DEPENDS += cross/mediainfo-25.04
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 # GCC >= 5 (DSM >= 7.0)
 ifeq ($(call version_ge, $(TC_GCC), 5),1)
@@ -13,3 +13,5 @@ DEPENDS = cross/mediainfo-latest
 else
 DEPENDS = cross/mediainfo-25.04
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/nnn/Makefile
+++ b/cross/nnn/Makefile
@@ -6,7 +6,7 @@ OPTIONAL_DEPENDS += cross/nnn-4.0
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, $(TC_GCC), 5.0),1)
 DEPENDS += cross/nnn-latest
@@ -16,3 +16,5 @@ else
 # 32-bit archs for DSM<7
 DEPENDS += cross/nnn-4.0
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/pngquant/Makefile
+++ b/cross/pngquant/Makefile
@@ -3,7 +3,7 @@ PKG_NAME = pngquant-main
 OPTIONAL_DEPENDS  = cross/pngquant3
 OPTIONAL_DEPENDS += cross/pngquant2
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5_ARCHS)),$(ARCH))
 # std=c11 not fully supported
@@ -13,3 +13,5 @@ DEPENDS = cross/pngquant2
 else
 DEPENDS = cross/pngquant3
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/rhash/Makefile
+++ b/cross/rhash/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = rhash-main
 OPTIONAL_DEPENDS  = cross/rhash-latest
 OPTIONAL_DEPENDS += cross/rhash-1.4.5
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 DEPENDS = cross/rhash-1.4.5
 else
 DEPENDS = cross/rhash-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/ripgrep/Makefile
+++ b/cross/ripgrep/Makefile
@@ -5,7 +5,7 @@ OPTIONAL_DEPENDS += cross/ripgrep-14
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS) $(PPC_ARCHS)),$(ARCH))
 # rustc >= 1.85 required
@@ -19,3 +19,5 @@ endif
 else
 DEPENDS += cross/ripgrep-latest
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/cross/z3/Makefile
+++ b/cross/z3/Makefile
@@ -3,10 +3,12 @@ PKG_NAME = z3-main
 OPTIONAL_DEPENDS += cross/z3-4.11
 OPTIONAL_DEPENDS += cross/z3-4.7
 
-include ../../mk/spksrc.main-depends.mk
+include ../../mk/spksrc.common.mk
 
 ifeq ($(call version_ge, $(TC_GCC), 5),1)
 DEPENDS = cross/z3-4.11
 else
 DEPENDS = cross/z3-4.7
 endif
+
+include ../../mk/spksrc.main-depends.mk

--- a/mk/spksrc.dependency-tree.mk
+++ b/mk/spksrc.dependency-tree.mk
@@ -10,11 +10,15 @@
 #  - Per-run temporary directories to avoid collisions
 #  - Optional dependency subtree exclusion
 #  - Optional filtering of output by dependency relation type (DEPENDS_TYPE)
+#  - Context-aware traversal: when ARCH and TCVERSION are both set, OPTIONAL_DEPENDS
+#    are excluded at every level so only toolchain-resolved DEPENDS are reported.
 #
 # Root-level Targets (available only when BASEDIR is empty):
 #  dependency-list-spk
 #      Runs dependency-list for every package under spk/* in parallel and
 #      aggregates the results into a sorted output.
+#      When ARCH and TCVERSION are provided, each package is evaluated in
+#      that toolchain context, yielding a resolved, arch-specific dependency list.
 #
 # Package-level Targets (available inside cross|spk|diyspk|toolchain directories):
 #  dependency-tree
@@ -24,11 +28,13 @@
 #
 #  dependency-flat
 #      Returns a sorted, unique list of dependency paths (one per line),
-#      filtered by DEPENDS_TYPE. Default: all types
+#      filtered by DEPENDS_TYPE.
+#      Default: all types when ARCH/TCVERSION are absent;
+#               OPTIONAL_DEPENDS excluded when both ARCH and TCVERSION are set.
 #
 #  dependency-list
 #      Prints a single-line, space-separated list of dependencies for the
-#      current package, filtered by DEPENDS_TYPE.  Default: all types
+#      current package, filtered by DEPENDS_TYPE.
 #      Output format:
 #          $(NAME): cross/foo cross/bar native/baz ...
 #
@@ -49,16 +55,25 @@
 #          dep-flat-mk-DEPENDS__cross__openssl3
 #          dep-flat-mk-NATIVE_DEPENDS__native__nasm
 #      Emits "TYPE dep/path", then recurses into the dependency traversing
-#      all types. Stamp is keyed on dep path only to avoid re-traversing;
-#      if already stamped the type annotation is still emitted for this relation.
+#      all applicable types. Stamp is keyed on dep path only to avoid
+#      re-traversing; if already stamped the type annotation is still emitted
+#      for this relation.
+#      ARCH and TCVERSION are forwarded at every recursion level so that
+#      conditional DEPENDS in sub-packages are evaluated in the correct
+#      toolchain context.
 #
 #  dependency-list-spk-%
 #      Executes dependency-list for a single spk package. Output is written
 #      to a temporary file and later aggregated by dependency-list-spk.
 #
 # Variables:
-#          ALL_DEPENDS: Sorted union of all dependency types for traversal.
+#          ALL_DEPENDS: Sorted union of dependency types used for traversal.
+#                       When ARCH and TCVERSION are both set, OPTIONAL_DEPENDS
+#                       is excluded; otherwise all types are included.
 #  DEP_FLAT_TARGETS_MK: Annotated dep-flat-mk-% targets for all dependencies.
+#                       Uses deferred expansion (=) so that DEPENDS defined
+#                       after the include of this file (e.g. in main-depends
+#                       packages) are captured correctly at evaluation time.
 #               RUN_ID: Unique identifier for the current dependency traversal run.
 #   DEP_FLAT_STAMP_DIR: Temporary directory used to cache visited dependencies.
 #                       Stamp files are named after the encoded dep path:
@@ -74,15 +89,40 @@
 #         DEPENDS_TYPE: Filter output by dependency relation type.
 #                       Values: DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS
 #                       Can be combined: "DEPENDS OPTIONAL_DEPENDS"
-#                       Default: all types included.
-#                       Traversal always visits all types regardless of this setting.
+#                       Default: all types when ARCH/TCVERSION absent;
+#                                DEPENDS BUILD_DEPENDS NATIVE_DEPENDS when both set.
+#                       Traversal always visits applicable types regardless of
+#                       this setting.
 #
 # Notes:
 #  - Target availability depends on call context:
 #        * Root level (BASEDIR empty): dependency-list-spk
 #        * Package directories: dependency-tree, dependency-flat, dependency-list
-#  - Packages with conditional dependencies must define OPTIONAL_DEPENDS
-#    to ensure all possible dependencies are discovered.
+#  - When ARCH and TCVERSION are both provided, OPTIONAL_DEPENDS are suppressed
+#    at every level of the traversal. Each package's conditional DEPENDS (e.g.
+#    based on TC_GCC or TC_KERNEL) are resolved in that toolchain context,
+#    producing an arch- and DSM-version-specific dependency list.
+#  - When ARCH and TCVERSION are absent, OPTIONAL_DEPENDS are included to
+#    ensure all possible dependencies across all toolchains are discovered.
+#    Packages with conditional dependencies must define OPTIONAL_DEPENDS as a
+#    superset of all possible DEPENDS variants for this to work correctly.
+#  - Packages using spksrc.main-depends.mk that require toolchain macros
+#    (version_ge, TC_GCC, TC_KERNEL, etc.) before their conditional DEPENDS
+#    must include spksrc.common.mk early, then define their DEPENDS, and
+#    include spksrc.main-depends.mk last. Example:
+#        OPTIONAL_DEPENDS = cross/foo-latest cross/foo-1.0
+#        include ../../mk/spksrc.common.mk
+#        ifeq ($(call version_ge, $(TC_GCC), 7.5),1)
+#        DEPENDS = cross/foo-latest
+#        else
+#        DEPENDS = cross/foo-1.0
+#        endif
+#        include ../../mk/spksrc.main-depends.mk
+#  - ALL_DEPENDS and DEP_FLAT_TARGETS_MK use deferred expansion (=) rather
+#    than immediate expansion (:=) so that DEPENDS assigned after the include
+#    of this file are visible when these variables are first used.
+#  - ARCH and TCVERSION are explicitly forwarded to every recursive make call
+#    so that sub-package Makefiles evaluate their conditional DEPENDS correctly.
 #  - Recursive make calls must not abort when DEPENDENCY_WALK=1 is set
 #    (errors are redirected to /dev/null).
 #  - Temporary directories are unique per run and removed automatically.
@@ -90,14 +130,14 @@
 ###############################################################################
 
 # Allows early access to stage0 environment
-include ../../mk/spksrc.common.mk
+include $(BASEDIR)/mk/spksrc.common.mk
 
 # DEPENDS_TYPE filters output by dependency relation type.
-# Traversal always visits all dependency types regardless of this setting.
 # Values: DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS
 # Can be combined: "DEPENDS OPTIONAL_DEPENDS"
-# Default: all types included with exception of OPTIONAL_DEPEND if
-#          ARCH and TCVERSION exists
+# Default: all types when ARCH and TCVERSION are absent.
+#          When both ARCH and TCVERSION are set, OPTIONAL_DEPENDS is excluded
+#          so that only toolchain-resolved DEPENDS are reported.
 _DEFAULT_DEPENDS_TYPE := DEPENDS BUILD_DEPENDS NATIVE_DEPENDS
 ifeq (,$(and $(ARCH),$(TCVERSION)))
   _DEFAULT_DEPENDS_TYPE += OPTIONAL_DEPENDS
@@ -105,20 +145,27 @@ endif
 DEPENDS_TYPE ?= $(_DEFAULT_DEPENDS_TYPE)
 
 # -------------------------------------------------------------------
-# ALL_DEPENDS: union of all dependency types — traversal is never filtered.
+# ALL_DEPENDS: union of dependency types used for traversal.
+#   When ARCH and TCVERSION are both set, OPTIONAL_DEPENDS is excluded
+#   so traversal follows only the resolved dependency graph for that
+#   toolchain context.  When absent, all types are included to discover
+#   every possible dependency across all toolchains.
 #
 # DEP_FLAT_TARGETS_MK: annotated dep-flat-mk-% targets encoding relation
-# type and dependency path:
-#   dep-flat-mk-DEPENDS__cross__openssl3
-#   dep-flat-mk-NATIVE_DEPENDS__native__nasm
-# dep-flat-mk-% extracts the type and path from the target name and emits
-# "TYPE dep/path" so dependency-flat and dependency-list can filter by
-# DEPENDS_TYPE without re-traversing the graph.
+#   type and dependency path:
+#       dep-flat-mk-DEPENDS__cross__openssl3
+#       dep-flat-mk-NATIVE_DEPENDS__native__nasm
+#   dep-flat-mk-% extracts the type and path from the target name and emits
+#   "TYPE dep/path" so dependency-flat and dependency-list can filter by
+#   DEPENDS_TYPE without re-traversing the graph.
 #
-# Also, if ARCH and TCVERSION are set then discard OPTIONAL_DEPENDS.
+# Both variables use deferred expansion (=) rather than immediate (:=) so
+# that DEPENDS defined after the include of this file — as is required for
+# packages using spksrc.main-depends.mk — are visible when these variables
+# are first evaluated (i.e. when dependency-flat-mk resolves its prerequisites).
 # -------------------------------------------------------------------
-ALL_DEPENDS         := $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(OPTIONAL_DEPENDS))
-DEP_FLAT_TARGETS_MK := $(strip \
+ALL_DEPENDS         = $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
+DEP_FLAT_TARGETS_MK = $(strip \
   $(addprefix dep-flat-mk-DEPENDS__,          $(subst /,__,$(DEPENDS))) \
   $(addprefix dep-flat-mk-BUILD_DEPENDS__,    $(subst /,__,$(BUILD_DEPENDS))) \
   $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))) \
@@ -165,22 +212,32 @@ $(SPK_LIST_STAMP_DIR):
 # -------------------------------------------------------------------
 ifeq ($(AT_ROOT_LEVEL),1)
 
-# At root level, only dependency-list-spk is available
+# At root level, only dependency-list-spk is available.
+# ARCH and TCVERSION are forwarded when provided so each package is
+# evaluated in the correct toolchain context.
 .PHONY: dependency-list-spk
 dependency-list-spk: | $(SPK_LIST_STAMP_DIR)
-	@$(MAKE) -j $(nproc) --silent --no-print-directory $(SPK_TARGETS)
+	@$(MAKE) -j $(nproc) --silent --no-print-directory \
+		$(if $(ARCH),ARCH=$(ARCH)) \
+		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+		$(SPK_TARGETS)
 	@cat $(SPK_LIST_STAMP_DIR)/*.out | sort
 	@rm -rf $(SPK_LIST_STAMP_DIR)
 
 # -------------------------------------------------------------------
 # dependency-list-spk-%
-# Runs dependency-list for a single spk package and writes output to a file
+# Runs dependency-list for a single spk package and writes output to a file.
+# ARCH and TCVERSION are forwarded so the package Makefile resolves its
+# conditional DEPENDS in the correct toolchain context.
 # -------------------------------------------------------------------
 .PHONY: dependency-list-spk-%
 dependency-list-spk-%: | $(SPK_LIST_STAMP_DIR)
 	@DEP_FLAT_RUN_ID=spk-$* \
 	DEP_FLAT_STAMP_DIR=/tmp/spksrc-dep-$* \
-	$(MAKE) -s --no-print-directory -C spk/$* dependency-list \
+	$(MAKE) -s --no-print-directory -C spk/$* \
+		$(if $(ARCH),ARCH=$(ARCH)) \
+		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+		dependency-list \
 		> $(SPK_LIST_STAMP_DIR)/$*.out 2>/dev/null || true
 
 else
@@ -190,38 +247,52 @@ else
 
 # -------------------------------------------------------------------
 # dependency-tree
-# Recursively prints a dependency tree with indentation based on MAKELEVEL
+# Recursively prints a dependency tree with indentation based on MAKELEVEL.
+# ARCH and TCVERSION are forwarded at each level so conditional DEPENDS
+# in sub-packages are evaluated in the correct toolchain context.
 # -------------------------------------------------------------------
 .PHONY: dependency-tree
 dependency-tree:
 	@echo $$(perl -e 'print "\\\t" x $(MAKELEVEL),"\n"')+ $(NAME) $(PKG_VERS)
 	@for depend in $$(echo "$(ALL_DEPENDS)" | tr ' ' '\n' | sort -u | tr '\n' ' ') ; \
 	do \
-	  DEPENDENCY_WALK=1 $(MAKE) -s -C ../../$$depend dependency-tree ; \
+	  DEPENDENCY_WALK=1 $(MAKE) -s -C ../../$$depend \
+	      $(if $(ARCH),ARCH=$(ARCH)) \
+	      $(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+	      dependency-tree ; \
 	done
 
 # -------------------------------------------------------------------
 # dependency-flat-raw
-# Internal target. Traverses all dependency types in parallel and emits
-# annotated lines "TYPE dep/path" via dep-flat-mk-% targets.
+# Internal target. Traverses all applicable dependency types in parallel
+# and emits annotated lines "TYPE dep/path" via dep-flat-mk-% targets.
 # Used by dependency-flat and dependency-list to filter by DEPENDS_TYPE
 # without re-traversing the dependency graph.
+# ARCH and TCVERSION are forwarded to dependency-flat-mk so that the
+# correct set of dependencies is traversed for the given toolchain context.
 # Cleans up the stamp directory on completion.
 # -------------------------------------------------------------------
 .PHONY: dependency-flat-raw
 dependency-flat-raw:
 	@PARALLEL_MAKE=max $(MAKE) -j $(nproc) --silent --no-print-directory \
+		$(if $(ARCH),ARCH=$(ARCH)) \
+		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
 		dependency-flat-mk 2>/dev/null || true
 	@rm -rf $(DEP_FLAT_STAMP_DIR)
 
 # -------------------------------------------------------------------
 # dependency-flat
 # Returns a sorted, unique list of dependency paths (one per line),
-# filtered by DEPENDS_TYPE. Default: all types, identical to original.
+# filtered by DEPENDS_TYPE.
+# Default: all types when ARCH/TCVERSION are absent;
+#          OPTIONAL_DEPENDS excluded when both ARCH and TCVERSION are set.
 # -------------------------------------------------------------------
 .PHONY: dependency-flat
 dependency-flat:
-	@$(MAKE) -s dependency-flat-raw \
+	@$(MAKE) -s \
+		$(if $(ARCH),ARCH=$(ARCH)) \
+		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+		dependency-flat-raw \
 		| awk -v types=" $(DEPENDS_TYPE) " ' \
 		  /^(DEPENDS|BUILD_DEPENDS|OPTIONAL_DEPENDS|NATIVE_DEPENDS) / { \
 		    if (index(types, " " $$1 " ") > 0) print $$2 \
@@ -250,8 +321,10 @@ dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
 #    Stamp file structure (empty file, presence = visited):
 #        $(DEP_FLAT_STAMP_DIR)/cross__openssl3
 #        $(DEP_FLAT_STAMP_DIR)/native__nasm
-#  - Recursively invokes dependency-flat-mk in the dependency directory,
-#    always traversing all types regardless of DEPENDS_TYPE.
+#  - Recursively invokes dependency-flat-mk in the dependency directory.
+#    ARCH and TCVERSION are forwarded so each sub-package evaluates its own
+#    conditional DEPENDS in the correct toolchain context, and excludes its
+#    own OPTIONAL_DEPENDS when the context is set.
 # -------------------------------------------------------------------
 .PHONY: dep-flat-mk-%
 dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
@@ -267,19 +340,26 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 	touch "$$stamp"; \
 	DEPENDENCY_WALK=1 \
 	$(MAKE) -s --output-sync=target \
-		-C ../../$$dep dependency-flat-mk
+		-C ../../$$dep \
+		$(if $(ARCH),ARCH=$(ARCH)) \
+		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+		dependency-flat-mk
 
 # -------------------------------------------------------------------
 # dependency-list
 # Prints a single-line, space-separated list of dependencies filtered
 # by DEPENDS_TYPE. Delegates to dependency-flat for traversal and filtering.
+# ARCH and TCVERSION are forwarded so the correct dependency graph is used.
 # Output format:
 #     $(NAME): cross/foo cross/bar native/baz ...
 # -------------------------------------------------------------------
 .PHONY: dependency-list
 dependency-list:
 	@echo -n "$(NAME): "
-	@$(MAKE) -s dependency-flat | tr '\n' ' '
+	@$(MAKE) -s \
+	    $(if $(ARCH),ARCH=$(ARCH)) \
+	    $(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+	    dependency-flat | tr '\n' ' '
 	@echo ""
 
 # End of package-level targets

--- a/mk/spksrc.main-depends.mk
+++ b/mk/spksrc.main-depends.mk
@@ -4,9 +4,6 @@
 # Do not initialize any environment to avoid variable leakage.
 DEFAULT_ENV = none
 
-# Common makefiles
-include ../../mk/spksrc.common.mk
-
 # nothing to download
 download:
 checksum:
@@ -24,6 +21,9 @@ endif
 
 # Common directories (must be set after ARCH_SUFFIX)
 include ../../mk/spksrc.directories.mk
+
+# Common makefiles
+include ../../mk/spksrc.common.mk
 
 #####
 


### PR DESCRIPTION
## Description

After further reviewing the output generated by `spksrc.dependency-tree.mk` following https://github.com/SynoCommunity/spksrc/pull/7121 it became obvious that a few dependencies where still missing from the output.  With the fixes now we get all the proper dependencies, even in the most extensive use-cases such as:
```
spksrc@spksrc13:~/ffmpeg8/spksrc$ make -C spk/synocli-videodriver/ dependency-list
make: Entering directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'
synocli-videodriver: cross/intel-gmmlib cross/intel-gmmlib-22.3 cross/intel-gmmlib-latest cross/intel-media-driver cross/intel-media-driver-22.5 cross/intel-media-driver-latest cross/intel-mediasdk cross/intel-mediasdk-22.5 cross/intel-mediasdk-latest cross/intel-vaapi-driver cross/libdrm cross/libpciaccess cross/libva cross/libva-2.17 cross/libva-latest cross/libva-utils cross/libva-utils-2.17 cross/libva-utils-latest 
make: Leaving directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'

spksrc@spksrc13:~/ffmpeg8/spksrc$ make -C spk/synocli-videodriver/ ARCH=x64 TCVERSION=6.2.4 dependency-list
make: Entering directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'
synocli-videodriver: cross/intel-gmmlib cross/intel-gmmlib-22.3 cross/intel-media-driver cross/intel-media-driver-22.5 cross/intel-mediasdk cross/intel-mediasdk-22.5 cross/intel-vaapi-driver cross/libdrm cross/libpciaccess cross/libva cross/libva-2.17 cross/libva-utils cross/libva-utils-2.17 
make: Leaving directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'

spksrc@spksrc13:~/ffmpeg8/spksrc$ make -C spk/synocli-videodriver/ ARCH=x64 TCVERSION=7.1 dependency-list
make: Entering directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'
synocli-videodriver: cross/bzip2 cross/cairo cross/cairo-latest cross/clinfo cross/dbus cross/elfutils cross/fontconfig cross/freetype cross/glib cross/glib-latest cross/intel-compute-runtime cross/intel-gmmlib cross/intel-gmmlib-latest cross/intel-gpu-tools cross/intel-graphics-compiler cross/intel-level-zero cross/intel-libvpl cross/intel-libvpl-tools cross/intel-media-driver cross/intel-media-driver-latest cross/intel-mediasdk cross/intel-mediasdk-latest cross/intel-opencl-clang-140 cross/intel-vaapi-driver cross/intel-vc-intrinsics cross/Khronos-glslang cross/Khronos-OpenCL-Headers cross/Khronos-SPIRV-Headers cross/Khronos-SPIRV-LLVM-Translator-140 cross/Khronos-SPIRV-Tools cross/Khronos-Vulkan-Headers cross/Khronos-Vulkan-Loader cross/Khronos-Vulkan-Tools cross/libcap cross/libdrm cross/libexpat cross/libffi cross/libgcrypt cross/libglvnd cross/libgpg-error cross/libiconv cross/libkmod cross/libmount cross/libpciaccess cross/libpng cross/libproc2 cross/libudev_219 cross/libuuid cross/libva cross/libva-latest cross/libva-utils cross/libva-utils-latest cross/llvm-140 cross/llvm-project-140.src cross/lz4 cross/mesa cross/ocl-icd cross/pcre2 cross/pixman cross/xz cross/zlib cross/zstd native/llvm-14.0 native/llvm-14.0-libclc 
make: Leaving directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'

spksrc@spksrc13:~/ffmpeg8/spksrc$ make -C spk/synocli-videodriver/ ARCH=x64 TCVERSION=7.2 dependency-list
make: Entering directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'
synocli-videodriver: cross/bzip2 cross/cairo cross/cairo-latest cross/clinfo cross/dbus cross/elfutils cross/fontconfig cross/freetype cross/glib cross/glib-latest cross/intel-compute-runtime cross/intel-gmmlib cross/intel-gmmlib-latest cross/intel-gpu-tools cross/intel-graphics-compiler cross/intel-level-zero cross/intel-libvpl cross/intel-libvpl-tools cross/intel-media-driver cross/intel-media-driver-latest cross/intel-mediasdk cross/intel-mediasdk-latest cross/intel-opencl-clang-140 cross/intel-vaapi-driver cross/intel-vc-intrinsics cross/Khronos-glslang cross/Khronos-OpenCL-Headers cross/Khronos-SPIRV-Headers cross/Khronos-SPIRV-LLVM-Translator-140 cross/Khronos-SPIRV-Tools cross/Khronos-Vulkan-Headers cross/Khronos-Vulkan-Loader cross/Khronos-Vulkan-Tools cross/libcap cross/libdrm cross/libexpat cross/libffi cross/libgcrypt cross/libglvnd cross/libgpg-error cross/libiconv cross/libkmod cross/libmount cross/libpciaccess cross/libpng cross/libproc2 cross/libudev_219 cross/libuuid cross/libva cross/libva-latest cross/libva-utils cross/libva-utils-latest cross/llvm-140 cross/llvm-project-140.src cross/lz4 cross/mesa cross/ocl-icd cross/pcre2 cross/pixman cross/xz cross/zlib cross/zstd native/llvm-14.0 native/llvm-14.0-libclc 
make: Leaving directory '/home/spksrc/ffmpeg8/spksrc/spk/synocli-videodriver'
```
This can also be called from the root directory such as:
```
spksrc@spksrc13:~/ffmpeg8/spksrc$ make dependency-list-spk | grep videodriver
synocli-videodriver: cross/intel-gmmlib cross/intel-gmmlib-22.3 cross/intel-gmmlib-latest cross/intel-media-driver cross/intel-media-driver-22.5 cross/intel-media-driver-latest cross/intel-mediasdk cross/intel-mediasdk-22.5 cross/intel-mediasdk-latest cross/intel-vaapi-driver cross/libdrm cross/libpciaccess cross/libva cross/libva-2.17 cross/libva-latest cross/libva-utils cross/libva-utils-2.17 cross/libva-utils-latest 

spksrc@spksrc13:~/ffmpeg8/spksrc$ make ARCH=x64 TCVERSION=6.2.4 dependency-list-spk | grep videodriver
synocli-videodriver: cross/intel-gmmlib cross/intel-gmmlib-22.3 cross/intel-media-driver cross/intel-media-driver-22.5 cross/intel-mediasdk cross/intel-mediasdk-22.5 cross/intel-vaapi-driver cross/libdrm cross/libpciaccess cross/libva cross/libva-2.17 cross/libva-utils cross/libva-utils-2.17 

spksrc@spksrc13:~/ffmpeg8/spksrc$ make ARCH=x64 TCVERSION=7.2 dependency-list-spk | grep videodriver
synocli-videodriver: cross/bzip2 cross/cairo cross/cairo-latest cross/clinfo cross/dbus cross/elfutils cross/fontconfig cross/freetype cross/glib cross/glib-latest cross/intel-compute-runtime cross/intel-gmmlib cross/intel-gmmlib-latest cross/intel-gpu-tools cross/intel-graphics-compiler cross/intel-level-zero cross/intel-libvpl cross/intel-libvpl-tools cross/intel-media-driver cross/intel-media-driver-latest cross/intel-mediasdk cross/intel-mediasdk-latest cross/intel-opencl-clang-140 cross/intel-vaapi-driver cross/intel-vc-intrinsics cross/Khronos-glslang cross/Khronos-OpenCL-Headers cross/Khronos-SPIRV-Headers cross/Khronos-SPIRV-LLVM-Translator-140 cross/Khronos-SPIRV-Tools cross/Khronos-Vulkan-Headers cross/Khronos-Vulkan-Loader cross/Khronos-Vulkan-Tools cross/libcap cross/libdrm cross/libexpat cross/libffi cross/libgcrypt cross/libglvnd cross/libgpg-error cross/libiconv cross/libkmod cross/libmount cross/libpciaccess cross/libpng cross/libproc2 cross/libudev_219 cross/libuuid cross/libva cross/libva-latest cross/libva-utils cross/libva-utils-latest cross/llvm-140 cross/llvm-project-140.src cross/lz4 cross/mesa cross/ocl-icd cross/pcre2 cross/pixman cross/xz cross/zlib cross/zstd native/llvm-14.0 native/llvm-14.0-libclc 
```

This had two root-causes:
1. `spksrc.dependency-tree.mk` needed additional changes in order for it to provide `ARCH` and `TCVERSION` in sub-make calls done.  makefile has been adapted accordingly.
2. All "main" cross makefiles where including `spksrc.main-depends.mk` too early.  In a `DEPENDENCY_WALK=1` the following conditions wouldn't be called as appearing afterwards.  Thus it required the include to be moved at the end of the file.  Likewise, any use-cases of macros requires including `spksrc.common.mk`.  As such a main file such as:
```
PKG_NAME = z3-main

OPTIONAL_DEPENDS += cross/z3-4.11
OPTIONAL_DEPENDS += cross/z3-4.7

include ../../mk/spksrc.main-depends.mk

ifeq ($(call version_ge, $(TC_GCC), 5),1)
DEPENDS = cross/z3-4.11
else
DEPENDS = cross/z3-4.7
endif
```
Would now look like:
```
PKG_NAME = z3-main

OPTIONAL_DEPENDS += cross/z3-4.11
OPTIONAL_DEPENDS += cross/z3-4.7

include ../../mk/spksrc.common.mk

ifeq ($(call version_ge, $(TC_GCC), 5),1)
DEPENDS = cross/z3-4.11
else
DEPENDS = cross/z3-4.7
endif

include ../../mk/spksrc.main-depends.mk
```

Follows-up https://github.com/SynoCommunity/spksrc/pull/7121

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
