### PR TITLE
help + docs: document DEPENDS_TYPE and EXCLUDE_DEPENDS

### DIFF
--- a/docs/developer-guide/packaging/build-rules.md
+++ b/docs/developer-guide/packaging/build-rules.md
@@ -45,6 +45,35 @@ wheel/crossenv targets are available — see
 `crossenv-<arch>-<tcvers>`, `download-wheels`, `wheelclean`, `wheelcleancache`,
 `crossenvclean`, `crossenvcleanall`.
 
+### Inspecting the dependency graph
+
+`dependency-tree`, `dependency-flat` and `dependency-list` share three optional
+variables (they do not apply to `dependency-tree`, which always prints the full
+traversal):
+
+| Variable | Effect |
+|----------|--------|
+| `DEPENDS_TYPE` | Filter the output by relation type. Values: `DEPENDS`, `BUILD_DEPENDS`, `OPTIONAL_DEPENDS`, `NATIVE_DEPENDS`; combine them with spaces. Defaults to all types, or `DEPENDS BUILD_DEPENDS NATIVE_DEPENDS` when `ARCH`+`TCVERSION` are set. The traversal always visits every applicable type; this only filters what is printed. |
+| `EXCLUDE_DEPENDS` | Space-separated list of dependencies to skip. An excluded dependency **and its entire subtree** are pruned from the walk — e.g. `EXCLUDE_DEPENDS="cross/ffmpeg7"`. |
+| `ARCH` + `TCVERSION` | Resolve the graph in a specific toolchain context, so version-gated and conditional `DEPENDS` evaluate as they would in a real build. Set both. When set, `OPTIONAL_DEPENDS` is excluded by default. |
+
+```bash
+# Runtime dependencies only, resolved for x64 / DSM 7.2
+make dependency-flat DEPENDS_TYPE="DEPENDS" ARCH=x64 TCVERSION=7.2
+
+# The tree without a heavy meta package and everything under it
+make dependency-list EXCLUDE_DEPENDS="cross/ffmpeg7"
+```
+
+From the **spksrc root**, `dependency-list-spk` runs `dependency-list` for every
+`spk/` package in parallel and aggregates the result. It honors the same three
+variables:
+
+```bash
+# Every spk's runtime deps, resolved for x64 / DSM 7.2
+make dependency-list-spk DEPENDS_TYPE="DEPENDS" ARCH=x64 TCVERSION=7.2
+```
+
 ## Build System Includes
 
 ### Cross Compilation

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -85,6 +85,9 @@ endif
 	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-tree" "print the resolved dependency graph"
 	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-flat" "flat, de-duplicated dependency list"
 	@printf "  \033[36m%-24s\033[0m %s\n" "dependency-list" "raw per-package dependency list"
+	@printf "  \033[33m%s\033[0m\n" "  DEPENDS_TYPE=\"DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS\" filters flat/list output"
+	@printf "  \033[33m%s\033[0m\n" "  EXCLUDE_DEPENDS=\"cross/foo ...\" skips those dependencies and their subtrees"
+	@printf "  \033[33m%s\033[0m\n" "  ARCH=... TCVERSION=... resolves the graph in that toolchain context"
 ifneq ($(SPKSRC_TREE),python)
 	@printf "\n\033[1mCleanup\033[0m\n"
 	@printf "  \033[36m%-24s\033[0m %s\n" "clean" "remove all work directories"

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -212,11 +212,13 @@ $(SPK_LIST_STAMP_DIR):
 # -------------------------------------------------------------------
 ifeq ($(AT_ROOT_LEVEL),1)
 
+##@ Inspect
+
 # At root level, only dependency-list-spk is available.
 # ARCH and TCVERSION are forwarded when provided so each package is
 # evaluated in the correct toolchain context.
 .PHONY: dependency-list-spk
-dependency-list-spk: | $(SPK_LIST_STAMP_DIR)
+dependency-list-spk: | $(SPK_LIST_STAMP_DIR)  ## Resolved deps for every spk; honors DEPENDS_TYPE, EXCLUDE_DEPENDS, ARCH, TCVERSION
 	@$(MAKE) -j $(nproc) --silent --no-print-directory \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \


### PR DESCRIPTION
You spotted that `EXCLUDE_DEPENDS` and `DEPENDS_TYPE` were only described in the header of `mk/spksrc.rules/dependency-tree.mk` — neither `make help` nor the docs mentioned them, even though they are the useful part of the `dependency-*` targets.

Added in #7028 (`EXCLUDE_DEPENDS`, `DEPENDS_TYPE`) and #7121 / #7124 (`ARCH`/`TCVERSION` context), they had no user-facing documentation. This surfaces them everywhere they apply.

## Package-level `make help`

The Inspect section now spells out the three modifiers:

```
Inspect
  dependency-tree          print the resolved dependency graph
  dependency-flat          flat, de-duplicated dependency list
  dependency-list          raw per-package dependency list
    DEPENDS_TYPE="DEPENDS BUILD_DEPENDS OPTIONAL_DEPENDS NATIVE_DEPENDS" filters flat/list output
    EXCLUDE_DEPENDS="cross/foo ..." skips those dependencies and their subtrees
    ARCH=... TCVERSION=... resolves the graph in that toolchain context
```

## Root `make help`

You were right that there's also a root-level call — `dependency-list-spk`, which resolves every `spk/`'s dependencies in parallel. It honors the same variables (they propagate to the per-package sub-makes through `MAKEFLAGS`), verified:

```
$ make dependency-list-spk DEPENDS_TYPE="NATIVE_DEPENDS"
adminer:
aria2:
...                       # empty where there are no native deps, vs the full list without the filter
```

It had no help entry at all, so it now appears under a new **Inspect** section in the root help:

```
Inspect
  dependency-list-spk  Resolved deps for every spk; honors DEPENDS_TYPE, EXCLUDE_DEPENDS, ARCH, TCVERSION
```

## Docs

`build-rules.md` gains an **Inspecting the dependency graph** subsection: a table of the three variables, two worked examples, and the root-level `dependency-list-spk` variant.

## Testing

`make help` at both levels, `make dependency-list-spk DEPENDS_TYPE=NATIVE_DEPENDS`, and `mkdocs build --strict` — all clean.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8
