### PR TITLE
Framework/meta: ordered PKG_CONFIG_LIBDIR shared across all channels

### DIFF
--- a/mk/spksrc.cross-cmake-toolchainfile.mk
+++ b/mk/spksrc.cross-cmake-toolchainfile.mk
@@ -15,13 +15,10 @@ TC_VARS_FILES := $(wildcard $(foreach b,$(DEFAULT_ENV),$(WORK_DIR)/tc_vars.$(b).
 # Include them (optional include)
 -include $(TC_VARS_FILES)
 
-# Ordered PKG_CONFIG_LIBDIR for the cmake channel (local first, then meta dirs).
-# PR #3 hoists this ordering into cross-env.mk for all channels.
-CMAKE_PKG_CONFIG_LIBDIR = $(PKG_CONFIG_LIBDIR)$(if $(strip $(META_PKGCONFIG_DIRS)),:$(subst $(space),:,$(strip $(META_PKGCONFIG_DIRS))))
-
-# OpenSSL root for find_package(OpenSSL) (which ignores pkg-config): first
-# PKG_CONFIG_LIBDIR dir providing libssl.so (local-first), else local staging.
-CMAKE_OPENSSL_ROOT_DIR = $(abspath $(firstword $(foreach d,$(subst :,$(space),$(CMAKE_PKG_CONFIG_LIBDIR)),$(if $(wildcard $(patsubst %/lib/pkgconfig,%,$(d))/lib/libssl.so),$(patsubst %/lib/pkgconfig,%,$(d)),)) $(STAGING_INSTALL_PREFIX)))
+# OpenSSL root for find_package(OpenSSL) (which ignores pkg-config): first dir of
+# the ordered PKG_CONFIG_LIBDIR (cross-env.mk) providing libssl.so (local-first),
+# else local staging.
+CMAKE_OPENSSL_ROOT_DIR = $(abspath $(firstword $(foreach d,$(subst :,$(space),$(PKG_CONFIG_LIBDIR)),$(if $(wildcard $(patsubst %/lib/pkgconfig,%,$(d))/lib/libssl.so),$(patsubst %/lib/pkgconfig,%,$(d)),)) $(STAGING_INSTALL_PREFIX)))
 
 # Meta staging roots for CMAKE_FIND_ROOT_PATH: cmake find_*() re-roots under it
 # (MODE=ONLY), so meta libs (absolute) must be listed there to be found.
@@ -87,7 +84,7 @@ endif
 	echo "set(CMAKE_INSTALL_RPATH_USE_LINK_PATH $(CMAKE_INSTALL_RPATH_USE_LINK_PATH))" ; \
 	echo
 	@echo "# set pkg-config path" ; \
-	echo 'set(ENV{PKG_CONFIG_LIBDIR} "$(subst $(space),:,$(abspath $(subst :,$(space),$(CMAKE_PKG_CONFIG_LIBDIR))))")'
+	echo 'set(ENV{PKG_CONFIG_LIBDIR} "$(subst $(space),:,$(abspath $(subst :,$(space),$(PKG_CONFIG_LIBDIR))))")'
 	@echo "# OpenSSL root (find_package(OpenSSL) ignores pkg-config)" ; \
 	echo 'set(OPENSSL_ROOT_DIR "$(CMAKE_OPENSSL_ROOT_DIR)")'
 ifneq ($(strip $(CMAKE_META_FIND_ROOTS)),)

--- a/mk/spksrc.cross-env.mk
+++ b/mk/spksrc.cross-env.mk
@@ -27,7 +27,10 @@
 ENV += WORK_DIR=$(WORK_DIR)
 ENV += INSTALL_PREFIX=$(INSTALL_PREFIX)
 
-PKG_CONFIG_LIBDIR = $(INSTALL_DIR)/$(INSTALL_PREFIX)/lib/pkgconfig
+# Ordered: local staging first (wins), then the meta pkgconfig dirs accumulated
+# and exported by SPK_BASE_TEMPLATE. Shared by autotools/meson (via ENV) and the
+# cmake toolchain file - pkg-config takes the first match, so local overrides meta.
+PKG_CONFIG_LIBDIR = $(INSTALL_DIR)/$(INSTALL_PREFIX)/lib/pkgconfig$(if $(strip $(META_PKGCONFIG_DIRS)),:$(subst $(space),:,$(strip $(META_PKGCONFIG_DIRS))))
 ENV += PKG_CONFIG_LIBDIR=$(PKG_CONFIG_LIBDIR)
 
 # Core toolchain variable definitions


### PR DESCRIPTION
## Summary

Third in the stacked series splitting the meta cross-dependency refactor (#7218). Hoist the **ordered `PKG_CONFIG_LIBDIR`** into `mk/spksrc.cross-env.mk` so all three build channels share one list.

`PKG_CONFIG_LIBDIR` becomes: **local staging first**, then the meta pkgconfig dirs accumulated and exported by `SPK_BASE_TEMPLATE` (#7222). pkg-config takes the first match, so a package's own local copy of a lib still wins over the shared meta one (the aiokafka/zlib case).

- **autotools / meson** consume it via `ENV` (already exported on line below).
- **cmake** consumes it via the toolchain file.

## Cleanup

#7223 added an interim **cmake-local** `CMAKE_PKG_CONFIG_LIBDIR` to make the cmake channel meta-aware before this hoist existed. Now that `cross-env.mk` provides the ordered list, that var is removed and the cmake `OPENSSL_ROOT_DIR` scan + the baked `set(ENV{PKG_CONFIG_LIBDIR})` use the shared `$(PKG_CONFIG_LIBDIR)`.

## Notes

- Standalone safety: with no meta present, the list collapses to the local staging dir → identical to master behavior. Validated locally (`make --eval`): `PKG_CONFIG_LIBDIR = <local>:<meta>` with a meta set, `<local>` alone without.
- This PR only touches `mk/`, so it does not auto-trigger the build matrix (paths filter is `spk/cross/python/native`); it is exercised by the next package build / the follow-up PRs.
- Builds on #7222 (`META_PKGCONFIG_DIRS`) and #7223 (cmake channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)