### PR TITLE
radarr: allow built-in auto-updates on DSM 7.2+

### DIFF
--- a/spk/radarr/Makefile
+++ b/spk/radarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = radarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 26
+SPK_REV = 27
 SPK_ICON = src/radarr.png
 
 OPTIONAL_DEPENDS = cross/libstdc++ cross/libe_sqlite3
@@ -12,7 +12,7 @@ DOTNET_CORE_ARCHS = 1
 MAINTAINER = Team Radarr
 MAINTAINER_URL = https://radarr.video/
 DESCRIPTION = Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
-CHANGELOG = "1. Update Radarr to v6.2.1.10461."
+CHANGELOG = "1. Dynamically set UpdateMethod based on DSM version, enabling self-update on DSM 7.2+."
 DISPLAY_NAME = Radarr
 HOMEPAGE = https://radarr.video/
 LICENSE = GPLv3
@@ -45,8 +45,6 @@ ifeq ($(call version_lt, ${TCVERSION}, 7.2),1)
 # Use libe_sqlite3 built for GLIBC 2.20–2.26 (DSM 6–7.1) instead of upstream ≥ 2.28
 DEPENDS += cross/libe_sqlite3
 POST_STRIP_TARGET += radarr_custom_libe_sqlite3
-# Disable auto-update for DSM < 7.2
-RADARR_UPDATE = disabled
 endif
 
 POST_STRIP_TARGET += radarr_extra_install
@@ -67,7 +65,3 @@ radarr_extra_install:
 	@install -m 755 -d $(STAGING_DIR)/var/.config/Radarr
 	@install -m 644 src/config.xml $(STAGING_DIR)/var/.config/Radarr/config.xml
 	@echo "PackageVersion=$(PACKAGE_VERSION)\nPackageAuthor=$(PACKAGE_AUTHOR)" > $(STAGING_DIR)/share/Radarr/package_info
-	@if [ "$(RADARR_UPDATE)" = "disabled" ]; then \
-		$(MSG) "Disable auto-update in package_info." ; \
-		echo "UpdateMethod=External" >> $(STAGING_DIR)/share/Radarr/package_info ; \
-	fi

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -23,22 +23,41 @@ SVC_BACKGROUND=y
 SVC_WAIT_TIMEOUT=90
 
 internal_update_supported() {
-    info_file="${SYNOPKG_PKGINST_TEMP_DIR}/share/Radarr/package_info"
+    # DSM >= 7.2: Radarr can self-update (upstream libe_sqlite3.so is GLIBC 2.28+ compatible)
+    # DSM < 7.2: Radarr cannot self-update (custom libe_sqlite3.so must be preserved)
+    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -gt 7 ] || \
+       { [ "${SYNOPKG_DSM_VERSION_MAJOR}" -eq 7 ] && [ "${SYNOPKG_DSM_VERSION_MINOR}" -ge 2 ]; }; then
+        return 0    # Supported
+    else
+        return 1    # Not supported
+    fi
+}
 
-    # If the file doesn't exist, assume update is supported
+configure_update_method() {
+    # Dynamically set UpdateMethod in package_info based on DSM version.
+    # Package is built without UpdateMethod so the default is BuiltIn.
+    # On DSM < 7.2 we must block Radarr's self-updater because it would
+    # overwrite the custom libe_sqlite3.so (built for GLIBC 2.20–2.26)
+    # with the upstream version requiring GLIBC >= 2.28, causing a crash.
+    local info_file="${SYNOPKG_PKGDEST}/share/Radarr/package_info"
     [ -f "$info_file" ] || return 0
 
-    # If the file contains "UpdateMethod=External", updates are NOT supported
-    if grep -q '^UpdateMethod=External' "$info_file" 2>/dev/null; then
-        return 1    # Not supported
+    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -gt 7 ] || \
+       { [ "${SYNOPKG_DSM_VERSION_MAJOR}" -eq 7 ] && [ "${SYNOPKG_DSM_VERSION_MINOR}" -ge 2 ]; }; then
+        # DSM >= 7.2: remove External so Radarr defaults to BuiltIn
+        sed -i '/^UpdateMethod=External$/d' "$info_file"
     else
-        return 0    # Supported
+        # DSM < 7.2: ensure External is set
+        grep -q '^UpdateMethod=External' "$info_file" 2>/dev/null || \
+            echo "UpdateMethod=External" >> "$info_file"
     fi
 }
 
 service_postinst ()
 {
     if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
+        configure_update_method
+
         if internal_update_supported; then
             # Make Radarr do an update check on start to avoid possible Radarr
             # downgrade when synocommunity package is updated
@@ -82,6 +101,8 @@ service_postupgrade ()
         # prevent overwrite of updated package_info
         rsync -aX --exclude=package_info "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share/" "${SYNOPKG_PKGDEST}/share" 2>&1
     fi
+
+    configure_update_method
 
     if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -lt 7 ]; then
         set_unix_permissions "${SYNOPKG_PKGDEST}/share"


### PR DESCRIPTION
## Motivation

The previous implementation baked `UpdateMethod=External` into `package_info` at build time when `TCVERSION < 7.2`. This meant packages built with TCVERSION=7.1 (the current default) always block Radarr's self-updater, even on DSM 7.2+ systems where the upstream `libe_sqlite3.so` (GLIBC ≥ 2.28) works fine.

This was introduced in commit [a755a5d](https://github.com/SynoCommunity/spksrc/commit/a755a5d) to protect the custom `libe_sqlite3.so` (built for GLIBC 2.20–2.26) on DSM 6–7.1 from being overwritten by Radarr's updater. The protection is necessary but was applied too broadly — it also blocks self-updates on DSM 7.2+ where the upstream library works.

### What changes

- **`spk/radarr/Makefile`**: Remove `RADARR_UPDATE = disabled` and the conditional `UpdateMethod=External` injection from `radarr_extra_install`. The `libe_sqlite3` custom build dependency is kept (still required for DSM < 7.2).
- **`spk/radarr/src/service-setup.sh`**: 
  - `internal_update_supported()` now checks DSM version instead of reading `package_info`
  - New `configure_update_method()` writes `UpdateMethod=External` to `package_info` only on DSM < 7.2
  - Called from `service_postinst` and `service_postupgrade`

### Behavior by DSM version

| Scenario | UpdateMethod in package_info | Radarr self-update |
|---|---|---|
| DSM 7.2+ fresh install | Removed → defaults to BuiltIn | ✅ Enabled |
| DSM 7.2+ upgrade | Removed → defaults to BuiltIn | ✅ Enabled |
| DSM 7.1 fresh install | Added External | ❌ Disabled |
| DSM 7.1 upgrade | Added External | ❌ Disabled |

## Linked issues

None (original issue: Radarr shows "Unable to update Radarr directly" on DSM 7.2.1)

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully

## Related PRs

Same fix applied to the other *arr packages:
- **Prowlarr**: [#7287](https://github.com/SynoCommunity/spksrc/pull/7287)
- **Lidarr**: [#7286](https://github.com/SynoCommunity/spksrc/pull/7286)