### PR TITLE
CI: build-time budget + checkpoint to survive the 6h job kill

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -134,7 +134,44 @@ fi
 # Initialize remaining packages list for tracking build progress
 remaining_packages="${build_packages}"
 
+# Build-time budget: stop at a package boundary before GitHub's 6h job kill so
+# the completed .spk and diagnostics still upload, and so we can report what was
+# left to build. Tunable via BUILD_BUDGET_SECONDS (default 5h45m); 0 disables it.
+build_budget=${BUILD_BUDGET_SECONDS:-20700}
+build_start=$(date +%s)
+: "${BUILD_REMAINING_FILE:=build_remaining.txt}"
+: "${BUILD_TIMEOUT_FILE:=build_timeout.txt}"
+budget_hit=0
+
 for package in ${build_packages}; do
+    # Persist not-yet-completed packages (current + pending) for the checkpoint.
+    echo "${remaining_packages}" | tr ' ' '\n' | grep -v '^$' > "${BUILD_REMAINING_FILE}"
+
+    # Stop at this package boundary if the build-time budget is exhausted, so the
+    # always() upload steps still run before the 6h job kill.
+    elapsed=$(( $(date +%s) - build_start ))
+    if [ "${build_budget}" -gt 0 ] && [ "${elapsed}" -ge "${build_budget}" ]; then
+        budget_hit=1
+        echo "::warning::Build-time budget (${build_budget}s) reached after ${elapsed}s; stopping before '${package}'"
+        {
+            echo "arch: ${GH_ARCH}"
+            echo "budget_seconds: ${build_budget}"
+            echo "elapsed_seconds: ${elapsed}"
+            echo "stopped_before: ${package}"
+            echo "remaining: ${remaining_packages}"
+        } > "${BUILD_TIMEOUT_FILE}"
+        break
+    fi
+
+    # Hard time cap for this package = remaining budget, so a long in-progress
+    # build is killed rather than overrunning the 6h job limit (a boundary check
+    # alone lets the current package finish, which can exceed the budget). timeout
+    # returns 124 (TERM) or 137 (KILL after the -k grace) when it fires.
+    build_cap=
+    if [ "${build_budget}" -gt 0 ]; then
+        build_cap="timeout -k 60 $(( build_budget - elapsed ))"
+    fi
+
     # Remove current package from remaining list at the start of each iteration
     remaining_packages=$(echo "${remaining_packages}" | tr ' ' '\n' | grep -vx "${package}" | tr '\n' ' ')
     echo "::group:: ---- build ${package}"
@@ -143,10 +180,10 @@ for package in ${build_packages}; do
     if [ "${GH_ARCH%%-*}" != "noarch" ]; then
         if [ "${package}" == "${PACKAGE_TO_PUBLISH}" ]; then
             echo "$ make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package}" >>build.log
-            make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
+            ${build_cap} make ${MAKE_ARGS}arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
         else
             echo "$ make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package}" >>build.log
-            make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
+            ${build_cap} make arch-${GH_ARCH%%-*}-${GH_ARCH##*-} -C ./spk/${package} |& tee >(tail -15 >>build.log)
         fi
     else
         if [ "${GH_ARCH}" = "noarch" ]; then
@@ -156,14 +193,32 @@ for package in ${build_packages}; do
         fi
         # noarch package must be first built then published
         echo "$ make TCVERSION=${TCVERSION} ARCH=noarch -C ./spk/${package}" >>build.log
-        make TCVERSION=${TCVERSION} ARCH=noarch -C ./spk/${package} |& tee >(tail -15 >>build.log)
+        ${build_cap} make TCVERSION=${TCVERSION} ARCH=noarch -C ./spk/${package} |& tee >(tail -15 >>build.log)
 
         if [ "${package}" == "${PACKAGE_TO_PUBLISH}" ]; then
             echo "$ make TCVERSION=${TCVERSION} ARCH=noarch -C ./spk/${package} ${MAKE_ARGS%%-}" >>build.log
-            make TCVERSION=${TCVERSION} ARCH=noarch -C ./spk/${package} ${MAKE_ARGS%%-} |& tee >(tail -15 >>build.log)
+            ${build_cap} make TCVERSION=${TCVERSION} ARCH=noarch -C ./spk/${package} ${MAKE_ARGS%%-} |& tee >(tail -15 >>build.log)
         fi
     fi
     result=$?
+
+    # Killed by the time cap = budget reached mid-build -> stop cleanly so the
+    # always() upload steps still run. The killed package is already listed in
+    # build_remaining.txt (written at the top of this iteration).
+    if [ "${build_budget}" -gt 0 ] && { [ ${result} -eq 124 ] || [ ${result} -eq 137 ]; }; then
+        budget_hit=1
+        elapsed=$(( $(date +%s) - build_start ))
+        echo "::warning::Build-time budget (${build_budget}s) reached during '${package}' (${elapsed}s); killed the in-progress build."
+        {
+            echo "arch: ${GH_ARCH}"
+            echo "budget_seconds: ${build_budget}"
+            echo "elapsed_seconds: ${elapsed}"
+            echo "stopped_during: ${package}"
+            echo "remaining: ${package} ${remaining_packages}"
+        } > "${BUILD_TIMEOUT_FILE}"
+        echo "::endgroup::"
+        break
+    fi
 
     # For a build to succeed a <package>_<arch>-<version>.spk must also be generated
     if [ ${result} -eq 0 ] && [ "$(ls -1 ./packages/$(sed -n -e '/^SPK_NAME/ s/.*= *//p' spk/${package}/Makefile)_*.spk 2>/dev/null)" ]; then
@@ -176,3 +231,8 @@ for package in ${build_packages}; do
 
     echo "::endgroup::"
 done
+
+# Clear the remaining list on a full pass (all packages processed).
+if [ "${budget_hit}" -eq 0 ]; then
+    : > "${BUILD_REMAINING_FILE}"
+fi

--- a/.github/actions/build_status.sh
+++ b/.github/actions/build_status.sh
@@ -16,6 +16,8 @@
 # BUILD_UNSUPPORTED_FILE    defines the name of the file with unsupported packages
 # BUILD_ERROR_FILE          defines the name of the file with build errors
 # BUILD_ERROR_LOGFILE       defines the name of the file with last 15 lines of build output for failed packages
+# BUILD_REMAINING_FILE      defines the name of the file listing packages not built (build-time budget)
+# BUILD_TIMEOUT_FILE        defines the name of the file with the build-time budget stop details
 #
 
 echo ""
@@ -52,8 +54,31 @@ else
 fi
 
 echo ""
+echo "NOT PROCESSED (build-time budget reached):"
+incomplete=0
+if [ -s "${BUILD_REMAINING_FILE}" ]; then
+    incomplete=1
+    # The package that was actively building when the budget hit (killed mid-build)
+    interrupted=
+    [ -f "${BUILD_TIMEOUT_FILE}" ] && interrupted=$(sed -n 's/^stopped_during:[[:space:]]*//p' "${BUILD_TIMEOUT_FILE}")
+    [ -n "${interrupted}" ] && echo "interrupted (killed mid-build): ${interrupted}"
+    echo "not built:"
+    cat "${BUILD_REMAINING_FILE}"
+    if [ -f "${BUILD_TIMEOUT_FILE}" ]; then
+        echo ""
+        cat "${BUILD_TIMEOUT_FILE}"
+    fi
+    echo ""
+    echo "::warning::Partial build: $(grep -c . "${BUILD_REMAINING_FILE}") package(s) not processed${interrupted:+, interrupted '${interrupted}' mid-build} (build-time budget). See NOT PROCESSED above."
+else
+    echo "none (all packages processed)."
+fi
+
+echo ""
+errors=0
 if [ -f "${BUILD_ERROR_FILE}" ]; then
     if [ $(cat "${BUILD_ERROR_FILE}" | wc -l) -gt 0 ]; then
+        errors=1
         echo "::error::ERRORS:%0A$(cat ${BUILD_ERROR_FILE} | sed ':a;N;$!ba;s/\n/%0A/g')"
         echo ""
         echo "See log file of the build job to analyze the error(s)."
@@ -62,11 +87,16 @@ if [ -f "${BUILD_ERROR_FILE}" ]; then
         echo
         cat "${BUILD_ERROR_LOGFILE}"
         echo ""
-        # let build status job fail
-        exit 1
     fi
 fi
+if [ "${errors}" -eq 0 ]; then
+    echo "ERRORS:"
+    echo "none."
+    echo ""
+fi
 
-echo "ERRORS:"
-echo "none."
-echo ""
+# Fail the job (red indicator) on real errors OR on an incomplete build
+# (build-time budget stopped it), so a partial build is not a misleading green.
+if [ "${errors}" -eq 1 ] || [ "${incomplete}" -eq 1 ]; then
+    exit 1
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,12 @@ on:
       - 'python/**'
       - 'native/**'
 
+env:
+  # Per-arch build-time budget (seconds): 20700 = 5h45m, below GitHub's 6h job
+  # kill. build.sh hard-stops the in-progress build at this ceiling so completed
+  # .spk/diagnostics still upload and the remaining packages are reported.
+  BUILD_BUDGET_SECONDS: "20700"
+
 jobs:
   prepare:
     name: Prepare for Build
@@ -479,6 +485,10 @@ jobs:
         # We don't want to stop the build on errors.
         # Errors are reported in "Build Status"
         continue-on-error: true
+        # Hard backstop below the 6h job kill in case build.sh's own budget can't
+        # stop in time (e.g. a single package hangs); the always() steps below
+        # still run and upload whatever completed.
+        timeout-minutes: 350
         uses: docker://ghcr.io/synocommunity/spksrc:latest
         with:
           entrypoint: ./.github/actions/build.sh
@@ -498,6 +508,9 @@ jobs:
           BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
+          BUILD_BUDGET_SECONDS: ${{ env.BUILD_BUDGET_SECONDS }}
+          BUILD_REMAINING_FILE: /github/workspace/build_remaining.txt
+          BUILD_TIMEOUT_FILE: /github/workspace/build_timeout.txt
 
       # Check disk space after build completes (success or failure)
       - name: Disk Space After Build
@@ -774,6 +787,8 @@ jobs:
           BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt
           BUILD_UNSUPPORTED_FILE: /github/workspace/build_unsupported.txt
           BUILD_SUCCESS_FILE: /github/workspace/build_success.txt
+          BUILD_REMAINING_FILE: /github/workspace/build_remaining.txt
+          BUILD_TIMEOUT_FILE: /github/workspace/build_timeout.txt
 
       # Assemble flat diagnostics and the full collected_logs tree
       # into artifacts/diagnostics/ for upload.
@@ -787,7 +802,8 @@ jobs:
           # Copy flat diagnostic files
           for file in disk_usage_start.txt disk_usage_end.txt docker_logs.txt \
                       build_errors.txt build_log_errors.txt \
-                      build_unsupported.txt build_success.txt; do
+                      build_unsupported.txt build_success.txt \
+                      build_remaining.txt build_timeout.txt; do
             [ -f "$file" ] && cp -p "$file" "artifacts/diagnostics/$file"
           done
 


### PR DESCRIPTION
## Problem

Per-arch package builds can exceed GitHub's hard **6h job limit**, which kills the job before the `if: always()` steps upload the completed `.spk` and diagnostics — so a long build loses everything *and* gives no indication of what was left to do.

## Mechanism

A per-arch **build-time budget** (`BUILD_BUDGET_SECONDS`, default **20700 = 5h45m**, below the 6h kill) enforced as a **hard cap**:

- **`.github/actions/build.sh`** — each package build runs under `timeout -k 60 <remaining-budget>`, so the **in-progress build is killed at the ceiling** instead of overrunning (a boundary check alone would let the current package finish and exceed 6h). The killed package is recorded in `build_remaining.txt`, and `build_timeout.txt` captures `stopped_during`/`stopped_before` + the remaining list.
- **`.github/actions/build_status.sh`** — reports **SUCCESS / UNSUPPORTED / NOT PROCESSED / ERRORS** in one place, names the package **interrupted mid-build**, and `exit 1` on a partial build (or real errors) so the job indicator goes **red** instead of a misleading green.
- **`.github/workflows/build.yml`** — passes the budget + checkpoint file paths, sets a `timeout-minutes: 350` backstop on the build step, and the existing `if: always()` upload steps still run on a budget stop → **completed `.spk` and diagnostics are preserved**, plus a `::warning::` annotation flags the partial build (naming the interrupted package).

## Notes

- `BUILD_BUDGET_SECONDS: 0` disables the budget.
- This PR only touches `.github/` so it does not trigger the heavy build workflow itself; the mechanism is exercised on the next real package build (or a manual dispatch). Extracted from the meta cmake work to land as a standalone CI improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)