### PR TITLE
ci: only cancel superseded runs and skip fork builds while a PR is draft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,10 +104,24 @@ env:
   # .spk/diagnostics still upload and the remaining packages are reported.
   BUILD_BUDGET_SECONDS: "20700"
 
+# Cancel a previous, now-superseded run when a new commit lands on the same
+# branch or pull request, instead of letting both full build matrices run to
+# completion. The event_name is part of the group so push, pull_request and
+# manual workflow_dispatch runs never cancel one another; a manual build &
+# publish (workflow_dispatch) is additionally never auto-cancelled.
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   prepare:
     name: Prepare for Build
     runs-on: ubuntu-latest
+    # Skip the automatic push/pull_request build on forks: a fork PR is already
+    # built by the pull_request event in the SynoCommunity/spksrc base repo, so
+    # also building it from the fork's push event would duplicate the whole
+    # matrix. workflow_dispatch on a fork is unaffected (different code path).
+    if: github.repository == 'SynoCommunity/spksrc' || github.event_name == 'workflow_dispatch'
     outputs:
       arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
       noarch_packages: ${{ steps.dependencies.outputs.noarch_packages }}
@@ -848,7 +862,7 @@ jobs:
     name: Consolidate Diagnostics
     needs: build
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && (github.repository == 'SynoCommunity/spksrc' || github.event_name == 'workflow_dispatch')
     steps:
       - name: Download all diagnostic artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,14 +104,15 @@ env:
   # .spk/diagnostics still upload and the remaining packages are reported.
   BUILD_BUDGET_SECONDS: "20700"
 
-# Cancel a previous, now-superseded run when a new commit lands on the same
-# branch or pull request, instead of letting both full build matrices run to
-# completion. The event_name is part of the group so push, pull_request and
-# manual workflow_dispatch runs never cancel one another; a manual build &
-# publish (workflow_dispatch) is additionally never auto-cancelled.
+# Cancel a previous, now-superseded run only while a pull request is still a
+# Draft, so iterative pushes during development don't pile up. Non-draft PR
+# builds and master/push builds are never cancelled — every merged commit keeps
+# its own build result on master — and workflow_dispatch (manual build &
+# publish) is never cancelled either. The event_name is part of the group so
+# push, pull_request and workflow_dispatch runs never cancel one another.
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
 
 jobs:
   # Decide whether the build should run at all. Upstream events (pull_request,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,14 +114,47 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
+  # Decide whether the build should run at all. Upstream events (pull_request,
+  # or push to SynoCommunity/spksrc) and manual workflow_dispatch always build.
+  # A fork's own push build is skipped while the branch has an open *draft* PR
+  # upstream: during development the authoritative full build still runs on the
+  # upstream PR, so re-running the fork's narrow build only wastes runner time.
+  # A push event carries no PR context, hence the API lookup here.
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.repository }}" = "SynoCommunity/spksrc" ] || \
+             [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Upstream or manual run -> build."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fork push: look up the branch's open PR in the upstream repo and skip
+          # the build while that PR is a draft. Any lookup failure falls back to
+          # building (fail-open).
+          draft=$(gh api \
+            "/repos/SynoCommunity/spksrc/pulls?head=${{ github.repository_owner }}:${{ github.ref_name }}&state=open" \
+            --jq '[.[].draft] | first // false' 2>/dev/null || echo false)
+          if [ "$draft" = "true" ]; then
+            echo "Fork push for a draft PR (${{ github.ref_name }}) -> skip build."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Fork push, PR not draft (or none) -> build."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare:
     name: Prepare for Build
     runs-on: ubuntu-latest
-    # Skip the automatic push/pull_request build on forks: a fork PR is already
-    # built by the pull_request event in the SynoCommunity/spksrc base repo, so
-    # also building it from the fork's push event would duplicate the whole
-    # matrix. workflow_dispatch on a fork is unaffected (different code path).
-    if: github.repository == 'SynoCommunity/spksrc' || github.event_name == 'workflow_dispatch'
+    needs: gate
+    if: needs.gate.outputs.should_build == 'true'
     outputs:
       arch_packages: ${{ steps.dependencies.outputs.arch_packages }}
       noarch_packages: ${{ steps.dependencies.outputs.noarch_packages }}
@@ -860,9 +893,9 @@ jobs:
 
   consolidate-diagnostics:
     name: Consolidate Diagnostics
-    needs: build
+    needs: [gate, build]
     runs-on: ubuntu-latest
-    if: always() && (github.repository == 'SynoCommunity/spksrc' || github.event_name == 'workflow_dispatch')
+    if: always() && needs.gate.outputs.should_build == 'true'
     steps:
       - name: Download all diagnostic artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
         run: |
           git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | grep -oP "^spk/\K[^\/]*" | sort -u | xargs
           echo "spk_packages=$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | grep -oP "^spk/\K[^\/]*" | sort -u | xargs)" >> $GITHUB_OUTPUT
-          git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | grep -oP "(cross|python|native)/[^\/]*" | sort -u | xargs
-          echo "dependency_folders=$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | grep -oP "(cross|python|native)/[^\/]*" | sort -u | xargs)" >> $GITHUB_OUTPUT
+          git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | grep -oP "^(cross|python|native)/[^\/]*" | sort -u | xargs
+          echo "dependency_folders=$(git diff --no-commit-id --name-only -r origin/master...${{github.event.pull_request.head.sha}} | grep -oP "^(cross|python|native)/[^\/]*" | sort -u | xargs)" >> $GITHUB_OUTPUT
 
       - name: Get changed spk_packages and dependency_folders of last commit for push
         if: github.event_name == 'push'
@@ -144,8 +144,8 @@ jobs:
         run: |
           git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -oP "^spk/\K[^\/]*" | sort -u | xargs
           echo "spk_packages=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -oP "^spk/\K[^\/]*" | sort -u | xargs)" >> $GITHUB_OUTPUT
-          git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -oP "(cross|python|native)/[^\/]*" | sort -u | xargs
-          echo "dependency_folders=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -oP "(cross|python|native)/[^\/]*" | sort -u | xargs)" >> $GITHUB_OUTPUT
+          git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -oP "^(cross|python|native)/[^\/]*" | sort -u | xargs
+          echo "dependency_folders=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -oP "^(cross|python|native)/[^\/]*" | sort -u | xargs)" >> $GITHUB_OUTPUT
 
       - name: Evaluate dependencies
         id: dependencies


### PR DESCRIPTION
## TL;DR

Two build behaviors are now gated on **PR Draft state** — **nothing changes outside draft**:

- **While a PR is a Draft** → superseded runs are cancelled (iterative pushes don't pile up) and the redundant fork build is skipped.
- **Non-draft PRs, `master` pushes, and manual runs** → unchanged: every build runs to completion.

Plus a small fix: the change-detection regex is anchored (`^`) so the new `mk/spksrc.cross/` / `mk/spksrc.native/` dirs aren't mis-detected as `cross/` / `native/` package folders.

---

## Background

While exercising heavy branches, the Build workflow piled up overlapping, multi-hour runs. Two compounding causes:

- **No `concurrency` guard** — successive pushes never cancelled the previous, superseded run, so several full arch matrices ran at once.
- **Fork + upstream builds on every push** — with an open fork PR, each push triggers a `push` build on the fork *and* a `pull_request` build upstream.

## 1. Cancel superseded runs (draft PRs only)

```yaml
concurrency:
  group: build-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
```

Concurrency is inherently per-repository (a fork run and an upstream run can never cancel each other) and keyed per ref + event. A superseded run is cancelled **only while the pull request is a Draft**, so iterative pushes during development don't pile up. Everything else runs to completion:

- **push to `master`** (each PR merge) → never cancelled, so every merged commit keeps its own visible build result;
- **non-draft PR** builds → never cancelled;
- **`workflow_dispatch`** (manual build & publish) → never cancelled.

## 2. Gate the fork build on PR draft state

The fork's `push` build is **not** a duplicate of the upstream PR build (thanks @hgy59 for the correction): the upstream `pull_request` build covers the full PR diff (`origin/master...HEAD`), while the fork `push` build covers only the latest commit (`git diff-tree HEAD`) — complementary, not redundant. So this PR no longer removes it.

Instead, a small `gate` job decides whether to build:

- **upstream events** (`pull_request`, or push to `SynoCommunity/spksrc`) and **`workflow_dispatch`** → always build;
- a **fork `push`** → skipped **only while the branch has an open *draft* PR** upstream, and builds normally again once the PR is non-draft / ready for review.

A `push` event carries no PR context, so the gate looks it up (fail-open on any error):

```yaml
draft=$(gh api \
  "/repos/SynoCommunity/spksrc/pulls?head=${{ github.repository_owner }}:${{ github.ref_name }}&state=open" \
  --jq '[.[].draft] | first // false' 2>/dev/null || echo false)
```

Net effect:

- when a fork doesn't use draft PRs, **its fork build is unchanged** — it keeps running on every push;
- keeping a PR in draft during development stops the redundant fork build, while the **upstream full build still runs on every push**;
- (1) cancels superseded upstream runs while in draft, keeping the queue clear during development;
- manual *Run workflow* stays available throughout.

### Why this rather than the earlier options

- **(a)** skip fork auto-builds entirely (first version of this PR) — drops the useful fast narrow build; rejected.
- **(b)** trigger `push` only on `master` — same downside for everyone.
- **(c)** do nothing — heavy matrices saturate the Actions queue and waste fork runner time during development.
- **(d, chosen)** gate the fork build on draft state — keeps the narrow fork build (as restored in #7214) for everyone outside draft, and only trades it away while a PR is explicitly marked WIP. No per-fork config variable required.

## 3. Anchored change-detection regex

The `dependency_folders` detection used `grep -oP "(cross|python|native)/[^/]*"`, which matched anywhere in a path. It is now anchored as `^(cross|python|native)/...`, mirroring the existing `^spk/` anchor for `spk_packages`. This drops false positives such as `mk/spksrc.cross/env-default.mk` → `cross/env-default.mk` while keeping every real top-level package folder.

## Validation

- `build.yml` parses as valid YAML; the `gate` job, the `prepare`/`consolidate-diagnostics` wiring, the draft-conditional concurrency and the anchored regex were verified.
- Anchored regex tested locally against this repo's change set: all `mk/spksrc.cross/` / `mk/spksrc.native/` false positives drop, every real `cross/` package folder is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
