### PR TITLE
ci: constrain the build concurrency group to draft PRs only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,14 +105,18 @@ env:
   BUILD_BUDGET_SECONDS: "20700"
 
 # Cancel a previous, now-superseded run only while a pull request is still a
-# Draft, so iterative pushes during development don't pile up. Non-draft PR
-# builds and master/push builds are never cancelled — every merged commit keeps
-# its own build result on master — and workflow_dispatch (manual build &
-# publish) is never cancelled either. The event_name is part of the group so
-# push, pull_request and workflow_dispatch runs never cancel one another.
+# Draft, so iterative pushes during development don't pile up. Every other run
+# (non-draft PR, master/push, manual workflow_dispatch) gets a unique per-run
+# group: a shared concurrency group always constrains — at most one running
+# plus one pending run, with older pending runs evicted — even when
+# cancel-in-progress is false, which would serialize non-draft PR builds,
+# silently drop queued master builds and forbid parallel manual builds.
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+  group: >-
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.draft
+        && format('build-{0}-{1}', github.workflow, github.ref)
+        || format('build-run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
 
 jobs:
   # Decide whether the build should run at all. Upstream events (pull_request,


### PR DESCRIPTION
## Description

Follow-up to #7238, fixing the regressions reported by @hgy59 in https://github.com/SynoCommunity/spksrc/pull/7238#issuecomment-4905809786: the concurrency rule ended up applying to **all** branches, serializing builds and preventing parallel manual builds.

Root cause: a shared GitHub Actions concurrency group always constrains runs — at most one *running* plus one *pending* run per group, with the older pending run evicted by a newer one — **even when `cancel-in-progress` is `false`**. So the group introduced by #7238:

- serialized non-draft PR builds (a new push waited for the previous run to finish);
- could silently drop queued master builds when merges overlap (the evicted pending run is cancelled → that commit never gets built);
- prevented running manual `workflow_dispatch` builds in parallel (all manual runs on master shared one group, regardless of package).

Fix: only ever share a concurrency group between runs of a **still-Draft pull request** (where cancelling the superseded run is the intended behavior). Every other run — non-draft PR, master/push, manual dispatch — gets a unique per-run group keyed on `run_id`, i.e. no queuing, no eviction, unlimited parallel runs, identical to the pre-#7238 behavior.

```yaml
concurrency:
  group: >-
    ${{ github.event_name == 'pull_request' && github.event.pull_request.draft
        && format('build-{0}-{1}', github.workflow, github.ref)
        || format('build-run-{0}', github.run_id) }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
```

The other half of #7238 (fork push builds skipped while a draft PR is open, via the `gate` job) is unaffected and keeps working as designed.

## Checklist

- [x] YAML validated; expression logic checked for the three event types (draft PR → shared group + cancel; non-draft PR / push / workflow_dispatch → unique group, never cancelled)

### Type of change

- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [x] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
