### PR TITLE
cross/chromaprint-fftw: distinct PKG_NAME to fix meta cookie collision

### DIFF
--- a/cross/chromaprint-fftw/Makefile
+++ b/cross/chromaprint-fftw/Makefile
@@ -1,9 +1,12 @@
-PKG_NAME = chromaprint
+# Distinct PKG_NAME from cross/chromaprint (same upstream, fftw FFT backend):
+# avoids a meta status-cookie collision that made a consumer skip building its
+# own cross/chromaprint. Download/extract still use the upstream "chromaprint".
+PKG_NAME = chromaprint-fftw
 PKG_VERS = 1.6.0
 PKG_EXT = tar.gz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_NAME = chromaprint-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/acoustid/chromaprint/releases/download/v$(PKG_VERS)
-PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+PKG_DIR = chromaprint-$(PKG_VERS)
 
 HOMEPAGE = https://acoustid.org/chromaprint
 COMMENT  = Chromaprint is the core component of the AcoustID project. It\'s a client-side library that implements a custom algorithm for extracting fingerprints from any audio source.


### PR DESCRIPTION
## Problem

`spk/chromaprint` fails on every arch except `x64-7.1` with:

```
===> Use existing shared objects from [ffmpeg7]
===> Processing dependencies of chromaprint
===> Use existing shared objects from [synocli-videodriver]
  cross/chromaprint: Nothing to be done for 'cross-stage2'.
===> No PLIST for chromaprint
/bin/bash: cd: .../install/var/packages/chromaprint/target: No such file or directory
make[3]: *** [spksrc.spk/copy.mk:57: copy_target] Error 2
```

## Root cause

`cross/chromaprint` and `cross/chromaprint-fftw` (same upstream, different FFT backend) **both used `PKG_NAME = chromaprint`**. The meta status-cookie sharing in `spksrc.spk-meta/base.mk` keys on `PKG_NAME`: `spk/chromaprint` uses `FFMPEG_PACKAGE = ffmpeg7`, and ffmpeg7 pulls `cross/chromaprint-fftw`. The meta therefore shares a `.chromaprint-*_done` cookie into the consumer, so `spk/chromaprint` thinks its own `cross/chromaprint` dependency is already built, skips it, and ends up with an empty install → `No PLIST` → `copy_target` fails.

## Fix

Give `cross/chromaprint-fftw` a distinct `PKG_NAME = chromaprint-fftw` (so its cookie/install-prefix no longer collide), while keeping download/extract on the upstream `chromaprint-1.6.0` tarball:

```makefile
PKG_NAME = chromaprint-fftw
PKG_DIST_NAME = chromaprint-$(PKG_VERS).$(PKG_EXT)
PKG_DIR = chromaprint-$(PKG_VERS)
```

## Notes / validation

- `ffmpeg4/5/6/7/8` depend on it by **folder path** (`cross/chromaprint-fftw`) — unchanged.
- `digests` already lists `chromaprint-1.6.0.tar.gz` (matches the unchanged dist name); the relative `PLIST` (`lib/libchromaprint.so*`) needs no change.
- `COOKIE_PREFIX` is now `chromaprint-fftw-` (distinct from `chromaprint-`), so the consumer builds its own `cross/chromaprint` again.
- ffmpeg7, spk/chromaprint, cross/chromaprint and cross/chromaprint-fftw all parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)