### PR TITLE
cross/vaultwarden: drop an import rustc 1.97 rejects

### DIFF
--- a/cross/vaultwarden/patches/001-drop-redundant-send-import.patch
+++ b/cross/vaultwarden/patches/001-drop-redundant-send-import.patch
@@ -1,0 +1,28 @@
+# Temporary: drop an import rustc 1.97 rejects, until a release carries the fix.
+#
+# `Send` is in the prelude, so importing it inside `mod id` is redundant. rustc
+# 1.97 started flagging that under `unused_imports`, and vaultwarden builds with
+# `-D unused`, turning it into a hard error:
+#
+#   error: unused import: `std::marker::Send`
+#      --> src/db/models/send.rs:369:9
+#
+# The import was only ever there because the parent module declares a `Send`
+# struct; the prelude still resolves the trait inside the child module, so the
+# line can simply go.
+#
+# Upstream removed it in "Misc updates and fixes" (169aa5efc, PR #7406) as part
+# of flattening `mod id` away. That rework is far larger than what we need here,
+# so drop the import alone and revert this patch once a release ships the fix.
+# 1.36.0 is the latest tag and still carries the line.
+#
+--- src/db/models/send.rs.orig
++++ src/db/models/send.rs
+@@ -366,7 +366,6 @@
+ pub mod id {
+     use derive_more::{AsRef, Deref, Display, From};
+     use macros::{IdFromParam, UuidFromParam};
+-    use std::marker::Send;
+     use std::path::Path;
+ 
+     #[derive(


### PR DESCRIPTION
## Problem

`cross/vaultwarden` no longer builds on **any** rust-capable arch. The CI runs an unpinned `stable` toolchain (`RUSTUP_TOOLCHAIN="stable"`), which is now **rustc 1.97.0**:

```
error: unused import: `std::marker::Send`
   --> src/db/models/send.rs:369:9
    |
369 |     use std::marker::Send;
    |         ^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D unused`
error: could not compile `vaultwarden` (bin "vaultwarden") due to 1 previous error
```

rustc 1.97 extended `unused_imports` to redundant imports of prelude items. `Send` is in the prelude, so importing it inside `mod id` is redundant; vaultwarden builds with `-D unused`, which turns the warning into a hard error. The import was only there because the parent module declares a `Send` struct — the prelude still resolves the trait inside the child module, so the line can simply go.

This is not arch-specific: it reproduces identically on `armv7-6.2.4` and `evansport-6.2.4`, and locally on `x64-7.1`.

## Fix

Upstream already removed the import in [169aa5efc](https://github.com/dani-garcia/vaultwarden/commit/169aa5efc) (dani-garcia/vaultwarden#7406), but folded it into a much larger rework that flattens the `mod id` namespace away — far more than we need. And no release carries it yet: **1.36.0 is the latest tag and still has the line**.

So this patches out the single import as a **temporary** measure. When upstream ships a release with the fix, this patch goes away together with the version bump.

No `SPK_REV` bump: removing a redundant import does not change the resulting binary's behaviour, and the package currently does not build at all.

## Testing

`cross/vaultwarden` built for `x64-7.1` against **rustc 1.97.0** (`2d8144b78`, 2026-07-07) — the exact version failing in CI — producing a 46 MB `vaultwarden` binary. `EXIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8