### PR TITLE
spk/ffmpeg{4,5,6}: disable via DISABLED (also accept DISABLED as an alias for BROKEN)

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -176,14 +176,14 @@ fi
 # Remove duplicate packages
 packages=$(printf '%s' "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
-# Remove BROKEN packages (marked with a BROKEN file) or invalid packages (no Makefile
-# and not in dependency list). Packages with a BROKEN file are always skipped regardless
-# of their presence in the dependency list.
+# Remove disabled packages (marked with a BROKEN or DISABLED file) or invalid packages
+# (no Makefile and not in dependency list). Packages with a BROKEN or DISABLED file are
+# always skipped regardless of their presence in the dependency list.
 filtered_packages=
 for package in ${packages}; do
-    if [ -f "./spk/${package}/BROKEN" ]; then
-        broken_reason=$(cat "./spk/${package}/BROKEN")
-        echo "===> Skipping BROKEN package: ${package} (${broken_reason})"
+    if [ -f "./spk/${package}/BROKEN" ] || [ -f "./spk/${package}/DISABLED" ]; then
+        broken_reason=$(cat "./spk/${package}/BROKEN" "./spk/${package}/DISABLED" 2>/dev/null)
+        echo "===> Skipping disabled package: ${package} (${broken_reason})"
     elif ! grep -q "^${package}:" "${DEPENDENCY_LIST}" && [ ! -f "./spk/${package}/Makefile" ]; then
         echo "===> Skipping invalid package (no Makefile, not in dependency list): ${package}"
     else

--- a/docs/contributing/package-lifecycle.md
+++ b/docs/contributing/package-lifecycle.md
@@ -12,13 +12,13 @@ When a package should no longer be offered for new installations, it follows **o
 
 ## The two tracks at a glance
 
-| | **Disabled** (`BROKEN`) | **Retired** (archived) |
+| | **Disabled** (`BROKEN` / `DISABLED`) | **Retired** (archived) |
 |---|---|---|
 | Git repository | source **kept** (dormant) | source **removed** |
 | Built / published | no | no |
 | On the [package site](https://synocommunity.com/packages) | no longer offered | shown as **archived** |
 | Basis for the decision | no longer supported **upstream**, but plausibly revivable | **too old and obviously obsolete** |
-| Reversible? | yes — remove the `BROKEN` file | only by re-introducing the package |
+| Reversible? | yes — remove the `BROKEN` / `DISABLED` file | only by re-introducing the package |
 
 In both cases, **existing installations keep working** — they simply receive no further updates.
 
@@ -32,7 +32,7 @@ A package stays active as long as it broadly satisfies all of the following:
 - **It is the preferred version** — not superseded by a newer package.
 - **It has a path to maintenance** — issues can realistically be fixed (an active maintainer, or a community-fixable build).
 
-## Track 1 — Disabled (`BROKEN`, kept in git)
+## Track 1 — Disabled (`BROKEN` / `DISABLED`, kept in git)
 
 For packages that **upstream no longer supports** (or whose upstream dropped the installation method SynoCommunity relies on), but that are recent or relevant enough to keep **dormant and revivable**.
 
@@ -46,7 +46,7 @@ The source is **kept in the tree** so the work is preserved and the package can 
 
 ### How to disable
 
-Create `spk/<package>/BROKEN` with a short, dated reason and a reference where applicable:
+Create a marker file in the package folder — either `spk/<package>/BROKEN` or `spk/<package>/DISABLED`; both are accepted and have the same effect. Use `DISABLED` when the package is intentionally turned off (e.g. no release planned) and `BROKEN` when it is actually failing — pick whichever reads best. Give it a short, dated reason and a reference where applicable:
 
 ```text
 Package no-longer maintained - superseded by ffmpeg7
@@ -57,11 +57,11 @@ Package no-longer maintained - superseded by ffmpeg7
 ref: https://www.home-assistant.io/blog/2025/05/22/deprecating-core-...
 ```
 
-The build framework skips any package that has a `BROKEN` file, and CI stops publishing it.
+The build framework skips any package that has a `BROKEN` or `DISABLED` file, and CI stops publishing it.
 
 ### Reactivating
 
-Removing the `BROKEN` file re-enables the package. This is appropriate when the blocking cause is resolved (upstream resumes support, a compatible runtime returns, the build is fixed) **and** a maintainer commits to keeping it working. A reactivation is validated by a normal build (locally or in CI) before merging.
+Removing the `BROKEN` / `DISABLED` file re-enables the package. This is appropriate when the blocking cause is resolved (upstream resumes support, a compatible runtime returns, the build is fixed) **and** a maintainer commits to keeping it working. A reactivation is validated by a normal build (locally or in CI) before merging.
 
 ## Track 2 — Retired (removed from git, archived online)
 

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -23,7 +23,9 @@ ifneq ($(DEPENDENCY_WALK),1)
 # required for packages that have folder name different to SPK_NAME (sonarr -> nzbget, mono_58 -> mono)
 SPK_FOLDER = $(notdir $(CURDIR))
 
-ifneq ($(wildcard BROKEN),)
+# A package is disabled by dropping a BROKEN or DISABLED file in its folder
+# (both are treated identically).
+ifneq ($(strip $(wildcard BROKEN) $(wildcard DISABLED)),)
   ifneq ($(BUILD_UNSUPPORTED_FILE),)
     $(shell echo $(date --date=now +"%Y.%m.%d %H:%M:%S") - $(SPK_FOLDER): Broken package >> $(BUILD_UNSUPPORTED_FILE))
   endif

--- a/spk/ffmpeg4/DISABLED
+++ b/spk/ffmpeg4/DISABLED
@@ -1,0 +1,6 @@
+Disabled: no new ffmpeg4 SPK release is planned at this time.
+
+Disabling the SPK keeps ffmpeg4 and its large codec dependency tree out of the
+build. Remove this file to build and release ffmpeg4 again if needed.
+
+-- th0ma7, 2026-07-13

--- a/spk/ffmpeg5/DISABLED
+++ b/spk/ffmpeg5/DISABLED
@@ -1,0 +1,6 @@
+Disabled: no new ffmpeg5 SPK release is planned at this time.
+
+Disabling the SPK keeps ffmpeg5 and its large codec dependency tree out of the
+build. Remove this file to build and release ffmpeg5 again if needed.
+
+-- th0ma7, 2026-07-13

--- a/spk/ffmpeg6/DISABLED
+++ b/spk/ffmpeg6/DISABLED
@@ -1,0 +1,6 @@
+Disabled: no new ffmpeg6 SPK release is planned at this time.
+
+Disabling the SPK keeps ffmpeg6 and its large codec dependency tree out of the
+build. Remove this file to build and release ffmpeg6 again if needed.
+
+-- th0ma7, 2026-07-13


### PR DESCRIPTION
## Summary

Disable **ffmpeg 4.x / 5.x / 6.x**: they are no longer part of the maintained build set — no new ffmpeg4/5/6 SPK release is planned at this time, and disabling them keeps their large codec dependency trees out of the build.

Packages are disabled **at the spk level** (the CI package filter in `.github/actions/prepare.sh` only looks at `spk/*/`), so a marker file is added to `spk/ffmpeg4`, `spk/ffmpeg5`, `spk/ffmpeg6`. Their `cross/ffmpeg{4,5,6}` libraries are left untouched — with no enabled consumer they simply aren't pulled into the build.

To let the intent read clearly, the framework now accepts either a **`BROKEN`** or a **`DISABLED`** file, with the same effect:
- `mk/spksrc.rules/pre-check.mk` — errors out on either at build time.
- `.github/actions/prepare.sh` — the CI skips the package on either.

`DISABLED` is used here because these packages are intentionally turned off, not broken.

## Test plan

```
$ make ARCH=x64 TCVERSION=7.1   # in spk/ffmpeg4 (has a DISABLED file)
../../mk/spksrc.rules/pre-check.mk:32: *** ffmpeg: Broken package.  Stop.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)