### PR TITLE
SickChill: Update requirements and service configuration

### DIFF
--- a/spk/sickchill/Makefile
+++ b/spk/sickchill/Makefile
@@ -41,9 +41,9 @@ DEPENDS += cross/openssl3
 
 # [greenlet]
 ifeq ($(call version_ge, $(TC_GCC), 5.0),1)
-WHEELS += src/requirements-crossenv-greenlet-v3.txt
+WHEELS += greenlet==3.5.1
 else
-WHEELS += src/requirements-crossenv-greenlet-v3-gcc4.txt
+WHEELS += greenlet==3.0.3
 WHEELS_CPPFLAGS += [greenlet] -std=c++11 -fpermissive
 endif
 
@@ -52,15 +52,21 @@ DEPENDS += cross/libxml2
 DEPENDS += cross/libxslt
 ifeq ($(call version_lt, $(TC_GCC), 5.0),1)
 WHEELS_CFLAGS += [lxml] -std=c11
+WHEELS += lxml==5.4.0
+else
+WHEELS += lxml==6.1.1
 endif
 
 # [msgpack]
 ifeq ($(call version_lt, $(TC_GCC), 5.0),1)
 WHEELS_CFLAGS += [msgpack] -std=c11
+WHEELS += msgpack==1.0.5
+else
+WHEELS += msgpack==1.2.0
 endif
+
+include ../../mk/spksrc.spk-meta.mk
 
 .PHONY: sickchill_extra_install
 sickchill_extra_install:
 	install -m 755 -d $(STAGING_DIR)/var
-
-include ../../mk/spksrc.spk-meta.mk

--- a/spk/sickchill/Makefile
+++ b/spk/sickchill/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = sickchill
 SPK_VERS = 20240301
-SPK_REV = 12
+SPK_REV = 13
 SPK_ICON = src/sickchill.png
 
 PYTHON_PACKAGE = python312
@@ -14,7 +14,7 @@ MAINTAINER = miigotu
 DESCRIPTION = Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.
 STARTABLE = yes
 DISPLAY_NAME = SickChill
-CHANGELOG = "1. Migrate to Python 3.12."
+CHANGELOG = "1. Maintenance update of packages for Setuptools in Python 3.12.13."
 
 HOMEPAGE = https://sickchill.github.io/
 LICENSE = GPLv3+

--- a/spk/sickchill/src/requirements-crossenv-greenlet-v3-gcc4.txt
+++ b/spk/sickchill/src/requirements-crossenv-greenlet-v3-gcc4.txt
@@ -1,9 +1,0 @@
-##
-## All configurations below are optional and
-## are provided to demonstrate how to build
-## various wheels.  Uncoment to enable.
-##
-
-# [greenlet]
-#   - Mandatory require full c++11 support
-greenlet==3.0.3

--- a/spk/sickchill/src/requirements-crossenv-greenlet-v3.txt
+++ b/spk/sickchill/src/requirements-crossenv-greenlet-v3.txt
@@ -1,9 +1,0 @@
-##
-## All configurations below are optional and
-## are provided to demonstrate how to build
-## various wheels.  Uncoment to enable.
-##
-
-# [greenlet]
-#   - Mandatory require full c++20 support added with gcc >= 8
-greenlet==3.1.1

--- a/spk/sickchill/src/requirements-crossenv.txt
+++ b/spk/sickchill/src/requirements-crossenv.txt
@@ -1,11 +1,13 @@
-# Generated using the requirements script on April 20, 2025
+# Generated using the requirements script on June 14, 2026
+# Command: ./generate_requirements.sh sickchill==2024.3.1 312
 
-cffi==1.17.1
-charset_normalizer==3.4.1
-cryptography==44.0.2
-#greenlet                       ==> supported version depends on gcc version
-lxml==5.3.2
-MarkupSafe==3.0.2
-msgpack==1.1.0
-sqlalchemy==2.0.40
-tornado==6.4.2
+cffi==2.0.0
+chardet==7.4.3
+charset_normalizer==3.4.7
+cryptography==44.0.3
+#greenlet==3.5.1                ==> supported version depends on gcc version
+#lxml==6.1.1                    ==> supported version depends on gcc version
+markupsafe==3.0.3
+#msgpack==1.2.0                 ==> supported version depends on gcc version
+sqlalchemy==2.0.50
+tornado==6.5.7

--- a/spk/sickchill/src/requirements-pure.txt
+++ b/spk/sickchill/src/requirements-pure.txt
@@ -1,43 +1,38 @@
-# Generated using the requirements script on April 20, 2025
+# Generated using the requirements script on June 14, 2026
+# Command: ./generate_requirements.sh sickchill==2024.3.1 312
 
 appdirs==1.4.4
 babelfish==0.6.1
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
 beekeeper_alt==2022.9.3
 bencode.py==4.0.0
-cachecontrol==0.14.2
-#certifi                            ==> python312
-chardet==5.2.0
+cachecontrol==0.14.4
+#certifi==2026.5.20                   ==> python312
 cinemagoer==2023.5.1
-click==8.1.8
+click==8.4.1
 configobj==5.0.9
-decorator==5.2.1
+decorator==5.3.1
 deluge_client==1.10.2
-dogpile.cache==1.3.4
-enzyme==0.5.2
+dogpile_cache==1.5.0
+enzyme==0.4.1
 future==1.0.0
 gntp==1.0.3
 guessit==3.8.0
-html5lib==1.1
-idna==3.10
+idna==3.18
 ifaddr==0.2.0
-imagesize==1.4.1
+imagesize==1.5.0
 ipaddress==1.0.23
-Js2Py==0.74
 jsonrpclib_pelix==0.4.3.4
 kodipydent_alt==2022.9.3
-mako==1.3.10
-markdown2==2.5.3
+mako==1.3.12
+markdown2==2.5.5
 new_rtorrent_python==1.0.1a0
-oauthlib==3.2.2
+oauthlib==3.3.1
 packaging==23.2
-pbr==6.1.1
-#pip                                ==> python312
+#pip==25.0.1                          ==> python312
 profilehooks==1.13.0
 putio_py==8.8.0
-pycparser==2.22
-pyjsparser==2.7.1
-pymediainfo==7.0.1
+pycparser==3.0
 pynma==1.0
 pyOpenSSL==24.3.0
 pysrt==1.1.2
@@ -45,29 +40,27 @@ python3_fanart==2.0.0
 python_dateutil==2.9.0.post0
 python_slugify==8.0.4
 python_twitter==3.5
-pytz==2025.2
+pytz==2026.2
 qbittorrent_api==2024.12.71
 rarfile==4.2
 rebulk==3.2.0
-requests==2.32.3
+requests==2.34.2
 requests_oauthlib==2.0.0
-Send2Trash==1.8.3
-#setuptools                         ==> python312
+send2trash==2.1.0
+#setuptools==82.0.1                   ==> python312
 sickchill==2024.3.1
-#six                                ==> python312
-soupsieve==2.6
-stevedore==5.4.1
+#six==1.17.0                          ==> python312
+soupsieve==2.8.4
+stevedore==5.8.0
 subliminal==2.1.0
 text_unidecode==1.3
 timeago==1.0.16
-tmdbsimple==2.9.1
+tmdbsimple==2.9.6
 tus_py==1.3.4
 tvdbsimple==1.0.6
-typing_extensions==4.13.2
-tzlocal==5.3.1
-Unidecode==1.3.8
-urllib3==2.4.0
+typing_extensions==4.15.0
+Unidecode==1.4.0
+urllib3==2.7.0
 validators==0.22.0
-webencodings==0.5.1
 win_inet_pton==1.1.0
-xmltodict==0.14.2
+xmltodict==1.0.4

--- a/spk/sickchill/src/requirements-pure.txt
+++ b/spk/sickchill/src/requirements-pure.txt
@@ -47,7 +47,7 @@ rebulk==3.2.0
 requests==2.34.2
 requests_oauthlib==2.0.0
 send2trash==2.1.0
-#setuptools==82.0.1                   ==> python312
+setuptools==81.0.0
 sickchill==2024.3.1
 #six==1.17.0                          ==> python312
 soupsieve==2.8.4

--- a/spk/sickchill/src/requirements-pure.txt
+++ b/spk/sickchill/src/requirements-pure.txt
@@ -2,7 +2,7 @@
 
 appdirs==1.4.4
 babelfish==0.6.1
-beautifulsoup4==4.13.4
+beautifulsoup4==4.14.3
 beekeeper_alt==2022.9.3
 bencode.py==4.0.0
 cachecontrol==0.14.2
@@ -14,7 +14,7 @@ configobj==5.0.9
 decorator==5.2.1
 deluge_client==1.10.2
 dogpile.cache==1.3.4
-enzyme==0.4.1
+enzyme==0.5.2
 future==1.0.0
 gntp==1.0.3
 guessit==3.8.0
@@ -37,7 +37,7 @@ profilehooks==1.13.0
 putio_py==8.8.0
 pycparser==2.22
 pyjsparser==2.7.1
-pymediainfo==6.1.0
+pymediainfo==7.0.1
 pynma==1.0
 pyOpenSSL==24.3.0
 pysrt==1.1.2

--- a/spk/sickchill/src/requirements-pure.txt
+++ b/spk/sickchill/src/requirements-pure.txt
@@ -51,7 +51,7 @@ setuptools==81.0.0
 sickchill==2024.3.1
 #six==1.17.0                          ==> python312
 soupsieve==2.8.4
-stevedore==5.8.0
+stevedore==5.4.1
 subliminal==2.1.0
 text_unidecode==1.3
 timeago==1.0.16

--- a/spk/sickchill/src/service-setup.sh
+++ b/spk/sickchill/src/service-setup.sh
@@ -3,8 +3,6 @@ PYTHON_DIR="/var/packages/python312/target/bin"
 # Add local bin, virtualenv along with python to the default PATH
 PATH="${SYNOPKG_PKGDEST}/env/bin:${SYNOPKG_PKGDEST}/bin:${PYTHON_DIR}:${PATH}"
 # Define other locations
-HOME="${SYNOPKG_PKGVAR}"
-PYTHON="${SYNOPKG_PKGDEST}/env/bin/python3"
 SC_BINARY="${SYNOPKG_PKGDEST}/env/bin/sickchill"
 SC_DATA_DIR="${SYNOPKG_PKGVAR}/data"
 SC_CFG_FILE="${SC_DATA_DIR}/config.ini"

--- a/spk/sickchill/src/wizard/install_uifile
+++ b/spk/sickchill/src/wizard/install_uifile
@@ -1,5 +1,5 @@
 [{
-    "step_title": "Setup credentials (You can edit these after install in the application settings)",
+    "step_title": "Setup credentials",
     "items": [{
         "type": "textfield",
         "desc": "HTTP username (set blank for no login)",


### PR DESCRIPTION
## Description

Minimal update to required packages as newer Setuptools now gives Deprecated Installer error on PymediaInfo 6.1.0

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
