### PR TITLE
cross/pgvector: Use COMPILE_ARGS (COMPILE_MAKE_OPTIONS was removed from framework)

### DIFF
--- a/cross/pgvector/Makefile
+++ b/cross/pgvector/Makefile
@@ -31,7 +31,7 @@ PGSQL_INC    = $(dir $(PG_CONFIG))../include
 # a minimal pg_config wrapper that only fixes --pgxs (native pg_config
 # returns a path without the postgresql/ subdirectory).
 PRE_COMPILE_TARGET = pgvector_pre_compile
-COMPILE_MAKE_OPTIONS = -j1 \
+COMPILE_ARGS = -j1 \
 	PG_CONFIG=$(WORK_DIR)/pg_config_wrapper \
 	PG_CPPFLAGS="-I$(PGSQL_INC)/server -I$(PGSQL_INC)" \
 	CC="$(TC_PATH)$(TC_PREFIX)gcc" \


### PR DESCRIPTION
## Description

This is a follow-on from #7277 to account for a change in the framework in #7280.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
