### PR TITLE
Mosquitto: Update to v2.1.2

### DIFF
--- a/cross/mosquitto/Makefile
+++ b/cross/mosquitto/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = mosquitto
-PKG_VERS = 2.0.22
+PKG_VERS = 2.1.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://mosquitto.org/files/source
@@ -7,27 +7,20 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS  = cross/c-ares
 DEPENDS += cross/openssl3
-DEPENDS += cross/libwebsockets
 DEPENDS += cross/cjson
+DEPENDS += cross/sqlite
 
-# cross/libwebsockets:
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+# C++17 required by mosquittopp, GCC < 7 not supported
+REQUIRED_MIN_DSM = 7.0
+REQUIRED_MIN_SRM = 1.3
+UNSUPPORTED_ARCHS = comcerto2k
 
 HOMEPAGE = https://www.mosquitto.org/
 COMMENT  = Eclipse Mosquitto is an open source (EPL/EDL licensed) message broker that implements the MQTT protocol versions 5.0, 3.1.1 and 3.1.
 LICENSE  = EPL 1.0 and EDL 1.0
 
-CONFIGURE_ARGS += -DWITH_WEBSOCKETS=ON
 CONFIGURE_ARGS += -DWITH_SRV=ON
 CONFIGURE_ARGS += -DDOCUMENTATION=OFF
-
-include ../../mk/spksrc.common.mk
-ifeq ($(call version_lt,$(TC_GCC),5),1)
-ADDITIONAL_CFLAGS += -std=c99
-endif
-ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
-# use clock_gettime of librt
-ADDITIONAL_LDFLAGS += -lrt
-endif
+CONFIGURE_ARGS += -DWITH_TESTS=OFF
 
 include ../../mk/spksrc.cross-cmake.mk

--- a/cross/mosquitto/PLIST
+++ b/cross/mosquitto/PLIST
@@ -6,8 +6,8 @@ bin:bin/mosquitto_rr
 bin:bin/mosquitto_sub
 lnk:lib/libmosquitto.so
 lnk:lib/libmosquitto.so.1
-lib:lib/libmosquitto.so.2.0.22
+lib:lib/libmosquitto.so.2.1.2
 lnk:lib/libmosquittopp.so
 lnk:lib/libmosquittopp.so.1
-lib:lib/libmosquittopp.so.2.0.22
+lib:lib/libmosquittopp.so.2.1.2
 lib:lib/mosquitto_dynamic_security.so

--- a/cross/mosquitto/digests
+++ b/cross/mosquitto/digests
@@ -1,3 +1,3 @@
-mosquitto-2.0.22.tar.gz SHA1 d031ae03b02bb9a0a7fd9a05e870f2f361457974
-mosquitto-2.0.22.tar.gz SHA256 2f752589ef7db40260b633fbdb536e9a04b446a315138d64a7ff3c14e2de6b68
-mosquitto-2.0.22.tar.gz MD5 3a239d3d50121134537798e0c6b6af11
+mosquitto-2.1.2.tar.gz SHA1 db7223806a23479cfd2a78b05d2934ec6a4230f4
+mosquitto-2.1.2.tar.gz SHA256 fd905380691ac65ea5a93779e8214941829e3d6e038d5edff9eac5fd74cbed02
+mosquitto-2.1.2.tar.gz MD5 6881c0ec211a1580aaf1b7e3927baf8f

--- a/spk/mosquitto/Makefile
+++ b/spk/mosquitto/Makefile
@@ -1,16 +1,19 @@
 SPK_NAME = mosquitto
-SPK_VERS = 2.0.22
-SPK_REV = 17
+SPK_VERS = 2.1.2
+SPK_REV = 18
 SPK_ICON = src/mosquitto.png
 
 DEPENDS = cross/mosquitto
 
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+# C++17 required by mosquittopp, GCC < 7 not supported
+REQUIRED_MIN_DSM = 7.0
+REQUIRED_MIN_SRM = 1.3
+UNSUPPORTED_ARCHS = comcerto2k
 
 MAINTAINER = SynoCommunity
 DESCRIPTION = Eclipse Mosquitto is an open source \(EPL/EDL licensed\) message broker that implements the MQTT protocol versions 5.0, 3.1.1 and 3.1.
 DISPLAY_NAME = Mosquitto
-CHANGELOG = "Update mosquitto to v2.0.22. Update libwebsockets to v4.3.7."
+CHANGELOG = "Update Mosquitto to v2.1.2."
 HOMEPAGE = https://www.mosquitto.org/
 LICENSE  = EPL/EDL
 


### PR DESCRIPTION
## Description

Update Mosquitto to v2.1.2. The new version requires C++17 (DSM 7.0+ / SRM 1.3+), adds sqlite as a dependency, and drops libwebsockets (replaced by built-in websockets).

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
