### PR TITLE
Framework/meta: introduce the meta cross-dependency environment (META_PKGCONFIG_DIRS + tc_vars.meta.mk)

### DIFF
--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -1,8 +1,8 @@
 ifndef SPKSRC_SPK_BASE_MK
 SPKSRC_SPK_BASE_MK := 1
 
-# meta_env target (generates the inspectable tc_vars.meta.mk), used by the
-# $(1)_meta_pre_depend hook below.
+# TC_VARS_META_MK file-target (generates the inspectable tc_vars.meta.mk),
+# used by the $(1)_meta_pre_depend hook below.
 include ../../mk/spksrc.spk/meta.mk
 
 # Define excluded library / package list
@@ -94,7 +94,7 @@ $(eval $(1)_STATUS_COOKIES := $(sort $(if $(strip $($(1)_PC)),,$(foreach cross,$
 $(eval PRE_DEPEND_TARGET += $(1)_meta_pre_depend)
 
 .PHONY: $(1)_meta_pre_depend
-$(1)_meta_pre_depend: $(1)_links $(1)_meta meta_env
+$(1)_meta_pre_depend: $(1)_links $(1)_meta $(TC_VARS_META_MK)
 
 .PHONY: $(1)_msg
 $(1)_msg:

--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -29,6 +29,12 @@ $(eval $(1)_STAGING_INSTALL_PREFIX := $(realpath $($(1)_PACKAGE_WORK_DIR)/instal
 $(eval export $(1)_INSTALL_PREFIX)
 $(eval export $(1)_STAGING_INSTALL_PREFIX)
 
+# Accumulate this meta's pkgconfig dir for the ordered PKG_CONFIG_LIBDIR.
+# Local staging stays first (wins); meta dirs are appended in call order and
+# consumed by cross-env.mk once all meta .mk files have run. Not exported:
+# sub-makes re-parse and re-accumulate, so exporting would double the list.
+$(eval META_PKGCONFIG_DIRS += $(if $(wildcard $($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig),$($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig,))
+
 # Set build flags so the package can find headers and libs at compile time,
 # and the dynamic linker will find them at runtime on the NAS.
 $(eval ADDITIONAL_CFLAGS    += $(if $(wildcard $($(1)_STAGING_INSTALL_PREFIX)),-I$($(1)_STAGING_INSTALL_PREFIX)/include,))
@@ -78,7 +84,7 @@ $(eval $(1)_STATUS_COOKIES := $(sort $(if $(strip $($(1)_PC)),,$(foreach cross,$
 $(eval PRE_DEPEND_TARGET += $(1)_meta_pre_depend)
 
 .PHONY: $(1)_meta_pre_depend
-$(1)_meta_pre_depend: $(1)_links $(1)_meta
+$(1)_meta_pre_depend: $(1)_links $(1)_meta meta_env
 
 .PHONY: $(1)_msg
 $(1)_msg:
@@ -94,5 +100,22 @@ $(1)_links: $(1)_msg
 	@$(foreach _done,$($(1)_STATUS_COOKIES),ln -sf $(_done) $(WORK_DIR) ;)
 
 endef
+
+# Materialize the meta cross-dependency environment into an inspectable
+# artifact (tc_vars.meta.mk, cleaned by spkclean's tc_vars*.mk glob).
+# Output-only in this phase: the live variables
+# (accumulator + cross-env.mk) drive the build; this file is for `cat`
+# inspection and to replace the opacity of the scattered $(eval export).
+# Shared across namespaces (not $(1)-prefixed); written once with the fully
+# accumulated environment.
+.PHONY: meta_env
+meta_env:
+	@mkdir -p $(WORK_DIR)
+	@echo "# Generated meta cross-dependency environment - $(NAME)"          > $(WORK_DIR)/tc_vars.meta.mk
+	@echo "META_PKGCONFIG_DIRS := $(strip $(META_PKGCONFIG_DIRS))"          >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR)"                       >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "ADDITIONAL_CFLAGS += $(ADDITIONAL_CFLAGS)"                       >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "ADDITIONAL_LDFLAGS += $(ADDITIONAL_LDFLAGS)"                     >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "OPENSSL_STAGING_INSTALL_PREFIX := $(OPENSSL_STAGING_INSTALL_PREFIX)" >> $(WORK_DIR)/tc_vars.meta.mk
 
 endif # ifndef SPKSRC_SPK_BASE_MK

--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -1,6 +1,10 @@
 ifndef SPKSRC_SPK_BASE_MK
 SPKSRC_SPK_BASE_MK := 1
 
+# meta_env target (generates the inspectable tc_vars.meta.mk), used by the
+# $(1)_meta_pre_depend hook below.
+include ../../mk/spksrc.spk/meta.mk
+
 # Define excluded library / package list
 # Note: covers both bare and lib-prefixed variants (e.g. lzma.pc AND liblzma.pc)
 EXCLUDED_LIBS = %bzip2.pc %lzma.pc %zlib.pc
@@ -106,22 +110,5 @@ $(1)_links: $(1)_msg
 	@$(foreach _done,$($(1)_STATUS_COOKIES),ln -sf $(_done) $(WORK_DIR) ;)
 
 endef
-
-# Materialize the meta cross-dependency environment into an inspectable
-# artifact (tc_vars.meta.mk, cleaned by spkclean's tc_vars*.mk glob).
-# Output-only in this phase: the live variables
-# (accumulator + cross-env.mk) drive the build; this file is for `cat`
-# inspection and to replace the opacity of the scattered $(eval export).
-# Shared across namespaces (not $(1)-prefixed); written once with the fully
-# accumulated environment.
-.PHONY: meta_env
-meta_env:
-	@mkdir -p $(WORK_DIR)
-	@echo "# Generated meta cross-dependency environment - $(NAME)"          > $(WORK_DIR)/tc_vars.meta.mk
-	@echo "META_PKGCONFIG_DIRS := $(strip $(META_PKGCONFIG_DIRS))"          >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR)"                       >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "ADDITIONAL_CFLAGS += $(ADDITIONAL_CFLAGS)"                       >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "ADDITIONAL_LDFLAGS += $(ADDITIONAL_LDFLAGS)"                     >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "OPENSSL_STAGING_INSTALL_PREFIX := $(OPENSSL_STAGING_INSTALL_PREFIX)" >> $(WORK_DIR)/tc_vars.meta.mk
 
 endif # ifndef SPKSRC_SPK_BASE_MK

--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -33,15 +33,10 @@ $(eval $(1)_STAGING_INSTALL_PREFIX := $(realpath $($(1)_PACKAGE_WORK_DIR)/instal
 $(eval export $(1)_INSTALL_PREFIX)
 $(eval export $(1)_STAGING_INSTALL_PREFIX)
 
-# Accumulate this meta's pkgconfig dir for the ordered PKG_CONFIG_LIBDIR.
-# Local staging stays first (wins); meta dirs are appended in call order and
-# consumed by cross-env.mk once all meta .mk files have run.
-#
-# Add-if-absent (not +=) and exported: cross/ dependency builds run as sub-makes
-# that do NOT re-run SPK_BASE_TEMPLATE, so they must inherit this list from the
-# environment to get the meta pkgconfig dirs (the old symlink-flatten reached
-# them via the shared staging dir; the ordered list must too). The add-if-absent
-# guard keeps the SPK's own re-parsing sub-makes from appending duplicates.
+# Accumulate this meta's pkgconfig dir (add-if-absent) for the ordered
+# PKG_CONFIG_LIBDIR. Exported so cross/ sub-makes - which don't re-run
+# SPK_BASE_TEMPLATE - inherit the list from the environment. Local staging
+# stays first (wins).
 $(eval META_PKGCONFIG_DIRS := $(META_PKGCONFIG_DIRS) $(filter-out $(META_PKGCONFIG_DIRS),$(if $(wildcard $($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig),$($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig,)))
 $(eval export META_PKGCONFIG_DIRS)
 

--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -31,9 +31,15 @@ $(eval export $(1)_STAGING_INSTALL_PREFIX)
 
 # Accumulate this meta's pkgconfig dir for the ordered PKG_CONFIG_LIBDIR.
 # Local staging stays first (wins); meta dirs are appended in call order and
-# consumed by cross-env.mk once all meta .mk files have run. Not exported:
-# sub-makes re-parse and re-accumulate, so exporting would double the list.
-$(eval META_PKGCONFIG_DIRS += $(if $(wildcard $($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig),$($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig,))
+# consumed by cross-env.mk once all meta .mk files have run.
+#
+# Add-if-absent (not +=) and exported: cross/ dependency builds run as sub-makes
+# that do NOT re-run SPK_BASE_TEMPLATE, so they must inherit this list from the
+# environment to get the meta pkgconfig dirs (the old symlink-flatten reached
+# them via the shared staging dir; the ordered list must too). The add-if-absent
+# guard keeps the SPK's own re-parsing sub-makes from appending duplicates.
+$(eval META_PKGCONFIG_DIRS := $(META_PKGCONFIG_DIRS) $(filter-out $(META_PKGCONFIG_DIRS),$(if $(wildcard $($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig),$($(1)_STAGING_INSTALL_PREFIX)/lib/pkgconfig,)))
+$(eval export META_PKGCONFIG_DIRS)
 
 # Set build flags so the package can find headers and libs at compile time,
 # and the dynamic linker will find them at runtime on the NAS.

--- a/mk/spksrc.spk/meta.mk
+++ b/mk/spksrc.spk/meta.mk
@@ -1,0 +1,29 @@
+ifndef SPKSRC_SPK_META_MK
+SPKSRC_SPK_META_MK := 1
+
+# Materialize the meta cross-dependency environment into an inspectable
+# artifact (tc_vars.meta.mk, cleaned by spkclean's tc_vars*.mk glob).
+#
+# This lives here rather than in the toolchain tc_vars generation
+# (spksrc.toolchain/) on purpose: unlike the toolchain tc_vars.* files (which
+# describe the toolchain identity and are generated once at stage1, in the
+# toolchain context), this one depends on the CONSUMER's meta graph
+# (META_PKGCONFIG_DIRS, openssl prefix, flags) accumulated by SPK_BASE_TEMPLATE,
+# so it can only be generated in the consumer context.
+#
+# Output-only for now: the live variables (accumulator + cross-env.mk) drive the
+# build; this file is for `cat` inspection and to replace the opacity of the
+# scattered $(eval export). Shared across namespaces (not $(1)-prefixed); written
+# once with the fully accumulated environment. Wired in via the
+# $(1)_meta_pre_depend hook in spksrc.spk/base.mk.
+.PHONY: meta_env
+meta_env:
+	@mkdir -p $(WORK_DIR)
+	@echo "# Generated meta cross-dependency environment - $(NAME)"          > $(WORK_DIR)/tc_vars.meta.mk
+	@echo "META_PKGCONFIG_DIRS := $(strip $(META_PKGCONFIG_DIRS))"          >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR)"                       >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "ADDITIONAL_CFLAGS += $(ADDITIONAL_CFLAGS)"                       >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "ADDITIONAL_LDFLAGS += $(ADDITIONAL_LDFLAGS)"                     >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "OPENSSL_STAGING_INSTALL_PREFIX := $(OPENSSL_STAGING_INSTALL_PREFIX)" >> $(WORK_DIR)/tc_vars.meta.mk
+
+endif # ifndef SPKSRC_SPK_META_MK

--- a/mk/spksrc.spk/meta.mk
+++ b/mk/spksrc.spk/meta.mk
@@ -4,26 +4,49 @@ SPKSRC_SPK_META_MK := 1
 # Materialize the meta cross-dependency environment into an inspectable
 # artifact (tc_vars.meta.mk, cleaned by spkclean's tc_vars*.mk glob).
 #
-# This lives here rather than in the toolchain tc_vars generation
-# (spksrc.toolchain/) on purpose: unlike the toolchain tc_vars.* files (which
-# describe the toolchain identity and are generated once at stage1, in the
-# toolchain context), this one depends on the CONSUMER's meta graph
-# (META_PKGCONFIG_DIRS, openssl prefix, flags) accumulated by SPK_BASE_TEMPLATE,
-# so it can only be generated in the consumer context.
+# Placement (spksrc.spk/ vs spksrc.toolchain/): this lives under spksrc.spk/ on
+# purpose. The toolchain tc_vars.* files describe the toolchain identity, are
+# generated once per arch at stage1, and their generator
+# (spksrc.toolchain/tc_vars.mk) is included ONLY by spksrc.toolchain.mk - it is
+# absent from the consumer/cross include graph (cross-cc.mk -> cross-env.mk only
+# READS the generated tc_vars). This artifact instead depends on the CONSUMER's
+# meta graph (META_PKGCONFIG_DIRS, openssl prefix, flags) accumulated by
+# SPK_BASE_TEMPLATE, which only exists at spk-stage2. So the recipe must live in
+# a file reachable from the consumer graph (base.mk -> here); the toolchain
+# generator cannot host it.
 #
-# Output-only for now: the live variables (accumulator + cross-env.mk) drive the
-# build; this file is for `cat` inspection and to replace the opacity of the
-# scattered $(eval export). Shared across namespaces (not $(1)-prefixed); written
-# once with the fully accumulated environment. Wired in via the
-# $(1)_meta_pre_depend hook in spksrc.spk/base.mk.
-.PHONY: meta_env
-meta_env:
+# It adopts the toolchain tc_vars file-target pattern (a named TC_VARS_META_MK
+# output + a real, cached file rule like make_tc_var_rule) rather than a .PHONY
+# that rewrites on every depend - same idempotent "generate once per WORK_DIR,
+# regenerated after a clean" semantics as the other tc_vars.* files.
+#
+# Output-only: the live variables (the SPK_BASE_TEMPLATE accumulator +
+# cross-env.mk) drive the build; this file is never -included - it exists for
+# `cat` inspection and to replace the opacity of the scattered $(eval export).
+# Shared across namespaces (not $(1)-prefixed); written once with the fully
+# accumulated environment. Wired in via the $(1)_meta_pre_depend hook in
+# spksrc.spk/base.mk.
+
+# Inspectable meta env artifact, named like the toolchain tc_vars.* family so
+# spkclean's tc_vars*.mk glob removes it (recursive '=' - WORK_DIR resolves lazily).
+TC_VARS_META_MK = $(WORK_DIR)/tc_vars.meta.mk
+
+# Cached file-target modeled on spksrc.toolchain/tc_vars.mk's make_tc_var_rule.
+# The content is fully expandable at parse time in the consumer context, so it
+# is emitted directly (no submake indirection needed, unlike the toolchain).
+$(TC_VARS_META_MK):
+	@$(MSG) "Generating $(TC_VARS_META_MK)"
 	@mkdir -p $(WORK_DIR)
-	@echo "# Generated meta cross-dependency environment - $(NAME)"          > $(WORK_DIR)/tc_vars.meta.mk
-	@echo "META_PKGCONFIG_DIRS := $(strip $(META_PKGCONFIG_DIRS))"          >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR)"                       >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "ADDITIONAL_CFLAGS += $(ADDITIONAL_CFLAGS)"                       >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "ADDITIONAL_LDFLAGS += $(ADDITIONAL_LDFLAGS)"                     >> $(WORK_DIR)/tc_vars.meta.mk
-	@echo "OPENSSL_STAGING_INSTALL_PREFIX := $(OPENSSL_STAGING_INSTALL_PREFIX)" >> $(WORK_DIR)/tc_vars.meta.mk
+	@echo "# Generated meta cross-dependency environment - $(NAME)"              > $@
+	@echo "META_PKGCONFIG_DIRS := $(strip $(META_PKGCONFIG_DIRS))"              >> $@
+	@echo "PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR)"                           >> $@
+	@echo "ADDITIONAL_CFLAGS += $(ADDITIONAL_CFLAGS)"                           >> $@
+	@echo "ADDITIONAL_LDFLAGS += $(ADDITIONAL_LDFLAGS)"                         >> $@
+	@echo "OPENSSL_STAGING_INSTALL_PREFIX := $(OPENSSL_STAGING_INSTALL_PREFIX)" >> $@
+
+# Convenience phony alias for direct invocation (`make meta_env`), mirroring the
+# toolchain's grouped generate_tc_vars_* targets.
+.PHONY: meta_env
+meta_env: $(TC_VARS_META_MK)
 
 endif # ifndef SPKSRC_SPK_META_MK

--- a/mk/spksrc.spk/meta.mk
+++ b/mk/spksrc.spk/meta.mk
@@ -1,39 +1,12 @@
 ifndef SPKSRC_SPK_META_MK
 SPKSRC_SPK_META_MK := 1
 
-# Materialize the meta cross-dependency environment into an inspectable
-# artifact (tc_vars.meta.mk, cleaned by spkclean's tc_vars*.mk glob).
-#
-# Placement (spksrc.spk/ vs spksrc.toolchain/): this lives under spksrc.spk/ on
-# purpose. The toolchain tc_vars.* files describe the toolchain identity, are
-# generated once per arch at stage1, and their generator
-# (spksrc.toolchain/tc_vars.mk) is included ONLY by spksrc.toolchain.mk - it is
-# absent from the consumer/cross include graph (cross-cc.mk -> cross-env.mk only
-# READS the generated tc_vars). This artifact instead depends on the CONSUMER's
-# meta graph (META_PKGCONFIG_DIRS, openssl prefix, flags) accumulated by
-# SPK_BASE_TEMPLATE, which only exists at spk-stage2. So the recipe must live in
-# a file reachable from the consumer graph (base.mk -> here); the toolchain
-# generator cannot host it.
-#
-# It adopts the toolchain tc_vars file-target pattern (a named TC_VARS_META_MK
-# output + a real, cached file rule like make_tc_var_rule) rather than a .PHONY
-# that rewrites on every depend - same idempotent "generate once per WORK_DIR,
-# regenerated after a clean" semantics as the other tc_vars.* files.
-#
-# Output-only: the live variables (the SPK_BASE_TEMPLATE accumulator +
-# cross-env.mk) drive the build; this file is never -included - it exists for
-# `cat` inspection and to replace the opacity of the scattered $(eval export).
-# Shared across namespaces (not $(1)-prefixed); written once with the fully
-# accumulated environment. Wired in via the $(1)_meta_pre_depend hook in
-# spksrc.spk/base.mk.
-
-# Inspectable meta env artifact, named like the toolchain tc_vars.* family so
-# spkclean's tc_vars*.mk glob removes it (recursive '=' - WORK_DIR resolves lazily).
+# Inspectable diagnostic artifact (tc_vars.meta.mk, never -included) of the meta
+# env accumulated by SPK_BASE_TEMPLATE. Under spksrc.spk/ (not toolchain/) as it
+# depends on the per-consumer meta graph, known only at spk-stage2. Cached
+# file-target named like tc_vars.* (cleaned by spkclean); meta_env is an alias.
 TC_VARS_META_MK = $(WORK_DIR)/tc_vars.meta.mk
 
-# Cached file-target modeled on spksrc.toolchain/tc_vars.mk's make_tc_var_rule.
-# The content is fully expandable at parse time in the consumer context, so it
-# is emitted directly (no submake indirection needed, unlike the toolchain).
 $(TC_VARS_META_MK):
 	@$(MSG) "Generating $(TC_VARS_META_MK)"
 	@mkdir -p $(WORK_DIR)
@@ -44,8 +17,6 @@ $(TC_VARS_META_MK):
 	@echo "ADDITIONAL_LDFLAGS += $(ADDITIONAL_LDFLAGS)"                         >> $@
 	@echo "OPENSSL_STAGING_INSTALL_PREFIX := $(OPENSSL_STAGING_INSTALL_PREFIX)" >> $@
 
-# Convenience phony alias for direct invocation (`make meta_env`), mirroring the
-# toolchain's grouped generate_tc_vars_* targets.
 .PHONY: meta_env
 meta_env: $(TC_VARS_META_MK)
 


### PR DESCRIPTION
## Summary

First in a stacked series splitting the meta cross-dependency refactor (#7218) into reviewable pieces. This PR lays the **foundation only**: it introduces the meta environment in `SPK_BASE_TEMPLATE` and materializes it as an inspectable artifact. The consumers of that environment land in follow-up PRs.

Two files touched (`mk/spksrc.spk/base.mk` +18, `mk/spksrc.spk/meta.mk` new):

- **Accumulate `META_PKGCONFIG_DIRS`** — each meta (python/ffmpeg/videodriver) appends its `lib/pkgconfig` dir, add-if-absent, and the list is exported so cross/ sub-makes inherit it.
- **Materialize `tc_vars.meta.mk`** — a cached file-target (`TC_VARS_META_MK`) modeled on the toolchain `tc_vars.*` family (cleaned by spkclean's `tc_vars*.mk` glob), wired via the `$(1)_meta_pre_depend` hook. `meta_env` is kept as a phony alias. Recipe extracted to `mk/spksrc.spk/meta.mk` (consumer-context — it depends on the per-consumer meta graph, unlike the toolchain generator which is arch-global).

## No behavior change on its own

This PR is intentionally **inert**: it accumulates `META_PKGCONFIG_DIRS` and writes a **diagnostic** `tc_vars.meta.mk` (never `-include`d), but nothing consumes the environment yet. The consumers arrive next in the stack:

1. **(this)** meta env foundation
2. CMake channel — `CMAKE_FIND_ROOT_PATH` meta roots, `OPENSSL_ROOT_DIR`, colon-aware `PKG_CONFIG_LIBDIR`
3. ordered `PKG_CONFIG_LIBDIR` (cross-env.mk) + OpenSSL scan
4. spksrc.meta mechanism rework (auto-build meta source, drop denylist/else, OpenSSL consolidation)
5. consumer exception removals

The pre-refactor denylist / `.pc` symlink-flatten / OpenSSL detection all remain untouched here and are reworked in PR 4.

Split from #7218 (which carries the full, already-validated history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)