### PR TITLE
docs: Fix 404 links in package index table

### DIFF
--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -41,59 +41,60 @@ Packages with detailed documentation are linked below. For packages without dedi
   <input id="pkgSearch" type="text" placeholder="Search package…" oninput="filterPkgTable()" size="30">
 </p>
 
+<!-- href targets use mkdocs directory URLs (no .md extension) -->
 <table id="pkgTable" markdown="0">
   <thead>
     <tr><th>Package</th><th>Category</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr data-category="Network"><td><a href="adguardhome.md">AdGuard Home</a></td><td>Network</td><td>Network-wide ad blocking</td></tr>
-    <tr data-category="Web Apps"><td><a href="adminer.md">Adminer</a></td><td>Web Apps</td><td>Database management</td></tr>
-    <tr data-category="Downloads"><td><a href="aria2.md">Aria2</a></td><td>Downloads</td><td>Multi-protocol download utility</td></tr>
-    <tr data-category="Media"><td><a href="beets.md">Beets</a></td><td>Media</td><td>Music library management</td></tr>
-    <tr data-category="Web Apps"><td><a href="bicbucstriim.md">BicBucStriim</a></td><td>Web Apps</td><td>eBook server</td></tr>
-    <tr data-category="Backup"><td><a href="borgbackup.md">BorgBackup</a></td><td>Backup</td><td>Deduplicating backup</td></tr>
-    <tr data-category="Backup"><td><a href="borgmatic.md">Borgmatic</a></td><td>Backup</td><td>BorgBackup automation</td></tr>
-    <tr data-category="Network"><td><a href="cloudflared.md">Cloudflared</a></td><td>Network</td><td>Cloudflare Tunnel client</td></tr>
-    <tr data-category="Media"><td><a href="comskip.md">Comskip</a></td><td>Media</td><td>Commercial detector for recorded TV</td></tr>
-    <tr data-category="Downloads"><td><a href="deluge.md">Deluge</a></td><td>Downloads</td><td>Feature-rich BitTorrent client</td></tr>
-    <tr data-category="Network"><td><a href="dnscrypt-proxy.md">DNSCrypt Proxy</a></td><td>Network</td><td>DNS encryption proxy</td></tr>
-    <tr data-category="Utilities"><td><a href="dsm-utilities.md">DSM Utilities</a></td><td>Utilities</td><td>Helpful DSM configuration for packages</td></tr>
-    <tr data-category="Backup"><td><a href="duplicity.md">Duplicity</a></td><td>Backup</td><td>Encrypted bandwidth-efficient backup</td></tr>
-    <tr data-category="Media"><td><a href="ffmpeg.md">FFmpeg</a></td><td>Media</td><td>Complete multimedia framework</td></tr>
-    <tr data-category="Web Apps"><td><a href="file-browser.md">File Browser</a></td><td>Web Apps</td><td>Web file browser</td></tr>
-    <tr data-category="Media Management"><td><a href="flexget.md">Flexget</a></td><td>Media Management</td><td>Multipurpose automation</td></tr>
-    <tr data-category="Development"><td><a href="git.md">Git</a></td><td>Development</td><td>Version control system</td></tr>
-    <tr data-category="Security"><td><a href="google-authenticator.md">Google Authenticator</a></td><td>Security</td><td>PAM module for two-factor authentication</td></tr>
-    <tr data-category="Home Automation"><td><a href="homeassistant.md">Home Assistant</a></td><td>Home Automation</td><td>Home automation platform</td></tr>
-    <tr data-category="Media Server"><td><a href="jellyfin.md">Jellyfin</a></td><td>Media Server</td><td>Media streaming server</td></tr>
-    <tr data-category="Media Server"><td><a href="kiwix.md">Kiwix</a></td><td>Media Server</td><td>Offline Wikipedia and content server</td></tr>
-    <tr data-category="Media Server"><td><a href="loom.md">Loom</a></td><td>Media Server</td><td>Federated and encrypted live streaming</td></tr>
-    <tr data-category="Storage"><td><a href="minio.md">MinIO</a></td><td>Storage</td><td>S3-compatible object storage</td></tr>
-    <tr data-category="Runtime"><td><a href="mono.md">Mono</a></td><td>Runtime</td><td>.NET runtime</td></tr>
-    <tr data-category="CLI"><td><a href="mosh.md">Mosh</a></td><td>CLI</td><td>Mobile shell for intermittent connectivity</td></tr>
-    <tr data-category="Home Automation"><td><a href="mosquitto.md">Mosquitto</a></td><td>Home Automation</td><td>MQTT message broker</td></tr>
-    <tr data-category="Web Apps"><td><a href="mozilla-sync.md">Mozilla Sync</a></td><td>Web Apps</td><td>Firefox Sync server</td></tr>
-    <tr data-category="Media Server"><td><a href="navidrome.md">Navidrome</a></td><td>Media Server</td><td>Music streaming server</td></tr>
-    <tr data-category="Monitoring"><td><a href="node-exporter.md">Node Exporter</a></td><td>Monitoring</td><td>Prometheus metrics exporter</td></tr>
-    <tr data-category="Web Apps"><td><a href="openlist.md">OpenList</a></td><td>Web Apps</td><td>Web bookmark management</td></tr>
-    <tr data-category="Web Apps"><td><a href="owncloud.md">ownCloud</a></td><td>Web Apps</td><td>File sync and share platform</td></tr>
-    <tr data-category="Media Management"><td><a href="radarr-sonarr.md">Radarr/Sonarr</a></td><td>Media Management</td><td>Movie &amp; TV series management</td></tr>
-    <tr data-category="Backup"><td><a href="rclone.md">Rclone</a></td><td>Backup</td><td>Cloud storage sync tool</td></tr>
-    <tr data-category="Downloads"><td><a href="rutorrent.md">ruTorrent</a></td><td>Downloads</td><td>Web-based BitTorrent client</td></tr>
-    <tr data-category="Automation"><td><a href="salt.md">Salt</a></td><td>Automation</td><td>Infrastructure automation</td></tr>
-    <tr data-category="Media Management"><td><a href="sickbeard-custom.md">SickBeard Custom</a></td><td>Media Management</td><td>SickBeard fork selector (archived)</td></tr>
-    <tr data-category="Sync"><td><a href="syncthing.md">Syncthing</a></td><td>Sync</td><td>Continuous file synchronization</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-devel.md">SynoCli Devel</a></td><td>CLI</td><td>Development tools</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-disk.md">SynoCli Disk</a></td><td>CLI</td><td>Disk utilities</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-file.md">SynoCli File</a></td><td>CLI</td><td>File management tools</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-kernel.md">SynoCli Kernel</a></td><td>CLI</td><td>Kernel module management</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-misc.md">SynoCli Misc</a></td><td>CLI</td><td>Miscellaneous utilities</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-monitor.md">SynoCli Monitor</a></td><td>CLI</td><td>System monitoring tools</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-net.md">SynoCli Net</a></td><td>CLI</td><td>Network utilities</td></tr>
-    <tr data-category="CLI"><td><a href="synocli-videodriver.md">SynoCli VideoDriver</a></td><td>CLI</td><td>Intel GPU drivers for hardware transcoding</td></tr>
-    <tr data-category="Kernel"><td><a href="synokernel-usbserial.md">SynoKernel USB Serial</a></td><td>Kernel</td><td>USB serial adapter drivers</td></tr>
-    <tr data-category="Downloads"><td><a href="transmission.md">Transmission</a></td><td>Downloads</td><td>Lightweight BitTorrent client</td></tr>
-    <tr data-category="Security"><td><a href="vaultwarden.md">Vaultwarden</a></td><td>Security</td><td>Bitwarden-compatible password manager</td></tr>
+    <tr data-category="Network"><td><a href="adguardhome/">AdGuard Home</a></td><td>Network</td><td>Network-wide ad blocking</td></tr>
+    <tr data-category="Web Apps"><td><a href="adminer/">Adminer</a></td><td>Web Apps</td><td>Database management</td></tr>
+    <tr data-category="Downloads"><td><a href="aria2/">Aria2</a></td><td>Downloads</td><td>Multi-protocol download utility</td></tr>
+    <tr data-category="Media"><td><a href="beets/">Beets</a></td><td>Media</td><td>Music library management</td></tr>
+    <tr data-category="Web Apps"><td><a href="bicbucstriim/">BicBucStriim</a></td><td>Web Apps</td><td>eBook server</td></tr>
+    <tr data-category="Backup"><td><a href="borgbackup/">BorgBackup</a></td><td>Backup</td><td>Deduplicating backup</td></tr>
+    <tr data-category="Backup"><td><a href="borgmatic/">Borgmatic</a></td><td>Backup</td><td>BorgBackup automation</td></tr>
+    <tr data-category="Network"><td><a href="cloudflared/">Cloudflared</a></td><td>Network</td><td>Cloudflare Tunnel client</td></tr>
+    <tr data-category="Media"><td><a href="comskip/">Comskip</a></td><td>Media</td><td>Commercial detector for recorded TV</td></tr>
+    <tr data-category="Downloads"><td><a href="deluge/">Deluge</a></td><td>Downloads</td><td>Feature-rich BitTorrent client</td></tr>
+    <tr data-category="Network"><td><a href="dnscrypt-proxy/">DNSCrypt Proxy</a></td><td>Network</td><td>DNS encryption proxy</td></tr>
+    <tr data-category="Utilities"><td><a href="dsm-utilities/">DSM Utilities</a></td><td>Utilities</td><td>Helpful DSM configuration for packages</td></tr>
+    <tr data-category="Backup"><td><a href="duplicity/">Duplicity</a></td><td>Backup</td><td>Encrypted bandwidth-efficient backup</td></tr>
+    <tr data-category="Media"><td><a href="ffmpeg/">FFmpeg</a></td><td>Media</td><td>Complete multimedia framework</td></tr>
+    <tr data-category="Web Apps"><td><a href="file-browser/">File Browser</a></td><td>Web Apps</td><td>Web file browser</td></tr>
+    <tr data-category="Media Management"><td><a href="flexget/">Flexget</a></td><td>Media Management</td><td>Multipurpose automation</td></tr>
+    <tr data-category="Development"><td><a href="git/">Git</a></td><td>Development</td><td>Version control system</td></tr>
+    <tr data-category="Security"><td><a href="google-authenticator/">Google Authenticator</a></td><td>Security</td><td>PAM module for two-factor authentication</td></tr>
+    <tr data-category="Home Automation"><td><a href="homeassistant/">Home Assistant</a></td><td>Home Automation</td><td>Home automation platform</td></tr>
+    <tr data-category="Media Server"><td><a href="jellyfin/">Jellyfin</a></td><td>Media Server</td><td>Media streaming server</td></tr>
+    <tr data-category="Media Server"><td><a href="kiwix/">Kiwix</a></td><td>Media Server</td><td>Offline Wikipedia and content server</td></tr>
+    <tr data-category="Media Server"><td><a href="loom/">Loom</a></td><td>Media Server</td><td>Federated and encrypted live streaming</td></tr>
+    <tr data-category="Storage"><td><a href="minio/">MinIO</a></td><td>Storage</td><td>S3-compatible object storage</td></tr>
+    <tr data-category="Runtime"><td><a href="mono/">Mono</a></td><td>Runtime</td><td>.NET runtime</td></tr>
+    <tr data-category="CLI"><td><a href="mosh/">Mosh</a></td><td>CLI</td><td>Mobile shell for intermittent connectivity</td></tr>
+    <tr data-category="Home Automation"><td><a href="mosquitto/">Mosquitto</a></td><td>Home Automation</td><td>MQTT message broker</td></tr>
+    <tr data-category="Web Apps"><td><a href="mozilla-sync/">Mozilla Sync</a></td><td>Web Apps</td><td>Firefox Sync server</td></tr>
+    <tr data-category="Media Server"><td><a href="navidrome/">Navidrome</a></td><td>Media Server</td><td>Music streaming server</td></tr>
+    <tr data-category="Monitoring"><td><a href="node-exporter/">Node Exporter</a></td><td>Monitoring</td><td>Prometheus metrics exporter</td></tr>
+    <tr data-category="Web Apps"><td><a href="openlist/">OpenList</a></td><td>Web Apps</td><td>Web bookmark management</td></tr>
+    <tr data-category="Web Apps"><td><a href="owncloud/">ownCloud</a></td><td>Web Apps</td><td>File sync and share platform</td></tr>
+    <tr data-category="Media Management"><td><a href="radarr-sonarr/">Radarr/Sonarr</a></td><td>Media Management</td><td>Movie &amp; TV series management</td></tr>
+    <tr data-category="Backup"><td><a href="rclone/">Rclone</a></td><td>Backup</td><td>Cloud storage sync tool</td></tr>
+    <tr data-category="Downloads"><td><a href="rutorrent/">ruTorrent</a></td><td>Downloads</td><td>Web-based BitTorrent client</td></tr>
+    <tr data-category="Automation"><td><a href="salt/">Salt</a></td><td>Automation</td><td>Infrastructure automation</td></tr>
+    <tr data-category="Media Management"><td><a href="sickbeard-custom/">SickBeard Custom</a></td><td>Media Management</td><td>SickBeard fork selector (archived)</td></tr>
+    <tr data-category="Sync"><td><a href="syncthing/">Syncthing</a></td><td>Sync</td><td>Continuous file synchronization</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-devel/">SynoCli Devel</a></td><td>CLI</td><td>Development tools</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-disk/">SynoCli Disk</a></td><td>CLI</td><td>Disk utilities</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-file/">SynoCli File</a></td><td>CLI</td><td>File management tools</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-kernel/">SynoCli Kernel</a></td><td>CLI</td><td>Kernel module management</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-misc/">SynoCli Misc</a></td><td>CLI</td><td>Miscellaneous utilities</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-monitor/">SynoCli Monitor</a></td><td>CLI</td><td>System monitoring tools</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-net/">SynoCli Net</a></td><td>CLI</td><td>Network utilities</td></tr>
+    <tr data-category="CLI"><td><a href="synocli-videodriver/">SynoCli VideoDriver</a></td><td>CLI</td><td>Intel GPU drivers for hardware transcoding</td></tr>
+    <tr data-category="Kernel"><td><a href="synokernel-usbserial/">SynoKernel USB Serial</a></td><td>Kernel</td><td>USB serial adapter drivers</td></tr>
+    <tr data-category="Downloads"><td><a href="transmission/">Transmission</a></td><td>Downloads</td><td>Lightweight BitTorrent client</td></tr>
+    <tr data-category="Security"><td><a href="vaultwarden/">Vaultwarden</a></td><td>Security</td><td>Bitwarden-compatible password manager</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Description

Follow-on fix for #7265.

The documented packages table uses raw HTML (`<table markdown="0">`) which MkDocs does not rewrite during build. Links used `.md` extensions (e.g. `href="adguardhome.md"`), but the built site uses directory URLs (`/packages/adguardhome/`), resulting in 404s.

Changed all `href` targets to use directory URLs (e.g. `href="adguardhome/"`), which resolve correctly on the live site. Added an HTML comment above the table to document the convention.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] This change requires a documentation update (e.g. Wiki)
