### PR TITLE
ffmpeg/videodriver: docs refresh, DESCRIPTION URL, and vainfo tools on DSM 6.2.4

### DIFF
--- a/docs/packages/ffmpeg.md
+++ b/docs/packages/ffmpeg.md
@@ -15,19 +15,23 @@ FFmpeg provides a set of command line tools to process audio and video media fil
 Commands are located in `/usr/local/ffmpeg<version>/bin` and libraries are required by
 other packages. In DSM 7.0+, they are located in `/volume1/@appstore/ffmpeg<version>/bin`.
 
-Symbolic links are made available through `/usr/local/bin` where the latest installed version becomes the default:
+Versioned symbolic links are made available through `/usr/local/bin`, one pair per installed version (no unversioned `ffmpeg`/`ffprobe` link):
 
-- `ffmpeg4`
-- `ffmpeg5`
-- `ffmpeg6`
-- `ffmpeg7`
-- `ffmpeg` → Last installed version
+- `ffmpeg4`, `ffmpeg5`, `ffmpeg6`, `ffmpeg7`, `ffmpeg8`
+- `ffprobe4`, `ffprobe5`, `ffprobe6`, `ffprobe7`, `ffprobe8`
+
+```bash
+ls -l /usr/local/bin/ff*
+# ffmpeg8  -> /var/packages/ffmpeg8/target/bin/ffmpeg8
+# ffprobe8 -> /var/packages/ffmpeg8/target/bin/ffprobe8
+# ...
+```
 
 ## Package Information
 
 | Property | Value |
 |----------|-------|
-| Package Name | ffmpeg4, ffmpeg5, ffmpeg6, ffmpeg7 |
+| Package Name | ffmpeg4, ffmpeg5, ffmpeg6, ffmpeg7, ffmpeg8 |
 | Upstream | [ffmpeg.org](https://ffmpeg.org/) |
 | License | LGPL/GPL |
 
@@ -192,20 +196,54 @@ This confirms OpenCL runtime and GPU compute path are operational.
 
 ### Vulkan Acceleration
 
-Vulkan may work on Synology models using a 5.10 kernel or newer using <https://github.com/007revad/Transcode_for_x25>.
+FFmpeg's Vulkan filters (`libplacebo`, `scale_vulkan`, `overlay_vulkan`, ...) run
+on the Vulkan device provided by the [SynoCli Video Driver](synocli-videodriver.md)
+(Mesa `anv`). Whether they are **runtime-usable** depends on the Synology **kernel**,
+and there are two distinct failure tiers.
 
-Vulkan fails on older Synology models:
+**Tier 1 — Vulkan does not initialize at all (oldest models):**
 ```bash
 /var/packages/synocli-videodriver/target/bin/vulkaninfo
 # ERROR: VK_ERROR_INITIALIZATION_FAILED
-```
 
-FFmpeg Vulkan initialization failure on older models:
-```bash
-ffmpeg7 -hide_banner -v verbose -init_hw_device vulkan
+ffmpeg8 -hide_banner -v verbose -init_hw_device vulkan
 # [AVHWDeviceContext @ ...] Device creation failure: VK_ERROR_INITIALIZATION_FAILED
 # Failed to set value 'vulkan' for option 'init_hw_device'
 ```
+
+**Tier 2 — Vulkan initializes, but filters fail (e.g. DS918+, Apollo Lake, DSM kernel 4.4.302+):**
+
+Here `vulkaninfo` sees the GPU and `ffmpeg -init_hw_device vulkan` succeeds, but any
+filter that uploads a frame to the GPU fails, because FFmpeg needs to export an
+**external Vulkan semaphore** for CPU↔GPU synchronization and the 4.4 kernel does not
+provide the required support (DRM `syncobj` / `sync_file` timeline export):
+
+```bash
+export VK_ICD_FILENAMES=/var/packages/synocli-videodriver/target/etc/vulkan/icd.d/intel_icd.x86_64.json
+vulkaninfo --summary        # OK: GPU0 = Intel(R) HD Graphics 500 (APL 2), Mesa anv 23.3.6
+
+ffmpeg8 -init_hw_device vulkan=vk:0 -filter_hw_device vk \
+  -f lavfi -i testsrc=size=1920x1080:rate=25:duration=3 \
+  -vf "format=yuv420p,hwupload,libplacebo=w=1280:h=720,hwdownload,format=yuv420p" -f null -
+# Failed to create semaphore: VK_ERROR_INVALID_EXTERNAL_HANDLE
+# [Parsed_hwupload_1] Failed to configure output pad on Parsed_hwupload_1
+# Error reinitializing filters!
+```
+
+This is a platform/kernel limitation, not a packaging issue: `libplacebo` is built and
+loadable (`ffmpeg8 -buildconf | grep libplacebo`), but the Vulkan frame pipeline cannot
+run. It affects **all** Vulkan filters, not just `libplacebo`.
+
+!!! note "It may work on newer Synology models"
+    Models shipping a newer kernel (5.10+, e.g. via
+    <https://github.com/007revad/Transcode_for_x25>) may expose the external-semaphore
+    support that the Vulkan filters need. If Vulkan filtering works on your NAS, please
+    [open an issue on spksrc](https://github.com/SynoCommunity/spksrc/issues) with your
+    model, DSM version, `uname -r` and the `ffmpeg ... libplacebo ...` result so we can
+    document the working configurations.
+
+For a functional HDR→SDR / GPU filtering path on current Synology kernels, use **OpenCL**
+(`tonemap_opencl`, see above) or **VA-API**, which do not require external-semaphore export.
 
 ### Choosing an Acceleration Path
 

--- a/mk/spksrc.spk-meta/videodriver.mk
+++ b/mk/spksrc.spk-meta/videodriver.mk
@@ -30,13 +30,13 @@ META_DEPENDS += $(VIDEODRV_DEPENDS)
 OPTIONAL_DEPENDS += $(VIDEODRV_OPTIONAL_DEPENDS)
 
 # Ship the GPU diagnostic tools with every DIRECT videodriver consumer
-# (x64, DSM 7.1+ — the only targets the tools package exists for). Indirect
-# consumers (videodriver via the ffmpeg rpath) rely on the ffmpeg chain,
-# and the tools package itself must not depend on itself.
+# (x64, DSM 6.2.4+ — where the tools package exists; on 6.2.4 it provides
+# vainfo only). Indirect consumers (videodriver via the ffmpeg rpath) rely
+# on the ffmpeg chain, and the tools package itself must not depend on itself.
 VIDEODRV_TOOLS_PACKAGE = synocli-videodriver-tools
 ifeq ($(strip $(VIDEODRV_INDIRECT_DEPENDS)),)
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
-ifeq ($(call version_ge, $(TCVERSION), 7.1),1)
+ifeq ($(call version_ge, $(TCVERSION), 6.2.4),1)
 ifneq ($(SPK_NAME),$(VIDEODRV_TOOLS_PACKAGE))
 SPK_DEPENDS := $(if $(strip $(SPK_DEPENDS)),$(SPK_DEPENDS):$(VIDEODRV_TOOLS_PACKAGE),$(VIDEODRV_TOOLS_PACKAGE))
 endif

--- a/spk/ffmpeg4/Makefile
+++ b/spk/ffmpeg4/Makefile
@@ -9,8 +9,8 @@ DEPENDS = cross/ffmpeg4
 VIDEODRV_PACKAGE = synocli-videodriver
 
 MAINTAINER = th0ma7
-DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
-DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
+DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/
+DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://docs.synocommunity.com/packages/ffmpeg/
 DISPLAY_NAME = FFmpeg $(firstword $(subst ., ,$(SPK_VERS)))
 STARTABLE = no
 

--- a/spk/ffmpeg5/Makefile
+++ b/spk/ffmpeg5/Makefile
@@ -12,8 +12,8 @@ VIDEODRV_PACKAGE = synocli-videodriver
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(OLD_PPC_ARCHS)
 
 MAINTAINER = th0ma7
-DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
-DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
+DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/
+DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://docs.synocommunity.com/packages/ffmpeg/
 DISPLAY_NAME = FFmpeg $(firstword $(subst ., ,$(SPK_VERS)))
 STARTABLE = no
 

--- a/spk/ffmpeg6/Makefile
+++ b/spk/ffmpeg6/Makefile
@@ -12,8 +12,8 @@ VIDEODRV_PACKAGE = synocli-videodriver
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(OLD_PPC_ARCHS)
 
 MAINTAINER = th0ma7
-DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
-DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
+DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/
+DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://docs.synocommunity.com/packages/ffmpeg/
 DISPLAY_NAME = FFmpeg $(firstword $(subst ., ,$(SPK_VERS)))
 STARTABLE = no
 

--- a/spk/ffmpeg7/Makefile
+++ b/spk/ffmpeg7/Makefile
@@ -12,8 +12,8 @@ VIDEODRV_PACKAGE = synocli-videodriver
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(OLD_PPC_ARCHS)
 
 MAINTAINER = th0ma7
-DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
-DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
+DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/
+DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://docs.synocommunity.com/packages/ffmpeg/
 DISPLAY_NAME = FFmpeg $(firstword $(subst ., ,$(SPK_VERS)))
 STARTABLE = no
 

--- a/spk/ffmpeg8/Makefile
+++ b/spk/ffmpeg8/Makefile
@@ -12,8 +12,8 @@ VIDEODRV_PACKAGE = synocli-videodriver
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(OLD_PPC_ARCHS)
 
 MAINTAINER = th0ma7
-DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
-DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://github.com/SynoCommunity/spksrc/wiki/FAQ-FFmpeg
+DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/
+DESCRIPTION_FRE = FFmpeg est une solution complète multiplateforme pour enregistrer, convertir et diffuser du contenu audio et vidéo. Il comprend libavcodec - la principale bibliothèque de codecs audio/vidéo.  Informations additionnelles concernant le paquet FFmpeg de SynoCommunity disponibles à https://docs.synocommunity.com/packages/ffmpeg/
 DISPLAY_NAME = FFmpeg $(firstword $(subst ., ,$(SPK_VERS)))
 STARTABLE = no
 

--- a/spk/synocli-videodriver-tools/Makefile
+++ b/spk/synocli-videodriver-tools/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-videodriver-tools
 SPK_VERS = 1.0
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/SynoPackagegreen-videodriver.png
 
 MAINTAINER = th0ma7
@@ -11,7 +11,10 @@ STARTABLE = no
 HOMEPAGE = https://gitlab.freedesktop.org/drm/igt-gpu-tools
 LICENSE  = MIT license
 
-REQUIRED_MIN_DSM = 7.1
+# VA-API tools (vainfo) work wherever synocli-videodriver provides VA-API,
+# i.e. down to DSM 6.2.4; the OpenCL/Vulkan/igt tools need the newer Intel
+# stack (DSM 7.1+) and are gated below.
+REQUIRED_MIN_DSM = 6.2.4
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(ARMv7_ARCHS) $(ARMv7L_ARCHS) $(ARMv8_ARCHS) $(PPC_ARCHS) $(i686_ARCHS)
 
 SERVICE_USER = auto
@@ -20,16 +23,19 @@ VIDEODRIVER = on
 # Link against the synocli-videodriver core libraries
 VIDEODRV_PACKAGE = synocli-videodriver
 
-CHANGELOG = "1. Initial release: diagnostic and monitoring tools split out of synocli-videodriver."
+CHANGELOG  = "1. Initial release: diagnostic and monitoring tools split out of synocli-videodriver.<br/>"
+CHANGELOG += "2. Provide vainfo down to DSM 6.2.4 (VA-API); OpenCL/Vulkan/igt tools remain DSM 7.1+."
 
 include ../../mk/spksrc.common.mk
 
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
-ifeq ($(call version_gt, $(TC_GCC), 5),1)
 
-# VA-API
+# VA-API (available on all supported DSM, including 6.2.4)
 DEPENDS  = cross/libva-utils
 SPK_COMMANDS  = bin/vainfo
+
+# OpenCL / Vulkan / GPU tools require the newer Intel stack (DSM 7.1+, GCC > 5)
+ifeq ($(call version_gt, $(TC_GCC), 5),1)
 
 # OpenCL
 DEPENDS += cross/clinfo
@@ -49,6 +55,7 @@ DEPENDS += cross/intel-libvpl-tools
 SPK_COMMANDS += bin/vpl-inspect
 
 endif
+
 endif
 
 include ../../mk/spksrc.spk-meta.mk


### PR DESCRIPTION
## Description

Follow-ups to the ffmpeg / videodriver work (#7257, #7258, #7260, #7271), based on hardware testing on a **DS918+ (Apollo Lake, DSM 7.2, kernel 4.4.302+)**.

### 1. FFmpeg documentation (`docs/packages/ffmpeg.md`)

- **Vulkan section rewritten** around real test results. There are two failure tiers:
  - *Tier 1* (oldest models): Vulkan does not initialize (`VK_ERROR_INITIALIZATION_FAILED`).
  - *Tier 2* (e.g. DS918+): Vulkan **initializes** (`vulkaninfo` sees the GPU, `-init_hw_device vulkan` succeeds), but any Vulkan filter fails at `hwupload` with `VK_ERROR_INVALID_EXTERNAL_HANDLE` — FFmpeg needs to export an external Vulkan semaphore for CPU↔GPU sync and the 4.4 kernel does not provide it. This affects **all** Vulkan filters, not just `libplacebo`, and is a platform/kernel limitation (the build itself is fine).
  - Added a note that newer Synology kernels (5.10+) may work, inviting users to open an issue with their model / DSM / `uname -r` / result so working configs get documented.
  - Point to **OpenCL** / **VA-API** as the functional GPU paths on current Synology kernels.
- Fixed the `/usr/local/bin` symlink list: versioned `ffmpegN` **and** `ffprobeN`, no unversioned `ffmpeg` link (which no longer exists), and added **ffmpeg8** throughout.

### 2. `ffmpeg4/5/6/7/8` DESCRIPTION URL

Point the package DESCRIPTION (EN + FR) to the new documentation site
<https://docs.synocommunity.com/packages/ffmpeg/> instead of the old wiki FAQ page.

### 3. `synocli-videodriver-tools` on DSM 6.2.4

The tools package required DSM 7.1 and gated every tool behind `GCC>5`, so it did not exist on DSM 6.2.4 — even though `synocli-videodriver` provides VA-API there. Now:

- `REQUIRED_MIN_DSM = 6.2.4`
- `vainfo` (via `cross/libva-utils`, which already ships a `2.17` variant for older DSM) is available on all supported x64 DSM
- `clinfo` / `vulkaninfo` / `lsgpu` / `intel_gpu_top` / `vpl-inspect` stay gated on the newer Intel stack (DSM 7.1+)
- the consumer auto-dependency gate in `videodriver.mk` is lowered to match, so ffmpeg on 6.2.4 also ships `vainfo`; `SPK_REV = 2`

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [x] Vulkan / VA-API / OpenCL behaviour verified on DS918+ (Apollo Lake, DSM 7.2)
- [ ] `synocli-videodriver-tools` install verified on DSM 6.2.4

### Type of change

- [x] Bug fix
- [ ] New Package
- [x] Package update
- [x] Includes small framework changes
- [x] This change requires a documentation update (e.g. Wiki)
