### PR TITLE
spksrc.common/stage0: keep package tc_vars generation in stage1

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -30,7 +30,7 @@
 #
 #   mk/spksrc.common.mk
 #   └── mk/spksrc.common/
-#       ├── stage0.mk  : setup $(WORK_DIR)/tc_vars.mk for minimal init
+#       ├── stage0.mk  : bootstrap toolchain & load its tc_vars (TC_GCC, ...)
 #       ├── archs.mk   : architecture and toolchain classification
 #       ├── logs.mk    : build log paths and logging helpers
 #       └── macros.mk  : generic GNU Make helper macros

--- a/mk/spksrc.common/stage0.mk
+++ b/mk/spksrc.common/stage0.mk
@@ -1,90 +1,88 @@
 ###############################################################################
 # mk/spksrc.common/stage0.mk
 #
-# Bootstraps the toolchain and its environment definitions BEFORE a package's
-# DEPENDS are parsed, so that version_ge($(TC_GCC),...) gated dependencies
-# (shaderc, vulkan, numpy, ...) are evaluated against a real GCC version
-# instead of an empty TC_GCC. This applies to BOTH cross/ packages (cross-cc.mk)
-# and spk/ packages (spk.mk) -- the latter resolve their meta DEPENDS at parse.
+# Early toolchain bootstrap: resolves TC_GCC (and TC_VERS, TC_KERNEL, ...)
+# BEFORE the package's DEPENDS are parsed, so version_ge($(TC_GCC),...) gated
+# dependencies (shaderc, vulkan, numpy, ...) evaluate against a real GCC
+# version instead of an empty one on a cold tree. Applies to both cross/ and
+# spk/ packages.
 #
-# For the very first package built in a cold tree the toolchain is not yet
-# extracted, so `<cross>-gcc -dumpversion` returns an EMPTY TC_GCC. This file
-# reproduces stage1's two calls (see mk/spksrc.cross-cc.mk) early enough for
-# the DEPENDS parse:
-#   1. build/extract the toolchain into its OWN work dir (target: toolchain)
-#   2. generate tc_vars*.mk into THIS package's WORK_DIR    (target: tcvars)
-# then -include the generated $(WORK_DIR)/tc_vars.mk (provides TC_GCC, ...).
+# ┌──────────────────────────────────────────────────────────────────────┐
+# │ stage0  (PARSE time, this file)                                      │
+# │                                                                      │
+# │   no explicit goal AND <TC work dir>/tc_vars.mk missing?             │
+# │        │                                                             │
+# │        ▼                                                             │
+# │   make WORK_DIR=<TC work dir> -C toolchain/<TC> toolchain            │
+# │        ├─ download / extract / patch / rust  (cookie-guarded)        │
+# │        └─ generates <TC work dir>/tc_vars*   (toolchain identity)    │
+# │   touch $(WORK_DIR)/.stage0-bootstrap_done   (trace: who triggered)  │
+# │        │                                                             │
+# │        ▼                                                             │
+# │   -include <TC work dir>/tc_vars.mk   ->   TC_GCC, TC_VERS, ...      │
+# │        │                                                             │
+# │        ▼                                                             │
+# │   DEPENDS parse evaluates version_ge($(TC_GCC),...) correctly        │
+# └──────────────────────────────────────────────────────────────────────┘
+#                                  │
+#                                  ▼  (recipes run after parse)
+# ┌──────────────────────────────────────────────────────────────────────┐
+# │ stage1  (RECIPE time, cross-cc.mk / spk.mk) -- NOT made obsolete     │
+# │                                                                      │
+# │   make -C toolchain/<TC> toolchain -> no-op when stage0 ran; the     │
+# │                                       REAL bootstrap on explicit     │
+# │                                       goals (stage0 skips those)     │
+# │   make WORK_DIR=<pkg work dir> \                                     │
+# │        -C toolchain/<TC> tcvars    -> SOLE generator of the package  │
+# │                                       $(WORK_DIR)/tc_vars* (needs    │
+# │                                       recipe ENV: INSTALL_PREFIX)    │
+# └──────────────────────────────────────────────────────────────────────┘
 #
-# Both sub-makes are idempotent (cookie-guarded): once the toolchain is built
-# and tc_vars generated, they are no-ops.
+# Why stage0 must NOT generate the package $(WORK_DIR)/tc_vars*: those files
+# embed INSTALL_PREFIX-derived paths (CMAKE_FIND_ROOT_PATH, -I/-L staging
+# flags), and INSTALL_PREFIX is recipe ENVIRONMENT (depend.mk/spk.mk) that
+# $(shell) does not see at parse time. Generating them here bakes in the
+# /usr/local default and drops .stage1-tcvars_done, so stage1 never fixes
+# them -> every cmake/autotools dependant breaks (libpng "Could NOT find
+# ZLIB", IGC "Could NOT find SPIRVLLVMTranslator", ...).
 #
-# Guards:
-#  - ARCH set and not noarch (or TCVERSION set).
-#  - NOT building inside the toolchain directory: when stage0 spawns the
-#    `toolchain`/`tcvars` sub-makes, their CURDIR contains "toolchain", so this
-#    guard makes stage0 a no-op there -> no recursion, no contamination. (This
-#    is also why we do NOT guard on `$(TC)`: spk.mk sets TC before including
-#    common.mk, and guarding on it would wrongly skip stage0 for every spk,
-#    leaving their TC_GCC-gated DEPENDS empty at parse.)
-#  - Bootstrap (the heavy sub-makes) only runs when no explicit build goal is
-#    given (MAKECMDGOALS empty, or only dependency-% recipes) and STAGE0_DONE is
-#    absent. The real build reaches the package parse via `$(MAKE) ARCH=.. TCVERSION=..`
-#    with NO goal (mk/spksrc.supported.mk build-arch-%), so the bootstrap fires.
-#  - tc_vars.mk is -included unconditionally (broad) so the parse sees TC_GCC
-#    whenever it has already been generated, regardless of goal.
+# Guards: ARCH non-noarch (or TCVERSION set); skipped inside toolchain/
+# (recursion; do NOT guard on $(TC): spk.mk sets it before common.mk);
+# bootstrap only fires on empty MAKECMDGOALS (or dependency-%), which is how
+# the real build parses packages (supported.mk build-arch-%). Native builds
+# run under `env -i` (depend.mk) -> ARCH empty -> excluded.
 #
-# Important:
-#  - Do NOT override MSG (e.g. `MSG=`). MSG defaults to `echo "===> "`; blanking
-#    it turns the toolchain_msg recipe line `$(MSG) "Preparing toolchain..."`
-#    into a bare `"Preparing toolchain..."`, which the shell tries to EXECUTE as
-#    a command -> Error 127, aborting the toolchain build before anything is
-#    downloaded/extracted. On a populated tree the toolchain cookie already
-#    exists so toolchain_msg never runs, which is why this stayed hidden on CI.
-#  - The sub-make stdout is redirected to stderr (`>&2`), NOT captured. $(shell)
-#    only captures fd 1, so sending the build output to fd 2 keeps it out of the
-#    makefile parse (no injection / broken parse) while still showing it on the
-#    console and in the build logs. (Using `>/dev/null` would also keep the parse
-#    safe but would hide the toolchain build progress from the console.)
-#  - STAGE0_DONE is only touched once TC_GCC actually resolved; otherwise it is
-#    left unmarked so the next invocation retries instead of freezing an empty
-#    TC_GCC.
+# Gotchas: never pass MSG= to the sub-make (a blank MSG turns recipe message
+# lines into shell commands -> Error 127 before anything is extracted). The
+# sub-make stdout goes to `>&2`: $(shell) only captures fd 1, so the build
+# output stays out of the parse yet remains visible on console and in logs.
 #
 ###############################################################################
-
-# stage0-private sentinel (no collision with the toolchain namespace)
-STAGE0_DONE := $(WORK_DIR)/.stage0-tcvars_done
 
 ifneq ($(filter-out noarch,$(ARCH))$(TCVERSION),)
 ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)
 
 # Toolchain-namespace vars -- defined INSIDE the "not in toolchain dir" guard so
 # they can never clobber spksrc.toolchain.mk's own definitions during a toolchain
-# build (there ARCH/TCVERSION are empty -> a bogus syno--/work path; and TC_WORK_DIR
-# in particular is `?=` there, so it would keep our wrong value).
-TC_VARS_MK  := $(WORK_DIR)/tc_vars.mk
+# build (there ARCH/TCVERSION are empty -> a bogus syno--/work path; and
+# TC_WORK_DIR in particular is `?=` there, so it would keep our wrong value).
 TC_WORK_DIR := $(abspath $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION)/work)
 
-# Bootstrap (heavy) only when no explicit build goal and not yet done
+# Bootstrap (heavy, cookie-guarded) only when no explicit build goal and the
+# toolchain is not ready. On success, drop a status cookie in the PACKAGE work
+# dir tracing WHICH package triggered the early bootstrap. Purely informational:
+# the bootstrap condition is the existence of $(TC_WORK_DIR)/tc_vars.mk, not
+# this cookie. Cleaned by spkclean (spk.mk) / clean (rm -fr work-*).
 ifeq ($(filter-out dependency-%,$(MAKECMDGOALS)),)
-ifeq ($(wildcard $(STAGE0_DONE)),)
-  ifeq ($(wildcard $(TC_VARS_MK)),)
-    $(info ===> Bootstrapping toolchain for $(ARCH)-$(TCVERSION) (stage0))
-  endif
+ifeq ($(wildcard $(TC_WORK_DIR)/tc_vars.mk),)
+  $(info ===> Bootstrapping toolchain for $(ARCH)-$(TCVERSION) (stage0))
   $(shell mkdir -p $(WORK_DIR))
-  $(shell $(MAKE) WORK_DIR=$(TC_WORK_DIR) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) toolchain >&2)
-  $(shell $(MAKE) WORK_DIR=$(WORK_DIR) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) tcvars >&2)
+  $(shell $(MAKE) WORK_DIR=$(TC_WORK_DIR) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION) toolchain >&2 && touch $(WORK_DIR)/.stage0-bootstrap_done)
 endif
 endif
 
-# Load toolchain variables for the parse (provides TC_GCC, TC_VERS, ...)
--include $(TC_VARS_MK)
-
-# Checkpoint once TC_GCC actually resolved so the bootstrap is not retried
-ifeq ($(wildcard $(STAGE0_DONE)),)
-ifneq ($(strip $(TC_GCC)),)
-  $(shell touch $(STAGE0_DONE))
-endif
-endif
+# Load toolchain-identity variables for the parse (TC_GCC, TC_VERS, ...)
+-include $(TC_WORK_DIR)/tc_vars.mk
 
 endif
 endif

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -569,7 +569,7 @@ spkclean:
 	       work-*/.depend_done \
 	       work-*/.icon_done \
 	       work-*/.strip_done \
-	       work-*/.stage0-tcvars_done \
+	       work-*/.stage0-bootstrap_done \
 	       work-*/.stage1-tcvars_done \
 	       work-*/.stage1-tkvars_done \
 	       work-*/.wheel_done \


### PR DESCRIPTION
## Description

Follows-up previous tentatives #7184 and #7192

stage0's parse-time $(shell) generated the package $(WORK_DIR)/tc_vars* without the recipe environment: INSTALL_PREFIX fell back to /usr/local, poisoning CMAKE_FIND_ROOT_PATH/staging flags for every dependant, and the .stage1-tcvars_done cookie dropped alongside blocked regeneration by stage1 (CI: libpng "Could NOT find ZLIB" on all archs).

stage0 now only builds the toolchain into its own work dir and -includes the toolchain-side tc_vars.mk (TC_GCC & co, package-agnostic). stage1 remains the sole generator of package tc_vars* and the real bootstrap for explicit-goal invocations. A .stage0-bootstrap_done cookie in the triggering package's work dir traces the early bootstrap (informational). spkclean updated accordingly; header rewritten with a stage0/stage1 flow diagram.

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
