### PR TITLE
PostgreSQL: Fix for ARMv7 builds

### DIFF
--- a/cross/libicu-74.2/Makefile
+++ b/cross/libicu-74.2/Makefile
@@ -55,10 +55,17 @@ DATA_PACKAGING = library
 endif
 CONFIGURE_ARGS += --with-data-packaging=$(DATA_PACKAGING)
 
-ifeq ($(strip $(DATA_PACKAGING)),"files")
+ifeq ($(strip $(DATA_PACKAGING)),files)
 # needs a custom install target to successfully build.
 INSTALL_TARGET = libicu_install_with_data_files
 endif
+
+ifeq ($(strip $(DATA_PACKAGING)),archive)
+# add the ICU data file.
+PLIST_TRANSFORM = sed -e '$$a rsc:share/icu/74.2/icudt74l.dat'
+endif
+
+PRE_COMPILE_TARGET = libicu_prepare_dir
 POST_INSTALL_TARGET = libicu_post_install
 
 CONFIGURE_ARGS += --with-cross-build=$(NATIVE_BUILD_DIR) 
@@ -74,6 +81,10 @@ include ../../mk/spksrc.cross-cc.mk
 .PHONY: libicu_install_with_data_files
 libicu_install_with_data_files:
 	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) ICUPKGDATA_DIR=$(INSTALL_PREFIX)/share install PREFIX=$(INSTALL_PREFIX)
+
+.PHONY: libicu_prepare_dir
+libicu_prepare_dir:
+	@mkdir -p $(WORK_DIR)/$(PKG_DIR)/data/out/tmp
 
 .PHONY: libicu_post_install
 libicu_post_install:

--- a/cross/libicu-74.2/Makefile
+++ b/cross/libicu-74.2/Makefile
@@ -62,7 +62,7 @@ endif
 
 ifeq ($(strip $(DATA_PACKAGING)),archive)
 # add the ICU data file.
-PLIST_TRANSFORM = sed -e '$$a rsc:share/icu/74.2/icudt74l.dat'
+PLIST_TRANSFORM = sed -e '$$a rsc:share/icu/*/icudt*.dat'
 endif
 
 PRE_COMPILE_TARGET = libicu_prepare_dir

--- a/cross/libicu-74.2/Makefile
+++ b/cross/libicu-74.2/Makefile
@@ -42,23 +42,18 @@ NATIVE_BUILD_DIR = $(realpath $(WORK_DIR)/../../../native/$(PKG_NAME)/work-nativ
 
 # the packaging can be customized in a dependent package by definition
 # of LIBICU_DATA_PACKAGING_MODE like:
-# export LIBICU_DATA_PACKAGING_MODE=files
+# export LIBICU_DATA_PACKAGING_MODE=archive
 # 
 # valid data packaging values are
 # - library (the default)
 # - archive
-# - files
+
 DATA_PACKAGING = $(LIBICU_DATA_PACKAGING_MODE)
 ifeq ($(strip $(DATA_PACKAGING)),)
 # default data packaging
 DATA_PACKAGING = library
 endif
 CONFIGURE_ARGS += --with-data-packaging=$(DATA_PACKAGING)
-
-ifeq ($(strip $(DATA_PACKAGING)),files)
-# needs a custom install target to successfully build.
-INSTALL_TARGET = libicu_install_with_data_files
-endif
 
 ifeq ($(strip $(DATA_PACKAGING)),archive)
 # add the ICU data file.
@@ -77,10 +72,6 @@ CONFIGURE_ARGS += --disable-tests
 ADDITIONAL_CFLAGS = -O3
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: libicu_install_with_data_files
-libicu_install_with_data_files:
-	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) ICUPKGDATA_DIR=$(INSTALL_PREFIX)/share install PREFIX=$(INSTALL_PREFIX)
 
 .PHONY: libicu_prepare_dir
 libicu_prepare_dir:

--- a/cross/libicu-latest/Makefile
+++ b/cross/libicu-latest/Makefile
@@ -42,23 +42,18 @@ NATIVE_BUILD_DIR = $(realpath $(WORK_DIR)/../../../native/$(PKG_NAME)/work-nativ
 
 # the packaging can be customized in a dependent package by definition
 # of LIBICU_DATA_PACKAGING_MODE like:
-# export LIBICU_DATA_PACKAGING_MODE=files
+# export LIBICU_DATA_PACKAGING_MODE=archive
 # 
 # valid data packaging values are
 # - library (the default)
 # - archive
-# - files
+
 DATA_PACKAGING = $(LIBICU_DATA_PACKAGING_MODE)
 ifeq ($(strip $(DATA_PACKAGING)),)
 # default data packaging
 DATA_PACKAGING = library
 endif
 CONFIGURE_ARGS += --with-data-packaging=$(DATA_PACKAGING)
-
-ifeq ($(strip $(DATA_PACKAGING)),files)
-# needs a custom install target to successfully build.
-INSTALL_TARGET = libicu_install_with_data_files
-endif
 
 ifeq ($(strip $(DATA_PACKAGING)),archive)
 # add the ICU data file.
@@ -77,10 +72,6 @@ CONFIGURE_ARGS += --disable-tests
 ADDITIONAL_CFLAGS = -O3
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: libicu_install_with_data_files
-libicu_install_with_data_files:
-	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) ICUPKGDATA_DIR=$(INSTALL_PREFIX)/share install PREFIX=$(INSTALL_PREFIX)
 
 .PHONY: libicu_prepare_dir
 libicu_prepare_dir:

--- a/cross/libicu-latest/Makefile
+++ b/cross/libicu-latest/Makefile
@@ -62,7 +62,7 @@ endif
 
 ifeq ($(strip $(DATA_PACKAGING)),archive)
 # add the ICU data file.
-PLIST_TRANSFORM = sed -e '$$a rsc:share/icu/77.1/icudt77l.dat'
+PLIST_TRANSFORM = sed -e '$$a rsc:share/icu/*/icudt*.dat'
 endif
 
 PRE_COMPILE_TARGET = libicu_prepare_dir

--- a/cross/libicu-latest/Makefile
+++ b/cross/libicu-latest/Makefile
@@ -55,10 +55,17 @@ DATA_PACKAGING = library
 endif
 CONFIGURE_ARGS += --with-data-packaging=$(DATA_PACKAGING)
 
-ifeq ($(strip $(DATA_PACKAGING)),"files")
+ifeq ($(strip $(DATA_PACKAGING)),files)
 # needs a custom install target to successfully build.
 INSTALL_TARGET = libicu_install_with_data_files
 endif
+
+ifeq ($(strip $(DATA_PACKAGING)),archive)
+# add the ICU data file.
+PLIST_TRANSFORM = sed -e '$$a rsc:share/icu/77.1/icudt77l.dat'
+endif
+
+PRE_COMPILE_TARGET = libicu_prepare_dir
 POST_INSTALL_TARGET = libicu_post_install
 
 CONFIGURE_ARGS += --with-cross-build=$(NATIVE_BUILD_DIR) 
@@ -74,6 +81,10 @@ include ../../mk/spksrc.cross-cc.mk
 .PHONY: libicu_install_with_data_files
 libicu_install_with_data_files:
 	$(RUN) $(MAKE) DESTDIR=$(INSTALL_DIR) ICUPKGDATA_DIR=$(INSTALL_PREFIX)/share install PREFIX=$(INSTALL_PREFIX)
+
+.PHONY: libicu_prepare_dir
+libicu_prepare_dir:
+	@mkdir -p $(WORK_DIR)/$(PKG_DIR)/data/out/tmp
 
 .PHONY: libicu_post_install
 libicu_post_install:

--- a/spk/postgresql/Makefile
+++ b/spk/postgresql/Makefile
@@ -26,8 +26,7 @@ include ../../mk/spksrc.common.mk
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
 # Use ICU archive data packaging to avoid runtime libicudata shared library
-# loading issues observed on DSM ARMv7 systems. Archive mode embeds ICU data
-# at build time and is significantly more stable than library mode in practice.
+# loading issues observed on DSM ARMv7 systems.
 export LIBICU_DATA_PACKAGING_MODE=archive
 
 # PostGIS requires GCC 5+ (GEOS 3.12.3 needs C++14)

--- a/spk/postgresql/Makefile
+++ b/spk/postgresql/Makefile
@@ -7,7 +7,7 @@ DEPENDS = cross/postgresql
 
 MAINTAINER = DigitalBox98
 DESCRIPTION = PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development. This package includes PostGIS spatial database extension for DSM 7+.
-CHANGELOG = "Fix for ARMv7 builds."
+CHANGELOG = "Use ICU archive data packaging to avoid ARMv7 runtime issues."
 DISPLAY_NAME = PostgreSQL
 STARTABLE = yes
 
@@ -25,11 +25,10 @@ include ../../mk/spksrc.common.mk
 # libicu-74.2 (used for GCC < 5 / DSM 6) doesn't support ARMv5
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
-# bugfix for libicudata error, solution proposed by Steven R. Loomis
-# in https://sourceforge.net/p/icu/mailman/message/36666855/
-ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
-export LIBICU_DATA_PACKAGING_MODE=files
-endif
+# Use ICU archive data packaging to avoid runtime libicudata shared library
+# loading issues observed on DSM ARMv7 systems. Archive mode embeds ICU data
+# at build time and is significantly more stable than library mode in practice.
+export LIBICU_DATA_PACKAGING_MODE=archive
 
 # PostGIS requires GCC 5+ (GEOS 3.12.3 needs C++14)
 # Only include postgis if toolchain GCC >= 5.0

--- a/spk/postgresql/Makefile
+++ b/spk/postgresql/Makefile
@@ -1,13 +1,13 @@
 SPK_NAME = postgresql
 SPK_VERS = 17.4
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/postgresql.png
 
 DEPENDS = cross/postgresql
 
 MAINTAINER = DigitalBox98
 DESCRIPTION = PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development. This package includes PostGIS spatial database extension for DSM 7+.
-CHANGELOG = "Initial package release."
+CHANGELOG = "Fix for ARMv7 builds."
 DISPLAY_NAME = PostgreSQL
 STARTABLE = yes
 
@@ -24,6 +24,12 @@ include ../../mk/spksrc.common.mk
 
 # libicu-74.2 (used for GCC < 5 / DSM 6) doesn't support ARMv5
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
+
+# bugfix for libicudata error, solution proposed by Steven R. Loomis
+# in https://sourceforge.net/p/icu/mailman/message/36666855/
+ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
+export LIBICU_DATA_PACKAGING_MODE=files
+endif
 
 # PostGIS requires GCC 5+ (GEOS 3.12.3 needs C++14)
 # Only include postgis if toolchain GCC >= 5.0

--- a/spk/postgresql/src/service-setup.sh
+++ b/spk/postgresql/src/service-setup.sh
@@ -25,20 +25,20 @@ run_as_user()
     if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ]; then
         eval "$@"
     else
-        su - ${EFF_USER} -s /bin/sh -c "$@"
+        su - "${EFF_USER}" -s /bin/sh -c "$@"
     fi
 }
 
 validate_preuninst()
 {
     # Validate backup directory if user requested database backup
-    if [ "${wizard_pg_dump_database}" = "true" ]; then
+    if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ] && [ "${wizard_pg_dump_database}" = "true" ]; then
         # Validate password by attempting to connect
         # Start server temporarily for validation
         run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} -l ${LOG_FILE} start"
 
         export PGPASSWORD="${wizard_pg_password}"
-        if ! ${SYNOPKG_PKGDEST}/bin/psql -h localhost -p ${SERVICE_PORT} -U ${EFF_USER} -d postgres -c "SELECT 1" > /dev/null 2>&1; then
+        if ! "${SYNOPKG_PKGDEST}/bin/psql" -h localhost -p "${SERVICE_PORT}" -U "${EFF_USER}" -d postgres -c "SELECT 1" > /dev/null 2>&1; then
             unset PGPASSWORD
             run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} stop"
             echo "Incorrect PostgreSQL administrator password"
@@ -70,63 +70,67 @@ validate_preuninst()
 
 service_postinst()
 {
-    # On DSM 6 (running as root), create data directory and set ownership
-    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
-        mkdir -p "${DATABASE_DIR}"
-        chown -R ${EFF_USER}:$(id -gn ${EFF_USER}) "${SYNOPKG_PKGVAR}"
+    if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
+        # On DSM 6 (running as root), create data directory and set ownership
+        if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
+            mkdir -p "${DATABASE_DIR}"
+            # shellcheck disable=SC2046
+            chown -R "${EFF_USER}":$(id -gn "${EFF_USER}") "${SYNOPKG_PKGVAR}"
+        fi
+
+        # Create password file for initdb (scram-sha-256 requires superuser password)
+        PWFILE="${SYNOPKG_PKGVAR}/.pwfile"
+        echo "${PG_PASSWORD}" > "${PWFILE}"
+        chmod 600 "${PWFILE}"
+        if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
+            # shellcheck disable=SC2046
+            chown "${EFF_USER}":$(id -gn "${EFF_USER}") "${PWFILE}"
+        fi
+
+        # Initialize database with peer auth for local connections (allows setup without password)
+        # scram-sha-256 for host connections from the start
+        run_as_user "${SYNOPKG_PKGDEST}/bin/initdb -D ${DATABASE_DIR} --encoding=UTF8 --locale=en_US.UTF8 --auth-local=peer --auth-host=scram-sha-256 --pwfile=${PWFILE}"
+
+        # Remove password file after initialization
+        rm -f "${PWFILE}"
+
+        # Configure postgresql.conf
+        # Set port from SERVICE_PORT (avoids conflict with Synology's PostgreSQL on 5432)
+        run_as_user "sed -e 's/^#port = 5432/port = ${SERVICE_PORT}/g' -i ${CFG_FILE}"
+        # Move Unix socket from /tmp to package var directory for persistence and security
+        run_as_user "sed -e \"s|^#unix_socket_directories = '/tmp'|unix_socket_directories = '${SYNOPKG_PKGVAR}'|g\" -i ${CFG_FILE}"
+        # Listen on all interfaces
+        run_as_user "sed -e \"s/^#listen_addresses = 'localhost'/listen_addresses = '*'/g\" -i ${CFG_FILE}"
+
+        # Start server temporarily to create roles
+        run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} -l ${LOG_FILE} start"
+
+        # Set password for the system user (peer auth allows connection without password via Unix socket)
+        run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c \"ALTER ROLE \\\"${EFF_USER}\\\" WITH PASSWORD '${PG_PASSWORD}';\""
+
+        # Create administrator role from wizard (peer auth via Unix socket)
+        run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c \"CREATE ROLE ${PG_USERNAME} PASSWORD '${PG_PASSWORD}' SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN REPLICATION BYPASSRLS;\""
+
+        # Enable PostGIS extension if available (requires GCC 5+ toolchain build)
+        if "${SYNOPKG_PKGDEST}/bin/psql" -h "${SYNOPKG_PKGVAR}" -p "${SERVICE_PORT}" -d postgres -c "SELECT 1 FROM pg_available_extensions WHERE name = 'postgis' AND installed_version IS NOT NULL" -t > /dev/null 2>&1; then
+            run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis;'"
+            run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c 'CREATE EXTENSION IF NOT EXISTS postgis;'"
+        fi
+
+        # Switch local authentication to scram-sha-256 for regular users
+        # Keep peer auth for the system user (sc-postgresql) to allow passwordless backups
+        # Order matters: first matching rule wins, so system user rule must come first
+        run_as_user "sed -e 's/^local.*all.*all.*peer$/local   all             ${EFF_USER}                           peer\\nlocal   all             all                                     scram-sha-256/' -i ${HBA_FILE}"
+
+        # Stop server (will be started by DSM)
+        run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} stop"
     fi
-
-    # Create password file for initdb (scram-sha-256 requires superuser password)
-    PWFILE="${SYNOPKG_PKGVAR}/.pwfile"
-    echo "${PG_PASSWORD}" > "${PWFILE}"
-    chmod 600 "${PWFILE}"
-    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
-        chown ${EFF_USER}:$(id -gn ${EFF_USER}) "${PWFILE}"
-    fi
-
-    # Initialize database with peer auth for local connections (allows setup without password)
-    # scram-sha-256 for host connections from the start
-    run_as_user "${SYNOPKG_PKGDEST}/bin/initdb -D ${DATABASE_DIR} --encoding=UTF8 --locale=en_US.UTF8 --auth-local=peer --auth-host=scram-sha-256 --pwfile=${PWFILE}"
-
-    # Remove password file after initialization
-    rm -f "${PWFILE}"
-
-    # Configure postgresql.conf
-    # Set port from SERVICE_PORT (avoids conflict with Synology's PostgreSQL on 5432)
-    run_as_user "sed -e 's/^#port = 5432/port = ${SERVICE_PORT}/g' -i ${CFG_FILE}"
-    # Move Unix socket from /tmp to package var directory for persistence and security
-    run_as_user "sed -e \"s|^#unix_socket_directories = '/tmp'|unix_socket_directories = '${SYNOPKG_PKGVAR}'|g\" -i ${CFG_FILE}"
-    # Listen on all interfaces
-    run_as_user "sed -e \"s/^#listen_addresses = 'localhost'/listen_addresses = '*'/g\" -i ${CFG_FILE}"
-
-    # Start server temporarily to create roles
-    run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} -l ${LOG_FILE} start"
-
-    # Set password for the system user (peer auth allows connection without password via Unix socket)
-    run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c \"ALTER ROLE \\\"${EFF_USER}\\\" WITH PASSWORD '${PG_PASSWORD}';\""
-
-    # Create administrator role from wizard (peer auth via Unix socket)
-    run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c \"CREATE ROLE ${PG_USERNAME} PASSWORD '${PG_PASSWORD}' SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN REPLICATION BYPASSRLS;\""
-
-    # Enable PostGIS extension if available (requires GCC 5+ toolchain build)
-    if ${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c "SELECT 1 FROM pg_available_extensions WHERE name = 'postgis' AND installed_version IS NOT NULL" -t > /dev/null 2>&1; then
-        run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis;'"
-        run_as_user "${SYNOPKG_PKGDEST}/bin/psql -h ${SYNOPKG_PKGVAR} -p ${SERVICE_PORT} -d postgres -c 'CREATE EXTENSION IF NOT EXISTS postgis;'"
-    fi
-
-    # Switch local authentication to scram-sha-256 for regular users
-    # Keep peer auth for the system user (sc-postgresql) to allow passwordless backups
-    # Order matters: first matching rule wins, so system user rule must come first
-    run_as_user "sed -e 's/^local.*all.*all.*peer$/local   all             ${EFF_USER}                           peer\\nlocal   all             all                                     scram-sha-256/' -i ${HBA_FILE}"
-
-    # Stop server (will be started by DSM)
-    run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} stop"
 }
 
 service_preuninst()
 {
     # Backup databases on user's request
-    if [ "${wizard_pg_dump_database}" = "true" ]; then
+    if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ] && [ "${wizard_pg_dump_database}" = "true" ]; then
         # Start server for backup
         run_as_user "${SYNOPKG_PKGDEST}/bin/pg_ctl -D ${DATABASE_DIR} -l ${LOG_FILE} start"
 
@@ -143,8 +147,8 @@ service_preuninst()
         # Dump all databases (excluding templates)
         # Use TCP/IP connection with password (PGPASSWORD) - runs as root to write to shared folders
         export PGPASSWORD="${wizard_pg_password}"
-        for database in $(${SYNOPKG_PKGDEST}/bin/psql -h localhost -p ${SERVICE_PORT} -U ${EFF_USER} -A -t -d postgres -c 'SELECT datname FROM pg_database WHERE datistemplate = false'); do
-            ${SYNOPKG_PKGDEST}/bin/pg_dump -h localhost -p ${SERVICE_PORT} -U ${EFF_USER} -Fc ${database} -f "${PG_BACKUP_DUMP_DIR}/${database}.dump"
+        for database in $("${SYNOPKG_PKGDEST}/bin/psql" -h localhost -p "${SERVICE_PORT}" -U "${EFF_USER}" -A -t -d postgres -c 'SELECT datname FROM pg_database WHERE datistemplate = false'); do
+            "${SYNOPKG_PKGDEST}/bin/pg_dump" -h localhost -p "${SERVICE_PORT}" -U "${EFF_USER}" -Fc "${database}" -f "${PG_BACKUP_DUMP_DIR}/${database}.dump"
         done
         unset PGPASSWORD
 

--- a/spk/znc/Makefile
+++ b/spk/znc/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = znc
 SPK_VERS = 1.10.1
-SPK_REV = 27
+SPK_REV = 28
 SPK_ICON = src/znc.png
 DSM_UI_DIR = app
 
@@ -48,11 +48,9 @@ DEPENDS += cross/znc
 
 include ../../mk/spksrc.common.mk
 
-ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS) $(ARMv7L_ARCHS)),$(ARCH))
-# bugfix for libicudata error, solution proposed by Steven R. Loomis
-# in https://sourceforge.net/p/icu/mailman/message/36666855/
-export LIBICU_DATA_PACKAGING_MODE=files
-endif
+# Use ICU archive data packaging to avoid runtime libicudata shared library
+# loading issues observed on DSM ARMv7 systems.
+export LIBICU_DATA_PACKAGING_MODE=archive
 
 include ../../mk/spksrc.spk-meta.mk
 


### PR DESCRIPTION
## Description

Follow-on from #4267 patching the recently-added PostgreSQL package. Switches ICU data packaging to `archive` to resolve `libicudata` loading failures on ARMv7. Also guards service setup/teardown behind `PKG_STATUS` checks and fixes shell quoting.

Fixes #7120

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
