### PR TITLE
videodriver.mk: Enforce supported archs to avoid false dependency

### DIFF
--- a/mk/spksrc.spk/videodriver.mk
+++ b/mk/spksrc.spk/videodriver.mk
@@ -1,3 +1,6 @@
+IS_VIDEODRV_SUPPORTED := $(findstring $(ARCH),$(x64_ARCHS) $(ARMv8_ARCHS))
+
+ifneq ($(IS_VIDEODRV_SUPPORTED),)
 
 # Set default videodriver package name
 ifeq ($(strip $(VIDEODRV_PACKAGE)),)
@@ -66,4 +69,6 @@ ifneq ($(and $(wildcard $(VIDEODRV_PACKAGE_WORK_DIR)),$(filter spk-stage2,$(MAKE
   $(eval $(call SPK_BASE_TEMPLATE,VIDEODRV))
 else
   DEPENDS += $(VIDEODRV_DEPENDS)
+endif
+
 endif


### PR DESCRIPTION
## Description

Ensure that unsupported arch do not add a `install_dep_packages="synocli-videodriver"` part of their `INFO` file by only supporting matching supported archs from `synocli-videodriver`.

This is just an immediate fix pending future work on meta-spk to review the automatic assessment of dependent packages.

Relates to https://github.com/SynoCommunity/spksrc/issues/7169
Tested against https://github.com/SynoCommunity/spksrc/pull/7035

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
