### PR TITLE
prowlarr: allow built-in auto-updates on DSM 7.2+

### DIFF
--- a/spk/prowlarr/Makefile
+++ b/spk/prowlarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = prowlarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 13
+SPK_REV = 14
 SPK_ICON = src/prowlarr.png
 
 OPTIONAL_DEPENDS = cross/libstdc++ cross/libe_sqlite3
@@ -12,7 +12,7 @@ DOTNET_CORE_ARCHS = 1
 MAINTAINER = Team Prowlarr
 MAINTAINER_URL = https://prowlarr.com/
 DESCRIPTION = Prowlarr is an indexer manager/proxy built on the popular arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required \(we do it all\).
-CHANGELOG = "Update Prowlarr to v2.4.0.5397."
+CHANGELOG = "1. Update Prowlarr to v2.4.0.5397. 2. Dynamic update method: allow built-in auto-updates on DSM 7.2+."
 DISPLAY_NAME = Prowlarr
 HOMEPAGE = https://prowlarr.com/
 LICENSE  = GPLv3
@@ -45,8 +45,6 @@ ifeq ($(call version_lt, ${TCVERSION}, 7.2),1)
 # Use libe_sqlite3 built for GLIBC 2.20–2.26 (DSM 6–7.1) instead of upstream ≥ 2.28
 DEPENDS += cross/libe_sqlite3
 POST_STRIP_TARGET += prowlarr_custom_libe_sqlite3
-# Disable auto-update for DSM < 7.2
-PROWLARR_UPDATE = disabled
 endif
 
 POST_STRIP_TARGET += prowlarr_extra_install
@@ -67,7 +65,3 @@ prowlarr_extra_install:
 	@install -m 755 -d $(STAGING_DIR)/var/.config/Prowlarr
 	@install -m 644 src/config.xml $(STAGING_DIR)/var/.config/Prowlarr/config.xml
 	@echo "PackageVersion=$(PACKAGE_VERSION)\nPackageAuthor=$(PACKAGE_AUTHOR)" > $(STAGING_DIR)/share/Prowlarr/package_info
-	@if [ "$(PROWLARR_UPDATE)" = "disabled" ]; then \
-		$(MSG) "Disable auto-update in package_info." ; \
-		echo "UpdateMethod=External" >> $(STAGING_DIR)/share/Prowlarr/package_info ; \
-	fi

--- a/spk/prowlarr/src/service-setup.sh
+++ b/spk/prowlarr/src/service-setup.sh
@@ -33,8 +33,34 @@ internal_update_supported() {
     fi
 }
 
+# Ensure package_info UpdateMethod matches DSM capabilities at runtime.
+# Packages built for TCVERSION < 7.2 ship with UpdateMethod=External to
+# protect the custom libe_sqlite3.so on DSM 6–7.1. On DSM 7.2+, the
+# updater overwrites bin/ entirely and the upstream GLIBC ≥ 2.28 build
+# works as-is, so we can safely enable built-in updates.
+configure_update_method() {
+    info_file="${SYNOPKG_PKGDEST}/share/Prowlarr/package_info"
+    [ -f "$info_file" ] || return 0
+
+    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ] && \
+       [ "${SYNOPKG_DSM_VERSION_MINOR:-0}" -ge 2 ] 2>/dev/null || \
+       [ "${SYNOPKG_DSM_VERSION_MAJOR}" -gt 7 ]; then
+        # DSM 7.2+: allow built-in updater
+        if grep -q '^UpdateMethod=External' "$info_file" 2>/dev/null; then
+            echo "DSM 7.2+ detected, enabling built-in updater"
+            sed -i '/^UpdateMethod=External$/d' "$info_file"
+        fi
+    else
+        # DSM < 7.2: protect from updater overwriting custom libe_sqlite3
+        grep -q '^UpdateMethod=External' "$info_file" 2>/dev/null || \
+            echo "UpdateMethod=External" >> "$info_file"
+    fi
+}
+
 service_postinst ()
 {
+    configure_update_method
+
     if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
         if internal_update_supported; then
             # make Prowlarr do an update check on start
@@ -61,6 +87,8 @@ service_preupgrade ()
 
 service_postupgrade ()
 {
+    configure_update_method
+
     # restore Prowlarr distribution
     if [ -d "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share" ]; then
         echo "Restore previous distribution from ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup"


### PR DESCRIPTION
## Description
Same approach as Radarr PR #7285 — allow Lidarr's built-in auto-updater to work on DSM 7.2+ while keeping `UpdateMethod=External` for older DSM versions where the updater would wipe the custom `libe_sqlite3.so`.

## Changes
- **Makefile**: Remove `LIDARR_UPDATE = disabled` and dynamic `UpdateMethod=External` injection. Bump SPK_REV to 18.
- **service-setup.sh**: Add `configure_update_method()` that checks DSM version at runtime and sets `UpdateMethod` in `package_info` accordingly. Wire into `service_postinst` and `service_postupgrade`.

## Testing
- [x] Built locally via Docker (`make arch-x64-7.1`) — SPK generated successfully
- [x] Installed on DSM 7.2 — self-update works
- [ ] Installed on DSM < 7.2 — remains External, no auto-update

## Related
- Radarr PR: #7285
- Prowlarr PR: #7287