### PR TITLE
native/postgresql: use COMPILE_TARGET hook to silence recipe override warning

### DIFF
--- a/native/postgresql/Makefile
+++ b/native/postgresql/Makefile
@@ -11,11 +11,13 @@ LICENSE = PostgreSQL License
 
 CONFIGURE_ARGS = --without-readline --without-zlib --without-icu
 
+# PostgreSQL's build system only generates headers when MAKELEVEL=0
+# Hook the compile target (COMPILE_TARGET) to set MAKELEVEL=0 for header generation
+COMPILE_TARGET = postgresql_compile_target
+
 include ../../mk/spksrc.native-cc.mk
 
-# PostgreSQL's build system only generates headers when MAKELEVEL=0
-# Override compile target to set MAKELEVEL=0 for header generation
-.PHONY: compile_target
-compile_target:
+.PHONY: postgresql_compile_target
+postgresql_compile_target:
 	@$(MSG) "Compiling native $(PKG_NAME)"
 	cd $(WORK_DIR)/$(PKG_DIR) && env MAKELEVEL=0 $(MAKE)


### PR DESCRIPTION
## Description

Replace the direct compile_target redefinition (which warned at every parse against spksrc.compile.mk's generic recipe) with the framework hook: `COMPILE_TARGET = postgresql_compile_target`, keeping the `MAKELEVEL=0` workaround for PostgreSQL header generation.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
