### PR TITLE
mk: don't pin build logs to the repo root

### DIFF
--- a/mk/spksrc.common/directories.mk
+++ b/mk/spksrc.common/directories.mk
@@ -36,7 +36,14 @@ endif
 
 ifndef LOG_DIR
 LOG_DIR = $(CURDIR)
+# Exported so that a package build's dependency sub-makes aggregate their logs
+# under the invoked package directory. Do NOT export at the repo root: the root
+# Makefile only orchestrates (it cd's into each package), so pinning LOG_DIR to
+# the root here would send every package's build logs to the repo root instead
+# of the package directory (build-<arch>.log, status-build.log, ...).
+ifneq ($(CURDIR),$(BASEDIR))
 export LOG_DIR
+endif
 endif
 
 ifndef INSTALL_DIR


### PR DESCRIPTION
## Problem

Running a per-package build from the spksrc root, e.g.:

```
make spk-python312-x64-6.2.4
```

drops `build-<arch>.log`, `status-build.log` and `build-native.log` into the **repo root**, where `git status` then shows them as untracked files. The logs also aggregate entries from deep dependency builds (zlib, sqlite, …) instead of staying under the package being built.

## Cause

In `mk/spksrc.common/directories.mk`:

```makefile
ifndef LOG_DIR
LOG_DIR = $(CURDIR)
export LOG_DIR
endif
```

`LOG_DIR` is **exported** and guarded by `ifndef`, so the *first* make process to evaluate it pins `LOG_DIR` to its own `$(CURDIR)` for every descendant. The root `Makefile` pulls in `spksrc.common.mk` (via `mk/spksrc.rules/tests.mk`), so evaluating it at the repo root sets and exports `LOG_DIR=<root>`. A recursive package build launched from the root then inherits that path.

This is preexisting on `master`.

## Fix

Only export `LOG_DIR` when not at the repo root (`CURDIR != BASEDIR`):

```makefile
ifndef LOG_DIR
LOG_DIR = $(CURDIR)
ifneq ($(CURDIR),$(BASEDIR))
export LOG_DIR
endif
endif
```

Package builds still export it, so a package's dependency sub-makes aggregate their logs under the invoked package directory (unchanged behaviour). The root orchestrator no longer pins it — each package computes its own `LOG_DIR`.

## Testing

`make spk-python312-aarch64-7.1` from the root:
- **before:** `build-aarch64-7.1.log`, `status-build.log`, `build-native.log` at the repo root
- **after:** all logs land under `spk/python312/`, repo root stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)