### PR TITLE
Immich: Preserve ML virtualenv across upgrades, refactor runtime config

### DIFF
--- a/spk/immich/Makefile
+++ b/spk/immich/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = immich
 SPK_VERS = 3.0.3
-SPK_REV = 2
+SPK_REV = 3
 SPK_ICON = src/immich.png
 
 DEPENDS = cross/immich cross/immich-geodata
@@ -12,7 +12,7 @@ UNSUPPORTED_ARCHS = $(32bit_ARCHS)
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = Immich
 DESCRIPTION = Self-hosted photo and video backup solution.
-CHANGELOG = "1. Update Immich to v3.0.3."
+CHANGELOG = "1. Update Immich to v3.0.3. <br/>2. Preserve ML virtualenv across upgrades."
 HOMEPAGE = https://immich.app
 LICENSE = GPLv3
 
@@ -37,3 +37,6 @@ immich_extra_install:
 	install -m 755 -d $(STAGING_DIR)/bin
 	install -m 755 src/bin/server-launcher.js $(STAGING_DIR)/bin/
 	install -m 755 src/bin/immich-ml-launcher.sh $(STAGING_DIR)/bin/
+	@$(MSG) Install runtime config template
+	install -m 755 -d $(STAGING_DIR)/etc
+	install -m 644 src/etc/immich.conf $(STAGING_DIR)/etc/immich.conf

--- a/spk/immich/src/etc/immich.conf
+++ b/spk/immich/src/etc/immich.conf
@@ -1,0 +1,9 @@
+IMMICH_BUILD_DATA=@immich_build_data@
+IMMICH_MEDIA_LOCATION=@media_path@
+IMMICH_MACHINE_LEARNING_URL=@ml_url@
+IMMICH_MACHINE_LEARNING_ENABLED=@ml_enabled@
+DB_PASSWORD=@db_password@
+DB_HOSTNAME=@db_hostname@
+DB_PORT=@db_port@
+DB_USERNAME=@db_username@
+REDIS_HOSTNAME=@redis_hostname@

--- a/spk/immich/src/service-setup.sh
+++ b/spk/immich/src/service-setup.sh
@@ -1,4 +1,12 @@
-# PostgreSQL connection settings
+# Configuration paths
+IMMICH_CONF="/var/packages/immich/etc/immich.conf"
+IMMICH_BUILD_DATA="${SYNOPKG_PKGDEST}/share/immich"
+
+# External dependencies
+NODE="/var/packages/Node.js_v22/target/usr/local/bin/node"
+FFMPEG_DIR="/var/packages/ffmpeg8/target/bin"
+
+# PostgreSQL connection
 PG_HOST="localhost"
 PG_PORT="5433"
 PG_ADMIN_USER="${wizard_pg_username_admin}"
@@ -7,20 +15,14 @@ PG_USER="immich"
 PG_DATABASE="immich"
 PG_PSQL="/usr/local/bin/psql"
 PG_PGDUMP="/usr/local/bin/pg_dump"
-PG_PASS_FILE="${SYNOPKG_PKGVAR}/db_password"
-if [ -n "${SHARE_PATH}" ]; then
-    MEDIA_PATH="${SHARE_PATH}"
-else
-    for SHARE_DIR in "/var/packages/${SYNOPKG_PKGNAME}/shares/"*/; do
-        [ -d "${SHARE_DIR}" ] && MEDIA_PATH="${SHARE_DIR}" && break
-    done
-fi
 
-NODE=/var/packages/Node.js_v22/target/usr/local/bin/node
-SERVER_LAUNCHER=/var/packages/immich/target/bin/server-launcher.js
-MLLAUNCHER=/var/packages/immich/target/bin/immich-ml-launcher.sh
-ML_DIR=/var/packages/immich/target/share/immich/immich-ml
-ML_VENV=/var/packages/immich/target/env-ml
+# Redis connection
+REDIS_HOSTNAME="localhost"
+
+# Service launchers
+SERVER_LAUNCHER="${SYNOPKG_PKGDEST}/bin/server-launcher.js"
+MLLAUNCHER="${SYNOPKG_PKGDEST}/bin/immich-ml-launcher.sh"
+ML_VENV="${SYNOPKG_PKGDEST}/env-ml"
 
 SVC_BACKGROUND=y
 SVC_WRITE_PID=y
@@ -29,25 +31,16 @@ SERVICE_COMMAND=""
 
 service_prestart()
 {
-    DB_PASSWORD="$(cat /var/packages/immich/var/db_password 2>/dev/null)"
-    export NODE_OPTIONS=--unhandled-rejections=warn
-    export DB_PASSWORD
-    export IMMICH_BUILD_DATA=/var/packages/immich/target/share/immich
-    export IMMICH_MEDIA_LOCATION="${MEDIA_PATH}"
-    export DB_HOSTNAME=localhost
-    export DB_PORT=5433
-    export DB_USERNAME=immich
-    export REDIS_HOSTNAME=localhost
-    export PATH="/var/packages/ffmpeg8/target/bin:${PATH}"
+    if [ -f "${IMMICH_CONF}" ]; then
+        set -a; . "${IMMICH_CONF}"; set +a
+    fi
+    export PATH="${FFMPEG_DIR}:${PATH}"
 
     SERVICE_COMMAND="${NODE} ${SERVER_LAUNCHER}"
 
-    if [ -x "${ML_VENV}/bin/python3" ]; then
-        export IMMICH_MACHINE_LEARNING_URL=http://127.0.0.1:3003
+    if [ "${IMMICH_MACHINE_LEARNING_ENABLED}" = "true" ]; then
         SERVICE_COMMAND="${SERVICE_COMMAND}
 ${MLLAUNCHER}"
-    else
-        export IMMICH_MACHINE_LEARNING_ENABLED=false
     fi
 }
 
@@ -112,18 +105,39 @@ service_preuninst ()
     fi
 }
 
+install_immich_config()
+{
+    mkdir -p "$(dirname "${IMMICH_CONF}")"
+    cp "${SYNOPKG_PKGDEST}/etc/immich.conf" "${IMMICH_CONF}"
+    sed -i -e "s|@immich_build_data@|${IMMICH_BUILD_DATA}|g" \
+           -e "s|@media_path@|${MEDIA_PATH}|g" \
+           -e "s|@ml_url@|${ML_URL}|g" \
+           -e "s|@ml_enabled@|${ML_ENABLED}|g" \
+           -e "s|@db_password@|${DB_PASSWORD}|g" \
+           -e "s|@db_hostname@|${PG_HOST}|g" \
+           -e "s|@db_port@|${PG_PORT}|g" \
+           -e "s|@db_username@|${PG_USER}|g" \
+           -e "s|@redis_hostname@|${REDIS_HOSTNAME}|g" \
+           "${IMMICH_CONF}"
+    chmod 600 "${IMMICH_CONF}"
+}
+
 service_postinst ()
 {
     if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
+        MEDIA_PATH="${SHARE_PATH}"
         for folder in encoded-video library upload profile thumbs backups; do
             mkdir -p "${MEDIA_PATH}/${folder}"
             touch "${MEDIA_PATH}/${folder}/.immich"
         done
-        printf '%s' "${wizard_pg_password_immich}" > "${PG_PASS_FILE}"
-        chmod 600 "${PG_PASS_FILE}"
-    fi
+        ML_URL=""; ML_ENABLED="false"
+        if [ "${wizard_enable_ml}" = "true" ]; then
+            ML_URL="http://127.0.0.1:3003"
+            ML_ENABLED="true"
+        fi
+        DB_PASSWORD="${wizard_pg_password_immich}"
+        install_immich_config
 
-    if [ "${SYNOPKG_PKG_STATUS}" = "INSTALL" ]; then
         PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "CREATE USER ${PG_USER} WITH PASSWORD '${wizard_pg_password_immich}' SUPERUSER;" 2>/dev/null || true
         PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "CREATE DATABASE ${PG_DATABASE} OWNER ${PG_USER};" 2>/dev/null || true
         for ext in vector unaccent cube earthdistance pg_trgm uuid-ossp; do
@@ -136,8 +150,50 @@ service_postinst ()
                 huggingface-hub numpy orjson pillow tokenizers \
                 fastapi uvicorn gunicorn pydantic pydantic-settings \
                 python-multipart rich aiocache rapidocr 2>&1 || true
+            # insightface pulls in opencv-python (GUI); force back to headless
             "${ML_VENV}/bin/pip3" install --force-reinstall --no-cache-dir opencv-python-headless 2>&1 || true
         fi
+    fi
+}
+
+service_save ()
+{
+    # Preserve ML virtualenv across upgrade (target dir is replaced)
+    [ -d "${ML_VENV}" ] && cp -a "${ML_VENV}" "${SYNOPKG_TEMP_UPGRADE_FOLDER}/env-ml"
+}
+
+service_restore ()
+{
+    # Restore ML virtualenv after upgrade
+    if [ -d "${SYNOPKG_TEMP_UPGRADE_FOLDER}/env-ml" ] && [ ! -d "${ML_VENV}" ]; then
+        cp -a "${SYNOPKG_TEMP_UPGRADE_FOLDER}/env-ml" "${ML_VENV}"
+        rm -rf "${SYNOPKG_TEMP_UPGRADE_FOLDER}/env-ml"
+    fi
+}
+
+service_postupgrade ()
+{
+    if [ ! -f "${IMMICH_CONF}" ]; then
+        DB_PASSWORD=""
+        [ -f "${SYNOPKG_PKGVAR}/db_password" ] && DB_PASSWORD="$(cat "${SYNOPKG_PKGVAR}/db_password")"
+        ML_URL=""; ML_ENABLED="false"
+        [ -x "${ML_VENV}/bin/python3" ] && ML_URL="http://127.0.0.1:3003" && ML_ENABLED="true"
+        MEDIA_PATH=""
+        for SHARE in "/var/packages/${SYNOPKG_PKGNAME}/shares/"*/; do
+            [ -d "${SHARE}" ] && MEDIA_PATH="$(realpath "${SHARE}")" && break
+        done
+        install_immich_config
+        rm -f "${SYNOPKG_PKGVAR}/db_password"
+    fi
+
+    # Upgrade ML wheels if ML is installed
+    if [ -x "${ML_VENV}/bin/python3" ]; then
+        "${ML_VENV}/bin/pip3" install --upgrade --no-cache-dir \
+            onnxruntime opencv-python-headless insightface \
+            huggingface-hub numpy orjson pillow tokenizers \
+            fastapi uvicorn gunicorn pydantic pydantic-settings \
+            python-multipart rich aiocache rapidocr 2>&1 || true
+        "${ML_VENV}/bin/pip3" install --force-reinstall --no-cache-dir opencv-python-headless 2>&1 || true
     fi
 }
 
@@ -146,7 +202,7 @@ service_postuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" = "UNINSTALL" ]; then
         PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "DROP DATABASE IF EXISTS ${PG_DATABASE};" 2>/dev/null || true
         PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "DROP USER IF EXISTS ${PG_USER};" 2>/dev/null || true
-        rm -f "${PG_PASS_FILE}"
+        rm -f "${IMMICH_CONF}"
         rm -rf "${ML_VENV}" 2>/dev/null || true
     fi
 }


### PR DESCRIPTION
## Description

Refactor Immich runtime configuration and fix ML virtualenv handling across upgrades.

- Store runtime env vars in `/etc/immich.conf` via template + `install_immich_config` helper
- Preserve ML virtualenv across package upgrades using `service_save`/`service_restore`
- Add `service_postupgrade` to migrate from old config format and upgrade ML wheels
- Remove share scanning fallback, use template-based config populated at install time

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
