### PR TITLE
cross/zabbix-agent: --with-openssl from the consolidated OPENSSL prefix

### DIFF
--- a/cross/zabbix-agent/Makefile
+++ b/cross/zabbix-agent/Makefile
@@ -47,7 +47,9 @@ CONFIGURE_ARGS += --disable-static
 CONFIGURE_ARGS += --enable-ipv6
 CONFIGURE_ARGS += --with-zlib=$(STAGING_INSTALL_PREFIX)
 CONFIGURE_ARGS += --with-libpthread=$(STAGING_INSTALL_PREFIX)
-CONFIGURE_ARGS += --with-openssl=$(STAGING_INSTALL_PREFIX)
+# openssl prefix from the single source of truth (cross-env.mk scan): the shared
+# meta staging if present, else the local staging (cross/openssl3).
+CONFIGURE_ARGS += --with-openssl=$(OPENSSL_STAGING_INSTALL_PREFIX)
 # --with-libcurl must define curl-config and not the directory (ERROR: checking for the version of libcurl... ./configure: line 18672: .../install/usr/local/zabbix-agent: Is a directory)
 CONFIGURE_ARGS += --with-libcurl=$(STAGING_INSTALL_PREFIX)/bin/curl-config
 CONFIGURE_ARGS += --with-libpcre2=$(STAGING_INSTALL_PREFIX)


### PR DESCRIPTION
## What

`cross/zabbix-agent` hardcoded `--with-openssl=$(STAGING_INSTALL_PREFIX)`. Switch it to the consolidated `OPENSSL_STAGING_INSTALL_PREFIX` (the single `PKG_CONFIG_LIBDIR`-scan derivation from `cross-env.mk`, #7229): meta staging when shared, local staging (`cross/openssl3`) standalone.

## Why

Follow-up to the meta cross-dependency rework (#7229): align zabbix-agent with the single OpenSSL source of truth instead of assuming the local staging prefix.

## Test

Standalone `cross/zabbix-agent arch-x64-7.1`: `checking for openssl options with pkg-config... found`, `SSL_connect in -lssl... yes`, builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
