### PR TITLE
Makefile: context-aware `make help` (root + per-package)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,18 +25,18 @@ HELP_AWK = awk -v topic="$(HELP_TOPIC)" ' \
 	    desc = $$0; sub(/.*\#\#[ \t]*/, "", desc); \
 	    if (topic == "" || index(tolower(section " " name), tolower(topic))) { \
 	      if (section != cur) { printf "\n\033[1m%s\033[0m\n", section; cur = section } \
-	      printf "  \033[36m%-17s\033[0m %s\n", name, desc; matched++ \
+	      printf "  \033[36m%-20s\033[0m %s\n", name, desc; matched++ \
 	    } \
 	  } \
 	  END { \
 	    if (matched == 0) { printf "\nNo target matches \"%s\".\n", topic } \
 	    else if (topic == "") { \
 	      printf "\n\033[1mPer-package (pattern) targets\033[0m\n"; \
-	      printf "  \033[36m%-17s\033[0m %s\n", "<spk>", "build one SPK (e.g. make tvheadend)"; \
-	      printf "  \033[36m%-17s\033[0m %s\n", "spk-<spk>-<arch>", "build one SPK for one arch (make spk-tvheadend-x64-7.1)"; \
-	      printf "  \033[36m%-17s\033[0m %s\n", "native-<name>", "build one native tool (e.g. make native-cmake)"; \
-	      printf "  \033[36m%-17s\033[0m %s\n", "toolchain-<arch>", "build one toolchain (make toolchain-x64-7.1)"; \
-	      printf "  \033[36m%-17s\033[0m %s\n", "kernel-<arch>", "build one kernel module set" \
+	      printf "  \033[36m%-28s\033[0m %s\n", "<spk>", "build one SPK (e.g. make tvheadend)"; \
+	      printf "  \033[36m%-28s\033[0m %s\n", "spk-<spk>-<arch>-<tcversion>", "build one SPK for one arch (make spk-tvheadend-x64-7.1)"; \
+	      printf "  \033[36m%-28s\033[0m %s\n", "native-<name>", "build one native tool (e.g. make native-cmake)"; \
+	      printf "  \033[36m%-28s\033[0m %s\n", "toolchain-<arch>", "build one toolchain (make toolchain-x64-7.1)"; \
+	      printf "  \033[36m%-28s\033[0m %s\n", "kernel-<arch>", "build one kernel module set" \
 	    } \
 	    printf "\nUse \033[36mmake help-<topic>\033[0m to filter (e.g. \033[36mmake help-clean\033[0m)\n\n" \
 	  }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 
+# Base definitions. Included explicitly (not relied upon via tests.mk) so the
+# root targets and `make help` do not depend on the still-evolving tests.mk.
+include mk/spksrc.common.mk
+
 # Include framework self-test
 include mk/spksrc.rules/tests.mk
 include mk/spksrc.rules/dependency-tree.mk

--- a/Makefile
+++ b/Makefile
@@ -7,56 +7,98 @@ AVAILABLE_TCS = $(notdir $(wildcard toolchain/syno-*))
 AVAILABLE_ARCHS = $(notdir $(subst syno-,/,$(AVAILABLE_TCS)))
 SUPPORTED_SPKS = $(sort $(patsubst spk/%/Makefile,%,$(wildcard spk/*/Makefile)))
 
+##@ General
+
+# help          : full grouped list of documented targets
+# help-<topic>  : filter by section or target name, e.g. "make help-clean"
+# Only targets carrying a "## description" are listed, so internal hook targets
+# (pre_*, post_*, *_msg) never appear.
+HELP_AWK = awk -v topic="$(HELP_TOPIC)" ' \
+	  BEGIN { printf "\n\033[1mspksrc\033[0m - Synology package build system\n" } \
+	  /^\#\#@/ { section = substr($$0, 5); next } \
+	  /^[a-zA-Z0-9_%-]+:.*\#\#[^@]/ { \
+	    name = $$0; sub(/:.*/, "", name); \
+	    desc = $$0; sub(/.*\#\#[ \t]*/, "", desc); \
+	    if (topic == "" || index(tolower(section " " name), tolower(topic))) { \
+	      if (section != cur) { printf "\n\033[1m%s\033[0m\n", section; cur = section } \
+	      printf "  \033[36m%-17s\033[0m %s\n", name, desc; matched++ \
+	    } \
+	  } \
+	  END { \
+	    if (matched == 0) { printf "\nNo target matches \"%s\".\n", topic } \
+	    else if (topic == "") { \
+	      printf "\n\033[1mPer-package (pattern) targets\033[0m\n"; \
+	      printf "  \033[36m%-17s\033[0m %s\n", "<spk>", "build one SPK (e.g. make tvheadend)"; \
+	      printf "  \033[36m%-17s\033[0m %s\n", "spk-<spk>-<arch>", "build one SPK for one arch (make spk-tvheadend-x64-7.1)"; \
+	      printf "  \033[36m%-17s\033[0m %s\n", "native-<name>", "build one native tool (e.g. make native-cmake)"; \
+	      printf "  \033[36m%-17s\033[0m %s\n", "toolchain-<arch>", "build one toolchain (make toolchain-x64-7.1)"; \
+	      printf "  \033[36m%-17s\033[0m %s\n", "kernel-<arch>", "build one kernel module set" \
+	    } \
+	    printf "\nUse \033[36mmake help-<topic>\033[0m to filter (e.g. \033[36mmake help-clean\033[0m)\n\n" \
+	  }' $(MAKEFILE_LIST)
+
+.PHONY: help
+help: HELP_TOPIC :=
+help:  ## Show this help; use "make help-<topic>" to filter (e.g. help-clean)
+	@$(HELP_AWK)
+
+help-%: HELP_TOPIC = $*
+help-%:
+	@$(HELP_AWK)
+
+##@ Build
 
 ifneq ($(firstword $(MAKECMDGOALS)),test)
-all: $(SUPPORTED_SPKS)
+all: $(SUPPORTED_SPKS)  ## Build every supported SPK (long; usually build one <spk> instead)
 endif
 
-all-noarch:
+all-noarch:  ## Build every noarch (override ARCH) SPK
 	@for spk in $(filter-out $(dir $(wildcard spk/*/BROKEN)),$(dir $(wildcard spk/*/Makefile))) ; \
 	do \
 	   grep -q "override ARCH" "$${spk}/Makefile" && $(MAKE) -C $${spk} ; \
 	done
 
+##@ Clean
+
 ifneq ($(firstword $(MAKECMDGOALS)),test)
-clean: $(addsuffix -clean,$(SUPPORTED_SPKS))
+clean: $(addsuffix -clean,$(SUPPORTED_SPKS))  ## Clean all SPK, native and cross work dirs
 clean: native-clean cross-clean
 endif
 
-dist-clean: clean
+dist-clean: clean  ## Clean everything, including kernel/toolchain/toolkit
 dist-clean: kernel-clean toolchain-clean toolkit-clean
 
-native-clean:
+native-clean:  ## Clean all native/ work dirs
 	@for native in $(dir $(wildcard native/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${native} clean ; \
 	done
 
-toolchain-clean:
+toolchain-clean:  ## Clean all toolchain/ work dirs
 	@for tc in $(dir $(wildcard toolchain/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${tc} clean ; \
 	done
 
-toolkit-clean:
+toolkit-clean:  ## Clean all toolkit/ work dirs
 	@for tk in $(dir $(wildcard toolkit/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${tk} clean ; \
 	done
 
-kernel-clean:
+kernel-clean:  ## Clean all kernel/ work dirs
 	@for kernel in $(dir $(wildcard kernel/*/Makefile)) ; \
 	do \
 	    rm -rf $${kernel}/work* ; \
 	done
 
-cross-clean:
+cross-clean:  ## Clean all cross/ work dirs
 	@for cross in $(dir $(wildcard cross/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${cross} clean ; \
 	done
 
-spk-clean:
+spk-clean:  ## Clean all spk/ work dirs
 	@for spk in $(filter-out $(dir $(wildcard spk/*/BROKEN)),$(dir $(wildcard spk/*/Makefile))) ; \
 	do \
 	    $(MAKE) -C $${spk} clean ; \
@@ -79,53 +121,59 @@ spk-$(1)-$(2): spk/$(1)/Makefile setup
 endef
 $(foreach arch,$(AVAILABLE_ARCHS),$(foreach spk,$(SUPPORTED_SPKS),$(eval $(call SPK_ARCH_template,$(spk),$(arch)))))
 
-prepare: downloads
+##@ Prepare
+
+prepare: downloads  ## Download sources and build all toolchains
 	@for tc in $(dir $(wildcard toolchain/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${tc} ; \
 	done
 
-downloads:
+downloads:  ## Download all cross/ package sources
 	@for dl in $(dir $(wildcard cross/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${tc} download ; \
 	done
 
-natives:
+natives:  ## Build all native/ tools
 	@for n in $(dir $(wildcard native/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${n} ; \
 	done
 
-native-digests:
+##@ Digests
+
+native-digests:  ## Regenerate digests for all native/ packages
 	@for n in $(dir $(wildcard native/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${n} digests ; \
 	done
 
-toolchain-digests:
+toolchain-digests:  ## Regenerate digests for all toolchain/ packages
 	@for tc in $(dir $(wildcard toolchain/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${tc} digests ; \
 	done
 
-toolkit-digests:
+toolkit-digests:  ## Regenerate digests for all toolkit/ packages
 	@for tk in $(dir $(wildcard toolkit/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${tk} digests ; \
 	done
 
-kernel-digests:
+kernel-digests:  ## Regenerate digests for all kernel/ packages
 	@for kernel in $(dir $(wildcard kernel/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${kernel} digests ; \
 	done
 
-cross-digests:
+cross-digests:  ## Regenerate digests for all cross/ packages
 	@for cross in $(dir $(wildcard cross/*/Makefile)) ; \
 	do \
 	    $(MAKE) -C $${cross} digests ; \
 	done
+
+##@ Lint
 
 jsonlint:
 ifeq (,$(shell which jsonlint))
@@ -133,11 +181,13 @@ ifeq (,$(shell which jsonlint))
 else
 	find spk/ -not -path "*work*" -regextype posix-extended -regex '.*(\.json|install_uifile\w*|upgrade_uifile\w*|app/config)' -print -exec jsonlint -q -c {} \;
 endif
-lint: jsonlint
+lint: jsonlint  ## Validate all package JSON / wizard files
+
+##@ Toolchain & kernel
 
 .PHONY: toolchains kernel-modules
-toolchains: $(addprefix toolchain-,$(AVAILABLE_ARCHS))
-kernel-modules: $(addprefix kernel-,$(AVAILABLE_ARCHS))
+toolchains: $(addprefix toolchain-,$(AVAILABLE_ARCHS))  ## Build every available toolchain
+kernel-modules: $(addprefix kernel-,$(AVAILABLE_ARCHS))  ## Build every available kernel
 
 toolchain-%:
 	-@cd toolchain/syno-$*/ && MAKEFLAGS= $(MAKE)
@@ -145,7 +195,9 @@ toolchain-%:
 kernel-%:
 	-@cd kernel/syno-$*/ && MAKEFLAGS= $(MAKE)
 
-setup: local.mk dsm-6.2.4 dsm-7.1
+##@ Setup
+
+setup: local.mk dsm-6.2.4 dsm-7.1  ## Create local.mk and set default DSM toolchains
 
 local.mk:
 	@echo "Creating local configuration \"local.mk\"..."
@@ -165,7 +217,7 @@ dsm-%: local.mk
 	@echo "Setting default toolchain version to DSM-$*"
 	@grep -q "^DEFAULT_TC.*=.*$*.*" local.mk || sed -i "/^DEFAULT_TC =/s/$$/ $*/" local.mk
 
-setup-synocommunity: setup
+setup-synocommunity: setup  ## Set up local.mk pointing at the SynoCommunity repository
 	@sed -i -e "s|PUBLISH_URL\s*=.*|PUBLISH_URL = https://api.synocommunity.com|" \
 		-e "s|DISTRIBUTOR\s*=.*|DISTRIBUTOR = SynoCommunity|" \
 		-e "s|DISTRIBUTOR_URL\s*=.*|DISTRIBUTOR_URL = https://synocommunity.com|" \

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ prepare: downloads  ## Download sources and build all toolchains
 downloads:  ## Download all cross/ package sources
 	@for dl in $(dir $(wildcard cross/*/Makefile)) ; \
 	do \
-	    $(MAKE) -C $${tc} download ; \
+	    $(MAKE) -C $${dl} download ; \
 	done
 
 natives:  ## Build all native/ tools

--- a/docs/developer-guide/basics/build-workflow.md
+++ b/docs/developer-guide/basics/build-workflow.md
@@ -50,10 +50,12 @@ make -C cross/curl help
 
 At the root it lists the orchestration targets (`setup`, `all`, `clean`,
 digests, lint, …) grouped by section; `make help-<topic>` filters them.
-Inside a `cross/`, `spk/` or `native/` package it lists that package's build
-lifecycle, the multi-arch targets (`all-supported`, `arch-<arch>`, …) and the
-maintenance targets. Only documented targets are shown, so the internal
-`pre_*` / `post_*` / `*_msg` hooks stay hidden.
+Inside a package (`cross/`, `spk/`, `native/`, `toolchain/`, `toolkit/`,
+`kernel/`, `diyspk/`) it lists that package's build lifecycle, the multi-arch
+targets (`all-supported`, `arch-<arch>-<tcvers>`, …), the inspection and
+maintenance targets, and — for Python SPKs — the wheel/crossenv targets. Only
+documented targets are shown, so the internal `pre_*` / `post_*` / `*_msg`
+hooks stay hidden.
 
 ### Build a Package
 

--- a/docs/developer-guide/basics/build-workflow.md
+++ b/docs/developer-guide/basics/build-workflow.md
@@ -34,6 +34,27 @@ block
 
 ## Basic Commands
 
+### Discovering targets (`make help`)
+
+`make help` is context-aware — run it wherever you are:
+
+```bash
+# At the spksrc root: repository-wide orchestration targets
+make help
+make help-clean          # filter the list by section or name
+
+# Inside a package: the targets relevant to that package
+make -C spk/transmission help
+make -C cross/curl help
+```
+
+At the root it lists the orchestration targets (`setup`, `all`, `clean`,
+digests, lint, …) grouped by section; `make help-<topic>` filters them.
+Inside a `cross/`, `spk/` or `native/` package it lists that package's build
+lifecycle, the multi-arch targets (`all-supported`, `arch-<arch>`, …) and the
+maintenance targets. Only documented targets are shown, so the internal
+`pre_*` / `post_*` / `*_msg` hooks stay hidden.
+
 ### Build a Package
 
 ```bash

--- a/docs/developer-guide/package-types/python.md
+++ b/docs/developer-guide/package-types/python.md
@@ -191,12 +191,10 @@ make WHEEL_NAME=lxml WHEEL_VERSION=5.2.2 crossenv-x64-7.2
 
 ### Cleanup
 
-Targets in increasing scope:
-
 ```bash
 make wheelclean         # built wheels + wheel status cookies
-make wheelcleancache    # also drop the local pip cache (work-*/pip)
-make wheelcleanall      # also drop the shared download cache (distrib/pip)
+make wheelcleancache    # the local pip cache only (work-*/pip)
+make wheelcleanall      # wheelclean + wheelcleancache + the shared cache (distrib/pip)
 make crossenvclean      # wheelclean + the crossenv dirs and their cookies
 make crossenvcleanall   # wheelcleanall + crossenvclean (everything)
 ```

--- a/docs/developer-guide/packaging/build-rules.md
+++ b/docs/developer-guide/packaging/build-rules.md
@@ -4,35 +4,45 @@ This page documents the build targets and rules available in spksrc.
 
 ## Build Targets
 
+Run `make help` inside any package directory for the authoritative,
+context-aware list. The tables below summarize the common targets.
+
 ### Cross Package Targets
 
 Run from `cross/<package>/` directory:
 
 | Target | Description |
 |--------|-------------|
-| `all` | Build everything (default) |
-| `download` | Download source archive |
-| `checksum` | Verify checksums |
-| `extract` | Extract source archive |
-| `patch` | Apply patches |
-| `configure` | Run configure script |
-| `compile` | Compile the source |
-| `install` | Install to staging |
-| `plist` | Generate PLIST file |
-| `clean` | Remove build artifacts |
+| `all` | Build everything (default; needs `ARCH=<arch> TCVERSION=<tcvers>`) |
+| `arch-<arch>-<tcvers>` | Build for one arch/version (e.g. `arch-x64-7.2`) |
+| `download` `checksum` `extract` `patch` `configure` `compile` `install` `plist` | Individual build lifecycle steps, in order |
+| `all-supported` / `all-latest` | Build for every supported / latest toolchain (needs `make setup` first) |
+| `dependency-tree` / `dependency-flat` / `dependency-list` | Inspect the dependency graph |
+| `clean` | Remove all work directories |
+| `smart-clean` | Remove this package's source and cookies (needs `ARCH`+`TCVERSION`) |
+| `digests` | Regenerate the digests file (auto-runs `download`) |
+| `rustup <args>` | Run rustup for the rust toolchain (e.g. `make rustup show`) |
 
 ### SPK Package Targets
 
-Run from `spk/<package>/` directory:
+Run from `spk/<package>/` directory (`diyspk/` behaves the same):
 
 | Target | Description |
 |--------|-------------|
-| `all` | Build SPK (default) |
-| `arch-<arch>-<version>` | Build for specific architecture (e.g., `arch-x64-7.2`) |
-| `all-supported` | Build for all architectures in `DEFAULT_TC` |
-| `package` | Create SPK file |
-| `publish` | Publish to package server |
-| `clean` | Remove build artifacts |
+| `all` | Build the SPK (default; needs `ARCH=<arch> TCVERSION=<tcvers>`) |
+| `arch-<arch>-<tcvers>` | Build for one arch/version (e.g. `arch-x64-7.2`) |
+| `all-supported` / `all-latest` | Build for every supported / latest toolchain (needs `make setup` first) |
+| `package` | Create the SPK file |
+| `dependency-tree` / `dependency-flat` / `dependency-list` | Inspect the dependency graph |
+| `clean` / `smart-clean` | Remove work directories / this package's source and cookies |
+| `download` / `digests` | Fetch source archive(s) / regenerate digests |
+| `rustup <args>` | Run rustup for the rust toolchain (e.g. `make rustup show`) |
+
+For Python SPKs (those setting `PYTHON_PACKAGE` or named `python3*`), additional
+wheel/crossenv targets are available — see
+[Python Packages](../package-types/python.md): `wheel-<arch>-<tcvers>`,
+`crossenv-<arch>-<tcvers>`, `download-wheels`, `wheelclean`, `wheelcleancache`,
+`crossenvclean`, `crossenvcleanall`.
 
 ## Build System Includes
 
@@ -53,10 +63,12 @@ include ../../mk/spksrc.cross-go.mk
 
 # Rust package
 include ../../mk/spksrc.cross-rust.mk
-
-# Python wheel
-include ../../mk/spksrc.python-module.mk
 ```
+
+For Python modules built as wheels under `python/` (numpy, pillow, ...), use
+`spksrc.python-wheel.mk` (or `spksrc.python-wheel-meson.mk` for meson builds);
+`spksrc.python-module.mk` builds a cross-compiled Python extension instead. See
+[Python Packages](../package-types/python.md).
 
 ### SPK Packaging
 

--- a/docs/developer-guide/packaging/build-rules.md
+++ b/docs/developer-guide/packaging/build-rules.md
@@ -32,7 +32,7 @@ Run from `spk/<package>/` directory (`diyspk/` behaves the same):
 | `all` | Build the SPK (default; needs `ARCH=<arch> TCVERSION=<tcvers>`) |
 | `arch-<arch>-<tcvers>` | Build for one arch/version (e.g. `arch-x64-7.2`) |
 | `all-supported` / `all-latest` | Build for every supported / latest toolchain (needs `make setup` first) |
-| `publish-all-supported` / `publish-all-latest` | Build and publish every supported / latest arch (needs `PUBLISH_URL`+`PUBLISH_API_KEY` in `local.mk`) |
+| `publish-all-supported` / `publish-all-latest` | Build and publish every supported / latest arch (run `make setup-synocommunity` first, then set `PUBLISH_API_KEY` in `local.mk`) |
 | `package` | Create the SPK file |
 | `dependency-tree` / `dependency-flat` / `dependency-list` | Inspect the dependency graph |
 | `clean` / `smart-clean` | Remove work directories / this package's source and cookies |

--- a/docs/developer-guide/packaging/build-rules.md
+++ b/docs/developer-guide/packaging/build-rules.md
@@ -32,6 +32,7 @@ Run from `spk/<package>/` directory (`diyspk/` behaves the same):
 | `all` | Build the SPK (default; needs `ARCH=<arch> TCVERSION=<tcvers>`) |
 | `arch-<arch>-<tcvers>` | Build for one arch/version (e.g. `arch-x64-7.2`) |
 | `all-supported` / `all-latest` | Build for every supported / latest toolchain (needs `make setup` first) |
+| `publish-all-supported` / `publish-all-latest` | Build and publish every supported / latest arch (needs `PUBLISH_URL`+`PUBLISH_API_KEY` in `local.mk`) |
 | `package` | Create the SPK file |
 | `dependency-tree` / `dependency-flat` / `dependency-list` | Inspect the dependency graph |
 | `clean` / `smart-clean` | Remove work directories / this package's source and cookies |

--- a/docs/framework/makefile-system.md
+++ b/docs/framework/makefile-system.md
@@ -130,6 +130,7 @@ spksrc.common.mk
 spksrc.common/
 ├── archs.mk                  # architecture classification / groups
 ├── directories.mk            # work/staging/distrib directory layout
+├── help.mk                   # context-aware `make help` inside a package
 ├── logs.mk                   # logging helpers
 ├── macros.mk                 # GNU Make helper macros
 └── stage0.mk                 # parse-time toolchain pre-bootstrap (TC_GCC)

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -62,9 +62,6 @@ include $(BASEDIR)/mk/spksrc.common/stage0.mk
 include $(BASEDIR)/mk/spksrc.common/archs.mk
 include $(BASEDIR)/mk/spksrc.common/logs.mk
 
-# Context-aware `make help` (only activates inside a package directory)
-include $(BASEDIR)/mk/spksrc.common/help.mk
-
 # Load local configuration
 LOCAL_CONFIG_MK = $(BASEDIR)/local.mk
 -include $(LOCAL_CONFIG_MK)
@@ -73,6 +70,12 @@ LOCAL_CONFIG_MK = $(BASEDIR)/local.mk
 
 # all will be the default target, regardless of what is defined
 default: all
+
+# Context-aware `make help` (only activates inside a package directory).
+# Included after 'default: all' so the help target never becomes the default
+# goal (it would otherwise shadow the build when running e.g. `make` or a
+# recursive arch build).
+include $(BASEDIR)/mk/spksrc.common/help.mk
 
 # Stop on first error
 SHELL := $(SHELL) -e

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -62,6 +62,9 @@ include $(BASEDIR)/mk/spksrc.common/stage0.mk
 include $(BASEDIR)/mk/spksrc.common/archs.mk
 include $(BASEDIR)/mk/spksrc.common/logs.mk
 
+# Context-aware `make help` (only activates inside a package directory)
+include $(BASEDIR)/mk/spksrc.common/help.mk
+
 # Load local configuration
 LOCAL_CONFIG_MK = $(BASEDIR)/local.mk
 -include $(LOCAL_CONFIG_MK)

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -59,7 +59,7 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-supported" "build for every supported arch"
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-latest" "build for the latest toolchains only"
 ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
-	@printf "  \033[36m%-24s\033[0m %s\n" "publish-all-supported" "build and publish every supported arch (needs PUBLISH_URL/PUBLISH_API_KEY)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "publish-all-supported" "build and publish every supported arch (after 'make setup-synocommunity' + PUBLISH_API_KEY)"
 	@printf "  \033[36m%-24s\033[0m %s\n" "publish-all-latest" "build and publish the latest toolchains only"
 endif
 endif

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -44,15 +44,16 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk native diyspk),)
 	@printf "  \033[36m%-24s\033[0m %s\n" "<step>" "run one build step, in order:"
 	@printf "  %-24s   %s\n" "" "$(HELP_STEPS)"
 endif
+ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
+	@printf "  \033[33m%s\033[0m\n" "  all and every <step> except download need ARCH=<arch> TCVERSION=<tcvers>"
+endif
 ifeq ($(SPKSRC_TREE),toolchain)
 	@printf "  \033[36m%-24s\033[0m %s\n" "tc_vars" "show the toolchain variables (TC_GCC, ...)"
 endif
 ifeq ($(SPKSRC_TREE),toolkit)
 	@printf "  \033[36m%-24s\033[0m %s\n" "tk_vars" "show the toolkit variables"
 endif
-ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
-	@printf "  \033[33m%s\033[0m\n" "  all and every <step> except download need ARCH=<arch> TCVERSION=<tcvers>"
-endif
+	@printf "  \033[36m%-24s\033[0m %s\n" "rustup <args>" "run rustup for the rust toolchain (e.g. make rustup show)"
 ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 	@printf "\n\033[1mMulti-arch\033[0m  (needs 'make setup' once at the spksrc root first)\n"
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-supported" "build for every supported arch"

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -24,6 +24,10 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 HELP_STEPS += plist
 endif
 
+# Python wheel targets apply to spk/diyspk packages that set PYTHON_PACKAGE or
+# are themselves a python3* package.
+HELP_PYTHON := $(strip $(PYTHON_PACKAGE))$(filter python3%,$(SPK_NAME) $(PKG_NAME))
+
 .PHONY: help
 help:
 	@printf "\n\033[1m%s\033[0m  (%s package)\n" "$(or $(SPK_NAME),$(PKG_NAME),$(notdir $(CURDIR)))" "$(SPKSRC_TREE)"
@@ -31,47 +35,49 @@ ifeq ($(SPKSRC_TREE),python)
 	@printf "\n  \033[33m%s\033[0m\n" "built only as an spk dependency - it has no direct build here"
 else
 	@printf "\n\033[1mBuild\033[0m\n"
-	@printf "  \033[36m%-22s\033[0m %s\n" "all" "build this package (default target)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "all" "build this package (default target)"
 ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
-	@printf "  \033[36m%-22s\033[0m %s\n" "arch-<arch>-<tcvers>" "build for one arch/version (e.g. arch-x64-7.1)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "arch-<arch>-<tcvers>" "build for one arch/version (e.g. arch-x64-7.1)"
 endif
-ifneq ($(filter $(SPKSRC_TREE),toolchain toolkit),)
-	@printf "  \033[36m%-22s\033[0m %s\n" "download" "fetch the source archive"
-else
-	@printf "  \033[36m%-22s\033[0m %s\n" "<step>" "run one build step, in order:"
-	@printf "  %-22s   %s\n" "" "$(HELP_STEPS)"
+ifneq ($(filter $(SPKSRC_TREE),cross spk native diyspk),)
+	@printf "  \033[36m%-24s\033[0m %s\n" "<step>" "run one build step, in order:"
+	@printf "  %-24s   %s\n" "" "$(HELP_STEPS)"
 endif
 ifeq ($(SPKSRC_TREE),toolchain)
-	@printf "  \033[36m%-22s\033[0m %s\n" "tc_vars" "show the toolchain variables (TC_GCC, ...)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "tc_vars" "show the toolchain variables (TC_GCC, ...)"
 endif
 ifeq ($(SPKSRC_TREE),toolkit)
-	@printf "  \033[36m%-22s\033[0m %s\n" "tk_vars" "show the toolkit variables"
+	@printf "  \033[36m%-24s\033[0m %s\n" "tk_vars" "show the toolkit variables"
 endif
 ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
-	@printf "  \033[33m%s\033[0m\n" "  all and every <step> except download/digests need ARCH=<arch> TCVERSION=<tcvers>"
+	@printf "  \033[33m%s\033[0m\n" "  all and every <step> except download need ARCH=<arch> TCVERSION=<tcvers>"
 endif
-ifneq ($(filter $(SPKSRC_TREE),cross spk),)
+ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 	@printf "\n\033[1mMulti-arch\033[0m  (needs 'make setup' once at the spksrc root first)\n"
-	@printf "  \033[36m%-22s\033[0m %s\n" "all-supported" "build for every supported arch"
-	@printf "  \033[36m%-22s\033[0m %s\n" "all-latest" "build for the latest toolchains only"
+	@printf "  \033[36m%-24s\033[0m %s\n" "all-supported" "build for every supported arch"
+	@printf "  \033[36m%-24s\033[0m %s\n" "all-latest" "build for the latest toolchains only"
 endif
 ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
-	@printf "\n\033[1mPython wheels\033[0m\n"
-	@printf "  \033[36m%-22s\033[0m %s\n" "wheel" "build the Python wheels listed in WHEELS"
-	@printf "  \033[36m%-22s\033[0m %s\n" "download-wheels" "download the wheel sources only"
-	@printf "  \033[36m%-22s\033[0m %s\n" "crossenv" "build the cross-compilation Python venv"
-	@printf "  \033[36m%-22s\033[0m %s\n" "crossenv-install-<w>" "install one wheel into a named crossenv"
+ifneq ($(HELP_PYTHON),)
+	@printf "\n\033[1mPython wheels\033[0m  (set WHEELS=\"pkg==ver\" to (re)build a single wheel on demand)\n"
+	@printf "  \033[36m%-24s\033[0m %s\n" "wheel-<arch>-<tcvers>" "build the package's wheels for one arch"
+	@printf "  \033[36m%-24s\033[0m %s\n" "crossenv-<arch>-<tcvers>" "build the cross-compilation Python venv"
+	@printf "  \033[36m%-24s\033[0m %s\n" "download-wheels" "download the wheel sources only"
+	@printf "  \033[36m%-24s\033[0m %s\n" "wheelclean" "remove wheel build state (run before rebuilding)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "crossenvclean" "remove the crossenv and wheel state"
+endif
 endif
 endif
 	@printf "\n\033[1mInspect\033[0m\n"
-	@printf "  \033[36m%-22s\033[0m %s\n" "dependency-tree" "print the resolved dependency graph"
-	@printf "  \033[36m%-22s\033[0m %s\n" "dependency-flat" "flat, de-duplicated dependency list"
-	@printf "  \033[36m%-22s\033[0m %s\n" "dependency-list" "raw per-package dependency list"
+	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-tree" "print the resolved dependency graph"
+	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-flat" "flat, de-duplicated dependency list"
+	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-list" "raw per-package dependency list"
 ifneq ($(SPKSRC_TREE),python)
 	@printf "\n\033[1mMaintenance\033[0m\n"
-	@printf "  \033[36m%-22s\033[0m %s\n" "clean" "remove all work directories"
-	@printf "  \033[36m%-22s\033[0m %s\n" "smart-clean" "remove this package's source and cookies (needs ARCH+TCVERSION)"
-	@printf "  \033[36m%-22s\033[0m %s\n" "digests" "regenerate the digests file"
+	@printf "  \033[36m%-24s\033[0m %s\n" "download" "fetch the source archive(s)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "clean" "remove all work directories"
+	@printf "  \033[36m%-24s\033[0m %s\n" "smart-clean" "remove this package's source and cookies (needs ARCH+TCVERSION)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "digests" "regenerate the digests file"
 endif
 	@printf "\nRun \033[36mmake help\033[0m at the spksrc root for repo-wide targets (setup, ...)\n\n"
 

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -1,0 +1,54 @@
+###############################################################################
+# spksrc.common/help.mk
+#
+# Package-level, context-aware `make help`. Included via spksrc.common.mk, it
+# only defines the target inside a package directory (cross/, spk/, native/,
+# toolchain/, kernel/) - detected from the parent directory name - so it never
+# collides with the orchestration help defined in the spksrc root Makefile.
+###############################################################################
+
+# spksrc.common.mk may be included more than once by a package; guard so the
+# help recipe is defined only once (avoids "overriding recipe" warnings).
+ifndef SPKSRC_HELP_MK
+SPKSRC_HELP_MK := 1
+
+# Name of the directory that contains this package (cross / spk / native / ...).
+SPKSRC_TREE := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+
+ifneq ($(filter $(SPKSRC_TREE),cross spk native toolchain kernel),)
+
+# The plain build pipeline; spk/ and cross/ additionally generate a PLIST.
+HELP_STEPS := download checksum extract patch configure compile install
+ifneq ($(filter $(SPKSRC_TREE),cross spk),)
+HELP_STEPS += plist
+endif
+
+.PHONY: help
+help:
+	@printf "\n\033[1m%s\033[0m  (%s package)\n" "$(or $(SPK_NAME),$(PKG_NAME),$(notdir $(CURDIR)))" "$(SPKSRC_TREE)"
+	@printf "\n\033[1mBuild\033[0m\n"
+	@printf "  \033[36m%-14s\033[0m %s\n" "all" "build this package (default)"
+ifneq ($(filter $(SPKSRC_TREE),cross spk native),)
+	@printf "  \033[36m%-14s\033[0m %s\n" "<step>" "run one build step, in order:"
+	@printf "  %-14s   %s\n" "" "$(HELP_STEPS)"
+endif
+ifneq ($(filter $(SPKSRC_TREE),cross spk),)
+	@printf "\n\033[1mMulti-arch\033[0m\n"
+	@printf "  \033[36m%-14s\033[0m %s\n" "arch-<arch>" "build one arch (e.g. arch-x64-7.1)"
+	@printf "  \033[36m%-14s\033[0m %s\n" "all-supported" "build every supported arch"
+	@printf "  \033[36m%-14s\033[0m %s\n" "all-latest" "build the latest toolchains only"
+	@printf "  \033[36m%-14s\033[0m %s\n" "supported" "list the supported arch-version pairs"
+	@printf "  \033[36m%-14s\033[0m %s\n" "latest" "list the latest arch-version pairs"
+	@printf "  \033[33m%s\033[0m\n" "  needs 'make setup' once at the spksrc root first"
+else ifeq ($(SPKSRC_TREE),native)
+	@printf "\n  \033[33m%s\033[0m\n" "host-native single build - no arch matrix"
+endif
+	@printf "\n\033[1mMaintenance\033[0m\n"
+	@printf "  \033[36m%-14s\033[0m %s\n" "clean" "remove all work directories"
+	@printf "  \033[36m%-14s\033[0m %s\n" "smart-clean" "remove only this package's source and cookies"
+	@printf "  \033[36m%-14s\033[0m %s\n" "digests" "regenerate the digests file"
+	@printf "\nRun \033[36mmake help\033[0m at the spksrc root for repo-wide targets (setup, ...)\n\n"
+
+endif
+
+endif

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -1,10 +1,11 @@
 ###############################################################################
 # spksrc.common/help.mk
 #
-# Package-level, context-aware `make help`. Included via spksrc.common.mk, it
-# only defines the target inside a package directory (cross/, spk/, native/,
-# toolchain/, kernel/) - detected from the parent directory name - so it never
-# collides with the orchestration help defined in the spksrc root Makefile.
+# Package-level, context-aware `make help`. Included via spksrc.common.mk (after
+# 'default: all' so it never becomes the default goal), it only defines the
+# target inside a package directory (cross/, spk/, native/, toolchain/,
+# toolkit/, kernel/, diyspk/, python/) - detected from the parent directory
+# name - so it never collides with the orchestration help in the root Makefile.
 ###############################################################################
 
 # spksrc.common.mk may be included more than once by a package; guard so the
@@ -15,47 +16,63 @@ SPKSRC_HELP_MK := 1
 # Name of the directory that contains this package (cross / spk / native / ...).
 SPKSRC_TREE := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
 
-ifneq ($(filter $(SPKSRC_TREE),cross spk native toolchain kernel),)
+ifneq ($(filter $(SPKSRC_TREE),cross spk native toolchain toolkit kernel diyspk python),)
 
-# The plain build pipeline; spk/ and cross/ additionally generate a PLIST.
+# Build lifecycle steps; spk/cross/diyspk additionally generate a PLIST.
 HELP_STEPS := download checksum extract patch configure compile install
-ifneq ($(filter $(SPKSRC_TREE),cross spk),)
+ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 HELP_STEPS += plist
 endif
 
 .PHONY: help
 help:
 	@printf "\n\033[1m%s\033[0m  (%s package)\n" "$(or $(SPK_NAME),$(PKG_NAME),$(notdir $(CURDIR)))" "$(SPKSRC_TREE)"
+ifeq ($(SPKSRC_TREE),python)
+	@printf "\n  \033[33m%s\033[0m\n" "built only as an spk dependency - it has no direct build here"
+else
 	@printf "\n\033[1mBuild\033[0m\n"
-	@printf "  \033[36m%-20s\033[0m %s\n" "all" "build this package (default)"
-ifneq ($(filter $(SPKSRC_TREE),cross spk native),)
-	@printf "  \033[36m%-20s\033[0m %s\n" "<step>" "run one build step, in order:"
-	@printf "  %-20s   %s\n" "" "$(HELP_STEPS)"
+	@printf "  \033[36m%-22s\033[0m %s\n" "all" "build this package (default target)"
+ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
+	@printf "  \033[36m%-22s\033[0m %s\n" "arch-<arch>-<tcvers>" "build for one arch/version (e.g. arch-x64-7.1)"
+endif
+ifneq ($(filter $(SPKSRC_TREE),toolchain toolkit),)
+	@printf "  \033[36m%-22s\033[0m %s\n" "download" "fetch the source archive"
+else
+	@printf "  \033[36m%-22s\033[0m %s\n" "<step>" "run one build step, in order:"
+	@printf "  %-22s   %s\n" "" "$(HELP_STEPS)"
+endif
+ifeq ($(SPKSRC_TREE),toolchain)
+	@printf "  \033[36m%-22s\033[0m %s\n" "tc_vars" "show the toolchain variables (TC_GCC, ...)"
+endif
+ifeq ($(SPKSRC_TREE),toolkit)
+	@printf "  \033[36m%-22s\033[0m %s\n" "tk_vars" "show the toolkit variables"
+endif
+ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
+	@printf "  \033[33m%s\033[0m\n" "  all and every <step> except download/digests need ARCH=<arch> TCVERSION=<tcvers>"
 endif
 ifneq ($(filter $(SPKSRC_TREE),cross spk),)
-	@printf "\n\033[1mMulti-arch\033[0m\n"
-	@printf "  \033[36m%-20s\033[0m %s\n" "arch-<arch>-<tcvers>" "build one arch/version (e.g. arch-x64-7.1)"
-	@printf "  \033[36m%-20s\033[0m %s\n" "all-supported" "build every supported arch"
-	@printf "  \033[36m%-20s\033[0m %s\n" "all-latest" "build the latest toolchains only"
-	@printf "  \033[36m%-20s\033[0m %s\n" "supported" "list the supported arch-version pairs"
-	@printf "  \033[36m%-20s\033[0m %s\n" "latest" "list the latest arch-version pairs"
-	@printf "  \033[33m%s\033[0m\n" "  needs 'make setup' once at the spksrc root first"
-else ifeq ($(SPKSRC_TREE),native)
-	@printf "\n  \033[33m%s\033[0m\n" "host-native single build - no arch matrix"
+	@printf "\n\033[1mMulti-arch\033[0m  (needs 'make setup' once at the spksrc root first)\n"
+	@printf "  \033[36m%-22s\033[0m %s\n" "all-supported" "build for every supported arch"
+	@printf "  \033[36m%-22s\033[0m %s\n" "all-latest" "build for the latest toolchains only"
 endif
-ifeq ($(SPKSRC_TREE),spk)
+ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
 	@printf "\n\033[1mPython wheels\033[0m\n"
-	@printf "  \033[36m%-20s\033[0m %s\n" "wheel" "build the Python wheels listed in WHEELS"
-	@printf "  \033[36m%-20s\033[0m %s\n" "download-wheels" "download the wheel sources only"
-	@printf "  \033[36m%-20s\033[0m %s\n" "crossenv" "build the cross-compilation Python venv"
-	@printf "  \033[36m%-20s\033[0m %s\n" "crossenv-install-<w>" "install one wheel into a named crossenv"
+	@printf "  \033[36m%-22s\033[0m %s\n" "wheel" "build the Python wheels listed in WHEELS"
+	@printf "  \033[36m%-22s\033[0m %s\n" "download-wheels" "download the wheel sources only"
+	@printf "  \033[36m%-22s\033[0m %s\n" "crossenv" "build the cross-compilation Python venv"
+	@printf "  \033[36m%-22s\033[0m %s\n" "crossenv-install-<w>" "install one wheel into a named crossenv"
+endif
 endif
 	@printf "\n\033[1mInspect\033[0m\n"
-	@printf "  \033[36m%-20s\033[0m %s\n" "dependency-tree" "print the resolved dependency graph"
+	@printf "  \033[36m%-22s\033[0m %s\n" "dependency-tree" "print the resolved dependency graph"
+	@printf "  \033[36m%-22s\033[0m %s\n" "dependency-flat" "flat, de-duplicated dependency list"
+	@printf "  \033[36m%-22s\033[0m %s\n" "dependency-list" "raw per-package dependency list"
+ifneq ($(SPKSRC_TREE),python)
 	@printf "\n\033[1mMaintenance\033[0m\n"
-	@printf "  \033[36m%-20s\033[0m %s\n" "clean" "remove all work directories"
-	@printf "  \033[36m%-20s\033[0m %s\n" "smart-clean" "remove only this package's source and cookies"
-	@printf "  \033[36m%-20s\033[0m %s\n" "digests" "regenerate the digests file"
+	@printf "  \033[36m%-22s\033[0m %s\n" "clean" "remove all work directories"
+	@printf "  \033[36m%-22s\033[0m %s\n" "smart-clean" "remove this package's source and cookies (needs ARCH+TCVERSION)"
+	@printf "  \033[36m%-22s\033[0m %s\n" "digests" "regenerate the digests file"
+endif
 	@printf "\nRun \033[36mmake help\033[0m at the spksrc root for repo-wide targets (setup, ...)\n\n"
 
 endif

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -16,6 +16,10 @@ SPKSRC_HELP_MK := 1
 # Name of the directory that contains this package (cross / spk / native / ...).
 SPKSRC_TREE := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
 
+# Never activate at the repo root (the root Makefile has its own help), even if
+# the spksrc checkout happens to live under a parent directory named like a
+# package tree (e.g. /home/user/spk/spksrc).
+ifneq ($(CURDIR),$(BASEDIR))
 ifneq ($(filter $(SPKSRC_TREE),cross spk native toolchain toolkit kernel diyspk python),)
 
 # Build lifecycle steps; spk/cross/diyspk additionally generate a PLIST.
@@ -70,9 +74,10 @@ ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
 	  printf "  \033[36m%-24s\033[0m %s\n" "crossenv-<arch>-<tcvers>" "build the cross-compilation Python venv" ; \
 	  printf "  \033[36m%-24s\033[0m %s\n" "download-wheels" "download the wheel sources only" ; \
 	  printf "  \033[36m%-24s\033[0m %s\n" "wheelclean" "remove wheel build state (run before rebuilding)" ; \
-	  printf "  \033[36m%-24s\033[0m %s\n" "wheelcleancache" "also drop the shared wheel download cache" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "wheelcleancache" "remove the local pip cache only (work-*/pip)" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "wheelcleanall" "wheelclean + caches, incl. the shared distrib/pip" ; \
 	  printf "  \033[36m%-24s\033[0m %s\n" "crossenvclean" "remove the crossenv and wheel state" ; \
-	  printf "  \033[36m%-24s\033[0m %s\n" "crossenvcleanall" "remove the crossenv, wheels and cache" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "crossenvcleanall" "remove the crossenv, wheels and all caches" ; \
 	fi
 endif
 endif
@@ -90,6 +95,8 @@ ifneq ($(SPKSRC_TREE),python)
 	@printf "  \033[33m%s\033[0m\n" "  to refresh digests: make clean, delete the file in distrib/, then make digests"
 endif
 	@printf "\nRun \033[36mmake help\033[0m at the spksrc root for repo-wide targets (setup, ...)\n\n"
+
+endif
 
 endif
 

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -27,26 +27,35 @@ endif
 help:
 	@printf "\n\033[1m%s\033[0m  (%s package)\n" "$(or $(SPK_NAME),$(PKG_NAME),$(notdir $(CURDIR)))" "$(SPKSRC_TREE)"
 	@printf "\n\033[1mBuild\033[0m\n"
-	@printf "  \033[36m%-14s\033[0m %s\n" "all" "build this package (default)"
+	@printf "  \033[36m%-20s\033[0m %s\n" "all" "build this package (default)"
 ifneq ($(filter $(SPKSRC_TREE),cross spk native),)
-	@printf "  \033[36m%-14s\033[0m %s\n" "<step>" "run one build step, in order:"
-	@printf "  %-14s   %s\n" "" "$(HELP_STEPS)"
+	@printf "  \033[36m%-20s\033[0m %s\n" "<step>" "run one build step, in order:"
+	@printf "  %-20s   %s\n" "" "$(HELP_STEPS)"
 endif
 ifneq ($(filter $(SPKSRC_TREE),cross spk),)
 	@printf "\n\033[1mMulti-arch\033[0m\n"
-	@printf "  \033[36m%-14s\033[0m %s\n" "arch-<arch>" "build one arch (e.g. arch-x64-7.1)"
-	@printf "  \033[36m%-14s\033[0m %s\n" "all-supported" "build every supported arch"
-	@printf "  \033[36m%-14s\033[0m %s\n" "all-latest" "build the latest toolchains only"
-	@printf "  \033[36m%-14s\033[0m %s\n" "supported" "list the supported arch-version pairs"
-	@printf "  \033[36m%-14s\033[0m %s\n" "latest" "list the latest arch-version pairs"
+	@printf "  \033[36m%-20s\033[0m %s\n" "arch-<arch>-<tcvers>" "build one arch/version (e.g. arch-x64-7.1)"
+	@printf "  \033[36m%-20s\033[0m %s\n" "all-supported" "build every supported arch"
+	@printf "  \033[36m%-20s\033[0m %s\n" "all-latest" "build the latest toolchains only"
+	@printf "  \033[36m%-20s\033[0m %s\n" "supported" "list the supported arch-version pairs"
+	@printf "  \033[36m%-20s\033[0m %s\n" "latest" "list the latest arch-version pairs"
 	@printf "  \033[33m%s\033[0m\n" "  needs 'make setup' once at the spksrc root first"
 else ifeq ($(SPKSRC_TREE),native)
 	@printf "\n  \033[33m%s\033[0m\n" "host-native single build - no arch matrix"
 endif
+ifeq ($(SPKSRC_TREE),spk)
+	@printf "\n\033[1mPython wheels\033[0m\n"
+	@printf "  \033[36m%-20s\033[0m %s\n" "wheel" "build the Python wheels listed in WHEELS"
+	@printf "  \033[36m%-20s\033[0m %s\n" "download-wheels" "download the wheel sources only"
+	@printf "  \033[36m%-20s\033[0m %s\n" "crossenv" "build the cross-compilation Python venv"
+	@printf "  \033[36m%-20s\033[0m %s\n" "crossenv-install-<w>" "install one wheel into a named crossenv"
+endif
+	@printf "\n\033[1mInspect\033[0m\n"
+	@printf "  \033[36m%-20s\033[0m %s\n" "dependency-tree" "print the resolved dependency graph"
 	@printf "\n\033[1mMaintenance\033[0m\n"
-	@printf "  \033[36m%-14s\033[0m %s\n" "clean" "remove all work directories"
-	@printf "  \033[36m%-14s\033[0m %s\n" "smart-clean" "remove only this package's source and cookies"
-	@printf "  \033[36m%-14s\033[0m %s\n" "digests" "regenerate the digests file"
+	@printf "  \033[36m%-20s\033[0m %s\n" "clean" "remove all work directories"
+	@printf "  \033[36m%-20s\033[0m %s\n" "smart-clean" "remove only this package's source and cookies"
+	@printf "  \033[36m%-20s\033[0m %s\n" "digests" "regenerate the digests file"
 	@printf "\nRun \033[36mmake help\033[0m at the spksrc root for repo-wide targets (setup, ...)\n\n"
 
 endif

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -58,6 +58,10 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 	@printf "\n\033[1mMulti-arch\033[0m  (needs 'make setup' once at the spksrc root first)\n"
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-supported" "build for every supported arch"
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-latest" "build for the latest toolchains only"
+ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
+	@printf "  \033[36m%-24s\033[0m %s\n" "publish-all-supported" "build and publish every supported arch (needs PUBLISH_URL/PUBLISH_API_KEY)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "publish-all-latest" "build and publish the latest toolchains only"
+endif
 endif
 ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
 	@if [ -n "$(HELP_PYTHON)" ]; then \

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -76,11 +76,13 @@ endif
 	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-flat" "flat, de-duplicated dependency list"
 	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-list" "raw per-package dependency list"
 ifneq ($(SPKSRC_TREE),python)
-	@printf "\n\033[1mMaintenance\033[0m\n"
-	@printf "  \033[36m%-24s\033[0m %s\n" "download" "fetch the source archive(s)"
+	@printf "\n\033[1mCleanup\033[0m\n"
 	@printf "  \033[36m%-24s\033[0m %s\n" "clean" "remove all work directories"
 	@printf "  \033[36m%-24s\033[0m %s\n" "smart-clean" "remove this package's source and cookies (needs ARCH+TCVERSION)"
-	@printf "  \033[36m%-24s\033[0m %s\n" "digests" "regenerate the digests file"
+	@printf "\n\033[1mMaintenance\033[0m\n"
+	@printf "  \033[36m%-24s\033[0m %s\n" "download" "fetch the source archive(s)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "digests" "regenerate the digests file (auto-runs download)"
+	@printf "  \033[33m%s\033[0m\n" "  to refresh digests: make clean, delete the file in distrib/, then make digests"
 endif
 	@printf "\nRun \033[36mmake help\033[0m at the spksrc root for repo-wide targets (setup, ...)\n\n"
 

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -25,8 +25,9 @@ HELP_STEPS += plist
 endif
 
 # Python wheel targets apply to spk/diyspk packages that set PYTHON_PACKAGE or
-# are themselves a python3* package.
-HELP_PYTHON := $(strip $(PYTHON_PACKAGE))$(filter python3%,$(SPK_NAME) $(PKG_NAME))
+# are themselves a python3* package. Deferred (=) so it is evaluated when the
+# recipe runs: PYTHON_PACKAGE is often set *after* spksrc.common.mk is included.
+HELP_PYTHON = $(strip $(PYTHON_PACKAGE))$(filter python3%,$(SPK_NAME) $(PKG_NAME))
 
 .PHONY: help
 help:
@@ -58,14 +59,16 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-latest" "build for the latest toolchains only"
 endif
 ifneq ($(filter $(SPKSRC_TREE),spk diyspk),)
-ifneq ($(HELP_PYTHON),)
-	@printf "\n\033[1mPython wheels\033[0m  (set WHEELS=\"pkg==ver\" to (re)build a single wheel on demand)\n"
-	@printf "  \033[36m%-24s\033[0m %s\n" "wheel-<arch>-<tcvers>" "build the package's wheels for one arch"
-	@printf "  \033[36m%-24s\033[0m %s\n" "crossenv-<arch>-<tcvers>" "build the cross-compilation Python venv"
-	@printf "  \033[36m%-24s\033[0m %s\n" "download-wheels" "download the wheel sources only"
-	@printf "  \033[36m%-24s\033[0m %s\n" "wheelclean" "remove wheel build state (run before rebuilding)"
-	@printf "  \033[36m%-24s\033[0m %s\n" "crossenvclean" "remove the crossenv and wheel state"
-endif
+	@if [ -n "$(HELP_PYTHON)" ]; then \
+	  printf "\n\033[1mPython wheels\033[0m  (WHEELS=\"pkg1==ver pkg2==ver ...\" restricts the (re)build to those wheels; unset rebuilds all of the package's wheels, or its default crossenv)\n" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "wheel-<arch>-<tcvers>" "build the package's wheels for one arch" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "crossenv-<arch>-<tcvers>" "build the cross-compilation Python venv" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "download-wheels" "download the wheel sources only" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "wheelclean" "remove wheel build state (run before rebuilding)" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "wheelcleancache" "also drop the shared wheel download cache" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "crossenvclean" "remove the crossenv and wheel state" ; \
+	  printf "  \033[36m%-24s\033[0m %s\n" "crossenvcleanall" "remove the crossenv, wheels and cache" ; \
+	fi
 endif
 endif
 	@printf "\n\033[1mInspect\033[0m\n"


### PR DESCRIPTION
## What

Make `make help` a first-class, **context-aware** entry point across spksrc.

### At the repository root
`make help` lists the orchestration targets grouped by section (General, Build, Clean, Prepare, Digests, Lint, Toolchain & kernel, Setup), plus the per-package pattern targets (`<spk>`, `spk-<spk>-<arch>-<tcversion>`, `native-<name>`, `toolchain-<arch>`, `kernel-<arch>`). `make help-<topic>` filters by section or name, e.g. `make help-clean`, `make help-toolchain`.

### Inside a package directory
`make help` prints the targets relevant to **that** context, for every tree: `cross/`, `spk/`, `diyspk/`, `native/`, `toolchain/`, `toolkit/`, `kernel/` and `python/`:

- **Build**: `all`, `arch-<arch>-<tcvers>` (cross/spk/kernel/diyspk), the `<step>` lifecycle (`download → checksum → extract → patch → configure → compile → install [→ plist]`), a reminder that `all` and every `<step>` except `download` need `ARCH`+`TCVERSION`, `tc_vars`/`tk_vars` (toolchain/toolkit) and the `rustup <args>` passthrough (e.g. `make rustup show`).
- **Multi-arch** (cross/spk/diyspk): `all-supported`, `all-latest`, plus `publish-all-supported` / `publish-all-latest` for spk/diyspk (after `make setup-synocommunity` + `PUBLISH_API_KEY`).
- **Python wheels** (spk/diyspk with `PYTHON_PACKAGE` or named `python3*`): `wheel-<arch>-<tcvers>`, `crossenv-<arch>-<tcvers>`, `download-wheels`, and the clean set `wheelclean` / `wheelcleancache` / `wheelcleanall` / `crossenvclean` / `crossenvcleanall`, with the `WHEELS="pkg==ver ..."` semantics in the header.
- **Inspect**: `dependency-tree` / `dependency-flat` / `dependency-list`.
- **Cleanup** / **Maintenance**: `clean`, `smart-clean`, `download`, `digests` (with a note that digests auto-runs download and how to force a refresh).
- **python/** tree: states the module is built as an spk dependency only, plus Inspect.

## How

- **Root** help (root `Makefile`) is generated from `##@ Section` headers and trailing `## description` comments — self-documenting, so it never drifts, and only documented targets appear (internal `pre_*`/`post_*`/`*_msg` hooks carry no `## ` and are hidden by construction). `help-<topic>` uses a `help-%` pattern rule so the topic is never mistaken for a build goal.
- **Package** help is a new `mk/spksrc.common/help.mk`, included by `spksrc.common.mk` **after** `default: all` so the help target can never become the default goal. It only activates when the parent directory is one of the known trees **and** `CURDIR != BASEDIR` (so a checkout living under a parent named e.g. `spk/` cannot shadow the root help). An include guard prevents "overriding recipe" warnings when `common.mk` is included more than once.
- `HELP_PYTHON` is a deferred (`=`) variable checked at recipe time, so the wheels section shows even when `PYTHON_PACKAGE` is set *after* `include spksrc.common.mk` (e.g. spk/borgbackup).

## Fixes folded in

- root `downloads` target looped over `dl` but invoked `make -C $${tc}` (empty variable) — broken loop, now fixed since help advertises it.
- docs aligned with the actual target inventory: `build-rules.md` (complete cross/spk tables, `arch-<arch>-<tcvers>` naming, python-wheel vs python-module include fix), `build-workflow.md` (make help note covering all trees), `python.md` (accurate wheel-clean target descriptions).

## Notes

- `make` with no target still builds `all`, at the root and in packages (verified: the help include is parsed after `default: all`).
- Verified in root, cross, spk, diyspk, native, toolchain, toolkit and python contexts.

### Example (inside `spk/borgbackup`)

```
borgbackup  (spk package)

Build
  all                      build this package (default target)
  arch-<arch>-<tcvers>     build for one arch/version (e.g. arch-x64-7.1)
  <step>                   run one build step, in order:
                             download checksum extract patch configure compile install plist
    all and every <step> except download need ARCH=<arch> TCVERSION=<tcvers>
  rustup <args>            run rustup for the rust toolchain (e.g. make rustup show)

Multi-arch  (needs 'make setup' once at the spksrc root first)
  all-supported            build for every supported arch
  all-latest               build for the latest toolchains only
  publish-all-supported    build and publish every supported arch (after 'make setup-synocommunity' + PUBLISH_API_KEY)
  publish-all-latest       build and publish the latest toolchains only

Python wheels  (WHEELS="pkg1==ver pkg2==ver ..." restricts the (re)build to those wheels; unset rebuilds all)
  wheel-<arch>-<tcvers>    build the package's wheels for one arch
  crossenv-<arch>-<tcvers> build the cross-compilation Python venv
  download-wheels          download the wheel sources only
  wheelclean               remove wheel build state (run before rebuilding)
  wheelcleancache          remove the local pip cache only (work-*/pip)
  wheelcleanall            wheelclean + caches, incl. the shared distrib/pip
  crossenvclean            remove the crossenv and wheel state
  crossenvcleanall         remove the crossenv, wheels and all caches

Inspect
  dependency-tree          print the resolved dependency graph
  dependency-flat          flat, de-duplicated dependency list
  dependency-list          raw per-package dependency list

Cleanup
  clean                    remove all work directories
  smart-clean              remove this package's source and cookies (needs ARCH+TCVERSION)

Maintenance
  download                 fetch the source archive(s)
  digests                  regenerate the digests file (auto-runs download)
    to refresh digests: make clean, delete the file in distrib/, then make digests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)