### PR TITLE
Fix fontconfig build when cross-compiling with a newer host GCC (14+).

### DIFF
--- a/cross/fontconfig/patches/001-fix-gperf-preprocessor-macros.patch
+++ b/cross/fontconfig/patches/001-fix-gperf-preprocessor-macros.patch
@@ -1,0 +1,27 @@
+# Fix fontconfig build when cross-compiling with a newer host GCC
+#
+# meson's cc.preprocess() on fcobjshash.gperf.h dumps all predefined compiler
+# macros into the preprocessed output. cutout.py then passes this verbatim to
+# gperf, which includes them in fcobjshash.gperf. When fcobjs.c includes this
+# generated file, GCC 8.x cross-compiler chokes on the redefined __STDC__,
+# __SIZEOF_INT__, _LP64 and other built-in macros.
+#
+# Fix: filter out all #define lines in cutout.py except legitimate fontconfig
+# macros (FC_*) and system includes/undefs that reference headers or FC_ names.
+#
+# References: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/
+# Affects: fontconfig 2.16.0, host GCC >= 12, cross GCC <= 9
+#
+--- ./src/cutout.py.orig	2025-01-17 15:15:05.000000000 +0000
++++ ./src/cutout.py	2026-05-26 22:53:47.999646381 +0000
+@@ -20,6 +20,10 @@ if __name__== '__main__':
+             if write and l:
+                 stripped = re.sub(r'^\s+', '', l)
+                 stripped = re.sub(r'\s*,\s*', ',', stripped)
++                if re.match(r'^#define ', stripped) and not re.match(r'^#define FC_', stripped):
++                    continue
++                if re.match(r'^#(undef|include)\s+[^"<F]', stripped):
++                    continue
+                 if not stripped.isspace() and stripped:
+                     out.write('%s\n' % stripped)
+ 

--- a/mk/spksrc.cross-cmake-env.mk
+++ b/mk/spksrc.cross-cmake-env.mk
@@ -12,7 +12,7 @@ endif
 # We normally build regular Release
 ifeq ($(strip $(CMAKE_BUILD_TYPE)),)
   ifeq ($(strip $(GCC_DEBUG_INFO)),1)
-    CMAKE_BUILD_TYPE = Debug
+    CMAKE_BUILD_TYPE = RelWithDebInfo
   else
     CMAKE_BUILD_TYPE = Release
   endif


### PR DESCRIPTION
## Description

meson's cc.preprocess() on fcobjshash.gperf.h dumps all predefined compiler macros into the preprocessed output. cutout.py then passes this verbatim to gperf, which includes them in fcobjshash.gperf. When fcobjs.c includes this generated file, GCC 8.x cross-compiler chokes on the redefined __STDC__, __SIZEOF_INT__, _LP64 and other built-in macros.

Fix: filter out all #define lines in cutout.py except legitimate fontconfig macros (FC_*) and system includes/undefs that reference headers or FC_ names.

References: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/
Affects: fontconfig 2.16.0, host GCC >= 12, cross GCC <= 9A
Suggested-by: Claude Sonnet 4.6 (Anthropic AI <https://anthropic.com>)

Refers to building `synocli-videodrier` in debug mode with `fontconfig` update https://github.com/SynoCommunity/spksrc/pull/7035

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
