### PR TITLE
docs: add a Framework Changes page, and document download mirrors

### DIFF
--- a/docs/developer-guide/packaging/makefile-variables.md
+++ b/docs/developer-guide/packaging/makefile-variables.md
@@ -19,6 +19,7 @@ This page documents the Makefile variables used in spksrc packages.
 | `PKG_EXT` | Yes | Source file extension (tar.gz, tar.xz, zip) |
 | `PKG_DIST_NAME` | Yes | Source filename to download |
 | `PKG_DIST_SITE` | Yes | Base URL for download |
+| `PKG_DIST_MIRRORS` | No | Extra base URLs to fall back to (see [Source downloads and mirrors](#source-downloads-and-mirrors)) |
 | `PKG_DIR` | Yes | Directory name after extraction |
 
 Example:
@@ -31,6 +32,57 @@ PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://curl.se/download
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 ```
+
+### Source downloads and mirrors
+
+A download is never a single request. The framework builds a list of candidate
+URLs, tries each in turn, and stops at the first success. The list is finite --
+the primary URL, plus the mirrors described below, de-duplicated -- and each
+candidate is retried `DOWNLOAD_TRIES` times (2 by default), so a download that
+cannot succeed fails instead of looping.
+
+**Well-known project mirrors are automatic.** If `PKG_DIST_SITE` points at one
+of the big source hosts, the framework already knows its mirrors and will try
+them without any declaration on your part:
+
+| If the URL is hosted on | Fallbacks are taken from |
+|-------------------------|--------------------------|
+| GNU (`ftp.gnu.org`, `ftpmirror.gnu.org`) | `GNU_MIRRORS` |
+| SourceForge (`downloads.sourceforge.net`) | `SOURCEFORGE_MIRRORS` |
+| GNOME (`download.gnome.org`) | `GNOME_MIRRORS` |
+| X.Org (`www.x.org`) | `XORG_MIRRORS` |
+| kernel.org (`cdn.kernel.org`) | `KERNEL_MIRRORS` |
+
+A candidate is built by replacing everything up to and including the family's
+tree-root marker (`/gnu/`, `/project/`, `/sources/`, ...) with the mirror base,
+so mirrors that host the tree under a different prefix still resolve correctly.
+Any other URL -- GitHub, a project's own server -- simply has no family, and the
+primary URL is used on its own.
+
+**`PKG_DIST_MIRRORS` covers everything else.** It takes a space-separated list of
+*base URLs*; `PKG_DIST_NAME` is appended to each. Use it when upstream is the
+right place to fetch from but cannot be relied on:
+
+```makefile
+PKG_DIST_SITE = https://znc.in/releases
+# znc.in serves the release tarballs, but it has been flaky (its TLS
+# certificate expired on 2026-07-14). Fall back to our own mirror.
+PKG_DIST_MIRRORS = https://github.com/SynoCommunity/spksrc/releases/download/sources
+```
+
+Two things to keep in mind:
+
+- The **file name must match**. The mirror has to serve the file under exactly
+  `PKG_DIST_NAME`. A distribution that repackages the tarball under its own name
+  (Debian's `znc_1.10.2.orig.tar.gz`, say) cannot be used as a mirror base.
+- The **digests still apply**. Every candidate is checked against `digests`, so a
+  mirror serving different bytes fails the build rather than poisoning it. This
+  is what makes it safe to list a third-party mirror at all.
+
+When no mirror serves the right file name, the durable answer is to upload the
+tarball to the SynoCommunity
+[`sources`](https://github.com/SynoCommunity/spksrc/releases/tag/sources)
+release and point `PKG_DIST_MIRRORS` at it.
 
 ### SPK Packages
 

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -1,0 +1,173 @@
+# Framework Changes
+
+A curated log of notable changes to the spksrc **build framework** — the `mk/`
+tree and the conventions every package Makefile relies on — newest first.
+
+This is **not** an exhaustive changelog (for that, see `git log -- mk/`). Each
+entry is collapsed to its date and title; expand it (▸) for what changed, why,
+and a link to the pull request. Efforts that span several pull requests are a
+single entry with the individual PRs nested inside.
+
+---
+
+??? note "July 13th 2026 — Build-variable standardization (3 PRs)"
+    A three-part effort so that every build system (autotools, CMake, Meson)
+    exposes the **same** package-facing variable names. Before it, a Makefile
+    looked different depending on the underlying build tool; after it, the same
+    variable means the same thing everywhere.
+
+    ??? note "`CONFIGURE_ARGS` — unify the configure arguments (#7279)"
+        CMake was the odd one out: it used `CMAKE_ARGS` / `ADDITIONAL_CMAKE_ARGS`
+        while autotools and Meson already passed their options through
+        `CONFIGURE_ARGS`.
+
+        - **What:** renamed `CMAKE_ARGS` → `CONFIGURE_ARGS` and
+          `ADDITIONAL_CMAKE_ARGS` → `ADDITIONAL_CONFIGURE_ARGS` across every cmake
+          package (no alias); `ADDITIONAL_CONFIGURE_ARGS` is now honoured by
+          autotools and Meson too.
+        - **Why:** one variable for "arguments to the configure step" regardless
+          of the build system. `ADDITIONAL_CONFIGURE_ARGS` remains for the rare
+          case where a package reuses `CONFIGURE_ARGS` for its own auxiliary
+          invocations and needs extra args to reach only the framework's call
+          (see `cross/x265`).
+        - Documented in
+          [Build System Selection](../developer-guide/packaging/makefile-variables.md#build-system-selection).
+        - Pull request: [#7279](https://github.com/SynoCommunity/spksrc/pull/7279)
+
+    ??? note "`COMPILE_ARGS` / `INSTALL_ARGS` — unify the compile & install arguments (#7280)"
+        The compile and install steps had an autotools-only slot
+        (`COMPILE_MAKE_OPTIONS` / `INSTALL_MAKE_OPTIONS`) with no CMake/Meson
+        equivalent.
+
+        - **What:** introduced `COMPILE_ARGS` and `INSTALL_ARGS`. On the autotools
+          / plain-make path they *are* the make command (replacing the removed
+          `*_MAKE_OPTIONS`); for CMake and Meson they are appended as-is to
+          `cmake --build` / `cmake --install` and `ninja` / `ninja install`.
+        - **Defaults on the make path:** when unset, `COMPILE_ARGS` defaults to
+          `-j$(NCPUS)` and `INSTALL_ARGS` to `install DESTDIR=… prefix=…`, so a
+          package's own make routines can reference them and inherit sensible
+          behaviour (e.g. `cross/cairo-1.16` gains `-j`; `cross/glibc-*` drop
+          their explicit `-j`).
+        - **Why the scoping matters:** the defaults are gated by `DEFAULT_ENV`
+          (and an `INSTALL_TARGET` python check) so they never leak into
+          CMake/Meson/rust/python builds — the native cmake/meson env files
+          declare `DEFAULT_ENV` for the same reason.
+        - Documented in
+          [Compile and Install Arguments](../developer-guide/packaging/makefile-variables.md#compile-and-install-arguments).
+        - Pull request: [#7280](https://github.com/SynoCommunity/spksrc/pull/7280)
+
+    ??? note "`BUILD_DIR` — unify the build directory (#7282)"
+        CMake, Meson and Ninja each had their own build-directory variable
+        (`CMAKE_BUILD_DIR` / `MESON_BUILD_DIR` / `NINJA_BUILD_DIR`).
+
+        - **What:** unified them on a single `BUILD_DIR`, set per build system by
+          the matching env file, and **extended out-of-tree build support to the
+          autotools / plain-make path**: it builds in-source by default and opts
+          in to an out-of-tree build by setting `BUILD_DIR`.
+        - **Why:** one name for "where the build happens", and a framework
+          mechanism for out-of-tree autotools builds that packages previously
+          hand-rolled — `cross/glibc` dropped its three custom
+          configure/compile/install targets in favour of a one-line `BUILD_DIR`.
+        - Pull request: [#7282](https://github.com/SynoCommunity/spksrc/pull/7282)
+
+??? note "July 13th 2026 — Disable a package with `BROKEN` or `DISABLED` (#7283)"
+    - **What:** a package is skipped when it has a `BROKEN` **or** a `DISABLED`
+      file in its folder — both are honoured by `spksrc.rules/pre-check.mk`
+      (build time) and the CI `prepare.sh` (package selection). Use `DISABLED`
+      when a package is intentionally turned off and `BROKEN` when it is actually
+      failing.
+    - **Why:** the marker file now reads its intent. First use: `spk/ffmpeg{4,5,6}`
+      were disabled — no new release is planned and disabling them keeps their
+      large codec dependency trees out of the build. See the
+      [package lifecycle](../contributing/package-lifecycle.md) guide.
+    - Pull request: [#7283](https://github.com/SynoCommunity/spksrc/pull/7283)
+
+??? note "July 2nd 2026 — Context-aware `make help` (#7250)"
+    Context-aware help at the repo root and inside each package.
+
+    Pull request: [#7250](https://github.com/SynoCommunity/spksrc/pull/7250)
+
+??? note "July 2nd 2026 — Build logs off the repo root (#7256)"
+    Build logs are no longer pinned to the repository root, keeping the tree clean.
+
+    Pull request: [#7256](https://github.com/SynoCommunity/spksrc/pull/7256)
+
+??? note "July 1st 2026 — Generic, bounded mirror fallback for downloads (#7254)"
+    A download used to be a single request to `PKG_DIST_SITE`: if that host was
+    down, or its TLS certificate had just expired, the build failed.
+
+    - **What:** the download logic was split into per-method macros, and a
+      download now walks a list of candidate URLs, stopping at the first success.
+      Mirrors of the big source hosts (GNU, SourceForge, GNOME, X.Org,
+      kernel.org) are tried automatically, and `PKG_DIST_MIRRORS` lets a package
+      name its own fallback base URLs.
+    - **Why bounded:** the candidate list is finite (primary URL + family mirrors
+      + `PKG_DIST_MIRRORS`, de-duplicated) and each is retried `DOWNLOAD_TRIES`
+      times, so a download that cannot succeed fails rather than looping.
+    - **Why it is safe:** every candidate is checked against `digests`, so a
+      mirror serving different bytes fails the build instead of poisoning it.
+    - Documented in
+      [Source downloads and mirrors](../developer-guide/packaging/makefile-variables.md#source-downloads-and-mirrors).
+    - Pull request: [#7254](https://github.com/SynoCommunity/spksrc/pull/7254)
+
+??? note "July 1st 2026 — `spksrc.cross-virtual.mk` rename (#7251)"
+    Renamed `spksrc.main-depends.mk` to describe what it is — the entry point for
+    virtual (dependency-only) packages.
+
+    Pull request: [#7251](https://github.com/SynoCommunity/spksrc/pull/7251)
+
+??? note "June 28th 2026 — Reorganize `mk/` into functional submodules (#7237)"
+    The flat `mk/` directory was reorganized into concern-based submodules
+    (`spksrc.spk-meta/`, `spksrc.service/`, `spksrc.wheel/`, `spksrc.cross/`,
+    `spksrc.native/`, `spksrc.build/`, …) so related logic lives together.
+
+    Pull request: [#7237](https://github.com/SynoCommunity/spksrc/pull/7237)
+
+??? note "June 28th 2026 — Boxed `*.mk` file headers (#7242)"
+    Standardized every `*.mk` header to one boxed format, so each file states its
+    purpose, inputs and outputs consistently.
+
+    Pull request: [#7242](https://github.com/SynoCommunity/spksrc/pull/7242)
+
+??? note "June 28th 2026 — `spksrc.cross-install.mk` rename (#7243)"
+    Renamed `install-resources.mk` and slimmed the install wrappers so the
+    cross/native install paths share one implementation.
+
+    Pull request: [#7243](https://github.com/SynoCommunity/spksrc/pull/7243)
+
+??? note "June 22nd–25th 2026 — Meta cross-dependency environment (4 PRs)"
+    How a "meta" package (ffmpeg, videodriver, python) exposes its
+    cross-dependencies to consumers.
+
+    ??? note "Introduce the meta cross-dependency environment (#7222)"
+        Introduced `META_PKGCONFIG_DIRS` + `tc_vars.meta.mk`.
+
+        Pull request: [#7222](https://github.com/SynoCommunity/spksrc/pull/7222)
+
+    ??? note "Resolve CMake meta deps via the toolchain file (#7223)"
+        Resolve `OPENSSL_ROOT_DIR` + `CMAKE_FIND_ROOT_PATH` through the generated
+        toolchain file instead of ad-hoc detection.
+
+        Pull request: [#7223](https://github.com/SynoCommunity/spksrc/pull/7223)
+
+    ??? note "Ordered `PKG_CONFIG_LIBDIR` shared across channels (#7228)"
+        A single ordered pkg-config search path shared across all channels, so
+        local staging reliably wins over meta directories.
+
+        Pull request: [#7228](https://github.com/SynoCommunity/spksrc/pull/7228)
+
+    ??? note "Meta mechanism rework (#7229)"
+        Auto-build the meta source, drop the denylist, consolidate OpenSSL.
+
+        Pull request: [#7229](https://github.com/SynoCommunity/spksrc/pull/7229)
+
+??? note "June 10th 2026 — Toolchain cache poisoning fix (#7196)"
+    A stale toolchain cache was silently dropping `TC_GCC`-gated `DEPENDS`.
+
+    Pull request: [#7196](https://github.com/SynoCommunity/spksrc/pull/7196)
+
+??? note "June 10th 2026 — Stage-0 toolchain bootstrap (#7184)"
+    Bootstrap the toolchain before deriving `TC_GCC`, so version-gated
+    dependencies (`version_ge TC_GCC …`) parse correctly on a cold tree.
+
+    Pull request: [#7184](https://github.com/SynoCommunity/spksrc/pull/7184)

--- a/docs/reference/makefile-reference.md
+++ b/docs/reference/makefile-reference.md
@@ -14,6 +14,7 @@ This is a comprehensive reference for all Makefile variables and targets in spks
 | `PKG_DIST_NAME` | Yes | Archive filename | `$(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)` |
 | `PKG_DIST_SITE` | Yes | Download URL base | `https://example.com/releases` |
 | `PKG_DIST_FILE` | No | Local filename (if different) | `curl-source.tar.gz` |
+| `PKG_DIST_MIRRORS` | No | Fallback base URLs, tried in turn if `PKG_DIST_SITE` fails ([details](../developer-guide/packaging/makefile-variables.md#source-downloads-and-mirrors)) | `https://github.com/SynoCommunity/spksrc/releases/download/sources` |
 | `PKG_DIST_ARCH` | No | Architecture-specific source designator | `$(PKG_DIST_ARCH_$(ARCH))` |
 | `PKG_DIR` | Yes | Directory after extraction | `$(PKG_NAME)-$(PKG_VERS)` |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ nav:
     - Makefile System: framework/makefile-system.md
     - Toolchain: framework/toolchain.md
     - Toolkit: framework/toolkit.md
+    - Changes: framework/changes.md
   - Reference:
     - reference/index.md
     - Architectures: reference/architectures.md


### PR DESCRIPTION
Two things, one of which explains the other.

## 1. A Framework Changes page

The framework has been moving fast, and there was nowhere for a contributor to see what changed and why — `git log -- mk/` is not a substitute.

`docs/framework/changes.md` is a git-log-style list: each entry **collapses to its date and title**, and expands (▸) to what changed, why, and a link to the pull request. Efforts spanning several PRs are a single entry with the individual PRs **nested inside**, so the default view reads like a changelog and the detail is one click away.

It covers the recent framework work back to June 2026 — the build-variable standardization series, `BROKEN`/`DISABLED`, the `mk/` reorganization, the meta cross-dependency series, the toolchain bootstrap fixes.

This page was originally part of #7282; it is split out here so that PR stays purely about `BUILD_DIR`.

## 2. Download mirrors, documented

Writing the page surfaced a gap. The bounded mirror fallback added in **#7254** is a real feature, and it was documented **nowhere** — `PKG_DIST_MIRRORS` did not appear anywhere under `docs/`.

So it is now documented in two places:

- **[Source downloads and mirrors](https://github.com/SynoCommunity/spksrc/blob/master/docs/developer-guide/packaging/makefile-variables.md)** — a new section in `makefile-variables.md` explaining that a download walks a bounded list of candidates; that mirrors for GNU / SourceForge / GNOME / X.Org / kernel.org are tried **automatically** based on `PKG_DIST_SITE`; and that `PKG_DIST_MIRRORS` covers everything else.
- The **variable table** in `makefile-reference.md`, with a link through to that section.

It covers the two things that actually catch people out:

- **The file name must match.** The mirror has to serve the file under exactly `PKG_DIST_NAME`. A distro that repackages the tarball under its own name (Debian's `znc_1.10.2.orig.tar.gz`) cannot be used as a mirror base.
- **The digests still apply.** Every candidate is checked against `digests`, so a mirror serving different bytes fails the build rather than poisoning it — which is what makes it safe to list a third-party mirror at all.

## Cross-linking

Entries in the changes page **link through to the section documenting the feature** they describe (`CONFIGURE_ARGS` → Build System Selection, `COMPILE_ARGS`/`INSTALL_ARGS` → Compile and Install Arguments, the mirror fallback → Source downloads and mirrors). The log is a way *into* the documentation rather than a duplicate of it.

## Testing

`mkdocs build --strict` — clean. That is what `.github/workflows/docs.yml` runs, and it fails on broken links.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8
