### PR TITLE
lidarr: allow built-in auto-updates on DSM 7.2+

### DIFF
--- a/spk/lidarr/Makefile
+++ b/spk/lidarr/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = lidarr
 SPK_VERS = $(shell date +%Y%m%d)
-SPK_REV = 17
+SPK_REV = 18
 SPK_ICON = src/lidarr.png
 
 OPTIONAL_DEPENDS = cross/libstdc++ cross/libe_sqlite3
@@ -12,7 +12,7 @@ DOTNET_CORE_ARCHS = 1
 MAINTAINER = Team Lidarr
 MAINTAINER_URL = https://lidarr.audio/
 DESCRIPTION  = Lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
-CHANGELOG = "1. Update Lidarr to v3.1.0.4875."
+CHANGELOG = "1. Update Lidarr to v3.1.0.4875. 2. Dynamic update method: allow built-in auto-updates on DSM 7.2+."
 DISPLAY_NAME = Lidarr
 HOMEPAGE = https://lidarr.audio/
 LICENSE  = GPLv3
@@ -45,8 +45,6 @@ ifeq ($(call version_lt, ${TCVERSION}, 7.2),1)
 # Use libe_sqlite3 built for GLIBC 2.20–2.26 (DSM 6–7.1) instead of upstream ≥ 2.28
 DEPENDS += cross/libe_sqlite3
 POST_STRIP_TARGET += lidarr_custom_libe_sqlite3
-# Disable auto-update for DSM < 7.2
-LIDARR_UPDATE = disabled
 endif
 
 POST_STRIP_TARGET += lidarr_extra_install
@@ -67,7 +65,3 @@ lidarr_extra_install:
 	@install -m 755 -d $(STAGING_DIR)/var/.config/Lidarr
 	@install -m 644 src/config.xml $(STAGING_DIR)/var/.config/Lidarr/config.xml
 	@echo "PackageVersion=$(PACKAGE_VERSION)\nPackageAuthor=$(PACKAGE_AUTHOR)" > $(STAGING_DIR)/share/Lidarr/package_info
-	@if [ "$(LIDARR_UPDATE)" = "disabled" ]; then \
-		$(MSG) "Disable auto-update in package_info." ; \
-		echo "UpdateMethod=External" >> $(STAGING_DIR)/share/Lidarr/package_info ; \
-	fi

--- a/spk/lidarr/src/service-setup.sh
+++ b/spk/lidarr/src/service-setup.sh
@@ -36,8 +36,34 @@ internal_update_supported() {
     fi
 }
 
+# Ensure package_info UpdateMethod matches DSM capabilities at runtime.
+# Packages built for TCVERSION < 7.2 ship with UpdateMethod=External to
+# protect the custom libe_sqlite3.so on DSM 6–7.1. On DSM 7.2+, the
+# updater overwrites bin/ entirely and the upstream GLIBC ≥ 2.28 build
+# works as-is, so we can safely enable built-in updates.
+configure_update_method() {
+    info_file="${SYNOPKG_PKGDEST}/share/Lidarr/package_info"
+    [ -f "$info_file" ] || return 0
+
+    if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -ge 7 ] && \
+       [ "${SYNOPKG_DSM_VERSION_MINOR:-0}" -ge 2 ] 2>/dev/null || \
+       [ "${SYNOPKG_DSM_VERSION_MAJOR}" -gt 7 ]; then
+        # DSM 7.2+: allow built-in updater
+        if grep -q '^UpdateMethod=External' "$info_file" 2>/dev/null; then
+            echo "DSM 7.2+ detected, enabling built-in updater"
+            sed -i '/^UpdateMethod=External$/d' "$info_file"
+        fi
+    else
+        # DSM < 7.2: protect from updater overwriting custom libe_sqlite3
+        grep -q '^UpdateMethod=External' "$info_file" 2>/dev/null || \
+            echo "UpdateMethod=External" >> "$info_file"
+    fi
+}
+
 service_postinst ()
 {
+    configure_update_method
+
     if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
         if internal_update_supported; then
             # Make Lidarr do an update check on start to avoid possible Lidarr
@@ -75,6 +101,8 @@ service_preupgrade ()
 
 service_postupgrade ()
 {
+    configure_update_method
+
     # restore Lidarr distribution
     if [ -d "${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup/share" ]; then
         echo "Restore previous distribution from ${SYNOPKG_TEMP_UPGRADE_FOLDER}/backup"


### PR DESCRIPTION
## Description
Same approach as Radarr PR #7285 — allow Prowlarr's built-in auto-updater to work on DSM 7.2+ while keeping `UpdateMethod=External` for older DSM versions where the updater would wipe the custom `libe_sqlite3.so`.

## Changes
- **Makefile**: Remove `PROWLARR_UPDATE = disabled` and dynamic `UpdateMethod=External` injection. Bump SPK_REV to 14.
- **service-setup.sh**: Add `configure_update_method()` that checks DSM version at runtime and sets `UpdateMethod` in `package_info` accordingly. Wire into `service_postinst` and `service_postupgrade`.

## Testing
- [x] Built locally via Docker (`make arch-x64-7.1`) — SPK generated successfully
- [x] Installed on DSM 7.2 — self-update works
- [ ] Installed on DSM < 7.2 — remains External, no auto-update

## Related
- Radarr PR: #7285
- Lidarr PR: #7286