### PR TITLE
Framework: Reliably inject PYTHON_PACKAGE into SPK_DEPENDS

### DIFF
--- a/mk/spksrc.spk/python.mk
+++ b/mk/spksrc.spk/python.mk
@@ -40,4 +40,5 @@ else
   export PYTHON_PACKAGE
   export PYTHON_PACKAGE_DIR
   BUILD_DEPENDS := $(call uniq,$(PYTHON_DEPENDS) $(BUILD_DEPENDS))
+  SPK_DEPENDS := $(call dedup,$(PYTHON_PACKAGE):$(SPK_DEPENDS),:)
 endif

--- a/spk/haproxy/Makefile
+++ b/spk/haproxy/Makefile
@@ -7,7 +7,6 @@ DEPENDS = cross/haproxy
 
 PYTHON_PACKAGE = python314
 WHEELS = src/requirements-crossenv.txt src/requirements-pure.txt
-SPK_DEPENDS = "${PYTHON_PACKAGE}"
 
 MAINTAINER = Diaoul
 DESCRIPTION = HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.


### PR DESCRIPTION
## Description

### Problem

The `spksrc.spk/python.mk` framework has a mechanism to auto-add `${PYTHON_PACKAGE}` to `SPK_DEPENDS` during the `spk-stage2` build phase. However, this only works when both:
1. `spk-stage2` is in `MAKECMDGOALS` (only true during the recursive `LOG_WRAPPED` make call)
2. `$(PYTHON_PACKAGE_WORK_DIR)` exists (i.e., Python was previously built for that architecture)

Condition 2 is unreliable. In CI's `all-supported` flow, Python is built first, so the work directory exists before dependent packages are built. But standalone `make arch-x64-7.2` builds skip this entirely, leaving packages without Python as a declared runtime dependency in `install_dep_packages`.

This gap was worked around in PR #7148 by adding an explicit `SPK_DEPENDS = "${PYTHON_PACKAGE}"` to the HAProxy Makefile.

### Fix

Added `SPK_DEPENDS := $(call dedup,$(PYTHON_PACKAGE):$(SPK_DEPENDS),:)` to the `else` branch of `python.mk`, which runs during the normal (non-`spk-stage2`) build path. This ensures `${PYTHON_PACKAGE}` is reliably prepended to `SPK_DEPENDS` for all build scenarios, not just when Python happens to have been pre-built.

### Changes

1. **`mk/spksrc.spk/python.mk`** — Add PYTHON_PACKAGE injection to the normal build path
2. **`spk/haproxy/Makefile`** — Remove now-redundant explicit `SPK_DEPENDS` (the framework handles it)


## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Includes small framework changes
