### PR TITLE
fix: five form fields (frontend_name, frontend_ip, f... in...

### DIFF
--- a/spk/haproxy/src/haproxy-dashboard/routes/main_routes.py
+++ b/spk/haproxy/src/haproxy-dashboard/routes/main_routes.py
@@ -8,11 +8,11 @@ main_bp = Blueprint('main', __name__)
 @requires_auth
 def index():
     if request.method == 'POST':
-        frontend_name = request.form['frontend_name']
-        frontend_ip = request.form['frontend_ip']
-        frontend_port = request.form['frontend_port']
-        lb_method = request.form['lb_method']
-        protocol = request.form['protocol']
+        frontend_name = request.form['frontend_name'].replace('\n', '').replace('\r', '')
+        frontend_ip = request.form['frontend_ip'].replace('\n', '').replace('\r', '')
+        frontend_port = request.form['frontend_port'].replace('\n', '').replace('\r', '')
+        lb_method = request.form['lb_method'].replace('\n', '').replace('\r', '')
+        protocol = request.form['protocol'].replace('\n', '').replace('\r', '')
         backend_name = request.form['backend_name']
         add_header = 'add_header' in request.form if 'add_header' in request.form else ''
         header_name = request.form['header_name']


### PR DESCRIPTION
## Summary
Fix high severity security issue in `spk/haproxy/src/haproxy-dashboard/routes/main_routes.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `spk/haproxy/src/haproxy-dashboard/routes/main_routes.py:11` |

**Description**: Five form fields (frontend_name, frontend_ip, frontend_port, lb_method, protocol) are read directly from HTTP form submissions without any sanitization or validation before being written into the HAProxy configuration file. An attacker can inject newline characters and HAProxy configuration directives into any of these fields, adding unauthorized frontends, backends, or ACL rules to the load balancer configuration.

## Changes
- `spk/haproxy/src/haproxy-dashboard/routes/main_routes.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
