### PR TITLE
cross+spk/nushell: fix the plugin build, update to 0.112.2

### DIFF
--- a/cross/nushell/Makefile
+++ b/cross/nushell/Makefile
@@ -1,5 +1,9 @@
 PKG_NAME = nushell
-PKG_VERS = 0.109.1
+# Do not go past 0.112.2 yet: nushell 0.113.0 pulls in the fff-search crate,
+# whose AVX2 path is gated on any(x86_64, x86) but imports std::arch::x86_64,
+# so it does not compile on 32-bit x86 (evansport). fff-search 0.9.7 narrows
+# the gate to x86_64 and fixes it, but is only published as a prerelease.
+PKG_VERS = 0.112.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/nushell/nushell/archive
@@ -8,6 +12,11 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 # for nu_plugin_gstat and nu_plugin_query
 DEPENDS = cross/openssl3
+
+# openssl-sys refuses to fall back to pkg-config when host and target differ,
+# so point it at the staging tree explicitly. Without this the plugins linking
+# OpenSSL only build when the target happens to match the build host (x64).
+ENV += OPENSSL_DIR=$(STAGING_INSTALL_PREFIX)
 
 # some archs are supported under DSM 6, but x64 isn't (BoringSSL issue with ring crates).
 # since nushell is a new package, we don't want to support DSM < 7 at all
@@ -26,10 +35,14 @@ POST_INSTALL_TARGET = nushell_install_plugins
 include ../../mk/spksrc.cross-rust.mk
 
 
+# Plugins are installed from crates.io, so they must be pinned to $(PKG_VERS):
+# nushell only loads plugins built against its own plugin protocol version.
+# --locked is deliberately not used here: it would force the lock file each
+# plugin was published with, which pins dependencies we cannot update.
 .PHONY: nushell_install_plugins
 nushell_install_plugins:
-	@$(MSG) "Install the default plugins '$(NUSHELL_PLUGINS)'"
+	@$(MSG) "Install the default plugins '$(NUSHELL_PLUGINS)' (v$(PKG_VERS))"
 	@for plugin in $(NUSHELL_PLUGINS); do \
 		$(MSG) "- Create plugin $${plugin}" ; \
-		$(RUN) cargo +$(TC_RUSTUP_TOOLCHAIN) install --root $(STAGING_INSTALL_PREFIX) --locked nu_plugin_$${plugin} --target $(RUST_TARGET) ; \
+		$(RUN) cargo +$(TC_RUSTUP_TOOLCHAIN) install --root $(STAGING_INSTALL_PREFIX) --version $(PKG_VERS) nu_plugin_$${plugin} --target $(RUST_TARGET) ; \
 	done

--- a/cross/nushell/digests
+++ b/cross/nushell/digests
@@ -1,3 +1,3 @@
-nushell-0.109.1.tar.gz SHA1 07dd557a648cd0705f62c39eb37518cd145ef4cc
-nushell-0.109.1.tar.gz SHA256 53d4611113a17ed3a29b0c81ea981d546a40dafca77fdcd9af7a7629ceabf48f
-nushell-0.109.1.tar.gz MD5 8e9a229ef9719de8955db032d0307887
+nushell-0.112.2.tar.gz SHA1 809d1823e2a0faee1b5c8353f1e8e4cba34c8a69
+nushell-0.112.2.tar.gz SHA256 32ebcfe41b6390145e90eb86273e221f22eeacd53ecac5274405f148fb4258c2
+nushell-0.112.2.tar.gz MD5 be1f36ee5fd49880186ded45967e4df3

--- a/spk/nushell/Makefile
+++ b/spk/nushell/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = nushell
-SPK_VERS = 0.109.1
-SPK_REV = 2
+SPK_VERS = 0.112.2
+SPK_REV = 3
 SPK_ICON = src/nushell.png
 
 DEPENDS = cross/nushell
@@ -11,7 +11,7 @@ MAINTAINER = SynoCommunity
 DESCRIPTION = A new type of shell. This package includes the nushell plugins 'inc' 'polars' 'gstat' 'formats' and 'query' and a script 'nu_install_plugins.sh'.
 DISPLAY_NAME = nu
 STARTABLE = no
-CHANGELOG = "Update Nushell to 0.109.1"
+CHANGELOG = "1. Update Nushell to 0.112.2.<br/>2. Pin the bundled plugins to the same version as the shell."
 
 HOMEPAGE = https://www.nushell.sh/
 LICENSE = MIT


### PR DESCRIPTION
## Problem

`cross/nushell` fails to build. Three separate problems, stacked.

### 1. The plugins were never pinned to the shell version

They were installed straight from crates.io with no version pin:

```make
cargo install --root $(STAGING_INSTALL_PREFIX) --locked nu_plugin_$${plugin} --target $(RUST_TARGET)
```

so cargo resolved each one to the **latest published** version, independent of the shell being built. The CI log shows `nu_plugin_polars v0.114.1` compiled while `PKG_VERS = 0.109.1`. nushell only loads plugins built against its own plugin protocol version, so the package was shipping mismatched plugins.

### 2. That drift broke the build (the `comcerto2k-7.1` failure)

The lock file published with `nu_plugin_polars 0.114.1` pins `ethnum 1.5.2`, and `--locked` forced it:

```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
  --> ethnum-1.5.2/src/error.rs:16:14
16 |     unsafe { mem::transmute(()) }
   = note: source type: `()` (0 bits)
   = note: target type: `TryFromIntError` (8 bits)
```

`ethnum` built a `TryFromIntError` by transmuting a `()`, assuming that std type is zero-sized. It is not anymore, so **rustc 1.97** rejects it - the same unpinned-`stable`-toolchain class of breakage as vaultwarden (#7288). `ethnum` removed the transmute in **1.5.3**.

### 3. The OpenSSL plugins never cross-compiled

Once ethnum was out of the way, `nu_plugin_gstat` and `nu_plugin_query` failed:

```
Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed
  $HOST = x86_64-unknown-linux-gnu
  $TARGET = i686-unknown-linux-gnu
```

`openssl-sys` refuses to fall back to pkg-config when host and target differ. This was masked because the plugin loop already died earlier on polars/ethnum, and it does not reproduce on x64, where the target happens to match the build host.

## Fix

- **Pin the plugins to `$(PKG_VERS)`** so they always match the shell.
- **Drop `--locked` on the plugin install.** It forces the lock each plugin was *published* with, pinning transitive dependencies we have no way to update; without it cargo resolves `ethnum` to the fixed 1.5.3. `--locked` stays on the main nushell build, where the lock ships in the source tarball we control through `PKG_VERS`.
- **Set `OPENSSL_DIR`**, as `cross/vaultwarden` already does.
- **Update nushell 0.109.1 -> 0.112.2.**

## Why 0.112.2 and not 0.114.1

nushell **0.113.0** pulls in the `fff-search` crate, which does not compile on 32-bit x86:

```rust
#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]   // gate admits both
unsafe fn normalize_bytes_avx2(...) {
    use std::arch::x86_64::*;                              // but imports x86_64 only
```

On i686 (evansport) the `cfg` lets the function through and `std::arch::x86_64` does not exist -> `error[E0432]`. It is a registry crate, so spksrc's `patches/` mechanism cannot reach it. `fff-search 0.9.7` narrows the gate to `x86_64` and fixes this, but is only published as a **prerelease** (`0.9.7-nightly.*`), which is not something to pin a production package to.

So 0.112.2 is the newest release that builds on every arch. A comment in the Makefile records the ceiling so we can move to 0.114+ once fff-search 0.9.7 is released. The alternative - 0.114.1 with evansport marked unsupported - trades an architecture for two minor versions, which did not seem worth it; happy to flip if you disagree.

## Testing

Built for **evansport-7.1** (i686 - the arch that failed) against **rustc 1.97.0**, the version that fails in CI: the shell and **all five plugins** (`inc` `polars` `gstat` `formats` `query`), with `ethnum` resolving to 1.5.3. Binaries confirmed `ELF 32-bit LSB pie executable, Intel i386`.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8
