### PR TITLE
ffmpeg6/7/8: restore the SYNO-videostation patches (incl. seek time)

### DIFF
--- a/cross/ffmpeg4/Makefile
+++ b/cross/ffmpeg4/Makefile
@@ -236,8 +236,10 @@ DEPENDS += cross/libaom
 CONFIGURE_ARGS += --enable-libaom
 endif
 
-# Add SVT-AV1 codec to supported ARCH
-ifeq ($(findstring $(ARCH),alpine comcerto2k monaco $(ARMv8_ARCHS) $(x64_ARCHS)),$(ARCH))
+# SVT-AV1 is 64-bit only -- its configure refuses 32-bit, and it now declares
+# REQUIRE_64BIT, so pulling it on a 32-bit arch (the old list named comcerto2k,
+# alpine and monaco, all ARMv7) fails the whole build. Gate it on the 64-bit archs.
+ifeq ($(findstring $(ARCH),$(64bit_ARCHS)),$(ARCH))
 DEPENDS += cross/svt-av1
 CONFIGURE_ARGS += --enable-libsvtav1
 endif

--- a/cross/ffmpeg5/Makefile
+++ b/cross/ffmpeg5/Makefile
@@ -210,8 +210,10 @@ DEPENDS += cross/libaom
 CONFIGURE_ARGS += --enable-libaom
 endif
 
-# Add SVT-AV1 codec to supported ARCH
-ifeq ($(findstring $(ARCH),alpine comcerto2k monaco $(ARMv8_ARCHS) $(x64_ARCHS)),$(ARCH))
+# SVT-AV1 is 64-bit only -- its configure refuses 32-bit, and it now declares
+# REQUIRE_64BIT, so pulling it on a 32-bit arch (the old list named comcerto2k,
+# alpine and monaco, all ARMv7) fails the whole build. Gate it on the 64-bit archs.
+ifeq ($(findstring $(ARCH),$(64bit_ARCHS)),$(ARCH))
 DEPENDS += cross/svt-av1
 CONFIGURE_ARGS += --enable-libsvtav1
 endif

--- a/cross/ffmpeg5/Makefile
+++ b/cross/ffmpeg5/Makefile
@@ -233,9 +233,6 @@ CONFIGURE_ARGS += --disable-armv5te
 CONFIGURE_ARGS += --disable-armv6
 CONFIGURE_ARGS += --disable-armv6t2
 CONFIGURE_ARGS += --disable-vfp
-ifeq ($(findstring $(ARCH),alpine),$(ARCH))
-CONFIGURE_ARGS += --extra-cflags=-DSYNO_ALPINE_NEON
-endif
 endif
 
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))

--- a/cross/ffmpeg6/Makefile
+++ b/cross/ffmpeg6/Makefile
@@ -36,6 +36,10 @@ endif
 # Must match $(SPK_REV) from spk/ffmpeg$(PKG_MINOR_VERS)/Makefile
 CONFIGURE_ARGS += --extra-version=$(shell sed -n 's/^SPK_REV = \(.*\)/\1/p' $(WORK_DIR)/../../../spk/ffmpeg$(PKG_MINOR_VERS)/Makefile)
 
+# Enable the Synology VideoStation compatibility code added by the
+# SYNO-* patch series (hls_seek_time, smooth streaming, srt tags, ...)
+CONFIGURE_ARGS += --extra-cflags=-DSYNO_VIDEOSTATION
+
 # Compiler workaround to enable DTS-HD MA stream decoding
 CONFIGURE_ARGS += --extra-cflags=-fno-if-conversion
 # Remove some of the noise while compiling

--- a/cross/ffmpeg6/Makefile
+++ b/cross/ffmpeg6/Makefile
@@ -216,12 +216,13 @@ DEPENDS += cross/libaom
 CONFIGURE_ARGS += --enable-libaom
 endif
 
-# Add SVT-AV1 codec to supported ARCH
-ifeq ($(findstring $(ARCH),alpine comcerto2k monaco $(ARMv8_ARCHS) $(x64_ARCHS)),$(ARCH))
+# SVT-AV1 is 64-bit only -- its configure refuses 32-bit, and it now declares
+# REQUIRE_64BIT, so pulling it on a 32-bit arch (the old list named comcerto2k,
+# alpine and monaco, all ARMv7) fails the whole build. Gate it on the 64-bit archs.
+ifeq ($(findstring $(ARCH),$(64bit_ARCHS)),$(ARCH))
 DEPENDS += cross/svt-av1
 CONFIGURE_ARGS += --enable-libsvtav1
 endif
-
 
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS)),$(ARCH))
 CONFIGURE_ARGS += --arch=arm

--- a/cross/ffmpeg6/Makefile
+++ b/cross/ffmpeg6/Makefile
@@ -232,9 +232,6 @@ CONFIGURE_ARGS += --disable-armv5te
 CONFIGURE_ARGS += --disable-armv6
 CONFIGURE_ARGS += --disable-armv6t2
 CONFIGURE_ARGS += --disable-vfp
-ifeq ($(findstring $(ARCH),alpine),$(ARCH))
-CONFIGURE_ARGS += --extra-cflags=-DSYNO_ALPINE_NEON
-endif
 endif
 
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))

--- a/cross/ffmpeg6/patches/0100-SYNO-videostation-hls-seek-time.patch
+++ b/cross/ffmpeg6/patches/0100-SYNO-videostation-hls-seek-time.patch
@@ -1,0 +1,120 @@
+diff -uprN ../ffmpeg-4.3-005/libavformat/segment.c ./libavformat/segment.c
+--- ../ffmpeg-4.3-005/libavformat/segment.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/segment.c	2020-06-16 19:54:41.332482718 -0400
+@@ -43,6 +43,8 @@
+ #include "libavutil/time_internal.h"
+ #include "libavutil/timestamp.h"
+ 
++#include "synoconfig.h"
++
+ typedef struct SegmentListEntry {
+     int index;
+     double start_time, end_time;
+@@ -123,6 +125,12 @@ typedef struct SegmentContext {
+     SegmentListEntry cur_entry;
+     SegmentListEntry *segment_list_entries;
+     SegmentListEntry *segment_list_entries_end;
++
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	int64_t seek_time;
++	AVPacket old_key_packet;
++	int filled;
++#endif
+ } SegmentContext;
+ 
+ static void print_csv_escaped_str(AVIOContext *ctx, const char *str)
+@@ -854,6 +862,10 @@ static int seg_write_header(AVFormatCont
+         if (!seg->individual_header_trailer)
+             oc->pb->seekable = 0;
+     }
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	av_init_packet(&seg->old_key_packet);
++	seg->filled = 1;
++#endif
+ 
+     return 0;
+ }
+@@ -885,6 +897,40 @@ static int seg_write_packet(AVFormatCont
+         }
+     }
+ 
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	int64_t pts = AV_NOPTS_VALUE;
++	if (0 < seg->seek_time && seg->filled) {
++		if (pkt->stream_index != seg->reference_stream_index) {
++			return 0;
++		}
++
++		if (pkt->pts != AV_NOPTS_VALUE) {
++			pts = pkt->pts;
++		} else if (pkt->dts != AV_NOPTS_VALUE) {
++			pts = pkt->dts;
++		}
++		if (pts >= 0) {
++			if (pkt->flags & AV_PKT_FLAG_KEY) {
++				seg->filled = 0;
++			} else if (NULL != seg->old_key_packet.data) {
++				seg->old_key_packet.pts = pkt->pts;
++				seg->old_key_packet.dts = pkt->dts;
++				seg->old_key_packet.duration = pkt->duration;
++				av_packet_unref(pkt);
++				av_init_packet(pkt);
++				av_packet_ref(pkt, &seg->old_key_packet);
++				seg->filled = 0;
++			}
++			av_packet_unref(&seg->old_key_packet);
++		} else {
++			if (pkt->flags & AV_PKT_FLAG_KEY) {
++				av_packet_unref(&seg->old_key_packet);
++				av_packet_ref(&seg->old_key_packet, pkt);
++			}
++			return 0;
++		}
++	}
++#endif
+ calc_times:
+     if (seg->times) {
+         end_pts = seg->segment_count < seg->nb_times ?
+@@ -971,6 +1017,15 @@ calc_times:
+            av_ts2str(pkt->pts), av_ts2timestr(pkt->pts, &st->time_base),
+            av_ts2str(pkt->dts), av_ts2timestr(pkt->dts, &st->time_base));
+ 
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++       if (0 < seg->seek_time) {
++               if (pkt->pts != AV_NOPTS_VALUE)
++                       pkt->pts += av_rescale_q(seg->seek_time, (AVRational) {1, 1000}, st->time_base);
++               if (pkt->dts != AV_NOPTS_VALUE)
++                       pkt->dts += av_rescale_q(seg->seek_time, (AVRational) {1, 1000}, st->time_base);
++       }
++#endif
++
+     ret = ff_write_chained(seg->avf, pkt->stream_index, pkt, s,
+                            seg->initial_offset || seg->reset_timestamps || seg->avf->oformat->interleave_packet);
+ 
+@@ -1085,6 +1140,9 @@ static const AVOption options[] = {
+     { "reset_timestamps", "reset timestamps at the beginning of each segment", OFFSET(reset_timestamps), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
+     { "initial_offset", "set initial timestamp offset", OFFSET(initial_offset), AV_OPT_TYPE_DURATION, {.i64 = 0}, -INT64_MAX, INT64_MAX, E },
+     { "write_empty_segments", "allow writing empty 'filler' segments", OFFSET(write_empty), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++    { "hls_seek_time",    "initial segment start time", OFFSET(seek_time), AV_OPT_TYPE_INT64, {.i64 = 0}, 0, INT_MAX, E },
++#endif
+     { NULL },
+ };
+ 
+Binary files ../ffmpeg-4.3-005/libavformat/.segment.c.rej.swp and ./libavformat/.segment.c.rej.swp differ
+diff -uprN ../ffmpeg-4.3-005/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-005/synoconfig.h	1969-12-31 19:00:00.000000000 -0500
++++ ./synoconfig.h	2020-06-16 19:53:14.125668365 -0400
+@@ -0,0 +1,12 @@
++#ifndef MY_ABC_HERE
++#define MY_ABC_HERE
++#endif
++
++/* Add ffmpeg option for HLS.
++ * -hls_seek_time:
++ *  Let output fragment ts start with this seek time
++ * See Video Station #1758
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_HLS_SEEK_TIME
++#endif

--- a/cross/ffmpeg6/patches/0101-SYNO-videostation-hls-costumized-ts-name.patch
+++ b/cross/ffmpeg6/patches/0101-SYNO-videostation-hls-costumized-ts-name.patch
@@ -1,0 +1,30 @@
+diff -uprN ../ffmpeg-4.3-020/libavformat/segment.c ./libavformat/segment.c
+--- ../ffmpeg-4.3-020/libavformat/segment.c	2020-06-16 19:54:41.000000000 -0400
++++ ./libavformat/segment.c	2020-06-16 19:57:31.891853716 -0400
+@@ -237,9 +237,15 @@ static int set_segment_filename(AVFormat
+ 
+     if ((ret = av_reallocp(&seg->cur_entry.filename, size)) < 0)
+         return ret;
++#ifdef SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
++    snprintf(seg->cur_entry.filename, size, "%s%03d",
++             seg->entry_prefix ? seg->entry_prefix : "",
++             seg->segment_idx);
++#else
+     snprintf(seg->cur_entry.filename, size, "%s%s",
+              seg->entry_prefix ? seg->entry_prefix : "",
+              av_basename(oc->url));
++#endif
+ 
+     return 0;
+ }
+diff -uprN ../ffmpeg-4.3-020/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-020/synoconfig.h	2020-06-16 19:53:14.000000000 -0400
++++ ./synoconfig.h	2020-06-16 19:57:31.891853716 -0400
+@@ -10,3 +10,7 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_SEEK_TIME
+ #endif
++
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
++#endif

--- a/cross/ffmpeg6/patches/0102-SYNO-videostation-skip-displaymatrix.patch
+++ b/cross/ffmpeg6/patches/0102-SYNO-videostation-skip-displaymatrix.patch
@@ -1,0 +1,59 @@
+--- ../ffmpeg-6.1.6-orig/libavformat/movenc.c	2026-06-20 21:32:00.000000000 +0000
++++ ./libavformat/movenc.c	2026-07-15 14:51:28.550018659 +0000
+@@ -115,6 +115,9 @@ static const AVOption options[] = {
+     { "use_stream_ids_as_track_ids", "use stream ids as track ids", offsetof(MOVMuxContext, use_stream_ids_as_track_ids), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
+     { "write_btrt", "force or disable writing btrt", offsetof(MOVMuxContext, write_btrt), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
+     { "write_tmcd", "force or disable writing tmcd", offsetof(MOVMuxContext, write_tmcd), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++    { "skip_displaymatrix", "Skip writing displaymatrix metadata.", offsetof(MOVMuxContext, skip_displaymatrix), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
++#endif
+     { "write_prft", "Write producer reference time box with specified time source", offsetof(MOVMuxContext, write_prft), AV_OPT_TYPE_INT, {.i64 = MOV_PRFT_NONE}, 0, MOV_PRFT_NB-1, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
+     { "wallclock", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_WALLCLOCK}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
+     { "pts", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_PTS}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
+@@ -2945,6 +2948,11 @@ static int mov_write_gmhd_tag(AVIOContex
+         avio_wb32(pb, 0); /* version */
+         update_size(pb, gpmd_pos);
+     }
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++        if (mov->skip_displaymatrix) {
++            display_matrix = NULL;
++        }
++#endif
+     return update_size(pb, pos);
+ }
+ 
+--- ../ffmpeg-6.1.6-orig/libavformat/movenc.h	2026-06-20 21:32:00.000000000 +0000
++++ ./libavformat/movenc.h	2026-07-15 14:51:28.551018677 +0000
+@@ -28,6 +28,8 @@
+ #include "movenccenc.h"
+ #include "libavcodec/packet_internal.h"
+ 
++#include "synoconfig.h"
++
+ #define MOV_FRAG_INFO_ALLOC_INCREMENT 64
+ #define MOV_INDEX_CLUSTER_SIZE 1024
+ #define MOV_TIMESCALE 1000
+@@ -199,6 +201,9 @@ typedef struct MOVMuxContext {
+     int rtp_flags;
+ 
+     int iods_skip;
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++    int skip_displaymatrix;
++#endif
+     int iods_video_profile;
+     int iods_audio_profile;
+ 
+--- ../ffmpeg-6.1.6-orig/synoconfig.h	2026-07-15 14:51:28.546631081 +0000
++++ ./synoconfig.h	2026-07-15 14:51:28.551301684 +0000
+@@ -14,3 +14,11 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
+ #endif
++
++/* Add skip displaymatrix config to movenc for video station offline transcoding.
++ * add flag "-skip_displaymatrix 1" to mov/mp4 format for skiping writing displaymatrix metadata.
++ * See Video Station #4464
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++#endif

--- a/cross/ffmpeg6/patches/0102-SYNO-videostation-skip-displaymatrix.patch
+++ b/cross/ffmpeg6/patches/0102-SYNO-videostation-skip-displaymatrix.patch
@@ -1,29 +1,31 @@
---- ../ffmpeg-6.1.6-orig/libavformat/movenc.c	2026-06-20 21:32:00.000000000 +0000
-+++ ./libavformat/movenc.c	2026-07-15 14:51:28.550018659 +0000
-@@ -115,6 +115,9 @@ static const AVOption options[] = {
-     { "use_stream_ids_as_track_ids", "use stream ids as track ids", offsetof(MOVMuxContext, use_stream_ids_as_track_ids), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
-     { "write_btrt", "force or disable writing btrt", offsetof(MOVMuxContext, write_btrt), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
-     { "write_tmcd", "force or disable writing tmcd", offsetof(MOVMuxContext, write_tmcd), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
+--- libavformat/movenc.c-orig2	2026-08-08 23:44:41.940696487 +0000
++++ libavformat/movenc.c	2026-08-08 23:45:49.320990742 +0000
+@@ -120,6 +120,9 @@ static const AVOption options[] = {
+     { "pts", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_PTS}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
+     { "empty_hdlr_name", "write zero-length name string in hdlr atoms within mdia and minf atoms", offsetof(MOVMuxContext, empty_hdlr_name), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
+     { "movie_timescale", "set movie timescale", offsetof(MOVMuxContext, movie_timescale), AV_OPT_TYPE_INT, {.i64 = MOV_TIMESCALE}, 1, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM},
 +#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
 +    { "skip_displaymatrix", "Skip writing displaymatrix metadata.", offsetof(MOVMuxContext, skip_displaymatrix), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
 +#endif
-     { "write_prft", "Write producer reference time box with specified time source", offsetof(MOVMuxContext, write_prft), AV_OPT_TYPE_INT, {.i64 = MOV_PRFT_NONE}, 0, MOV_PRFT_NB-1, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
-     { "wallclock", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_WALLCLOCK}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
-     { "pts", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_PTS}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, "prft"},
-@@ -2945,6 +2948,11 @@ static int mov_write_gmhd_tag(AVIOContex
-         avio_wb32(pb, 0); /* version */
-         update_size(pb, gpmd_pos);
-     }
-+#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
-+        if (mov->skip_displaymatrix) {
-+            display_matrix = NULL;
-+        }
-+#endif
-     return update_size(pb, pos);
- }
+     { NULL },
+ };
  
---- ../ffmpeg-6.1.6-orig/libavformat/movenc.h	2026-06-20 21:32:00.000000000 +0000
-+++ ./libavformat/movenc.h	2026-07-15 14:51:28.551018677 +0000
+@@ -3505,7 +3508,13 @@ static int mov_write_tkhd_tag(AVIOContex
+                                      st->codecpar->nb_coded_side_data,
+                                      AV_PKT_DATA_DISPLAYMATRIX);
+         if (sd && sd->size == 9 * sizeof(*display_matrix))
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++            if (mov->skip_displaymatrix) {
++               display_matrix = NULL;
++            }
++#else
+             display_matrix = (uint32_t *)sd->data;
++#endif
+     }
+ 
+     if (track->flags & MOV_TRACK_ENABLED)
+--- ../ffmpeg-7.0.2/libavformat/movenc.h	2024-08-02 22:55:22.000000000 +0000
++++ ./libavformat/movenc.h	2024-09-24 23:19:32.992183584 +0000
 @@ -28,6 +28,8 @@
  #include "movenccenc.h"
  #include "libavcodec/packet_internal.h"
@@ -33,7 +35,7 @@
  #define MOV_FRAG_INFO_ALLOC_INCREMENT 64
  #define MOV_INDEX_CLUSTER_SIZE 1024
  #define MOV_TIMESCALE 1000
-@@ -199,6 +201,9 @@ typedef struct MOVMuxContext {
+@@ -205,6 +207,9 @@ typedef struct MOVMuxContext {
      int rtp_flags;
  
      int iods_skip;

--- a/cross/ffmpeg6/patches/0103-SYNO-videostation-webm-seek-time.patch
+++ b/cross/ffmpeg6/patches/0103-SYNO-videostation-webm-seek-time.patch
@@ -1,0 +1,104 @@
+diff -uprN ../ffmpeg-4.3-022/libavformat/matroskaenc.c ./libavformat/matroskaenc.c
+--- ../ffmpeg-4.3-022/libavformat/matroskaenc.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/matroskaenc.c	2020-06-27 16:37:13.468256460 -0400
+@@ -67,6 +67,8 @@ enum {
+     DEFAULT_MODE_PASSTHROUGH,
+ };
+ 
++#include "synoconfig.h"
++
+ typedef struct ebml_master {
+     int64_t         pos;                ///< absolute offset in the containing AVIOContext where the master's elements start
+     int             sizebytes;          ///< how many bytes were reserved for the size
+@@ -157,6 +159,11 @@ typedef struct MatroskaMuxContext {
+     int                 default_mode;
+ 
+     uint32_t            segment_uid[4];
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++       int64_t seek_time;
++       AVPacket old_key_packet;
++       int unfilled;
++#endif
+ } MatroskaMuxContext;
+ 
+ /** 2 bytes * 7 for EBML IDs, 7 1-byte EBML lengths, 6 1-byte uint,
+@@ -1935,6 +1942,11 @@ static int mkv_write_header(AVFormatCont
+             mkv->cluster_size_limit = 32 * 1024;
+     }
+ 
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++	av_init_packet(&mkv->old_key_packet);
++	mkv->unfilled = 1;
++#endif
++
+     return 0;
+ }
+ 
+@@ -2374,6 +2386,41 @@ static int mkv_write_packet(AVFormatCont
+     if (ret < 0)
+         return ret;
+ 
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++       int64_t pts = AV_NOPTS_VALUE;
++       if (0 < mkv->seek_time && mkv->unfilled) {
++               if (codec_type != AVMEDIA_TYPE_VIDEO) {
++                       return 0;
++               }
++
++               if (pkt->pts != AV_NOPTS_VALUE) {
++                       pts = pkt->pts;
++               } else if (pkt->dts != AV_NOPTS_VALUE) {
++                       pts = pkt->dts;
++               }
++               if (pts >= 0) {
++                       if (pkt->flags & AV_PKT_FLAG_KEY) {
++                               mkv->unfilled = 0;
++                       } else if (NULL != mkv->old_key_packet.data) {
++                               mkv->old_key_packet.pts = pkt->pts;
++                               mkv->old_key_packet.dts = pkt->dts;
++                               mkv->old_key_packet.duration = pkt->duration;
++                               av_packet_unref(pkt);
++                               av_init_packet(pkt);
++                               av_packet_ref(pkt, &mkv->old_key_packet);
++                               mkv->unfilled = 0;
++                       }
++                       av_packet_unref(&mkv->old_key_packet);
++               } else {
++                       if (pkt->flags & AV_PKT_FLAG_KEY) {
++                               av_packet_unref(&mkv->old_key_packet);
++                               av_packet_ref(&mkv->old_key_packet, pkt);
++                       }
++                       return 0;
++               }
++       }
++#endif
++
+     if (mkv->cluster_pos != -1) {
+         if (mkv->tracks[pkt->stream_index].write_dts)
+             cluster_time = pkt->dts - mkv->cluster_pts;
+@@ -2788,6 +2835,9 @@ static const AVOption options[] = {
+     { "dash", "Create a WebM file conforming to WebM DASH specification", OFFSET(is_dash), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "dash_track_number", "Track number for the DASH stream", OFFSET(dash_track_number), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, INT_MAX, FLAGS },
+     { "live", "Write files assuming it is a live stream.", OFFSET(is_live), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++    { "webm_seek_time",    "seek time", OFFSET(seek_time), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, FLAGS },
++#endif
+     { "allow_raw_vfw", "allow RAW VFW mode", OFFSET(allow_raw_vfw), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "write_crc32", "write a CRC32 element inside every Level 1 element", OFFSET(write_crc), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, FLAGS },
+     { "default_mode", "Controls how a track's FlagDefault is inferred", OFFSET(default_mode), AV_OPT_TYPE_INT, { .i64 = DEFAULT_MODE_INFER }, DEFAULT_MODE_INFER, DEFAULT_MODE_PASSTHROUGH, FLAGS, "default_mode" },
+diff -uprN ../ffmpeg-4.3-022/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-022/synoconfig.h	2020-06-16 20:00:07.000000000 -0400
++++ ./synoconfig.h	2020-06-27 16:35:13.221186636 -0400
+@@ -22,3 +22,12 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
+ #endif
++ 
++/* Add ffmpeg option for WEBM.
++ * -webm_seek_time:
++ *  Let output stream with the seek time
++ * See Video Station #2170
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++#endif

--- a/cross/ffmpeg6/patches/0110-SYNO-smooth-streaming.patch
+++ b/cross/ffmpeg6/patches/0110-SYNO-smooth-streaming.patch
@@ -1,0 +1,106 @@
+diff -uprN ../ffmpeg-4.3-023/libavformat/smoothstreamingenc.c ./libavformat/smoothstreamingenc.c
+--- ../ffmpeg-4.3-023/libavformat/smoothstreamingenc.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/smoothstreamingenc.c	2020-06-16 20:08:21.691804931 -0400
+@@ -39,6 +39,8 @@
+ #include "libavutil/mathematics.h"
+ #include "libavutil/intreadwrite.h"
+ 
++#include "synoconfig.h"
++
+ typedef struct Fragment {
+     char file[1024];
+     char infofile[1024];
+@@ -77,6 +79,11 @@ typedef struct SmoothStreamingContext {
+     OutputStream *streams;
+     int has_video, has_audio;
+     int nb_fragments;
++#ifdef SYNO_SMOOTH_STREAMING
++	char *fragment_url;
++	int fragment_length;
++	int seek_time;
++#endif
+ } SmoothStreamingContext;
+ 
+ static int ism_write(void *opaque, uint8_t *buf, int buf_size)
+@@ -250,8 +257,13 @@ static int write_manifest(AVFormatContex
+     avio_printf(out, ">\n");
+     if (c->has_video) {
+         int last = -1, index = 0;
+-        avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks);
+-        for (i = 0; i < s->nb_streams; i++) {
++#ifdef SYNO_SMOOTH_STREAMING
++	avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"%    sQualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks,
++					(NULL == c->fragment_url) ? "" :  c->fragment_url);
++#else
++		avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks);
++#endif
++		for (i = 0; i < s->nb_streams; i++) {
+             OutputStream *os = &c->streams[i];
+             if (s->streams[i]->codecpar->codec_type != AVMEDIA_TYPE_VIDEO)
+                 continue;
+@@ -264,8 +276,13 @@ static int write_manifest(AVFormatContex
+     }
+     if (c->has_audio) {
+         int last = -1, index = 0;
+-        avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks);
+-        for (i = 0; i < s->nb_streams; i++) {
++#ifdef SYNO_SMOOTH_STREAMING
++avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"%    sQualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks,
++					(NULL == c->fragment_url) ? "" :  c->fragment_url);
++#else
++		avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks);
++#endif
++		for (i = 0; i < s->nb_streams; i++) {
+             OutputStream *os = &c->streams[i];
+             if (s->streams[i]->codecpar->codec_type != AVMEDIA_TYPE_AUDIO)
+                 continue;
+@@ -555,6 +572,14 @@ static int ism_flush(AVFormatContext *s,
+                 return ret;
+         }
+ 
++#ifdef SYNO_SMOOTH_STREAMING
++        if (0 != c->fragment_length) {
++                start_ts = (int64_t)((int64_t)os->nb_fragments * (int64_t)c->fragment_length * (int64_t)10000000);
++        }
++        if (0 != c->seek_time) {
++                start_ts += (int64_t)((int64_t)c->seek_time * (int64_t)10000000);
++        }
++#endif
+         snprintf(header_filename, sizeof(header_filename), "%s/FragmentInfo(%s=%"PRIu64")", os->dirname, os->stream_type_tag, start_ts);
+         snprintf(target_filename, sizeof(target_filename), "%s/Fragments(%s=%"PRIu64")", os->dirname, os->stream_type_tag, start_ts);
+         copy_moof(s, filename, header_filename, moof_size);
+@@ -640,7 +665,12 @@ static const AVOption options[] = {
+     { "lookahead_count", "number of lookahead fragments", OFFSET(lookahead_count), AV_OPT_TYPE_INT, { .i64 = 2 }, 0, INT_MAX, E },
+     { "min_frag_duration", "minimum fragment duration (in microseconds)", OFFSET(min_frag_duration), AV_OPT_TYPE_INT64, { .i64 = 5000000 }, 0, INT_MAX, E },
+     { "remove_at_exit", "remove all fragments when finished", OFFSET(remove_at_exit), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
+-    { NULL },
++#ifdef SYNO_SMOOTH_STREAMING
++	{ "fragment_url", "set fragment url in manifest", OFFSET(fragment_url), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, E },
++    { "fragment_length", "let file name of output fragment mp4 with the duration (in seconds)", OFFSET(fragment_length), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
++    { "seek_time", "add seek time to fragment file (in seconds)", OFFSET(seek_time), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
++#endif
++     { NULL },
+ };
+ 
+ static const AVClass ism_class = {
+diff -uprN ../ffmpeg-4.3-023/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-023/synoconfig.h	2020-06-16 20:01:36.286633640 -0400
++++ ./synoconfig.h	2020-06-16 20:08:21.691804931 -0400
+@@ -31,3 +31,17 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_WEBM_SEEK_TIME
+ #endif
++
++/* Add ffmpeg option for smooth streaming.
++ * -fragment_url:
++ *  This option can overwrite fragment url in Manifest for smooth streaming.
++ * -fragment_length:
++ *  Let file name of output fragment mp4 with this duration
++ *  This setting dependes on x264 option to make it work
++ * -seek_time:
++ *  Let file name fo output fragment mp4 start with this seek time
++ * See Video Station #659
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_SMOOTH_STREAMING
++#endif

--- a/cross/ffmpeg7/Makefile
+++ b/cross/ffmpeg7/Makefile
@@ -36,6 +36,10 @@ endif
 # Must match $(SPK_REV) from spk/ffmpeg$(PKG_MINOR_VERS)/Makefile
 CONFIGURE_ARGS += --extra-version=$(shell sed -n 's/^SPK_REV = \(.*\)/\1/p' $(WORK_DIR)/../../../spk/ffmpeg$(PKG_MINOR_VERS)/Makefile)
 
+# Enable the Synology VideoStation compatibility code added by the
+# SYNO-* patch series (hls_seek_time, smooth streaming, srt tags, ...)
+CONFIGURE_ARGS += --extra-cflags=-DSYNO_VIDEOSTATION
+
 # Compiler workaround to enable DTS-HD MA stream decoding
 CONFIGURE_ARGS += --extra-cflags=-fno-if-conversion
 # Remove some of the noise while compiling

--- a/cross/ffmpeg7/Makefile
+++ b/cross/ffmpeg7/Makefile
@@ -244,9 +244,6 @@ CONFIGURE_ARGS += --disable-armv5te
 CONFIGURE_ARGS += --disable-armv6
 CONFIGURE_ARGS += --disable-armv6t2
 CONFIGURE_ARGS += --disable-vfp
-ifeq ($(findstring $(ARCH),alpine),$(ARCH))
-CONFIGURE_ARGS += --extra-cflags=-DSYNO_ALPINE_NEON
-endif
 endif
 
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))

--- a/cross/ffmpeg7/patches/0100-SYNO-videostation-hls-seek-time.patch
+++ b/cross/ffmpeg7/patches/0100-SYNO-videostation-hls-seek-time.patch
@@ -1,0 +1,120 @@
+diff -uprN ../ffmpeg-4.3-005/libavformat/segment.c ./libavformat/segment.c
+--- ../ffmpeg-4.3-005/libavformat/segment.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/segment.c	2020-06-16 19:54:41.332482718 -0400
+@@ -43,6 +43,8 @@
+ #include "libavutil/time_internal.h"
+ #include "libavutil/timestamp.h"
+ 
++#include "synoconfig.h"
++
+ typedef struct SegmentListEntry {
+     int index;
+     double start_time, end_time;
+@@ -123,6 +125,12 @@ typedef struct SegmentContext {
+     SegmentListEntry cur_entry;
+     SegmentListEntry *segment_list_entries;
+     SegmentListEntry *segment_list_entries_end;
++
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	int64_t seek_time;
++	AVPacket old_key_packet;
++	int filled;
++#endif
+ } SegmentContext;
+ 
+ static void print_csv_escaped_str(AVIOContext *ctx, const char *str)
+@@ -854,6 +862,10 @@ static int seg_write_header(AVFormatCont
+         if (!seg->individual_header_trailer)
+             oc->pb->seekable = 0;
+     }
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	av_init_packet(&seg->old_key_packet);
++	seg->filled = 1;
++#endif
+ 
+     return 0;
+ }
+@@ -885,6 +897,40 @@ static int seg_write_packet(AVFormatCont
+         }
+     }
+ 
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	int64_t pts = AV_NOPTS_VALUE;
++	if (0 < seg->seek_time && seg->filled) {
++		if (pkt->stream_index != seg->reference_stream_index) {
++			return 0;
++		}
++
++		if (pkt->pts != AV_NOPTS_VALUE) {
++			pts = pkt->pts;
++		} else if (pkt->dts != AV_NOPTS_VALUE) {
++			pts = pkt->dts;
++		}
++		if (pts >= 0) {
++			if (pkt->flags & AV_PKT_FLAG_KEY) {
++				seg->filled = 0;
++			} else if (NULL != seg->old_key_packet.data) {
++				seg->old_key_packet.pts = pkt->pts;
++				seg->old_key_packet.dts = pkt->dts;
++				seg->old_key_packet.duration = pkt->duration;
++				av_packet_unref(pkt);
++				av_init_packet(pkt);
++				av_packet_ref(pkt, &seg->old_key_packet);
++				seg->filled = 0;
++			}
++			av_packet_unref(&seg->old_key_packet);
++		} else {
++			if (pkt->flags & AV_PKT_FLAG_KEY) {
++				av_packet_unref(&seg->old_key_packet);
++				av_packet_ref(&seg->old_key_packet, pkt);
++			}
++			return 0;
++		}
++	}
++#endif
+ calc_times:
+     if (seg->times) {
+         end_pts = seg->segment_count < seg->nb_times ?
+@@ -971,6 +1017,15 @@ calc_times:
+            av_ts2str(pkt->pts), av_ts2timestr(pkt->pts, &st->time_base),
+            av_ts2str(pkt->dts), av_ts2timestr(pkt->dts, &st->time_base));
+ 
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++       if (0 < seg->seek_time) {
++               if (pkt->pts != AV_NOPTS_VALUE)
++                       pkt->pts += av_rescale_q(seg->seek_time, (AVRational) {1, 1000}, st->time_base);
++               if (pkt->dts != AV_NOPTS_VALUE)
++                       pkt->dts += av_rescale_q(seg->seek_time, (AVRational) {1, 1000}, st->time_base);
++       }
++#endif
++
+     ret = ff_write_chained(seg->avf, pkt->stream_index, pkt, s,
+                            seg->initial_offset || seg->reset_timestamps || seg->avf->oformat->interleave_packet);
+ 
+@@ -1085,6 +1140,9 @@ static const AVOption options[] = {
+     { "reset_timestamps", "reset timestamps at the beginning of each segment", OFFSET(reset_timestamps), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
+     { "initial_offset", "set initial timestamp offset", OFFSET(initial_offset), AV_OPT_TYPE_DURATION, {.i64 = 0}, -INT64_MAX, INT64_MAX, E },
+     { "write_empty_segments", "allow writing empty 'filler' segments", OFFSET(write_empty), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++    { "hls_seek_time",    "initial segment start time", OFFSET(seek_time), AV_OPT_TYPE_INT64, {.i64 = 0}, 0, INT_MAX, E },
++#endif
+     { NULL },
+ };
+ 
+Binary files ../ffmpeg-4.3-005/libavformat/.segment.c.rej.swp and ./libavformat/.segment.c.rej.swp differ
+diff -uprN ../ffmpeg-4.3-005/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-005/synoconfig.h	1969-12-31 19:00:00.000000000 -0500
++++ ./synoconfig.h	2020-06-16 19:53:14.125668365 -0400
+@@ -0,0 +1,12 @@
++#ifndef MY_ABC_HERE
++#define MY_ABC_HERE
++#endif
++
++/* Add ffmpeg option for HLS.
++ * -hls_seek_time:
++ *  Let output fragment ts start with this seek time
++ * See Video Station #1758
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_HLS_SEEK_TIME
++#endif

--- a/cross/ffmpeg7/patches/0101-SYNO-videostation-hls-costumized-ts-name.patch
+++ b/cross/ffmpeg7/patches/0101-SYNO-videostation-hls-costumized-ts-name.patch
@@ -1,0 +1,30 @@
+diff -uprN ../ffmpeg-4.3-020/libavformat/segment.c ./libavformat/segment.c
+--- ../ffmpeg-4.3-020/libavformat/segment.c	2020-06-16 19:54:41.000000000 -0400
++++ ./libavformat/segment.c	2020-06-16 19:57:31.891853716 -0400
+@@ -237,9 +237,15 @@ static int set_segment_filename(AVFormat
+ 
+     if ((ret = av_reallocp(&seg->cur_entry.filename, size)) < 0)
+         return ret;
++#ifdef SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
++    snprintf(seg->cur_entry.filename, size, "%s%03d",
++             seg->entry_prefix ? seg->entry_prefix : "",
++             seg->segment_idx);
++#else
+     snprintf(seg->cur_entry.filename, size, "%s%s",
+              seg->entry_prefix ? seg->entry_prefix : "",
+              av_basename(oc->url));
++#endif
+ 
+     return 0;
+ }
+diff -uprN ../ffmpeg-4.3-020/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-020/synoconfig.h	2020-06-16 19:53:14.000000000 -0400
++++ ./synoconfig.h	2020-06-16 19:57:31.891853716 -0400
+@@ -10,3 +10,7 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_SEEK_TIME
+ #endif
++
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
++#endif

--- a/cross/ffmpeg7/patches/0102-SYNO-videostation-skip-displaymatrix.patch
+++ b/cross/ffmpeg7/patches/0102-SYNO-videostation-skip-displaymatrix.patch
@@ -1,0 +1,47 @@
+--- ../ffmpeg-7.0.2/libavformat/movenc.c	2024-08-02 22:55:25.000000000 +0000
++++ ./libavformat/movenc.c	2024-09-24 23:27:44.198262220 +0000
+@@ -124,6 +124,9 @@ static const AVOption options[] = {
+       { "pts", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_PTS}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, .unit = "prft"},
+       { "wallclock", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_WALLCLOCK}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, .unit = "prft"},
+     { "write_tmcd", "force or disable writing tmcd", offsetof(MOVMuxContext, write_tmcd), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++    { "skip_displaymatrix", "Skip writing displaymatrix metadata.", offsetof(MOVMuxContext, skip_displaymatrix), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
++#endif
+     { NULL },
+ };
+ 
+@@ -3505,7 +3508,13 @@ static int mov_write_tkhd_tag(AVIOContex
+                                      st->codecpar->nb_coded_side_data,
+                                      AV_PKT_DATA_DISPLAYMATRIX);
+         if (sd && sd->size == 9 * sizeof(*display_matrix))
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++            if (mov->skip_displaymatrix) {
++               display_matrix = NULL;
++            }
++#else
+             display_matrix = (uint32_t *)sd->data;
++#endif
+     }
+ 
+     if (track->flags & MOV_TRACK_ENABLED)
+--- ../ffmpeg-7.0.2/libavformat/movenc.h	2024-08-02 22:55:22.000000000 +0000
++++ ./libavformat/movenc.h	2024-09-24 23:19:32.992183584 +0000
+@@ -28,6 +28,8 @@
+ #include "movenccenc.h"
+ #include "libavcodec/packet_internal.h"
+ 
++#include "synoconfig.h"
++
+ #define MOV_FRAG_INFO_ALLOC_INCREMENT 64
+ #define MOV_INDEX_CLUSTER_SIZE 1024
+ #define MOV_TIMESCALE 1000
+@@ -205,6 +207,9 @@ typedef struct MOVMuxContext {
+     int rtp_flags;
+ 
+     int iods_skip;
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++    int skip_displaymatrix;
++#endif
+     int iods_video_profile;
+     int iods_audio_profile;
+ 

--- a/cross/ffmpeg7/patches/0102-SYNO-videostation-skip-displaymatrix.patch
+++ b/cross/ffmpeg7/patches/0102-SYNO-videostation-skip-displaymatrix.patch
@@ -45,3 +45,17 @@
      int iods_video_profile;
      int iods_audio_profile;
  
+--- ../ffmpeg-7.1.5-orig/synoconfig.h	2026-07-15 14:51:28.546631081 +0000
++++ ./synoconfig.h	2026-07-15 14:51:28.551301684 +0000
+@@ -14,3 +14,11 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
+ #endif
++
++/* Add skip displaymatrix config to movenc for video station offline transcoding.
++ * add flag "-skip_displaymatrix 1" to mov/mp4 format for skiping writing displaymatrix metadata.
++ * See Video Station #4464
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++#endif

--- a/cross/ffmpeg7/patches/0103-SYNO-videostation-webm-seek-time.patch
+++ b/cross/ffmpeg7/patches/0103-SYNO-videostation-webm-seek-time.patch
@@ -1,0 +1,104 @@
+diff -uprN ../ffmpeg-7.1.3-orig/libavformat/matroskaenc.c ./libavformat/matroskaenc.c
+--- ../ffmpeg-7.1.3-orig/libavformat/matroskaenc.c	2025-11-21 01:15:18.000000000 +0000
++++ ./libavformat/matroskaenc.c	2025-12-27 00:17:35.208681789 +0000
+@@ -93,6 +93,8 @@ enum {
+     DEFAULT_MODE_PASSTHROUGH,
+ };
+ 
++#include "synoconfig.h"
++
+ typedef struct ebml_master {
+     int64_t         pos;                ///< absolute offset in the containing AVIOContext where the master's elements start
+     int             sizebytes;          ///< how many bytes were reserved for the size
+@@ -261,6 +263,11 @@ typedef struct MatroskaMuxContext {
+     int                 move_cues_to_front;
+ 
+     uint32_t            segment_uid[4];
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++       int64_t seek_time;
++       AVPacket old_key_packet;
++       int unfilled;
++#endif
+ } MatroskaMuxContext;
+ 
+ /** 2 bytes * 3 for EBML IDs, 3 1-byte EBML lengths, 8 bytes for 64 bit
+@@ -2684,6 +2691,11 @@ static int mkv_write_header(AVFormatCont
+             mkv->cluster_size_limit = 32 * 1024;
+     }
+ 
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++	av_init_packet(&mkv->old_key_packet);
++	mkv->unfilled = 1;
++#endif
++
+     return 0;
+ }
+ 
+@@ -3077,6 +3089,41 @@ static int mkv_write_packet(AVFormatCont
+     if (ret < 0)
+         return ret;
+ 
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++       int64_t pts = AV_NOPTS_VALUE;
++       if (0 < mkv->seek_time && mkv->unfilled) {
++               if (codec_type != AVMEDIA_TYPE_VIDEO) {
++                       return 0;
++               }
++
++               if (pkt->pts != AV_NOPTS_VALUE) {
++                       pts = pkt->pts;
++               } else if (pkt->dts != AV_NOPTS_VALUE) {
++                       pts = pkt->dts;
++               }
++               if (pts >= 0) {
++                       if (pkt->flags & AV_PKT_FLAG_KEY) {
++                               mkv->unfilled = 0;
++                       } else if (NULL != mkv->old_key_packet.data) {
++                               mkv->old_key_packet.pts = pkt->pts;
++                               mkv->old_key_packet.dts = pkt->dts;
++                               mkv->old_key_packet.duration = pkt->duration;
++                               av_packet_unref(pkt);
++                               av_init_packet(pkt);
++                               av_packet_ref(pkt, &mkv->old_key_packet);
++                               mkv->unfilled = 0;
++                       }
++                       av_packet_unref(&mkv->old_key_packet);
++               } else {
++                       if (pkt->flags & AV_PKT_FLAG_KEY) {
++                               av_packet_unref(&mkv->old_key_packet);
++                               av_packet_ref(&mkv->old_key_packet, pkt);
++                       }
++                       return 0;
++               }
++       }
++#endif
++
+     if (mkv->cluster_pos != -1) {
+         if (mkv->tracks[pkt->stream_index].write_dts)
+             cluster_time = pkt->dts - mkv->cluster_pts;
+@@ -3544,6 +3591,9 @@ static const AVOption options[] = {
+     { "dash", "create a WebM file conforming to WebM DASH specification", OFFSET(is_dash), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "dash_track_number", "track number for the DASH stream", OFFSET(dash_track_number), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, INT_MAX, FLAGS },
+     { "live", "write files assuming it is a live stream", OFFSET(is_live), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++    { "webm_seek_time",    "seek time", OFFSET(seek_time), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, FLAGS },
++#endif
+     { "allow_raw_vfw", "allow raw VFW mode", OFFSET(allow_raw_vfw), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "flipped_raw_rgb", "store raw RGB bitmaps in VFW mode in bottom-up mode", OFFSET(flipped_raw_rgb), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "write_crc32", "write a CRC32 element inside every Level 1 element", OFFSET(write_crc), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, FLAGS },
+diff -uprN ../ffmpeg-7.1.3-orig/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-7.1.3-orig/synoconfig.h	2025-12-27 00:18:43.532108129 +0000
++++ ./synoconfig.h	2025-12-27 00:16:12.155415334 +0000
+@@ -14,3 +14,12 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
+ #endif
++ 
++/* Add ffmpeg option for WEBM.
++ * -webm_seek_time:
++ *  Let output stream with the seek time
++ * See Video Station #2170
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++#endif

--- a/cross/ffmpeg7/patches/0110-SYNO-smooth-streaming.patch
+++ b/cross/ffmpeg7/patches/0110-SYNO-smooth-streaming.patch
@@ -1,0 +1,106 @@
+diff -uprN ../ffmpeg-4.3-023/libavformat/smoothstreamingenc.c ./libavformat/smoothstreamingenc.c
+--- ../ffmpeg-4.3-023/libavformat/smoothstreamingenc.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/smoothstreamingenc.c	2020-06-16 20:08:21.691804931 -0400
+@@ -39,6 +39,8 @@
+ #include "libavutil/mathematics.h"
+ #include "libavutil/intreadwrite.h"
+ 
++#include "synoconfig.h"
++
+ typedef struct Fragment {
+     char file[1024];
+     char infofile[1024];
+@@ -77,6 +79,11 @@ typedef struct SmoothStreamingContext {
+     OutputStream *streams;
+     int has_video, has_audio;
+     int nb_fragments;
++#ifdef SYNO_SMOOTH_STREAMING
++	char *fragment_url;
++	int fragment_length;
++	int seek_time;
++#endif
+ } SmoothStreamingContext;
+ 
+ static int ism_write(void *opaque, uint8_t *buf, int buf_size)
+@@ -250,8 +257,13 @@ static int write_manifest(AVFormatContex
+     avio_printf(out, ">\n");
+     if (c->has_video) {
+         int last = -1, index = 0;
+-        avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks);
+-        for (i = 0; i < s->nb_streams; i++) {
++#ifdef SYNO_SMOOTH_STREAMING
++	avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"%    sQualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks,
++					(NULL == c->fragment_url) ? "" :  c->fragment_url);
++#else
++		avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks);
++#endif
++		for (i = 0; i < s->nb_streams; i++) {
+             OutputStream *os = &c->streams[i];
+             if (s->streams[i]->codecpar->codec_type != AVMEDIA_TYPE_VIDEO)
+                 continue;
+@@ -264,8 +276,13 @@ static int write_manifest(AVFormatContex
+     }
+     if (c->has_audio) {
+         int last = -1, index = 0;
+-        avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks);
+-        for (i = 0; i < s->nb_streams; i++) {
++#ifdef SYNO_SMOOTH_STREAMING
++avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"%    sQualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks,
++					(NULL == c->fragment_url) ? "" :  c->fragment_url);
++#else
++		avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks);
++#endif
++		for (i = 0; i < s->nb_streams; i++) {
+             OutputStream *os = &c->streams[i];
+             if (s->streams[i]->codecpar->codec_type != AVMEDIA_TYPE_AUDIO)
+                 continue;
+@@ -555,6 +572,14 @@ static int ism_flush(AVFormatContext *s,
+                 return ret;
+         }
+ 
++#ifdef SYNO_SMOOTH_STREAMING
++        if (0 != c->fragment_length) {
++                start_ts = (int64_t)((int64_t)os->nb_fragments * (int64_t)c->fragment_length * (int64_t)10000000);
++        }
++        if (0 != c->seek_time) {
++                start_ts += (int64_t)((int64_t)c->seek_time * (int64_t)10000000);
++        }
++#endif
+         snprintf(header_filename, sizeof(header_filename), "%s/FragmentInfo(%s=%"PRIu64")", os->dirname, os->stream_type_tag, start_ts);
+         snprintf(target_filename, sizeof(target_filename), "%s/Fragments(%s=%"PRIu64")", os->dirname, os->stream_type_tag, start_ts);
+         copy_moof(s, filename, header_filename, moof_size);
+@@ -640,7 +665,12 @@ static const AVOption options[] = {
+     { "lookahead_count", "number of lookahead fragments", OFFSET(lookahead_count), AV_OPT_TYPE_INT, { .i64 = 2 }, 0, INT_MAX, E },
+     { "min_frag_duration", "minimum fragment duration (in microseconds)", OFFSET(min_frag_duration), AV_OPT_TYPE_INT64, { .i64 = 5000000 }, 0, INT_MAX, E },
+     { "remove_at_exit", "remove all fragments when finished", OFFSET(remove_at_exit), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
+-    { NULL },
++#ifdef SYNO_SMOOTH_STREAMING
++	{ "fragment_url", "set fragment url in manifest", OFFSET(fragment_url), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, E },
++    { "fragment_length", "let file name of output fragment mp4 with the duration (in seconds)", OFFSET(fragment_length), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
++    { "seek_time", "add seek time to fragment file (in seconds)", OFFSET(seek_time), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
++#endif
++     { NULL },
+ };
+ 
+ static const AVClass ism_class = {
+diff -uprN ../ffmpeg-4.3-023/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-023/synoconfig.h	2020-06-16 20:01:36.286633640 -0400
++++ ./synoconfig.h	2020-06-16 20:08:21.691804931 -0400
+@@ -31,3 +31,17 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_WEBM_SEEK_TIME
+ #endif
++
++/* Add ffmpeg option for smooth streaming.
++ * -fragment_url:
++ *  This option can overwrite fragment url in Manifest for smooth streaming.
++ * -fragment_length:
++ *  Let file name of output fragment mp4 with this duration
++ *  This setting dependes on x264 option to make it work
++ * -seek_time:
++ *  Let file name fo output fragment mp4 start with this seek time
++ * See Video Station #659
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_SMOOTH_STREAMING
++#endif

--- a/cross/ffmpeg8/Makefile
+++ b/cross/ffmpeg8/Makefile
@@ -36,6 +36,10 @@ endif
 # Must match $(SPK_REV) from spk/ffmpeg$(PKG_MINOR_VERS)/Makefile
 CONFIGURE_ARGS += --extra-version=$(shell sed -n 's/^SPK_REV = \(.*\)/\1/p' $(WORK_DIR)/../../../spk/ffmpeg$(PKG_MINOR_VERS)/Makefile)
 
+# Enable the Synology VideoStation compatibility code added by the
+# SYNO-* patch series (hls_seek_time, smooth streaming, srt tags, ...)
+CONFIGURE_ARGS += --extra-cflags=-DSYNO_VIDEOSTATION
+
 # Compiler workaround to enable DTS-HD MA stream decoding
 CONFIGURE_ARGS += --extra-cflags=-fno-if-conversion
 # Remove some of the noise while compiling

--- a/cross/ffmpeg8/Makefile
+++ b/cross/ffmpeg8/Makefile
@@ -244,9 +244,6 @@ CONFIGURE_ARGS += --disable-armv5te
 CONFIGURE_ARGS += --disable-armv6
 CONFIGURE_ARGS += --disable-armv6t2
 CONFIGURE_ARGS += --disable-vfp
-ifeq ($(findstring $(ARCH),alpine),$(ARCH))
-CONFIGURE_ARGS += --extra-cflags=-DSYNO_ALPINE_NEON
-endif
 endif
 
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))

--- a/cross/ffmpeg8/patches/0100-SYNO-videostation-hls-seek-time.patch
+++ b/cross/ffmpeg8/patches/0100-SYNO-videostation-hls-seek-time.patch
@@ -1,0 +1,120 @@
+diff -uprN ../ffmpeg-4.3-005/libavformat/segment.c ./libavformat/segment.c
+--- ../ffmpeg-4.3-005/libavformat/segment.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/segment.c	2020-06-16 19:54:41.332482718 -0400
+@@ -43,6 +43,8 @@
+ #include "libavutil/time_internal.h"
+ #include "libavutil/timestamp.h"
+ 
++#include "synoconfig.h"
++
+ typedef struct SegmentListEntry {
+     int index;
+     double start_time, end_time;
+@@ -123,6 +125,12 @@ typedef struct SegmentContext {
+     SegmentListEntry cur_entry;
+     SegmentListEntry *segment_list_entries;
+     SegmentListEntry *segment_list_entries_end;
++
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	int64_t seek_time;
++	AVPacket old_key_packet;
++	int filled;
++#endif
+ } SegmentContext;
+ 
+ static void print_csv_escaped_str(AVIOContext *ctx, const char *str)
+@@ -854,6 +862,10 @@ static int seg_write_header(AVFormatCont
+         if (!seg->individual_header_trailer)
+             oc->pb->seekable = 0;
+     }
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	av_init_packet(&seg->old_key_packet);
++	seg->filled = 1;
++#endif
+ 
+     return 0;
+ }
+@@ -885,6 +897,40 @@ static int seg_write_packet(AVFormatCont
+         }
+     }
+ 
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++	int64_t pts = AV_NOPTS_VALUE;
++	if (0 < seg->seek_time && seg->filled) {
++		if (pkt->stream_index != seg->reference_stream_index) {
++			return 0;
++		}
++
++		if (pkt->pts != AV_NOPTS_VALUE) {
++			pts = pkt->pts;
++		} else if (pkt->dts != AV_NOPTS_VALUE) {
++			pts = pkt->dts;
++		}
++		if (pts >= 0) {
++			if (pkt->flags & AV_PKT_FLAG_KEY) {
++				seg->filled = 0;
++			} else if (NULL != seg->old_key_packet.data) {
++				seg->old_key_packet.pts = pkt->pts;
++				seg->old_key_packet.dts = pkt->dts;
++				seg->old_key_packet.duration = pkt->duration;
++				av_packet_unref(pkt);
++				av_init_packet(pkt);
++				av_packet_ref(pkt, &seg->old_key_packet);
++				seg->filled = 0;
++			}
++			av_packet_unref(&seg->old_key_packet);
++		} else {
++			if (pkt->flags & AV_PKT_FLAG_KEY) {
++				av_packet_unref(&seg->old_key_packet);
++				av_packet_ref(&seg->old_key_packet, pkt);
++			}
++			return 0;
++		}
++	}
++#endif
+ calc_times:
+     if (seg->times) {
+         end_pts = seg->segment_count < seg->nb_times ?
+@@ -971,6 +1017,15 @@ calc_times:
+            av_ts2str(pkt->pts), av_ts2timestr(pkt->pts, &st->time_base),
+            av_ts2str(pkt->dts), av_ts2timestr(pkt->dts, &st->time_base));
+ 
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++       if (0 < seg->seek_time) {
++               if (pkt->pts != AV_NOPTS_VALUE)
++                       pkt->pts += av_rescale_q(seg->seek_time, (AVRational) {1, 1000}, st->time_base);
++               if (pkt->dts != AV_NOPTS_VALUE)
++                       pkt->dts += av_rescale_q(seg->seek_time, (AVRational) {1, 1000}, st->time_base);
++       }
++#endif
++
+     ret = ff_write_chained(seg->avf, pkt->stream_index, pkt, s,
+                            seg->initial_offset || seg->reset_timestamps || seg->avf->oformat->interleave_packet);
+ 
+@@ -1085,6 +1140,9 @@ static const AVOption options[] = {
+     { "reset_timestamps", "reset timestamps at the beginning of each segment", OFFSET(reset_timestamps), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
+     { "initial_offset", "set initial timestamp offset", OFFSET(initial_offset), AV_OPT_TYPE_DURATION, {.i64 = 0}, -INT64_MAX, INT64_MAX, E },
+     { "write_empty_segments", "allow writing empty 'filler' segments", OFFSET(write_empty), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
++#ifdef SYNO_VIDEOSTATION_HLS_SEEK_TIME
++    { "hls_seek_time",    "initial segment start time", OFFSET(seek_time), AV_OPT_TYPE_INT64, {.i64 = 0}, 0, INT_MAX, E },
++#endif
+     { NULL },
+ };
+ 
+Binary files ../ffmpeg-4.3-005/libavformat/.segment.c.rej.swp and ./libavformat/.segment.c.rej.swp differ
+diff -uprN ../ffmpeg-4.3-005/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-005/synoconfig.h	1969-12-31 19:00:00.000000000 -0500
++++ ./synoconfig.h	2020-06-16 19:53:14.125668365 -0400
+@@ -0,0 +1,12 @@
++#ifndef MY_ABC_HERE
++#define MY_ABC_HERE
++#endif
++
++/* Add ffmpeg option for HLS.
++ * -hls_seek_time:
++ *  Let output fragment ts start with this seek time
++ * See Video Station #1758
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_HLS_SEEK_TIME
++#endif

--- a/cross/ffmpeg8/patches/0101-SYNO-videostation-hls-costumized-ts-name.patch
+++ b/cross/ffmpeg8/patches/0101-SYNO-videostation-hls-costumized-ts-name.patch
@@ -1,0 +1,30 @@
+diff -uprN ../ffmpeg-4.3-020/libavformat/segment.c ./libavformat/segment.c
+--- ../ffmpeg-4.3-020/libavformat/segment.c	2020-06-16 19:54:41.000000000 -0400
++++ ./libavformat/segment.c	2020-06-16 19:57:31.891853716 -0400
+@@ -237,9 +237,15 @@ static int set_segment_filename(AVFormat
+ 
+     if ((ret = av_reallocp(&seg->cur_entry.filename, size)) < 0)
+         return ret;
++#ifdef SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
++    snprintf(seg->cur_entry.filename, size, "%s%03d",
++             seg->entry_prefix ? seg->entry_prefix : "",
++             seg->segment_idx);
++#else
+     snprintf(seg->cur_entry.filename, size, "%s%s",
+              seg->entry_prefix ? seg->entry_prefix : "",
+              av_basename(oc->url));
++#endif
+ 
+     return 0;
+ }
+diff -uprN ../ffmpeg-4.3-020/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-020/synoconfig.h	2020-06-16 19:53:14.000000000 -0400
++++ ./synoconfig.h	2020-06-16 19:57:31.891853716 -0400
+@@ -10,3 +10,7 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_SEEK_TIME
+ #endif
++
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
++#endif

--- a/cross/ffmpeg8/patches/0102-SYNO-videostation-skip-displaymatrix.patch
+++ b/cross/ffmpeg8/patches/0102-SYNO-videostation-skip-displaymatrix.patch
@@ -1,0 +1,47 @@
+--- ../ffmpeg-7.0.2/libavformat/movenc.c	2024-08-02 22:55:25.000000000 +0000
++++ ./libavformat/movenc.c	2024-09-24 23:27:44.198262220 +0000
+@@ -124,6 +124,9 @@ static const AVOption options[] = {
+       { "pts", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_PTS}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, .unit = "prft"},
+       { "wallclock", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = MOV_PRFT_SRC_WALLCLOCK}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM, .unit = "prft"},
+     { "write_tmcd", "force or disable writing tmcd", offsetof(MOVMuxContext, write_tmcd), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++    { "skip_displaymatrix", "Skip writing displaymatrix metadata.", offsetof(MOVMuxContext, skip_displaymatrix), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
++#endif
+     { NULL },
+ };
+ 
+@@ -3505,7 +3508,13 @@ static int mov_write_tkhd_tag(AVIOContex
+                                      st->codecpar->nb_coded_side_data,
+                                      AV_PKT_DATA_DISPLAYMATRIX);
+         if (sd && sd->size == 9 * sizeof(*display_matrix))
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++            if (mov->skip_displaymatrix) {
++               display_matrix = NULL;
++            }
++#else
+             display_matrix = (uint32_t *)sd->data;
++#endif
+     }
+ 
+     if (track->flags & MOV_TRACK_ENABLED)
+--- ../ffmpeg-7.0.2/libavformat/movenc.h	2024-08-02 22:55:22.000000000 +0000
++++ ./libavformat/movenc.h	2024-09-24 23:19:32.992183584 +0000
+@@ -28,6 +28,8 @@
+ #include "movenccenc.h"
+ #include "libavcodec/packet_internal.h"
+ 
++#include "synoconfig.h"
++
+ #define MOV_FRAG_INFO_ALLOC_INCREMENT 64
+ #define MOV_INDEX_CLUSTER_SIZE 1024
+ #define MOV_TIMESCALE 1000
+@@ -205,6 +207,9 @@ typedef struct MOVMuxContext {
+     int rtp_flags;
+ 
+     int iods_skip;
++#ifdef SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++    int skip_displaymatrix;
++#endif
+     int iods_video_profile;
+     int iods_audio_profile;
+ 

--- a/cross/ffmpeg8/patches/0102-SYNO-videostation-skip-displaymatrix.patch
+++ b/cross/ffmpeg8/patches/0102-SYNO-videostation-skip-displaymatrix.patch
@@ -45,3 +45,17 @@
      int iods_video_profile;
      int iods_audio_profile;
  
+--- ../ffmpeg-8.1.2-orig/synoconfig.h	2026-07-15 14:51:28.546631081 +0000
++++ ./synoconfig.h	2026-07-15 14:51:28.551301684 +0000
+@@ -14,3 +14,11 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
+ #endif
++
++/* Add skip displaymatrix config to movenc for video station offline transcoding.
++ * add flag "-skip_displaymatrix 1" to mov/mp4 format for skiping writing displaymatrix metadata.
++ * See Video Station #4464
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_SKIP_DISPLAYMATRIX
++#endif

--- a/cross/ffmpeg8/patches/0103-SYNO-videostation-webm-seek-time.patch
+++ b/cross/ffmpeg8/patches/0103-SYNO-videostation-webm-seek-time.patch
@@ -1,0 +1,104 @@
+diff -uprN ../ffmpeg-7.1.3-orig/libavformat/matroskaenc.c ./libavformat/matroskaenc.c
+--- ../ffmpeg-7.1.3-orig/libavformat/matroskaenc.c	2025-11-21 01:15:18.000000000 +0000
++++ ./libavformat/matroskaenc.c	2025-12-27 00:17:35.208681789 +0000
+@@ -93,6 +93,8 @@ enum {
+     DEFAULT_MODE_PASSTHROUGH,
+ };
+ 
++#include "synoconfig.h"
++
+ typedef struct ebml_master {
+     int64_t         pos;                ///< absolute offset in the containing AVIOContext where the master's elements start
+     int             sizebytes;          ///< how many bytes were reserved for the size
+@@ -261,6 +263,11 @@ typedef struct MatroskaMuxContext {
+     int                 move_cues_to_front;
+ 
+     uint32_t            segment_uid[4];
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++       int64_t seek_time;
++       AVPacket old_key_packet;
++       int unfilled;
++#endif
+ } MatroskaMuxContext;
+ 
+ /** 2 bytes * 3 for EBML IDs, 3 1-byte EBML lengths, 8 bytes for 64 bit
+@@ -2684,6 +2691,11 @@ static int mkv_write_header(AVFormatCont
+             mkv->cluster_size_limit = 32 * 1024;
+     }
+ 
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++	av_init_packet(&mkv->old_key_packet);
++	mkv->unfilled = 1;
++#endif
++
+     return 0;
+ }
+ 
+@@ -3077,6 +3089,41 @@ static int mkv_write_packet(AVFormatCont
+     if (ret < 0)
+         return ret;
+ 
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++       int64_t pts = AV_NOPTS_VALUE;
++       if (0 < mkv->seek_time && mkv->unfilled) {
++               if (codec_type != AVMEDIA_TYPE_VIDEO) {
++                       return 0;
++               }
++
++               if (pkt->pts != AV_NOPTS_VALUE) {
++                       pts = pkt->pts;
++               } else if (pkt->dts != AV_NOPTS_VALUE) {
++                       pts = pkt->dts;
++               }
++               if (pts >= 0) {
++                       if (pkt->flags & AV_PKT_FLAG_KEY) {
++                               mkv->unfilled = 0;
++                       } else if (NULL != mkv->old_key_packet.data) {
++                               mkv->old_key_packet.pts = pkt->pts;
++                               mkv->old_key_packet.dts = pkt->dts;
++                               mkv->old_key_packet.duration = pkt->duration;
++                               av_packet_unref(pkt);
++                               av_init_packet(pkt);
++                               av_packet_ref(pkt, &mkv->old_key_packet);
++                               mkv->unfilled = 0;
++                       }
++                       av_packet_unref(&mkv->old_key_packet);
++               } else {
++                       if (pkt->flags & AV_PKT_FLAG_KEY) {
++                               av_packet_unref(&mkv->old_key_packet);
++                               av_packet_ref(&mkv->old_key_packet, pkt);
++                       }
++                       return 0;
++               }
++       }
++#endif
++
+     if (mkv->cluster_pos != -1) {
+         if (mkv->tracks[pkt->stream_index].write_dts)
+             cluster_time = pkt->dts - mkv->cluster_pts;
+@@ -3544,6 +3591,9 @@ static const AVOption options[] = {
+     { "dash", "create a WebM file conforming to WebM DASH specification", OFFSET(is_dash), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "dash_track_number", "track number for the DASH stream", OFFSET(dash_track_number), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, INT_MAX, FLAGS },
+     { "live", "write files assuming it is a live stream", OFFSET(is_live), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
++#ifdef SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++    { "webm_seek_time",    "seek time", OFFSET(seek_time), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, FLAGS },
++#endif
+     { "allow_raw_vfw", "allow raw VFW mode", OFFSET(allow_raw_vfw), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "flipped_raw_rgb", "store raw RGB bitmaps in VFW mode in bottom-up mode", OFFSET(flipped_raw_rgb), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+     { "write_crc32", "write a CRC32 element inside every Level 1 element", OFFSET(write_crc), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, FLAGS },
+diff -uprN ../ffmpeg-7.1.3-orig/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-7.1.3-orig/synoconfig.h	2025-12-27 00:18:43.532108129 +0000
++++ ./synoconfig.h	2025-12-27 00:16:12.155415334 +0000
+@@ -14,3 +14,12 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_HLS_COSTUMIZED_TS_NAME
+ #endif
++ 
++/* Add ffmpeg option for WEBM.
++ * -webm_seek_time:
++ *  Let output stream with the seek time
++ * See Video Station #2170
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_VIDEOSTATION_WEBM_SEEK_TIME
++#endif

--- a/cross/ffmpeg8/patches/0110-SYNO-smooth-streaming.patch
+++ b/cross/ffmpeg8/patches/0110-SYNO-smooth-streaming.patch
@@ -1,0 +1,106 @@
+diff -uprN ../ffmpeg-4.3-023/libavformat/smoothstreamingenc.c ./libavformat/smoothstreamingenc.c
+--- ../ffmpeg-4.3-023/libavformat/smoothstreamingenc.c	2020-06-15 14:54:24.000000000 -0400
++++ ./libavformat/smoothstreamingenc.c	2020-06-16 20:08:21.691804931 -0400
+@@ -39,6 +39,8 @@
+ #include "libavutil/mathematics.h"
+ #include "libavutil/intreadwrite.h"
+ 
++#include "synoconfig.h"
++
+ typedef struct Fragment {
+     char file[1024];
+     char infofile[1024];
+@@ -77,6 +79,11 @@ typedef struct SmoothStreamingContext {
+     OutputStream *streams;
+     int has_video, has_audio;
+     int nb_fragments;
++#ifdef SYNO_SMOOTH_STREAMING
++	char *fragment_url;
++	int fragment_length;
++	int seek_time;
++#endif
+ } SmoothStreamingContext;
+ 
+ static int ism_write(void *opaque, uint8_t *buf, int buf_size)
+@@ -250,8 +257,13 @@ static int write_manifest(AVFormatContex
+     avio_printf(out, ">\n");
+     if (c->has_video) {
+         int last = -1, index = 0;
+-        avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks);
+-        for (i = 0; i < s->nb_streams; i++) {
++#ifdef SYNO_SMOOTH_STREAMING
++	avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"%    sQualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks,
++					(NULL == c->fragment_url) ? "" :  c->fragment_url);
++#else
++		avio_printf(out, "<StreamIndex Type=\"video\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(video={start time})\">\n", video_streams, video_chunks);
++#endif
++		for (i = 0; i < s->nb_streams; i++) {
+             OutputStream *os = &c->streams[i];
+             if (s->streams[i]->codecpar->codec_type != AVMEDIA_TYPE_VIDEO)
+                 continue;
+@@ -264,8 +276,13 @@ static int write_manifest(AVFormatContex
+     }
+     if (c->has_audio) {
+         int last = -1, index = 0;
+-        avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks);
+-        for (i = 0; i < s->nb_streams; i++) {
++#ifdef SYNO_SMOOTH_STREAMING
++avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"%    sQualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks,
++					(NULL == c->fragment_url) ? "" :  c->fragment_url);
++#else
++		avio_printf(out, "<StreamIndex Type=\"audio\" QualityLevels=\"%d\" Chunks=\"%d\" Url=\"QualityLevels({bitrate})/Fragments(audio={start time})\">\n", audio_streams, audio_chunks);
++#endif
++		for (i = 0; i < s->nb_streams; i++) {
+             OutputStream *os = &c->streams[i];
+             if (s->streams[i]->codecpar->codec_type != AVMEDIA_TYPE_AUDIO)
+                 continue;
+@@ -555,6 +572,14 @@ static int ism_flush(AVFormatContext *s,
+                 return ret;
+         }
+ 
++#ifdef SYNO_SMOOTH_STREAMING
++        if (0 != c->fragment_length) {
++                start_ts = (int64_t)((int64_t)os->nb_fragments * (int64_t)c->fragment_length * (int64_t)10000000);
++        }
++        if (0 != c->seek_time) {
++                start_ts += (int64_t)((int64_t)c->seek_time * (int64_t)10000000);
++        }
++#endif
+         snprintf(header_filename, sizeof(header_filename), "%s/FragmentInfo(%s=%"PRIu64")", os->dirname, os->stream_type_tag, start_ts);
+         snprintf(target_filename, sizeof(target_filename), "%s/Fragments(%s=%"PRIu64")", os->dirname, os->stream_type_tag, start_ts);
+         copy_moof(s, filename, header_filename, moof_size);
+@@ -640,7 +665,12 @@ static const AVOption options[] = {
+     { "lookahead_count", "number of lookahead fragments", OFFSET(lookahead_count), AV_OPT_TYPE_INT, { .i64 = 2 }, 0, INT_MAX, E },
+     { "min_frag_duration", "minimum fragment duration (in microseconds)", OFFSET(min_frag_duration), AV_OPT_TYPE_INT64, { .i64 = 5000000 }, 0, INT_MAX, E },
+     { "remove_at_exit", "remove all fragments when finished", OFFSET(remove_at_exit), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
+-    { NULL },
++#ifdef SYNO_SMOOTH_STREAMING
++	{ "fragment_url", "set fragment url in manifest", OFFSET(fragment_url), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, E },
++    { "fragment_length", "let file name of output fragment mp4 with the duration (in seconds)", OFFSET(fragment_length), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
++    { "seek_time", "add seek time to fragment file (in seconds)", OFFSET(seek_time), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
++#endif
++     { NULL },
+ };
+ 
+ static const AVClass ism_class = {
+diff -uprN ../ffmpeg-4.3-023/synoconfig.h ./synoconfig.h
+--- ../ffmpeg-4.3-023/synoconfig.h	2020-06-16 20:01:36.286633640 -0400
++++ ./synoconfig.h	2020-06-16 20:08:21.691804931 -0400
+@@ -31,3 +31,17 @@
+ #if defined(SYNO_VIDEOSTATION)
+ #define SYNO_VIDEOSTATION_WEBM_SEEK_TIME
+ #endif
++
++/* Add ffmpeg option for smooth streaming.
++ * -fragment_url:
++ *  This option can overwrite fragment url in Manifest for smooth streaming.
++ * -fragment_length:
++ *  Let file name of output fragment mp4 with this duration
++ *  This setting dependes on x264 option to make it work
++ * -seek_time:
++ *  Let file name fo output fragment mp4 start with this seek time
++ * See Video Station #659
++ */
++#if defined(SYNO_VIDEOSTATION)
++#define SYNO_SMOOTH_STREAMING
++#endif

--- a/spk/ffmpeg6/DISABLED
+++ b/spk/ffmpeg6/DISABLED
@@ -1,6 +1,0 @@
-Disabled: no new ffmpeg6 SPK release is planned at this time.
-
-Disabling the SPK keeps ffmpeg6 and its large codec dependency tree out of the
-build. Remove this file to build and release ffmpeg6 again if needed.
-
--- th0ma7, 2026-07-13

--- a/spk/ffmpeg6/Makefile
+++ b/spk/ffmpeg6/Makefile
@@ -1,9 +1,9 @@
 SPK_NAME = ffmpeg6
 SPK_VERS = 6.1.6
 SKG_MINOR_VERS = $(firstword $(subst ., ,$(SPK_VERS)))
-SPK_REV = 7
+SPK_REV = 9
 SPK_ICON = src/ffmpeg6.png
-CHANGELOG = "1. Update ffmpeg to 6.1.6 with the jellyfin v6.0.1-8 patchset ported to 6.1<br/>2. Re-enable libjxl (JPEG-XL)<br/>3. Now using new synocli-videodriver package<br/>4. Align package with ffmpeg7/ffmpeg8"
+CHANGELOG = "1. Restore the SYNO-videostation patches"
 
 DEPENDS = cross/ffmpeg6
 VIDEODRV_PACKAGE = synocli-videodriver

--- a/spk/ffmpeg7/Makefile
+++ b/spk/ffmpeg7/Makefile
@@ -1,9 +1,9 @@
 SPK_NAME = ffmpeg7
 SPK_VERS = 7.1.5
 SKG_MINOR_VERS = $(firstword $(subst ., ,$(SPK_VERS)))
-SPK_REV = 9
+SPK_REV = 10
 SPK_ICON = src/ffmpeg7.png
-CHANGELOG = "1. Update to version 7.1.5"
+CHANGELOG = "1. Restore the SYNO-videostation patches"
 
 DEPENDS = cross/ffmpeg7
 VIDEODRV_PACKAGE = synocli-videodriver

--- a/spk/ffmpeg8/Makefile
+++ b/spk/ffmpeg8/Makefile
@@ -1,9 +1,9 @@
 SPK_NAME = ffmpeg8
 SPK_VERS = 8.1.2
 SKG_MINOR_VERS = $(firstword $(subst ., ,$(SPK_VERS)))
-SPK_REV = 2
+SPK_REV = 3
 SPK_ICON = src/ffmpeg8.png
-CHANGELOG = "1. Update to version 8.1.2"
+CHANGELOG = "1. Restore the SYNO-videostation patches"
 
 DEPENDS = cross/ffmpeg8
 VIDEODRV_PACKAGE = synocli-videodriver


### PR DESCRIPTION
Restores the **SYNO-videostation** patch set to ffmpeg6/7/8. It was dropped from those packages in #7187 during a patch cleanup, which broke Video Station seek there; ffmpeg4/5 still carry it. Context: darknebular/Wrapper_VideoStation#77.

## What's restored (5 patches × 3 versions)

| Patch | Purpose |
|-------|---------|
| `0100-SYNO-videostation-hls-seek-time` | **HLS seek time** |
| `0103-SYNO-videostation-webm-seek-time` | **WebM seek time** |
| `0101-SYNO-videostation-hls-costumized-ts-name` | HLS custom `.ts` naming |
| `0102-SYNO-videostation-skip-displaymatrix` | skip displaymatrix on mov/mp4 |
| `0110-SYNO-smooth-streaming` | smooth streaming |

## Porting

- **ffmpeg7 (7.1.5)** and **ffmpeg8 (8.1.2)**: the pre-#7187 patches apply **as-is**.
- **ffmpeg6 (6.1.6)**: only `0102` needed work — the displaymatrix hunk in `mov_write_tkhd_tag` no longer matched, because the side-data API changed (`av_packet_side_data_get` / `sd->size` replaced the old `av_stream_get_side_data` / `display_matrix_size`). `0102` is **regenerated against 6.1.6** so it applies without fuzz. The two **seek-time patches apply unchanged on all three**.

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8