### PR TITLE
cross/boost, cross/boost_1.70: standardize python staging prefix

### DIFF
--- a/cross/boost/Makefile
+++ b/cross/boost/Makefile
@@ -43,7 +43,7 @@ ADDITIONAL_CXXFLAGS += -Wno-deprecated-declarations
 
 ifneq ($(strip $(WITH_PYTHON_LIBRARY)),)
 CONFIGURE_ARGS += --with-python=$(WORK_DIR)/../../../native/$(PYTHON_NAME)/work-native/install/usr/local/bin/$(PYTHON_NAME)
-ADDITIONAL_CXXFLAGS += -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) -fpermissive
+ADDITIONAL_CXXFLAGS += -I$(or $(PYTHON_STAGING_INSTALL_PREFIX),$(STAGING_INSTALL_PREFIX))/$(PYTHON_INC_DIR) -fpermissive
 endif
 
 include ../../mk/spksrc.common.mk
@@ -75,7 +75,7 @@ boost_pre_compile:
 	@rm -rf $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 	@$(RUN) sh -c 'echo "using gcc : ${TC_GCC} : $${CXX} : <address-model>\"$(ADDRESS_MODEL)\" <cflags>\"$(CFLAGS)\" <cxxflags>\"$(CXXFLAGS) $(ADDITIONAL_CXXFLAGS)\" <linkflags>\"$(LDFLAGS)\" <link>\"shared\" ; " > $(WORK_DIR)/$(PKG_DIR)/user-config.jam'
 ifneq ($(strip $(WITH_PYTHON_LIBRARY)),)
-	@echo "using python : $(PYTHON_VERSION) : : $(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
+	@echo "using python : $(PYTHON_VERSION) : : $(or $(PYTHON_STAGING_INSTALL_PREFIX),$(STAGING_INSTALL_PREFIX))/$(PYTHON_INC_DIR) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 endif
 	@echo "project : requirements <cxxflags>$(OFLAGS) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 

--- a/cross/boost_1.70/Makefile
+++ b/cross/boost_1.70/Makefile
@@ -46,7 +46,7 @@ ADDITIONAL_CXXFLAGS += -Wno-deprecated-declarations
 
 ifneq ($(strip $(WITH_PYTHON_LIBRARY)),)
 CONFIGURE_ARGS += --with-python=$(WORK_DIR)/../../../native/$(PYTHON_NAME)/work-native/install/usr/local/bin/$(PYTHON_NAME)
-ADDITIONAL_CXXFLAGS += -I$(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) -fpermissive
+ADDITIONAL_CXXFLAGS += -I$(or $(PYTHON_STAGING_INSTALL_PREFIX),$(STAGING_INSTALL_PREFIX))/$(PYTHON_INC_DIR) -fpermissive
 endif
 
 include ../../mk/spksrc.common.mk
@@ -78,7 +78,7 @@ boost_compile:
 	@rm -rf $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 	@$(RUN) sh -c 'echo "using gcc : ${TC_GCC} : $${CXX} : <address-model>\"$(ADDRESS_MODEL)\" <cflags>\"$(CFLAGS)\" <cxxflags>\"$(CXXFLAGS) $(ADDITIONAL_CXXFLAGS)\" <linkflags>\"$(LDFLAGS)\" <link>\"shared\" ; " > $(WORK_DIR)/$(PKG_DIR)/user-config.jam'
 ifneq ($(strip $(WITH_PYTHON_LIBRARY)),)
-	@echo "using python : $(PYTHON_VERSION) : : $(STAGING_INSTALL_PREFIX)/$(PYTHON_INC_DIR) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
+	@echo "using python : $(PYTHON_VERSION) : : $(or $(PYTHON_STAGING_INSTALL_PREFIX),$(STAGING_INSTALL_PREFIX))/$(PYTHON_INC_DIR) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 endif
 	@echo "project : requirements <cxxflags>$(OFLAGS) ;" >> $(WORK_DIR)/$(PKG_DIR)/user-config.jam
 	$(RUN) ./b2 --user-config=$(WORK_DIR)/$(PKG_DIR)/user-config.jam


### PR DESCRIPTION
## Summary

Align `cross/boost` and `cross/boost_1.70` with `cross/boost_1.86` (#7073) by deriving the python include directory from `$(or $(PYTHON_STAGING_INSTALL_PREFIX),$(STAGING_INSTALL_PREFIX))` instead of hardcoding `$(STAGING_INSTALL_PREFIX)`, in the `WITH_PYTHON_LIBRARY` block of each Makefile.

## Context

This is a small, self-contained split extracted from the meta cross-dependency refactor in **#7218**. It is intentionally isolated because it stands on its own and has no functional impact today (see below); pulling it out keeps #7218 focused.

## Why

`cross/boost_1.86` already uses the `$(or ...)` form; `cross/boost` and `cross/boost_1.70` did not. Standardizing the three variants removes a gratuitous difference and lets a shared/meta python staging prefix flow through uniformly should a future consumer request `boost-python` from the 1.78/1.70 variants under the meta mechanism (#7218), where `PYTHON_STAGING_INSTALL_PREFIX` resolves to the shared meta python staging rather than the local one.

## No behavior change

Two reasons this is inert on its own:

1. `PYTHON_STAGING_INSTALL_PREFIX` defaults to `STAGING_INSTALL_PREFIX` (`mk/spksrc.crossenv.mk`, `mk/spksrc.wheel-env.mk`), so `$(or ...)` resolves identically today.
2. The changed line lives under `ifneq ($(strip $(WITH_PYTHON_LIBRARY)),)`, which is only enabled when `BOOST_LIBRARIES` contains `python`. The current consumers of these two variants do not request it:
   - `cross/mkvtoolnix` -> `cross/boost`: `BOOST_LIBRARIES = regex date_time`
   - `cross/mkvtoolnix_22` -> `cross/boost_1.70`: `BOOST_LIBRARIES = system filesystem regex date_time`

   Only `cross/boost_1.86` (via `spk/deluge`, which requests `python`) ever exercises this path, and it already carries the change.

Pure consistency / future-proofing; safe to merge independently of #7218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)