### PR TITLE
cross/nmap: --with-openssl from the consolidated OPENSSL prefix

### DIFF
--- a/cross/nmap/Makefile
+++ b/cross/nmap/Makefile
@@ -19,9 +19,9 @@ CONFIGURE_ARGS  = --without-zenmap
 CONFIGURE_ARGS += --without-ndiff
 CONFIGURE_ARGS += --with-liblua=included
 CONFIGURE_ARGS += --with-libpcre=included
-ifneq ($(wildcard $(OPENSSL_STAGING_INSTALL_PREFIX)),)
+# openssl prefix from the single source of truth (cross-env.mk scan): the shared
+# meta staging if present, else the local staging (cross/openssl3).
 CONFIGURE_ARGS += --with-openssl=$(OPENSSL_STAGING_INSTALL_PREFIX)
-endif
 
 ADDITIONAL_CPPFLAGS = -O3
 


### PR DESCRIPTION
## What

`cross/nmap` (autotools) set `--with-openssl` only when a meta provided OpenSSL, behind a meta-only `ifneq`. Switch it to the consolidated `OPENSSL_STAGING_INSTALL_PREFIX` (the single `PKG_CONFIG_LIBDIR` scan from `cross-env.mk`, #7229):

```make
# openssl prefix from the single source of truth (cross-env.mk scan): the shared
# meta staging if present, else the local staging (cross/openssl3).
CONFIGURE_ARGS += --with-openssl=$(OPENSSL_STAGING_INSTALL_PREFIX)
```

`OPENSSL_STAGING_INSTALL_PREFIX` always resolves to at least the local staging, so the meta-only conditional is no longer needed. This is the same form now used by `cross/zabbix-agent` (#7231).

## Why

Follow-up to the meta cross-dependency rework (#7229): nmap was the remaining autotools consumer still gating openssl behind a meta-only branch.

## Test

Standalone `cross/nmap arch-x64-7.1`: configure receives `--with-openssl=<local staging>`, `checking openssl/ssl.h usability... yes`, builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
