### PR TITLE
toolchain: detect Fortran by probing the compiler (prep for the gcc8 overlay)

### DIFF
--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -65,6 +65,21 @@ If you only read one thing, read this. The details are in the dated log below.
 
 ---
 
+??? note "July 2026 — Detect Fortran by probing the compiler (#7321)"
+    - **What:** `TC_HAS_FORTRAN` was a static "7.x / SRM 1.3 / 6.2.4-x64 ship
+      gfortran" table; it is now a probe of the actual `gfortran` binary, evaluated
+      (like `TC_HAS_LIBATOMIC`) in the tc_vars sub-make after the toolchain is
+      extracted, so cross packages read the baked result.
+    - **Why:** the table is a proxy for the stock toolchains only -- it cannot see a
+      compiler swapped in underneath, e.g. a gcc overlay that adds gfortran to an
+      arch the table calls Fortran-less. Probing the binary stays correct whatever
+      provides it, and gives the same answer as the table on every stock toolchain
+      today.
+    - No package-facing change.
+    - Pull request: [#7321](https://github.com/SynoCommunity/spksrc/pull/7321)
+
+---
+
 ??? note "July 2026 — Toolchain ABI and link flags reach every language (#7314)"
     A toolchain's ABI/arch flags now consistently reach every language and the
     link, and two link-time libraries stopped being hand-maintained arch lists.

--- a/mk/spksrc.toolchain/tc-flags.mk
+++ b/mk/spksrc.toolchain/tc-flags.mk
@@ -42,16 +42,19 @@ endif
 ####
 # Define capabilities
 
-# we can't check whether gfortran exists, because toolchain is not yet extracted
-ifeq ($(strip $(firstword $(subst ., ,$(TC_VERS)))),7)
-TC_HAS_FORTRAN = 1
-else ifeq ($(strip $(TC_VERS)),1.3)
-TC_HAS_FORTRAN = 1
-else ifeq ($(strip $(TC_VERS)),6.2.4)
-ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
-TC_HAS_FORTRAN = 1
-endif
-endif
+# Does this toolchain ship a Fortran compiler? Ask it, rather than tabulate per
+# DSM/arch. A hardcoded "7.x, SRM 1.3 and 6.2.4-x64 have Fortran" list is a proxy
+# that only holds for the stock toolchains: it cannot see a compiler swapped in
+# underneath -- a gcc8 overlay, say, adds gfortran to a 6.2.4 arch the list calls
+# Fortran-less. Probing the actual binary stays correct whatever provides it.
+#
+# Lazy on purpose, exactly like TC_HAS_LIBATOMIC below: the ifneq's that read it
+# force the wildcard, and it only needs to be right where it is consumed -- the
+# tc_vars sub-make, which re-parses this file after the toolchain is extracted, so
+# the binary is there to find. Cross packages read the baked tc_vars result and
+# never re-probe. (At the first, pre-extract parse it is empty; that value is not
+# consumed -- the sub-make's is.)
+TC_HAS_FORTRAN = $(if $(wildcard $(TC_WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)gfortran),1)
 
 TOOLS = ld ldshared:"gcc -shared" cpp nm cc:gcc as ranlib cxx:g++ ar strip objdump objcopy readelf
 ifneq ($(strip $(TC_HAS_FORTRAN)),)

--- a/spk/python314-wheels/Makefile
+++ b/spk/python314-wheels/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python314-wheels
 SPK_VERS = 1.0
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/python3-pip.png
 
 # Compiler must support std=c++11

--- a/spk/python314-wheels/Makefile
+++ b/spk/python314-wheels/Makefile
@@ -1,7 +1,7 @@
 SPK_NAME = python314-wheels
 SPK_VERS = 1.0
 SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$(SPK_VERS)))
-SPK_REV = 2
+SPK_REV = 1
 SPK_ICON = src/python3-pip.png
 
 # Compiler must support std=c++11


### PR DESCRIPTION
## What

Replace the static `TC_HAS_FORTRAN` DSM/arch table with a probe of the actual
gfortran binary, the same lazy way `TC_HAS_LIBATOMIC` probes libatomic.

## Why

Preparing the ground for the gcc8 overlay (#7299). The current detection --
"7.x, SRM 1.3 and 6.2.4-x64 ship gfortran" -- is a proxy that only describes the
stock toolchains. It cannot see a compiler swapped in underneath: a gcc8 overlay
adds gfortran to, say, a 6.2.4 arch the table calls Fortran-less. Probing the
binary stays correct whatever provides it, so the overlay lights up Fortran with
no further framework change.

## How

- `tc-flags.mk`: `TC_HAS_FORTRAN = $(if $(wildcard .../bin/$(TC_PREFIX)gfortran),1)`.
  Lazy like `TC_HAS_LIBATOMIC`: the `ifneq`s that read it force the wildcard, and it
  only has to be right in the tc_vars sub-make, which re-parses this file after the
  toolchain is extracted; cross packages read the baked result.

## Validation

Same answer as the old table on every extracted stock toolchain, parse OK:

| toolchain | gfortran present | `TC_HAS_FORTRAN` |
|---|---|---|
| x64-7.2 | yes | `1` |
| 88f6281 / hi3535 / qoriq (6.2.4) | no | *(empty)* |

`FFLAGS`/`FC` appear for x64-7.2 and are absent for the 6.2.4 archs. End to end on
CI, `python314-wheels` built with `FC=…/x86_64-pc-linux-gnu-gfortran` and scipy
compiled (which needs gfortran) -- proving the probe set `TC_HAS_FORTRAN` where
gfortran is present.

The `python314-wheels` rev bump is a **CI validation trigger** -- a `mk/` change
alone builds nothing (build.yml filters on spk/cross/python/native). It rebuilds
scipy, a gfortran consumer, exercising the probe on the archs that ship gfortran.
**To be reverted before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
