### PR TITLE
docs: Fix category filter and remove duplicate table

### DIFF
--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -108,49 +108,5 @@ function filterPkgTable() {
   });
 }
 </script>
-| [Adminer](adminer.md) | Web Apps | Database management |
-| [Aria2](aria2.md) | Downloads | Multi-protocol download utility |
-| [Beets](beets.md) | Media | Music library management |
-| [BorgBackup](borgbackup.md) | Backup | Deduplicating backup |
-| [Borgmatic](borgmatic.md) | Backup | BorgBackup automation |
-| [Cloudflared](cloudflared.md) | Network | Cloudflare Tunnel client |
-| [Comskip](comskip.md) | Media | Commercial detector for recorded TV |
-| [Deluge](deluge.md) | Downloads | Feature-rich BitTorrent client |
-| [DNSCrypt Proxy](dnscrypt-proxy.md) | Network | DNS encryption proxy |
-| [DSM Utilities](dsm-utilities.md) | Utilities | Helpful DSM configuration for packages |
-| [Duplicity](duplicity.md) | Backup | Encrypted bandwidth-efficient backup |
-| [FFmpeg](ffmpeg.md) | Media | Complete multimedia framework |
-| [File Browser](file-browser.md) | Web Apps | Web file browser |
-| [Flexget](flexget.md) | Media Management | Multipurpose automation |
-| [Git](git.md) | Development | Version control system |
-| [Google Authenticator](google-authenticator.md) | Security | PAM module for two-factor authentication |
-| [Home Assistant](homeassistant.md) | Home Automation | Home automation platform |
-| [Jellyfin](jellyfin.md) | Media Server | Media streaming server |
-| [Kiwix](kiwix.md) | Media Server | Offline Wikipedia and content server |
-| [Loom](loom.md) | Media Server | Federated and encrypted live streaming |
-| [MinIO](minio.md) | Storage | S3-compatible object storage |
-| [Mono](mono.md) | Runtime | .NET runtime |
-| [Mosh](mosh.md) | CLI | Mobile shell for intermittent connectivity |
-| [Mosquitto](mosquitto.md) | Home Automation | MQTT message broker |
-| [Mozilla Sync](mozilla-sync.md) | Web Apps | Firefox Sync server |
-| [Navidrome](navidrome.md) | Media Server | Music streaming server |
-| [Node Exporter](node-exporter.md) | Monitoring | Prometheus metrics exporter |
-| [ownCloud](owncloud.md) | Web Apps | File sync and share platform |
-| [Rclone](rclone.md) | Backup | Cloud storage sync tool |
-| [ruTorrent](rutorrent.md) | Downloads | Web-based BitTorrent client |
-| [Salt](salt.md) | Automation | Infrastructure automation |
-| [SickBeard Custom](sickbeard-custom.md) | Media Management | SickBeard fork selector (archived) |
-| [SynoCli Devel](synocli-devel.md) | CLI | Development tools |
-| [SynoCli Disk](synocli-disk.md) | CLI | Disk utilities |
-| [SynoCli File](synocli-file.md) | CLI | File management tools |
-| [SynoCli Kernel](synocli-kernel.md) | CLI | Kernel module management |
-| [SynoCli Misc](synocli-misc.md) | CLI | Miscellaneous utilities |
-| [SynoCli Monitor](synocli-monitor.md) | CLI | System monitoring tools |
-| [SynoCli Net](synocli-net.md) | CLI | Network utilities |
-| [SynoCli VideoDriver](synocli-videodriver.md) | CLI | Intel GPU drivers for hardware transcoding |
-| [SynoKernel USB Serial](synokernel-usbserial.md) | Kernel | USB serial adapter drivers |
-| [Syncthing](syncthing.md) | Sync | Continuous file synchronization |
-| [Transmission](transmission.md) | Downloads | Lightweight BitTorrent client |
-| [Vaultwarden](vaultwarden.md) | Security | Bitwarden-compatible password manager |
 
 For the most up-to-date list of packages, visit [synocommunity.com/packages](https://synocommunity.com/packages).

--- a/docs/reference/package-ports.md
+++ b/docs/reference/package-ports.md
@@ -122,7 +122,7 @@ The following ports are used by SynoCommunity packages.
 
 <script>
 function filterPortTable() {
-  var f = document.getElementById('catFilter').value.toLowerCase();
+  var f = document.getElementById('catFilter').value;
   var q = document.getElementById('portSearch').value.toLowerCase();
   document.querySelectorAll('#portTable tbody tr').forEach(function (r) {
     var okCat = !f || r.getAttribute('data-category') === f;


### PR DESCRIPTION
## Description

Follow-on fix for #7265.

### Changes

- Fix package ports category filter: dropdown selection now correctly filters rows (Title Case mismatch between `data-category` attributes and filter value)
- Remove duplicate documented packages table left over after the HTML/JS table migration (the old markdown table was rendering below the interactive table)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] This change requires a documentation update (e.g. Wiki)
