### PR TITLE
LibYAML: Add libyaml-0.so symlink for pkg-config compatibility

### DIFF
--- a/cross/libyaml/Makefile
+++ b/cross/libyaml/Makefile
@@ -14,4 +14,10 @@ LICENSE  = MIT
 GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --disable-static
 
+POST_INSTALL_TARGET = libyaml_post_install
+
 include ../../mk/spksrc.cross-cc.mk
+
+.PHONY: libyaml_post_install
+libyaml_post_install:
+	ln -sf libyaml.so $(STAGING_INSTALL_PREFIX)/lib/libyaml-0.so


### PR DESCRIPTION
## Description

`cross/libyaml` builds with `--disable-static`, resulting in `libtool` creating only `libyaml.so` and `libyaml-0.so.2` in the install prefix — but **not** `libyaml-0.so`. cmake targets that use pkg-config to find libyaml (e.g., via `yaml-0.1.pc`) get `-lyaml-0` as the linker flag, which fails because `libyaml-0.so` doesn't exist.

This adds a `POST_INSTALL_TARGET` that creates the missing `libyaml-0.so → libyaml.so` symlink, fixing the link step for downstream consumers without modifying libyaml's source or .pc files.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
