### PR TITLE
Fix tcp wrappers

### DIFF
--- a/cross/stunnel/Makefile
+++ b/cross/stunnel/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = stunnel
 PKG_VERS = 5.77
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://www.stunnel.org/downloads
+PKG_DIST_SITE = https://www.stunnel.org/archive/5.x
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/tcp_wrappers cross/openssl3

--- a/cross/tcp_wrappers/patches/001-tcp_wrappers-7.6-shared-lib.patch
+++ b/cross/tcp_wrappers/patches/001-tcp_wrappers-7.6-shared-lib.patch
@@ -1,12 +1,14 @@
 # inspired by  http://www.linuxfromscratch.org/patches/blfs/5.1/tcp_wrappers-7.6-shared-lib-plus-plus.patch
+# now found on https://www.trac.clfs.org/browser/scripts/patches/tcp_wrappers-7.6-gcc34-1.patch?rev=2cf9b0737362a720eeaad3ed09d813ca926eaefb
 # adjusted for SynoCommunity
-# - relocate patch file ro source path
+# - relocate patch file to source path
 # - avoid patch and installation of man pages
 # - limit patch to linux target
+# - NETGROUP not defined (libnsl not found with TCVERSION >= 7.2)
 # remarks:
 # - only libwrap is used, binaries are lacking to find shared lib at runtime
---- Makefile.org	1997-03-21 18:27:21.000000000 +0000
-+++ Makefile	2020-11-07 14:01:31.027674067 +0000
+--- Makefile.orig	1997-03-21 18:27:21.000000000 +0000
++++ Makefile	2026-06-11 10:40:16.372922281 +0000
 @@ -1,5 +1,8 @@
  # @(#) Makefile 1.23 97/03/21 19:27:20
  
@@ -16,19 +18,18 @@
  what:
  	@echo
  	@echo "Usage: edit the REAL_DAEMON_DIR definition in the Makefile then:"
-@@ -143,8 +146,9 @@
+@@ -143,8 +146,8 @@
  
  linux:
  	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
 -	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ=setenv.o \
 -	NETGROUP= TLI= EXTRA_CFLAGS="-DBROKEN_SO_LINGER" all
-+	LIBS=-lnsl RANLIB=ranlib ARFLAGS=rv AUX_OBJ=weak_symbols.o \
-+	NETGROUP=-DNETGROUP TLI= VSYSLOG= BUGS= all \
-+	EXTRA_CFLAGS="-DSYS_ERRLIST_DEFINED -DHAVE_WEAKSYMS -D_REENTRANT"
++	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ=weak_symbols.o \
++	NETGROUP= TLI= EXTRA_CFLAGS="-DHAVE_WEAKSYMS -D_REENTRANT" all
  
  # This is good for many SYSV+BSD hybrids with NIS, probably also for HP-UX 7.x.
  hpux hpux8 hpux9 hpux10:
-@@ -391,7 +395,7 @@
+@@ -391,7 +394,7 @@
  # the ones provided with this source distribution. The environ.c module
  # implements setenv(), getenv(), and putenv().
  
@@ -37,7 +38,7 @@
  #AUX_OBJ= environ.o
  #AUX_OBJ= environ.o strcasecmp.o
  
-@@ -454,7 +458,8 @@
+@@ -454,7 +457,8 @@
  # host name aliases. Compile with -DSOLARIS_24_GETHOSTBYNAME_BUG to work
  # around this. The workaround does no harm on other Solaris versions.
  
@@ -47,16 +48,7 @@
  #BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DINET_ADDR_BUG
  #BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DSOLARIS_24_GETHOSTBYNAME_BUG
  
-@@ -464,7 +469,7 @@
- # If your system supports NIS or YP-style netgroups, enable the following
- # macro definition. Netgroups are used only for host access control.
- #
--#NETGROUP= -DNETGROUP
-+NETGROUP= -DNETGROUP
- 
- ###############################################################
- # System dependencies: whether or not your system has vsyslog()
-@@ -514,7 +519,7 @@
+@@ -514,7 +518,7 @@
  #
  # The LOG_XXX names below are taken from the /usr/include/syslog.h file.
  
@@ -65,7 +57,7 @@
  
  # The syslog priority at which successful connections are logged.
  
-@@ -610,7 +615,7 @@
+@@ -610,7 +614,7 @@
  # Paranoid mode implies hostname lookup. In order to disable hostname
  # lookups altogether, see the next section.
  
@@ -74,7 +66,7 @@
  
  ########################################
  # Optional: turning off hostname lookups
-@@ -623,7 +628,7 @@
+@@ -623,7 +627,7 @@
  # In order to perform selective hostname lookups, disable paranoid
  # mode (see previous section) and comment out the following definition.
  
@@ -83,7 +75,7 @@
  
  #############################################
  # Optional: Turning on host ADDRESS checking
-@@ -649,7 +654,7 @@
+@@ -649,7 +653,7 @@
  # source-routed traffic in the kernel. Examples: 4.4BSD derivatives,
  # Solaris 2.x, and Linux. See your system documentation for details.
  #
@@ -92,7 +84,7 @@
  
  ## End configuration options
  ############################
-@@ -657,20 +662,37 @@
+@@ -657,20 +661,37 @@
  # Protection against weird shells or weird make programs.
  
  SHELL	= /bin/sh
@@ -132,7 +124,7 @@
  FROM_OBJ= fromhost.o
  
  KIT	= README miscd.c tcpd.c fromhost.c hosts_access.c shell_cmd.c \
-@@ -684,46 +706,73 @@
+@@ -684,46 +705,73 @@
  	refuse.c tcpdchk.8 setenv.c inetcf.c inetcf.h scaffold.c \
  	scaffold.h tcpdmatch.8 README.NIS
  
@@ -225,7 +217,7 @@
  
  shar:	$(KIT)
  	@shar $(KIT)
-@@ -739,7 +788,8 @@
+@@ -739,7 +787,8 @@
  
  clean:
  	rm -f tcpd miscd safe_finger tcpdmatch tcpdchk try-from *.[oa] core \
@@ -235,7 +227,7 @@
  
  tidy:	clean
  	chmod -R a+r .
-@@ -885,5 +935,6 @@
+@@ -885,5 +934,6 @@
  update.o: mystdarg.h
  update.o: tcpd.h
  vfprintf.o: cflags

--- a/cross/tcp_wrappers/patches/003-use-strerror.patch
+++ b/cross/tcp_wrappers/patches/003-use-strerror.patch
@@ -1,0 +1,83 @@
+# use strerror_r() instead of deprecated sys_nerr and sys_errlist.
+# 
+# - sys_nerr/sys_errlist are finally removed in glibc 2.32
+# 
+--- percent_m.c.orig	1994-12-28 16:42:37.000000000 +0000
++++ percent_m.c	2026-06-11 10:19:52.545384485 +0000
+@@ -13,10 +13,6 @@
+ #include <string.h>
+ 
+ extern int errno;
+-#ifndef SYS_ERRLIST_DEFINED
+-extern char *sys_errlist[];
+-extern int sys_nerr;
+-#endif
+ 
+ #include "mystdarg.h"
+ 
+@@ -29,11 +25,7 @@
+ 
+     while (*bp = *cp)
+ 	if (*cp == '%' && cp[1] == 'm') {
+-	    if (errno < sys_nerr && errno > 0) {
+-		strcpy(bp, sys_errlist[errno]);
+-	    } else {
+-		sprintf(bp, "Unknown error %d", errno);
+-	    }
++	    strcpy(bp, strerror(errno));
+ 	    bp += strlen(bp);
+ 	    cp += 2;
+ 	} else {
+
+--- tli.c.orig	1997-03-21 18:27:26.000000000 +0000
++++ tli.c	2026-06-11 10:28:08.103624483 +0000
+@@ -40,8 +40,6 @@
+ 
+ extern char *nc_sperror();
+ extern int errno;
+-extern char *sys_errlist[];
+-extern int sys_nerr;
+ extern int t_errno;
+ extern char *t_errlist[];
+ extern int t_nerr;
+@@ -305,12 +303,8 @@
+ 	    return (t_errlist[t_errno]);
+ 	}
+     } else {
+-	if (errno < 0 || errno >= sys_nerr) {
+-	    sprintf(buf, "Unknown UNIX error %d", errno);
+-	    return (buf);
+-	} else {
+-	    return (sys_errlist[errno]);
+-	}
++	strcpy(buf, strerror(errno));
++	return (buf);
+     }
+ }
+ 
+--- tli-sequent.c.orig	1994-12-28 16:42:51.000000000 +0000
++++ tli-sequent.c	2026-06-11 10:28:48.311869435 +0000
+@@ -31,8 +31,6 @@
+ #include <string.h>
+ 
+ extern int errno;
+-extern char *sys_errlist[];
+-extern int sys_nerr;
+ extern int t_errno;
+ extern char *t_errlist[];
+ extern int t_nerr;
+@@ -157,12 +155,8 @@
+ 	    return (t_errlist[t_errno]);
+ 	}
+     } else {
+-	if (errno < 0 || errno >= sys_nerr) {
+-	    sprintf(buf, "Unknown UNIX error %d", errno);
+-	    return (buf);
+-	} else {
+-	    return (sys_errlist[errno]);
+-	}
++	strcpy(buf, strerror(errno));
++	return (buf);
+     }
+ }
+ 


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

fix for glibc >= 2.32
- patch sources to use strerror instead of deprecated sys_nerr/sys_errlist

This is related to #6614

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
