### PR TITLE
spk/tvheadend: re-enable and finish the MEDIA_LIBS/.pc-list removal

### DIFF
--- a/mk/spksrc.spk/base.mk
+++ b/mk/spksrc.spk/base.mk
@@ -69,8 +69,8 @@ $(eval DEPENDS := $(call uniq,$($(1)_DIRECT_DEPENDS) $(DEPENDS)))
 # an entry for it (e.g. with a version constraint like python314>=3.14.5-4)
 $(if $(filter $($(1)_PACKAGE) $($(1)_PACKAGE)=% $($(1)_PACKAGE)<% $($(1)_PACKAGE)>%,$(subst :, ,$(subst ",,$(SPK_DEPENDS)))),,$(eval SPK_DEPENDS := $(call dedup,$($(1)_PACKAGE):$(SPK_DEPENDS),:)))
 
-# Build list of status cookies to symlink (skip if $(1)_PC is set)
-$(eval $(1)_STATUS_COOKIES := $(sort $(if $(strip $($(1)_PC)),,$(foreach cross,$(filter-out $(EXCLUDED_NAME),$(foreach pkg_name,$(shell $(MAKE) ARCH=$(ARCH) TCVERSION=$(TCVERSION) dependency-list -C $(realpath $($(1)_PACKAGE_WORK_DIR)/../) 2>/dev/null | grep ^$($(1)_PACKAGE) | cut -f2 -d:),$(shell sed -n 's/^PKG_NAME = \(.*\)/\1/p' $(realpath $(CURDIR)/../../$(pkg_name)/Makefile)))),$(wildcard $($(1)_PACKAGE_WORK_DIR)/.$(cross)-*_done)))))
+# Build list of status cookies to symlink
+$(eval $(1)_STATUS_COOKIES := $(sort $(foreach cross,$(filter-out $(EXCLUDED_NAME),$(foreach pkg_name,$(shell $(MAKE) ARCH=$(ARCH) TCVERSION=$(TCVERSION) dependency-list -C $(realpath $($(1)_PACKAGE_WORK_DIR)/../) 2>/dev/null | grep ^$($(1)_PACKAGE) | cut -f2 -d:),$(shell sed -n 's/^PKG_NAME = \(.*\)/\1/p' $(realpath $(CURDIR)/../../$(pkg_name)/Makefile)))),$(wildcard $($(1)_PACKAGE_WORK_DIR)/.$(cross)-*_done))))
 
 # Register pre-depend hook so _links runs before dependency compilation
 $(eval PRE_DEPEND_TARGET += $(1)_meta_pre_depend)

--- a/mk/spksrc.spk/ffmpeg.mk
+++ b/mk/spksrc.spk/ffmpeg.mk
@@ -16,18 +16,6 @@ OPTIONAL_DEPENDS += $(FFMPEG_DEPENDS)
 # exists for the stage2 SPK_BASE_TEMPLATE parse.
 BUILD_DEPENDS := $(call uniq,spk/$(FFMPEG_PACKAGE) $(BUILD_DEPENDS))
 
-# Re-use all default ffmpeg mandatory libraries
-FFMPEG_PC  = libavcodec.pc
-FFMPEG_PC += libavfilter.pc
-FFMPEG_PC += libavformat.pc
-FFMPEG_PC += libavutil.pc
-FFMPEG_PC += libpostproc.pc
-FFMPEG_PC += libswresample.pc
-FFMPEG_PC += libswscale.pc
-# Also include openssl
-FFMPEG_PC += libssl.pc
-FFMPEG_PC += openssl.pc
-
 # $(1)_meta hook required by base.mk; no extra action for this meta.
 .PHONY: FFMPEG_meta
 FFMPEG_meta: ;

--- a/spk/tvheadend/BROKEN
+++ b/spk/tvheadend/BROKEN
@@ -1,1 +1,0 @@
-Too long for this build - temporary disabled

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -48,23 +48,9 @@ OPTIONAL_DEPENDS += python/pandas
 
 WHEELS += src/requirements-pure.txt
 
-# Use media and other libraries from FFMPEG_PACKAGE shared libraries
-MEDIA_LIBS  = fdk-aac.pc
-MEDIA_LIBS += fontconfig.pc
-MEDIA_LIBS += ogg.pc
-MEDIA_LIBS += opus.pc
-MEDIA_LIBS += libpcre2-8.pc
-MEDIA_LIBS += libpcre2-32.pc
-MEDIA_LIBS += libpcre2-posix.pc
-MEDIA_LIBS += theoradec.pc
-MEDIA_LIBS += theoraenc.pc
-MEDIA_LIBS += theora.pc
-MEDIA_LIBS += vorbisenc.pc
-MEDIA_LIBS += vorbisfile.pc
-MEDIA_LIBS += vorbis.pc
-MEDIA_LIBS += vpx.pc
-MEDIA_LIBS += x264.pc
-MEDIA_LIBS += x265.pc
+# Media/other libraries from the ffmpeg meta (and videodriver for fontconfig /
+# libpcre2) are resolved via the ordered PKG_CONFIG_LIBDIR - no MEDIA_LIBS list
+# to symlink anymore (FFMPEG_meta is a no-op since spksrc.spk/ffmpeg.mk).
 
 include ../../mk/spksrc.common.mk
 


### PR DESCRIPTION
## What

Complete the `MEDIA_LIBS` / `.pc`-list removal that the meta rework (#7229) started, and re-enable tvheadend:

- **spk/tvheadend**: remove `BROKEN`; drop the dead `MEDIA_LIBS` list.
- **mk/spksrc.spk/ffmpeg.mk**: drop the `FFMPEG_PC` list.
- **mk/spksrc.spk/base.mk**: drop the now-unused `$(1)_PC` gate on `$(1)_STATUS_COOKIES`.

## Why

`tvheadend` was disabled via `BROKEN` with the reason *"Too long for this build - temporary disabled"* — a CI build-time limitation, not a build failure. That limitation is now handled by the build-time budget + checkpoint mechanism (#7226), so the package can be re-enabled.

The rest finishes removing the old `.pc`-symlink sharing:
- `FFMPEG_meta` no longer symlinks `MEDIA_LIBS` (it is a no-op since the ordered `PKG_CONFIG_LIBDIR` resolves those `.pc` directly), so the `MEDIA_LIBS` definition in tvheadend was its only remaining reference and is now dead. The media/other libs (x264, x265, vorbis, theora, opus, fdk-aac, vpx from ffmpeg7; fontconfig, libpcre2-* from synocli-videodriver) are found via pkg-config.
- `FFMPEG_PC` only fed the old `.pc` allowlist (gone with #7229) and then lingered solely as a flag that made the ffmpeg meta skip build-status-cookie sharing. Removing it — and the matching `$(1)_PC` gate in `base.mk` — makes all three metas (python/ffmpeg/videodriver) share build-status cookies uniformly.

## Note on CI

tvheadend is one of the heaviest builds; on the busiest matrix entry (x64-7.1, which also builds the full Intel videodriver/Vulkan stack) it may still hit the time budget and report `NOT PROCESSED` rather than a real error. It builds cleanly on the other arches/toolchains (e.g. aarch64-7.1, x64-6.2.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
