### PR TITLE
libplacebo: find vk.xml in the videodriver staging on DSM 7.2 (fix #7260 regression)

### DIFF
--- a/cross/libplacebo/Makefile
+++ b/cross/libplacebo/Makefile
@@ -16,6 +16,16 @@ DEPENDS += cross/Khronos-Vulkan-Tools
 DEPENDS += cross/shaderc
 
 CONFIGURE_ARGS += -Dopengl=disabled
-CONFIGURE_ARGS += -Dvulkan-registry=$(STAGING_INSTALL_PREFIX)/share/vulkan/registry/vk.xml
+
+# vk.xml is installed by cross/Khronos-Vulkan-Headers. When libplacebo is built
+# as part of a videodriver meta consumer (e.g. ffmpeg on DSM 7.2, where GCC>=12
+# enables libplacebo), Vulkan-Headers is shared through the meta build cookies
+# and only installed into the videodriver staging, not libplacebo's own — so
+# look there as well. The local staging takes precedence for standalone builds.
+# (evaluated when CONFIGURE_ARGS is expanded at configure time, i.e. after depend)
+VULKAN_REGISTRY = $(firstword $(wildcard \
+	$(STAGING_INSTALL_PREFIX)/share/vulkan/registry/vk.xml \
+	$(VIDEODRV_STAGING_INSTALL_PREFIX)/share/vulkan/registry/vk.xml))
+CONFIGURE_ARGS += -Dvulkan-registry=$(VULKAN_REGISTRY)
 
 include ../../mk/spksrc.cross-meson.mk


### PR DESCRIPTION
## Description

Fixes a DSM 7.2 build regression introduced by #7260.

Since #7260 moved `libplacebo` out of `synocli-videodriver` into the `ffmpeg*` packages, its meson build fails on DSM 7.2 (where GCC >= 12 enables libplacebo) with:

```
FileNotFoundError: .../ffmpeg8/target/share/vulkan/registry/vk.xml
while executing ['.../src/vulkan/utils_gen.py', ...]
FAILED: src/vulkan/utils_gen.c
```

`vk.xml` is installed by `cross/Khronos-Vulkan-Headers`. The videodriver meta shares that dependency through its build-status cookies, so the consuming `ffmpeg` package sees Vulkan-Headers as already built and **skips installing it into its own staging** — the registry file only exists in the videodriver staging, while libplacebo looked for it under its own `$(STAGING_INSTALL_PREFIX)`.

Resolve `-Dvulkan-registry` against **both** stagings, local first:

```make
VULKAN_REGISTRY = $(firstword $(wildcard \
	$(STAGING_INSTALL_PREFIX)/share/vulkan/registry/vk.xml \
	$(VIDEODRV_STAGING_INSTALL_PREFIX)/share/vulkan/registry/vk.xml))
CONFIGURE_ARGS += -Dvulkan-registry=$(VULKAN_REGISTRY)
```

- **meta consumer build** (ffmpeg on 7.2): the local copy is skipped, so it falls back to the videodriver staging where the file actually lives — exactly where ffmpeg already gets its Vulkan headers and libs from.
- **standalone `cross/libplacebo` build** (no meta, `VIDEODRV_STAGING_INSTALL_PREFIX` empty): Vulkan-Headers is built into the local staging and the local path is used.

Evaluated at configure time (after `depend`), so the `$(wildcard)` reflects which staging actually holds the file. The single `cross/libplacebo` is shared by ffmpeg6/7/8, so this one change covers all three.

Only DSM 7.2+ is affected (on 7.1 the toolchain GCC is 8.5 < 12 and libplacebo is not built).

## Checklist

- [x] Make expansion of the registry path verified across the three cases (local only / videodriver only / both)
- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully

### Type of change

- [x] Bug fix
- [ ] New Package
- [ ] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
