### PR TITLE
gh-action: fix toolchain cache poisoning silently dropping TC_GCC-gated DEPENDS

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -70,6 +70,7 @@ done
 # actual installation state of cargo/rust within the distrib folder.
 rm -f toolchain/syno-${GH_ARCH}/work/.toolchain*_done
 rm -f toolchain/syno-${GH_ARCH}/work/.stage[01]-*_done
+rm -f toolchain/syno-${GH_ARCH}/work/tc_vars.*
 
 # ===========================================================================
 # 2. Select packages to build for this arch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -450,7 +450,7 @@ jobs:
         if: ${{ contains(matrix.arch,'qoriq') == false }}
         with:
           path: toolchain/*/work
-          key: toolchain-${{ matrix.arch }}-v3-${{ hashFiles(format('toolchain/syno-{0}/digests',matrix.arch)) }}
+          key: toolchain-${{ matrix.arch }}-v4-${{ hashFiles(format('toolchain/syno-{0}/digests',matrix.arch)) }}
 
       # Check disk space after toolchain cache restore
       - name: Disk Space After Cache Restore

--- a/mk/spksrc.common/stage0.mk
+++ b/mk/spksrc.common/stage0.mk
@@ -46,11 +46,13 @@
 # them -> every cmake/autotools dependant breaks (libpng "Could NOT find
 # ZLIB", IGC "Could NOT find SPIRVLLVMTranslator", ...).
 #
-# Guards: ARCH non-noarch (or TCVERSION set); skipped inside toolchain/
-# (recursion; do NOT guard on $(TC): spk.mk sets it before common.mk);
-# bootstrap only fires on empty MAKECMDGOALS (or dependency-%), which is how
-# the real build parses packages (supported.mk build-arch-%). Native builds
-# run under `env -i` (depend.mk) -> ARCH empty -> excluded.
+# Guards: ARCH non-noarch AND TCVERSION both required (a sub-make carrying
+# TCVERSION alone would derive a bogus toolchain/syno--<vers> work path and
+# attempt to bootstrap it); skipped inside toolchain/ (recursion; do NOT
+# guard on $(TC): spk.mk sets it before common.mk); bootstrap only fires on
+# empty MAKECMDGOALS (or dependency-%), which is how the real build parses
+# packages (supported.mk build-arch-%). Native builds run under `env -i`
+# (depend.mk) -> ARCH empty -> excluded.
 #
 # Gotchas: never pass MSG= to the sub-make (a blank MSG turns recipe message
 # lines into shell commands -> Error 127 before anything is extracted). The
@@ -59,7 +61,8 @@
 #
 ###############################################################################
 
-ifneq ($(filter-out noarch,$(ARCH))$(TCVERSION),)
+ifneq ($(strip $(filter-out noarch,$(ARCH))),)
+ifneq ($(strip $(TCVERSION)),)
 ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)
 
 # Toolchain-namespace vars -- defined INSIDE the "not in toolchain dir" guard so
@@ -84,5 +87,6 @@ endif
 # Load toolchain-identity variables for the parse (TC_GCC, TC_VERS, ...)
 -include $(TC_WORK_DIR)/tc_vars.mk
 
+endif
 endif
 endif


### PR DESCRIPTION
## Description

CI builds were green but wrong: DSM 7.1 built the same dependency set as DSM 6.2.4 (e.g. ffmpeg7 shipped libvpx-1.14 instead of libvpx-latest).

The toolchain cache carried a `tc_vars.mk` generated before gcc was extracted, i.e. with an empty `TC_GCC`. Caches are immutable per key,  `build.sh` only stripped the status cookies, and the `tcvars` rules are bare file targets that never refresh an existing file — so every run parsed with an empty `TC_GCC` and silently dropped all `version_*()` gated DEPENDS.

- **build.sh**: also remove `tc_vars.*` alongside the status cookies
- **build.yml**: bump toolchain cache key `v3` → `v4` to purge poisoned entries
- **stage0.mk**: require both `ARCH` and `TCVERSION` to bootstrap (TCVERSION alone derived a bogus `toolchain/syno--<vers>` path, polluting logs)

Validated locally by simulating the poisoned cache: tc_vars regenerated, gates resolve correctly; cold/warm trees and direct toolchain builds unaffected.

Follows-up previous tentatives https://github.com/SynoCommunity/spksrc/pull/7184 and https://github.com/SynoCommunity/spksrc/pull/7192 and #7194

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
