### PR TITLE
mk: unify the build directory on BUILD_DIR

### DIFF
--- a/cross/chromaprint-fftw/Makefile
+++ b/cross/chromaprint-fftw/Makefile
@@ -17,7 +17,7 @@ DEPENDS = cross/fftw
 # compiler too old
 UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
-CMAKE_BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)
+BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)
 
 include ../../mk/spksrc.cross-cmake.mk
 

--- a/cross/glibc-2.28/Makefile
+++ b/cross/glibc-2.28/Makefile
@@ -15,9 +15,11 @@ GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.common.mk
 
-CONFIGURE_TARGET = glibc_configure_target
-COMPILE_TARGET = glibc_compile_taget
-INSTALL_TARGET = glibc_install_target
+# glibc must be built outside its source tree: opt in to an out-of-tree build.
+BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)-build
+
+# glibc sets its prefix at configure time, so install only needs DESTDIR.
+INSTALL_ARGS = install DESTDIR=$(INSTALL_DIR)
 
 CONFIGURE_ARGS  = --enable-shared
 CONFIGURE_ARGS += --enable-kernel=$(word 1,$(subst ., ,$(TC_KERNEL))).$(word 2,$(subst ., ,$(TC_KERNEL)))
@@ -33,16 +35,3 @@ CONFIGURE_ARGS += ac_cv_prog_MAKEINFO=false
 ADDITIONAL_CFLAGS = -O2
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: glibc_configure_target
-glibc_configure_target:
-	@mkdir $(WORK_DIR)/$(PKG_DIR)-build
-	$(RUN) && cd ../$(PKG_DIR)-build && env $(ENV) ../$(PKG_DIR)/configure $(REAL_CONFIGURE_ARGS)
-
-.PHONY: glibc_compile_taget
-glibc_compile_taget:
-	@$(RUN) && cd ../$(PKG_DIR)-build && env $(ENV) $(PSTAT_TIME) $(MAKE) $(COMPILE_ARGS)
-
-.PHONY: glibc_install_target
-glibc_install_target:
-	@$(RUN) && cd ../$(PKG_DIR)-build && env $(ENV) $(MAKE) install DESTDIR=$(INSTALL_DIR)

--- a/cross/glibc-latest/Makefile
+++ b/cross/glibc-latest/Makefile
@@ -15,9 +15,11 @@ GNU_CONFIGURE = 1
 
 include ../../mk/spksrc.common.mk
 
-CONFIGURE_TARGET = glibc_configure_target
-COMPILE_TARGET = glibc_compile_taget
-INSTALL_TARGET = glibc_install_target
+# glibc must be built outside its source tree: opt in to an out-of-tree build.
+BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)-build
+
+# glibc sets its prefix at configure time, so install only needs DESTDIR.
+INSTALL_ARGS = install DESTDIR=$(INSTALL_DIR)
 
 CONFIGURE_ARGS  = --enable-shared
 CONFIGURE_ARGS += --enable-kernel=$(word 1,$(subst ., ,$(TC_KERNEL))).$(word 2,$(subst ., ,$(TC_KERNEL)))
@@ -33,16 +35,3 @@ CONFIGURE_ARGS += ac_cv_prog_MAKEINFO=false
 ADDITIONAL_CFLAGS = -O2
 
 include ../../mk/spksrc.cross-cc.mk
-
-.PHONY: glibc_configure_target
-glibc_configure_target:
-	@mkdir $(WORK_DIR)/$(PKG_DIR)-build
-	@$(RUN) && cd ../$(PKG_DIR)-build && env $(ENV) ../$(PKG_DIR)/configure $(REAL_CONFIGURE_ARGS)
-
-.PHONY: glibc_compile_taget
-glibc_compile_taget:
-	@$(RUN) && cd ../$(PKG_DIR)-build && env $(ENV) $(PSTAT_TIME) $(MAKE) $(COMPILE_ARGS)
-
-.PHONY: glibc_install_target
-glibc_install_target:
-	@$(RUN) && cd ../$(PKG_DIR)-build && env $(ENV) $(MAKE) install DESTDIR=$(INSTALL_DIR)

--- a/cross/intel-graphics-compiler/Makefile
+++ b/cross/intel-graphics-compiler/Makefile
@@ -86,4 +86,4 @@ include ../../mk/spksrc.cross-cmake.mk
 
 # Requires access to:
 #   Build time (IGC/Release/CMCLTranslatorTool): 'CMCLTranslatorTool', 'elf_packager', 'vcb'
-ENV += PATH=$(CMAKE_BUILD_DIR)/IGC/$(CMAKE_BUILD_TYPE):$$PATH
+ENV += PATH=$(BUILD_DIR)/IGC/$(CMAKE_BUILD_TYPE):$$PATH

--- a/cross/jasper/Makefile
+++ b/cross/jasper/Makefile
@@ -21,6 +21,6 @@ CONFIGURE_ARGS += -DCMAKE_C_FLAGS_RELEASE="-O"
 # Avoid build dir within source:
 # The useof an in-source build is not officially supported and is 
 # therefore disallowed by default. 
-CMAKE_BUILD_DIR = $(abspath $(CMAKE_BASE_DIR)/../jasper.build)
+BUILD_DIR = $(abspath $(CMAKE_BASE_DIR)/../jasper.build)
 
 include ../../mk/spksrc.cross-cmake.mk

--- a/cross/llvm-140/Makefile
+++ b/cross/llvm-140/Makefile
@@ -22,7 +22,7 @@ DEPENDS = cross/zlib
 # -----------------------------------------------------------------------------
 # Directories
 # -----------------------------------------------------------------------------
-CMAKE_BUILD_DIR = $(WORK_DIR)/$(PKG_NAME).build
+BUILD_DIR = $(WORK_DIR)/$(PKG_NAME).build
 CMAKE_SOURCE_DIR = $(WORK_DIR)/llvm-project/llvm
 LLVM_BIN_DIR = $(abspath $(PWD)/../../native/llvm-14.0/work-native/install/usr/local/bin)
 

--- a/cross/mariadb-connector-c-3.3.11/Makefile
+++ b/cross/mariadb-connector-c-3.3.11/Makefile
@@ -71,8 +71,8 @@ include ../../mk/spksrc.cross-cmake.mk
 .PHONY: mariadb_post_install
 mariadb_post_install:
 	@cd $(WORK_DIR) && ln -s $(PKG_DIR) $(PKG_NAME)
-	install -m 755 -d $(CMAKE_BUILD_DIR)/NATIVE/bin
-	install -m 755 $(CURDIR)/mariadb_config $(CMAKE_BUILD_DIR)/NATIVE/bin
-	@sed -i -e 's%@STAGING_INSTALL_PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(CMAKE_BUILD_DIR)/NATIVE/bin/mariadb_config
-	@sed -i -e 's%@VERSION@%$(PKG_VERS)%g' $(CMAKE_BUILD_DIR)/NATIVE/bin/mariadb_config
-	@sed -i -e 's%@SOCKET@%$(MYSQL_DB_SOCKET)%g' $(CMAKE_BUILD_DIR)/NATIVE/bin/mariadb_config
+	install -m 755 -d $(BUILD_DIR)/NATIVE/bin
+	install -m 755 $(CURDIR)/mariadb_config $(BUILD_DIR)/NATIVE/bin
+	@sed -i -e 's%@STAGING_INSTALL_PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(BUILD_DIR)/NATIVE/bin/mariadb_config
+	@sed -i -e 's%@VERSION@%$(PKG_VERS)%g' $(BUILD_DIR)/NATIVE/bin/mariadb_config
+	@sed -i -e 's%@SOCKET@%$(MYSQL_DB_SOCKET)%g' $(BUILD_DIR)/NATIVE/bin/mariadb_config

--- a/cross/mariadb-connector-c-latest/Makefile
+++ b/cross/mariadb-connector-c-latest/Makefile
@@ -58,8 +58,8 @@ include ../../mk/spksrc.cross-cmake.mk
 .PHONY: mariadb_post_install
 mariadb_post_install:
 	@cd $(WORK_DIR) && ln -s $(PKG_DIR) $(PKG_NAME)
-	install -m 755 -d $(CMAKE_BUILD_DIR)/NATIVE/bin
-	install -m 755 $(CURDIR)/mariadb_config $(CMAKE_BUILD_DIR)/NATIVE/bin
-	@sed -i -e 's%@STAGING_INSTALL_PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(CMAKE_BUILD_DIR)/NATIVE/bin/mariadb_config
-	@sed -i -e 's%@VERSION@%$(PKG_VERS)%g' $(CMAKE_BUILD_DIR)/NATIVE/bin/mariadb_config
-	@sed -i -e 's%@SOCKET@%$(MYSQL_DB_SOCKET)%g' $(CMAKE_BUILD_DIR)/NATIVE/bin/mariadb_config
+	install -m 755 -d $(BUILD_DIR)/NATIVE/bin
+	install -m 755 $(CURDIR)/mariadb_config $(BUILD_DIR)/NATIVE/bin
+	@sed -i -e 's%@STAGING_INSTALL_PREFIX@%$(STAGING_INSTALL_PREFIX)%g' $(BUILD_DIR)/NATIVE/bin/mariadb_config
+	@sed -i -e 's%@VERSION@%$(PKG_VERS)%g' $(BUILD_DIR)/NATIVE/bin/mariadb_config
+	@sed -i -e 's%@SOCKET@%$(MYSQL_DB_SOCKET)%g' $(BUILD_DIR)/NATIVE/bin/mariadb_config

--- a/cross/netdata/Makefile
+++ b/cross/netdata/Makefile
@@ -67,11 +67,11 @@ netdata_compile:
 	fi
 	@$(MSG) Patching protobuf rules for native protoc
 	@PROTOC=$$(realpath $(WORK_DIR)/../../../native/protoc_33/work-native/bin/protoc 2>/dev/null); \
-	NINJA=$(CMAKE_BUILD_DIR)/build.ninja; \
+	NINJA=$(BUILD_DIR)/build.ninja; \
 	if [ -n "$$PROTOC" ] && [ -f "$$NINJA" ]; then \
 		sed -i "s|protobuf::protoc|$$PROTOC|g" $$NINJA; \
 		sed -i '/protoc/s|-I\([^ ]*\)/src/aclk/aclk-schemas[[:space:]]|-I\1/src/aclk/aclk-schemas/proto |g' $$NINJA; \
 		sed -i '/protoc/s|--cpp_out=\([^ ]*\)/src/aclk/aclk-schemas[[:space:]]|--cpp_out=\1/src/aclk/aclk-schemas/proto |g' $$NINJA; \
 		sed -i '/INCLUDES.*src\/aclk\/aclk-schemas/s|\(-I[^ ]*src/aclk/aclk-schemas\)\([[:space:]]\)|\1\2\1/proto\2|g' $$NINJA; \
 	fi
-	$(RUN) cmake --build $(CMAKE_BUILD_DIR) -j $(NCPUS)
+	$(RUN) cmake --build $(BUILD_DIR) -j $(NCPUS)

--- a/cross/umurmur/Makefile
+++ b/cross/umurmur/Makefile
@@ -24,4 +24,4 @@ include ../../mk/spksrc.cross-cmake.mk
 .PHONY: umurmur_install
 umurmur_install:
 	install -d -m 755 $(STAGING_INSTALL_PREFIX)/bin
-	install -m 755 $(CMAKE_BUILD_DIR)/bin/umurmurd $(STAGING_INSTALL_PREFIX)/bin
+	install -m 755 $(BUILD_DIR)/bin/umurmurd $(STAGING_INSTALL_PREFIX)/bin

--- a/cross/x265/Makefile
+++ b/cross/x265/Makefile
@@ -15,7 +15,7 @@ PRE_COMPILE_TARGET = x265_pre_compile
 CMAKE_SOURCE_DIR = source
 
 # Build directories for default, 12 and 10 bit depth
-CMAKE_BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)/buildAll
+BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)/buildAll
 CMAKE_BUILD_12B = $(WORK_DIR)/$(PKG_DIR)/build12bit
 CMAKE_BUILD_10B = $(WORK_DIR)/$(PKG_DIR)/build10bit
 
@@ -86,5 +86,5 @@ x265_pre_compile:
 	@$(RUN) ninja -C $(CMAKE_BUILD_12B)
 	@$(MSG) Build 10BIT libraries
 	@$(RUN) ninja -C $(CMAKE_BUILD_10B)
-	@$(RUN) ln -sf $(CMAKE_BUILD_12B)/libx265.a $(CMAKE_BUILD_DIR)/libx265_main12.a
-	@$(RUN) ln -sf $(CMAKE_BUILD_10B)/libx265.a $(CMAKE_BUILD_DIR)/libx265_main10.a
+	@$(RUN) ln -sf $(CMAKE_BUILD_12B)/libx265.a $(BUILD_DIR)/libx265_main12.a
+	@$(RUN) ln -sf $(CMAKE_BUILD_10B)/libx265.a $(BUILD_DIR)/libx265_main10.a

--- a/cross/znc/Makefile
+++ b/cross/znc/Makefile
@@ -89,11 +89,11 @@ znc_update_modules:
 .PHONY: znc_post_install
 znc_post_install:
 	@$(MSG) "Building extra modules"
-	@$(MSG) CMAKE_BUILD_DIR: $(CMAKE_BUILD_DIR)/znc-buildmod
-	@chmod +x $(CMAKE_BUILD_DIR)/znc-buildmod
+	@$(MSG) BUILD_DIR: $(BUILD_DIR)/znc-buildmod
+	@chmod +x $(BUILD_DIR)/znc-buildmod
 	@rm -fr $(WORK_DIR)/modules
 	@cp -R modules $(WORK_DIR)/
 	@$(RUN) sed -i 's|$(INSTALL_PREFIX)|$(STAGING_INSTALL_PREFIX)|g' $(STAGING_INSTALL_PREFIX)/share/znc/cmake/znc_internal.cmake
-	cd $(WORK_DIR)/modules && env $(ENV) sh -c 'CMAKE_PREFIX_PATH=$(STAGING_INSTALL_PREFIX) $(CMAKE_BUILD_DIR)/znc-buildmod $(EXTRA_MODULES)'
+	cd $(WORK_DIR)/modules && env $(ENV) sh -c 'CMAKE_PREFIX_PATH=$(STAGING_INSTALL_PREFIX) $(BUILD_DIR)/znc-buildmod $(EXTRA_MODULES)'
 	@$(RUN) sed -i 's|$(STAGING_INSTALL_PREFIX)|$(INSTALL_PREFIX)|g' $(STAGING_INSTALL_PREFIX)/share/znc/cmake/znc_internal.cmake
 	@install -m 644 $(WORK_DIR)/modules/*.so $(STAGING_INSTALL_PREFIX)/lib/znc/

--- a/docs/reference/makefile-reference.md
+++ b/docs/reference/makefile-reference.md
@@ -61,6 +61,7 @@ This is a comprehensive reference for all Makefile variables and targets in spks
 | `GNU_CONFIGURE` | 0 | Set to 1 to use autoconf |
 | `CONFIGURE_ARGS` | | Arguments for configure script |
 | `ADDITIONAL_CONFIGURE_ARGS` | | Extra args appended after `CONFIGURE_ARGS` (autotools / CMake / Meson); for the framework invocation only |
+| `BUILD_DIR` | | Opt-in out-of-tree build directory; unset builds in-source |
 | `PRE_CONFIGURE_TARGET` | | Target to run before configure |
 | `POST_CONFIGURE_TARGET` | | Target to run after configure |
 
@@ -70,6 +71,7 @@ This is a comprehensive reference for all Makefile variables and targets in spks
 |----------|---------|-------------|
 | `CMAKE_USE_TOOLCHAIN_FILE` | 1 | Use generated toolchain file |
 | `CONFIGURE_ARGS` | | Additional CMake arguments |
+| `BUILD_DIR` | `$(WORK_DIR)/$(PKG_DIR)/build` | Out-of-tree build directory |
 | `CMAKE_BUILD_TYPE` | Release | Build type |
 | `CMAKE_USE_NINJA` | | Build with Ninja instead of Make |
 | `CMAKE_USE_NASM` | | Build the native NASM assembler first |
@@ -81,6 +83,7 @@ This is a comprehensive reference for all Makefile variables and targets in spks
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CONFIGURE_ARGS` | | Meson options, passed to `meson setup` |
+| `BUILD_DIR` | `$(WORK_DIR)/$(PKG_DIR)/builddir` | Out-of-tree build directory |
 | `MESON_BUILD_TYPE` | release | Build type |
 
 ### Rust (Cargo)

--- a/mk/spksrc.build.mk
+++ b/mk/spksrc.build.mk
@@ -22,6 +22,20 @@
 #     themselves, so plist stays under spksrc.build/ as a build-pipeline step.
 ###############################################################################
 
+# Out-of-tree build directory support. cmake and meson always build in a
+# separate $(BUILD_DIR) (provided by their env files). The autotools / plain
+# GNU make path builds in-source by default and opts in to an out-of-tree build
+# by setting BUILD_DIR: the make steps then run from it via BUILD_RUN, with the
+# configure script invoked from the source tree. Empty BUILD_DIR keeps the
+# historical in-source build.
+ifneq ($(strip $(BUILD_DIR)),)
+BUILD_RUN        = cd $(BUILD_DIR) && env $(ENV)
+CONFIGURE_SCRIPT = $(WORK_DIR)/$(PKG_DIR)/configure
+else
+BUILD_RUN        = $(RUN)
+CONFIGURE_SCRIPT = ./configure
+endif
+
 include ../../mk/spksrc.build/download.mk
 
 checksum: download

--- a/mk/spksrc.build/compile.mk
+++ b/mk/spksrc.build/compile.mk
@@ -52,9 +52,9 @@ pre_compile_target: compile_msg
 
 compile_target:  $(PRE_COMPILE_TARGET)
 ifeq ($(filter $(NCPUS),0 1),)
-	@$(RUN) $(MAKE) $(if $(findstring -j,$(COMPILE_ARGS)),,-j$(NCPUS)) $(COMPILE_ARGS)
+	@$(BUILD_RUN) $(MAKE) $(if $(findstring -j,$(COMPILE_ARGS)),,-j$(NCPUS)) $(COMPILE_ARGS)
 else
-	@$(RUN) $(MAKE) $(COMPILE_ARGS)
+	@$(BUILD_RUN) $(MAKE) $(COMPILE_ARGS)
 endif
 
 

--- a/mk/spksrc.build/configure.mk
+++ b/mk/spksrc.build/configure.mk
@@ -71,7 +71,8 @@ configure_msg:
 pre_configure_target: configure_msg
 
 configure_target:  $(PRE_CONFIGURE_TARGET)
-	$(RUN) ./configure $(REAL_CONFIGURE_ARGS)
+	@test -z "$(BUILD_DIR)" || mkdir -p $(BUILD_DIR)
+	$(BUILD_RUN) $(CONFIGURE_SCRIPT) $(REAL_CONFIGURE_ARGS)
 
 post_configure_target: $(CONFIGURE_TARGET)
 

--- a/mk/spksrc.build/install.mk
+++ b/mk/spksrc.build/install.mk
@@ -85,11 +85,11 @@ $(PRE_INSTALL_PLIST):
 pre_install_target: install_msg_target $(PRE_INSTALL_PLIST)
 
 install_target: $(PRE_INSTALL_TARGET)
-	$(RUN) $(MAKE) $(INSTALL_ARGS)
+	$(BUILD_RUN) $(MAKE) $(INSTALL_ARGS)
 
 post_install_target: $(INSTALL_TARGET)
 ifeq ($(strip $(GCC_NO_DEBUG_INFO)),1)
-	$(RUN) $(MAKE) distclean
+	$(BUILD_RUN) $(MAKE) distclean
 endif
 
 $(INSTALL_PLIST):

--- a/mk/spksrc.build/ninja.mk
+++ b/mk/spksrc.build/ninja.mk
@@ -14,10 +14,7 @@ ENV += PKG_CONFIG=/usr/bin/pkg-config
 # CMake - begin
 ifeq ($(strip $(CMAKE_USE_NINJA)),1)
 
-# Set default build directory
-ifeq ($(strip $(NINJA_BUILD_DIR)),)
-NINJA_BUILD_DIR = $(CMAKE_BUILD_DIR)
-endif
+# BUILD_DIR is already provided by env-cmake.mk / env-meson.mk
 
 # set default use destdir
 ifeq ($(strip $(NINJA_USE_DESTDIR)),)
@@ -35,8 +32,7 @@ endif
 # Meson - begin (default)
 else
 
-# Set default build directory
-NINJA_BUILD_DIR = $(MESON_BUILD_DIR)
+# BUILD_DIR is already provided by env-meson.mk
 # set default use destdir
 NINJA_USE_DESTDIR = 1
 # set default destdir directory
@@ -69,11 +65,11 @@ endif
 # default ninja compile:
 ninja_compile_target:
 	@$(MSG) - Ninja compile
-	@$(MSG)    - Ninja build path = $(NINJA_BUILD_DIR)
+	@$(MSG)    - Ninja build path = $(BUILD_DIR)
 ifeq ($(strip $(CMAKE_USE_NINJA)),1)
 	@$(MSG)    - Use NASM = $(CMAKE_USE_NASM)
 endif
-	$(RUN) ninja -C $(NINJA_BUILD_DIR) $(COMPILE_ARGS)
+	$(RUN) ninja -C $(BUILD_DIR) $(COMPILE_ARGS)
 
 .PHONY: ninja_install_target
 
@@ -83,9 +79,9 @@ ninja_install_target:
 	@$(MSG)    - Ninja installation path = $(NINJA_DESTDIR)
 	@$(MSG)    - Ninja use DESTDIR = $(NINJA_USE_DESTDIR)
 ifeq ($(strip $(NINJA_USE_DESTDIR)),0)
-	$(RUN) ninja -C $(NINJA_BUILD_DIR) install $(INSTALL_ARGS)
+	$(RUN) ninja -C $(BUILD_DIR) install $(INSTALL_ARGS)
 else
-	$(RUN) DESTDIR=$(NINJA_DESTDIR) ninja -C $(NINJA_BUILD_DIR) install $(INSTALL_ARGS)
+	$(RUN) DESTDIR=$(NINJA_DESTDIR) ninja -C $(BUILD_DIR) install $(INSTALL_ARGS)
 endif
 
 .PHONY: ninja_post_install_target
@@ -93,6 +89,6 @@ endif
 # default ninja post-install: clean
 ninja_post_install_target:
 	@$(MSG) - Ninja post-install \(clean\)
-	-$(RUN) ninja -C $(NINJA_BUILD_DIR) clean || true
-	$(RUN) rm -f $(NINJA_BUILD_DIR)/build.ninja
-	$(RUN) rm -f $(NINJA_BUILD_DIR)/compile_commands.json
+	-$(RUN) ninja -C $(BUILD_DIR) clean || true
+	$(RUN) rm -f $(BUILD_DIR)/build.ninja
+	$(RUN) rm -f $(BUILD_DIR)/compile_commands.json

--- a/mk/spksrc.cross-cmake.mk
+++ b/mk/spksrc.cross-cmake.mk
@@ -89,17 +89,17 @@ cmake_configure_target: cmake_generate_toolchain_file
 	@$(MSG)    - Use DESTDIR = $(CMAKE_USE_DESTDIR)
 	@$(MSG)    - CMake = $(shell which cmake) [$(shell cmake --version | head -1 | awk '{print $$NF}')]
 	@$(MSG)    - Path DESTDIR = $(CMAKE_DESTDIR)
-	@$(MSG)    - Path BUILD_DIR = $(CMAKE_BUILD_DIR)
+	@$(MSG)    - Path BUILD_DIR = $(BUILD_DIR)
 	@$(MSG)    - Path CMAKE_SOURCE_DIR = $(CMAKE_SOURCE_DIR)
 	@$(RUN) rm -rf CMakeCache.txt CMakeFiles
-	$(RUN) cmake -S $(CMAKE_SOURCE_DIR) -B $(CMAKE_BUILD_DIR) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS) $(CMAKE_DIR)
+	$(RUN) cmake -S $(CMAKE_SOURCE_DIR) -B $(BUILD_DIR) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS) $(CMAKE_DIR)
 
 .PHONY: cmake_compile_target
 
 # default compile:
 cmake_compile_target:
 	@$(MSG) - CMake compile
-	$(RUN) cmake --build $(CMAKE_BUILD_DIR) -j $(NCPUS) $(COMPILE_ARGS)
+	$(RUN) cmake --build $(BUILD_DIR) -j $(NCPUS) $(COMPILE_ARGS)
 
 .PHONY: cmake_install_target
 
@@ -107,9 +107,9 @@ cmake_compile_target:
 cmake_install_target:
 	@$(MSG) - CMake install
 ifeq ($(strip $(CMAKE_USE_DESTDIR)),0)
-	$(RUN) cmake --install $(CMAKE_BUILD_DIR) $(INSTALL_ARGS)
+	$(RUN) cmake --install $(BUILD_DIR) $(INSTALL_ARGS)
 else
-	$(RUN) DESTDIR=$(CMAKE_DESTDIR) cmake --install $(CMAKE_BUILD_DIR) $(INSTALL_ARGS)
+	$(RUN) DESTDIR=$(CMAKE_DESTDIR) cmake --install $(BUILD_DIR) $(INSTALL_ARGS)
 endif
 
 .PHONY: cmake_post_install_target
@@ -118,7 +118,7 @@ endif
 # only called when GCC_NO_DEBUG_INFO=1
 cmake_post_install_target:
 	@$(MSG) - CMake post-install \(clean\)
-	$(RUN) cmake --build $(CMAKE_BUILD_DIR) --target clean
+	$(RUN) cmake --build $(BUILD_DIR) --target clean
 
 ###
 

--- a/mk/spksrc.cross-meson.mk
+++ b/mk/spksrc.cross-meson.mk
@@ -55,11 +55,11 @@ include ../../mk/spksrc.build/ninja.mk
 meson_configure_target: meson_generate_crossfile
 	@$(MSG) - Meson configure
 	@$(MSG)    - Dependencies = $(DEPENDS)
-	@$(MSG)    - Build path = $(MESON_BUILD_DIR)
+	@$(MSG)    - Build path = $(BUILD_DIR)
 	@$(MSG)    - Configure ARGS = $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
 	@$(MSG)    - Install prefix = $(INSTALL_PREFIX)
-	@$(MSG) meson setup $(MESON_BASE_DIR) $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
-	$(RUN) meson setup $(MESON_BASE_DIR) $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
+	@$(MSG) meson setup $(MESON_BASE_DIR) $(BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
+	$(RUN) meson setup $(MESON_BASE_DIR) $(BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
 
 ###
 

--- a/mk/spksrc.cross/cmake-toolchainfile.mk
+++ b/mk/spksrc.cross/cmake-toolchainfile.mk
@@ -8,7 +8,7 @@
 # Per-dependency configuration for CMake build
 CMAKE_TOOLCHAIN_FILE_NAME = $(ARCH)-toolchain.cmake
 CMAKE_TOOLCHAIN_FILE_WRK = $(WORK_DIR)/tc_vars.cmake
-CMAKE_TOOLCHAIN_FILE_PKG = $(CMAKE_BUILD_DIR)/$(CMAKE_TOOLCHAIN_FILE_NAME)
+CMAKE_TOOLCHAIN_FILE_PKG = $(BUILD_DIR)/$(CMAKE_TOOLCHAIN_FILE_NAME)
 
 
 ifeq ($(strip $(CMAKE_USE_TOOLCHAIN_FILE)),ON)
@@ -31,9 +31,9 @@ CMAKE_META_FIND_ROOTS = $(foreach d,$(META_PKG_CONFIG_LIBDIR),$(abspath $(patsub
 
 .PHONY: $(CMAKE_TOOLCHAIN_FILE_PKG)
 $(CMAKE_TOOLCHAIN_FILE_PKG):
-ifeq ($(wildcard $(CMAKE_BUILD_DIR)),)
-	@$(MSG) Creating CMake build directory: $(CMAKE_BUILD_DIR)
-	@mkdir --parents $(CMAKE_BUILD_DIR)
+ifeq ($(wildcard $(BUILD_DIR)),)
+	@$(MSG) Creating CMake build directory: $(BUILD_DIR)
+	@mkdir --parents $(BUILD_DIR)
 endif
 	@$(MSG) Generating $(CMAKE_TOOLCHAIN_FILE_PKG)
 	@env $(ENV) $(MAKE) --no-print-directory cmake_pkg_toolchain > $(CMAKE_TOOLCHAIN_FILE_PKG) 2>/dev/null;

--- a/mk/spksrc.cross/env-cmake.mk
+++ b/mk/spksrc.cross/env-cmake.mk
@@ -129,8 +129,8 @@ ifeq ($(strip $(CMAKE_BASE_DIR)),)
 endif
 
 # set default build directory
-ifeq ($(strip $(CMAKE_BUILD_DIR)),)
-  CMAKE_BUILD_DIR = $(CMAKE_BASE_DIR)/build
+ifeq ($(strip $(BUILD_DIR)),)
+  BUILD_DIR = $(CMAKE_BASE_DIR)/build
 endif
 
 # Define per arch specific common options

--- a/mk/spksrc.cross/env-meson.mk
+++ b/mk/spksrc.cross/env-meson.mk
@@ -15,8 +15,8 @@ MESON_BASE_DIR = $(WORK_DIR)/$(PKG_DIR)
 endif
 
 # Set default build directory
-ifeq ($(strip $(MESON_BUILD_DIR)),)
-MESON_BUILD_DIR = $(MESON_BASE_DIR)/builddir
+ifeq ($(strip $(BUILD_DIR)),)
+BUILD_DIR = $(MESON_BASE_DIR)/builddir
 endif
 
 # Set other build options

--- a/mk/spksrc.native-cmake.mk
+++ b/mk/spksrc.native-cmake.mk
@@ -70,18 +70,18 @@ cmake_configure_target:
 	@$(MSG)    - Use NASM = $(CMAKE_USE_NASM)
 	@$(MSG)    - Use DESTDIR = $(CMAKE_USE_DESTDIR)
 	@$(MSG)    - Path DESTDIR = $(CMAKE_DESTDIR)
-	@$(MSG)    - Path BUILD_DIR = $(CMAKE_BUILD_DIR)
+	@$(MSG)    - Path BUILD_DIR = $(BUILD_DIR)
 	@$(MSG)    - Path CMAKE_SOURCE_DIR = $(CMAKE_SOURCE_DIR)
 	$(RUN) rm -rf CMakeCache.txt CMakeFiles
-	$(RUN) mkdir --parents $(CMAKE_BUILD_DIR)
-	cd $(CMAKE_BUILD_DIR) && env $(ENV) cmake -S $(CMAKE_SOURCE_DIR) -B $(CMAKE_BUILD_DIR) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS) $(CMAKE_DIR)
+	$(RUN) mkdir --parents $(BUILD_DIR)
+	cd $(BUILD_DIR) && env $(ENV) cmake -S $(CMAKE_SOURCE_DIR) -B $(BUILD_DIR) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS) $(CMAKE_DIR)
 
 .PHONY: cmake_compile_target
 
 # default compile:
 cmake_compile_target:
 	@$(MSG) - CMake compile
-	env $(ENV) cmake --build $(CMAKE_BUILD_DIR) -j $(NCPUS) $(COMPILE_ARGS)
+	env $(ENV) cmake --build $(BUILD_DIR) -j $(NCPUS) $(COMPILE_ARGS)
 
 .PHONY: cmake_install_target
 
@@ -89,9 +89,9 @@ cmake_compile_target:
 cmake_install_target:
 	@$(MSG) - CMake install
 ifeq ($(strip $(CMAKE_USE_DESTDIR)),0)
-	cd $(CMAKE_BUILD_DIR) && env $(ENV) $(MAKE) install $(INSTALL_ARGS)
+	cd $(BUILD_DIR) && env $(ENV) $(MAKE) install $(INSTALL_ARGS)
 else
-	cd $(CMAKE_BUILD_DIR) && env $(ENV) $(MAKE) install DESTDIR=$(CMAKE_DESTDIR) $(INSTALL_ARGS)
+	cd $(BUILD_DIR) && env $(ENV) $(MAKE) install DESTDIR=$(CMAKE_DESTDIR) $(INSTALL_ARGS)
 endif
 
 #####

--- a/mk/spksrc.native-meson.mk
+++ b/mk/spksrc.native-meson.mk
@@ -52,10 +52,10 @@ include ../../mk/spksrc.build/ninja.mk
 meson_configure_target:
 	@$(MSG) - Meson configure
 	@$(MSG)    - Dependencies = $(DEPENDS)
-	@$(MSG)    - Build path = $(MESON_BUILD_DIR)
+	@$(MSG)    - Build path = $(BUILD_DIR)
 	@$(MSG)    - Configure ARGS = $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
 	@$(MSG)    - Install prefix = $(INSTALL_PREFIX)
-	cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV) meson $(MESON_BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
+	cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV) meson $(BUILD_DIR) -Dprefix=$(INSTALL_PREFIX) $(CONFIGURE_ARGS) $(ADDITIONAL_CONFIGURE_ARGS)
 
 #####
 

--- a/mk/spksrc.native/env-cmake.mk
+++ b/mk/spksrc.native/env-cmake.mk
@@ -63,6 +63,6 @@ ifeq ($(strip $(CMAKE_BASE_DIR)),)
 endif
 
 # set default build directory
-ifeq ($(strip $(CMAKE_BUILD_DIR)),)
-  CMAKE_BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)/build
+ifeq ($(strip $(BUILD_DIR)),)
+  BUILD_DIR = $(WORK_DIR)/$(PKG_DIR)/build
 endif

--- a/mk/spksrc.native/env-meson.mk
+++ b/mk/spksrc.native/env-meson.mk
@@ -9,8 +9,8 @@
 # COMPILE_ARGS / INSTALL_ARGS defaults are not applied to native meson builds.
 DEFAULT_ENV ?= meson
 
-ifeq ($(strip $(MESON_BUILD_DIR)),)
-MESON_BUILD_DIR = builddir
+ifeq ($(strip $(BUILD_DIR)),)
+BUILD_DIR = builddir
 endif
 
 # Set other build options

--- a/mk/spksrc.python-wheel-meson.mk
+++ b/mk/spksrc.python-wheel-meson.mk
@@ -98,7 +98,7 @@ build_meson_python_wheel:
 	   $$(which cross-python) -m build -w -n -x . \
 	   $(foreach arg,$(CONFIGURE_ARGS),-Csetup-args=\"$(arg)\" ) \
 	   $(foreach arg,$(INSTALL_ARGS),-Cinstall-args=\"$(arg)\" ) \
-	   -Cbuilddir=\"$(MESON_BUILD_DIR)\" \
+	   -Cbuilddir=\"$(BUILD_DIR)\" \
 	   --outdir $(WHEELHOUSE) \
 	   --verbose ; \
 	cd $(MESON_BASE_DIR) && env $(ENV_MESON) \
@@ -107,7 +107,7 @@ build_meson_python_wheel:
 	   $$(which cross-python) -m build -w -n -x . \
 	   $(foreach arg,$(CONFIGURE_ARGS),-Csetup-args="$(arg)" ) \
 	   $(foreach arg,$(INSTALL_ARGS),-Cinstall-args="$(arg)" ) \
-	   -Cbuilddir="$(MESON_BUILD_DIR)" \
+	   -Cbuilddir="$(BUILD_DIR)" \
 	   --outdir $(WHEELHOUSE) \
 	   --verbose ; \
 	} > >(tee --append $(WHEEL_LOG)) 2>&1 ; [ $${PIPESTATUS[0]} -eq 0 ] || false

--- a/native/llvm-140/Makefile
+++ b/native/llvm-140/Makefile
@@ -18,7 +18,7 @@ BUILD_DEPENDS += cross/llvm-project-140.src
 # -----------------------------------------------------------------------------
 # Directories
 # -----------------------------------------------------------------------------
-CMAKE_BUILD_DIR = $(WORK_DIR)/$(PKG_NAME).build
+BUILD_DIR = $(WORK_DIR)/$(PKG_NAME).build
 CMAKE_SOURCE_DIR = $(WORK_DIR)/llvm-project/llvm
 
 # -----------------------------------------------------------------------------
@@ -26,7 +26,7 @@ CMAKE_SOURCE_DIR = $(WORK_DIR)/llvm-project/llvm
 # -----------------------------------------------------------------------------
 POST_INSTALL_TARGET = llvm_post_install_target
 llvm_post_install_target:
-	$(RUN) install -m 755 $(CMAKE_BUILD_DIR)/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
+	$(RUN) install -m 755 $(BUILD_DIR)/bin/clang-tblgen $(STAGING_INSTALL_PREFIX)/bin/clang-tblgen
 
 # -----------------------------------------------------------------------------
 # CMake arguments


### PR DESCRIPTION
## Summary

Third part of the build-variable standardization series (after #7279 and #7280). CMake, Meson and Ninja each had their own build-directory variable (`CMAKE_BUILD_DIR` / `MESON_BUILD_DIR` / `NINJA_BUILD_DIR`). Unify them on a single `BUILD_DIR`, set per build system by the matching env file, and extend out-of-tree build support to the autotools / plain GNU make path.

Three reviewable commits:

1. **unify the build directory on `BUILD_DIR`** — `env-cmake.mk` / `env-meson.mk` set `BUILD_DIR` (default `…/build` and `…/builddir` respectively); Ninja and the cmake/meson mk files use it. Also adds out-of-tree support to the autotools / plain GNU make path: in-source by default, opt in by setting `BUILD_DIR` — the configure/compile/install steps then run from `$(BUILD_DIR)` via `BUILD_RUN`, with configure invoked from the source tree.
2. **use `BUILD_DIR` in packages** that set a custom build dir (`chromaprint-fftw`, `jasper`, `llvm-140`, `x265`, `native/llvm-140`) or reference it (`intel-graphics-compiler`, `mariadb-connector-c*`, `netdata`, `umurmur`, `znc`). x265's own `CMAKE_BUILD_12B` / `CMAKE_BUILD_10B` helpers are left as-is.
3. **`cross/glibc` builds out-of-tree via `BUILD_DIR`** — glibc had three custom targets that hand-rolled its out-of-tree configure/compile/install; with the framework support that is redundant, so it sets `BUILD_DIR` + `INSTALL_MAKE_OPTIONS` and drops all three custom targets (glibc-2.28 and glibc-latest).

> **Note:** this PR is branched on `master` without #7279 / #7280, so it will need a rebase once those merge (overlapping mk / docs changes).

## Test plan

- `cross/cjson` (CMake → Ninja, default `BUILD_DIR`) — `EXIT=0`
- `cross/jasper` (CMake, custom `BUILD_DIR`) — `EXIT=0`, builds in `jasper.build`
- `cross/popt` (autotools, in-source by default) — `EXIT=0`
- `cross/popt` with `BUILD_DIR=…` (autotools out-of-tree opt-in) — `EXIT=0`, configure/compile/install run from the build dir
- `cross/glibc-2.28` out-of-tree configure — `EXIT=0`, `config.status` in `glibc-2.28-build`
- Docs updated (`makefile-reference.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)