### PR TITLE
Framework: Guard CI workflows to skip on forks (allow manual dispatch)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ on:
 jobs:
   prepare:
     name: Prepare for Build
+    if: github.repository == 'SynoCommunity/spksrc' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
@@ -368,7 +369,7 @@ jobs:
     name: Build
     needs: [prepare, set-defaults]
     runs-on: ubuntu-latest
-    if: ${{ needs.set-defaults.outputs.has_entries == 'true' }}
+    if: needs.set-defaults.outputs.has_entries == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-defaults.outputs.matrix) }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'SynoCommunity'
+    if: github.repository == 'SynoCommunity/spksrc'
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   build:
+    if: github.repository == 'SynoCommunity/spksrc'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,12 +45,12 @@ jobs:
       - name: Build documentation
         run: mkdocs build --strict
       - name: Upload artifact
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/docs-migration')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./site
   deploy:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/docs-migration')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository == 'SynoCommunity/spksrc' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Prevents CI workflows from automatically running on forks of the repository, saving GitHub Actions runner minutes. Fork owners can still manually trigger builds via `workflow_dispatch`.

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| **build.yml** | Runs on push/PR to any fork | Only runs on `SynoCommunity/spksrc` or manual trigger |
| **lint.yml** | Runs on push/PR to any fork | Same guard |
| **docs.yml** | Runs on PR to any fork, had `docs-migration` refs | Same guard, `docs-migration` branches removed |
| **docker.yml** | `repository_owner` check | `repository == SynoCommunity/spksrc` (no manual bypass) |

## Details

- All workflows now use `github.repository == 'SynoCommunity/spksrc'` consistently
- `workflow_dispatch` bypass only on `build.yml` and `lint.yml` (useful for fork testing)
- `docker.yml` has no manual bypass — pushing to `ghcr.io/synocommunity` from a fork would always fail
- `docs.yml` had stale `docs-migration` branch references removed


Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small GitHub Action changes
