### PR TITLE
spksrc.common/stage0: bootstrap toolchain before deriving TC_GCC

### DIFF
--- a/mk/spksrc.common/stage0.mk
+++ b/mk/spksrc.common/stage0.mk
@@ -43,9 +43,31 @@ ifeq ($(wildcard $(STAGE0_DONE)),)
     $(info ===> Generating $(TC_VARS_MK) (stage0))
   endif
   $(shell mkdir -p $(WORK_DIR))
-  $(shell $(MAKE) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) MSG= tc_vars > $(TC_VARS_MK) 2>/dev/null)
-  $(shell touch $(STAGE0_DONE))
+  # Make sure the cross toolchain is actually extracted BEFORE reading tc_vars: the
+  # tc_vars target derives TC_GCC by running `<cross>-gcc -dumpversion`, which returns
+  # an EMPTY TC_GCC when the toolchain binaries are not unpacked yet. For the very first
+  # package built in a clean tree the toolchain is still cold at this point, so an empty
+  # TC_GCC would silently drop every version_gt($(TC_GCC),...) gated DEPENDS (shaderc,
+  # vulkan, opencl, ...). Reproduce stage1 here (it is cookie-guarded -> no-op once the
+  # toolchain is built): first build/extract the toolchain into its own work dir, then
+  # generate the tc_vars*.mk set into this package WORK_DIR -- exactly the two calls
+  # cross-cc.mk / spk.mk used to do at stage1, but early enough for the DEPENDS parse.
+  # `tcvars` WRITES $(WORK_DIR)/tc_vars*.mk itself (it does not echo to stdout like the
+  # `tc_vars` target), so no `> file` redirection. stdout is sent to /dev/null only to
+  # keep the sub-make's output from being captured by $(shell) and injected into this
+  # makefile (which would break the parse); stderr is left ALONE so real toolchain
+  # build/extract errors stay visible in the build log.
+  TC_WORK_DIR := $(abspath $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION)/work)
+  $(shell $(MAKE) WORK_DIR=$(TC_WORK_DIR) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) MSG= toolchain >/dev/null)
+  $(shell $(MAKE) WORK_DIR=$(WORK_DIR) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) MSG= tcvars >/dev/null)
   $(eval -include $(TC_VARS_MK))
+  # Only mark stage0 done once TC_GCC actually resolved (the toolchain gcc was present).
+  # Otherwise leave it UNMARKED so the next make invocation regenerates, instead of
+  # freezing an empty TC_GCC that would silently drop every version_gt($(TC_GCC),...)
+  # gated DEPENDS for the very first package built in a cold tree.
+  ifneq ($(strip $(TC_GCC)),)
+  $(shell touch $(STAGE0_DONE))
+  endif
 endif
 endif
 endif


### PR DESCRIPTION
## Description

stage0 reads TC_GCC from tc_vars, which derives it by running the cross compiler (`-dumpversion`). For the first package in a clean tree the toolchain is not extracted yet, so TC_GCC is empty and every version_gt($(TC_GCC),N) gated DEPENDS is silently dropped: on x64-7.1 synocli-videodriver skipped its GPU stack (mesa/vulkan/opencl/shaderc) while ffmpeg7 - built later with a warm TC_GCC=8.5.0 - enabled --enable-libshaderc and failed configure ("shaderc not found"). Only the first package was cold, so it only showed in clean CI builds.

Fix: in stage0 (included early by cross-cc.mk and spk.mk) reproduce the stage1 bootstrap up front - extract the toolchain then generate tc_vars* into the package WORK_DIR - so TC_GCC is set before DEPENDS are parsed (cookie-guarded, no-op once built). Only mark STAGE0_DONE once TC_GCC resolved, so a cold pass is not frozen empty. Sub-make stdout -> /dev/null (must not pollute the parse); stderr left visible so toolchain errors show.

Issue identified in #7035

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
