### PR TITLE
SABnzbd: Add python314 runtime dependency

### DIFF
--- a/spk/sabnzbd/Makefile
+++ b/spk/sabnzbd/Makefile
@@ -1,9 +1,10 @@
 SPK_NAME = sabnzbd
 SPK_VERS = 5.0.3
-SPK_REV = 80
+SPK_REV = 81
 SPK_ICON = src/sabnzbd.png
 
 PYTHON_PACKAGE = python314
+SPK_DEPENDS = "${PYTHON_PACKAGE}"
 
 DEPENDS = cross/ionice cross/coreutils cross/par2cmdline-turbo cross/7zz cross/sabnzbd
 OPTIONAL_DEPENDS = cross/unrar7 cross/unrar


### PR DESCRIPTION
## Description

This is a follow-on from #7126 to fix the missing `python314` runtime dependency.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Bug fix