### PR TITLE
Borg: Fix lz4 header detection after Python 3.14 migration

### DIFF
--- a/cross/lz4/PLIST
+++ b/cross/lz4/PLIST
@@ -1,3 +1,6 @@
+rsc:include/lz4.h
+rsc:include/lz4hc.h
+rsc:include/lz4frame.h
 lnk:lib/liblz4.so
 lnk:lib/liblz4.so.1
 lib:lib/liblz4.so.1.10.0

--- a/cross/lz4/PLIST
+++ b/cross/lz4/PLIST
@@ -1,6 +1,3 @@
-rsc:include/lz4.h
-rsc:include/lz4hc.h
-rsc:include/lz4frame.h
 lnk:lib/liblz4.so
 lnk:lib/liblz4.so.1
 lib:lib/liblz4.so.1.10.0

--- a/spk/borgbackup/Makefile
+++ b/spk/borgbackup/Makefile
@@ -74,9 +74,13 @@ SPK_USR_LOCAL_LINKS = bin:env/bin/borg bin:env/bin/borgmatic bin:env/bin/emborg
 # spksrc.wheel-env.mk or spksrc.spk-meta.mk
 ENV += BORG_LIBACL_PREFIX="$(STAGING_INSTALL_PREFIX)"
 ENV += BORG_LIBB2_PREFIX="$(STAGING_INSTALL_PREFIX)"
-ENV += BORG_LIBLZ4_PREFIX="$(STAGING_INSTALL_PREFIX)"
 ENV += BORG_LIBXXHASH_PREFIX="$(STAGING_INSTALL_PREFIX)"
 ENV += BORG_LIBZSTD_PREFIX="$(STAGING_INSTALL_PREFIX)"
+# BORG_LIBLZ4_PREFIX: prefer the Python install prefix (where lz4 was
+# installed during stage-1), fall back to own staging prefix.
+_prefixed := $(abspath $(WORK_DIR)/../../../spk/$(PYTHON_PACKAGE)/work-$(ARCH)-$(TCVERSION)/install/var/packages/$(PYTHON_PACKAGE)/target)
+ENV += BORG_LIBLZ4_PREFIX=$(or $(wildcard $(_prefixed)),$(STAGING_INSTALL_PREFIX))
+ENV += PKG_CONFIG_PATH=$(or $(wildcard $(_prefixed)/lib/pkgconfig),$(STAGING_INSTALL_PREFIX)/lib/pkgconfig)
 ENV += BORG_OPENSSL_PREFIX="$(OPENSSL_STAGING_INSTALL_PREFIX)"
 
 # [borgbackup]


### PR DESCRIPTION
## Description

### Problem
After migrating borgbackup from Python 3.11 to Python 3.14, CI builds fail on all architectures with:

```
src/borg/compress.c:1253:10: fatal error: lz4.h: No such file or directory
```

The `cross/lz4` package is built during python314's stage-1 (installing headers to python314's prefix) and is not rebuilt for borgbackup's stage-2 due to dependency caching. The existing `BORG_LIBLZ4_PREFIX=$(STAGING_INSTALL_PREFIX)` pointed to borgbackup's own staging prefix where `lz4.h` was never installed. Borgbackup's setup.py then fell back to host `pkg-config`, which found the CI image's `liblz4-dev`, but the cross-compiler couldn't locate the host's `/usr/include/lz4.h` because it resolves paths against the cross-sysroot.

### Fix
Point `BORG_LIBLZ4_PREFIX` and `PKG_CONFIG_PATH` to the Python install prefix where `cross/lz4` was actually installed during stage-1:

```makefile
_prefixed := $(abspath $(WORK_DIR)/../../../spk/$(PYTHON_PACKAGE)/work-$(ARCH)-$(TCVERSION)/install/var/packages/$(PYTHON_PACKAGE)/target)
ENV += PKG_CONFIG_PATH=$(_prefixed)/lib/pkgconfig
ENV += BORG_LIBLZ4_PREFIX=$(_prefixed)
```

Also reverts the earlier `cross/lz4/PLIST` header change — headers are not typically tracked in PLIST files for cross packages.

### Files changed
- `spk/borgbackup/Makefile` — point `BORG_LIBLZ4_PREFIX` and `PKG_CONFIG_PATH` to Python install prefix

Fixes #7162

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
