### PR TITLE
ci: one build per pull request, and cancel it when superseded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,12 +119,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
 
 jobs:
-  # Decide whether the build should run at all. Upstream events (pull_request,
-  # or push to SynoCommunity/spksrc) and manual workflow_dispatch always build.
-  # A fork's own push build is skipped while the branch has an open *draft* PR
-  # upstream: during development the authoritative full build still runs on the
-  # upstream PR, so re-running the fork's narrow build only wastes runner time.
-  # A push event carries no PR context, hence the API lookup here.
+  # Decide whether the build should run at all.
+  #  - pull_request and workflow_dispatch always build (the pull_request run is the
+  #    authoritative CI: the whole branch, origin/master...HEAD).
+  #  - push to master always builds (a merge, or a release push).
+  #  - push to a non-master branch is only the latest commit (git diff-tree); if the
+  #    branch already has an open PR, the pull_request build covers the whole branch,
+  #    so this narrow push build is redundant:
+  #      * upstream-hosted branch -> skip it (it only duplicates the PR build);
+  #      * fork branch -> skip only while the PR is a draft (its push build is
+  #        complementary and kept for non-draft, per #7238), to silence dev noise.
+  # A push carries no PR context, hence the API lookup here (fail-open on error).
   gate:
     name: Gate
     runs-on: ubuntu-latest
@@ -135,24 +140,48 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.repository }}" = "SynoCommunity/spksrc" ] || \
+          # pull_request and workflow_dispatch: always build.
+          if [ "${{ github.event_name }}" = "pull_request" ] || \
              [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Upstream or manual run -> build."
+            echo "PR or manual run -> build."
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Fork push: look up the branch's open PR in the upstream repo and skip
-          # the build while that PR is a draft. Any lookup failure falls back to
-          # building (fail-open).
-          draft=$(gh api \
-            "/repos/SynoCommunity/spksrc/pulls?head=${{ github.repository_owner }}:${{ github.ref_name }}&state=open" \
-            --jq '[.[].draft] | first // false' 2>/dev/null || echo false)
-          if [ "$draft" = "true" ]; then
-            echo "Fork push for a draft PR (${{ github.ref_name }}) -> skip build."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Fork push, PR not draft (or none) -> build."
+          # push event from here on. A push to master (merge / release) always builds.
+          if [ "${{ github.ref_name }}" = "master" ]; then
+            echo "Push to master -> build."
             echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Push to a non-master branch. Look up an open PR for it upstream (a push
+          # carries no PR context); fail-open to building on any lookup error.
+          prs=$(gh api \
+            "/repos/SynoCommunity/spksrc/pulls?head=${{ github.repository_owner }}:${{ github.ref_name }}&state=open" \
+            2>/dev/null || echo '[]')
+          if [ "${{ github.repository }}" = "SynoCommunity/spksrc" ]; then
+            # Upstream-hosted branch: the pull_request build already runs the whole
+            # branch, so skip this redundant push build whenever an open PR covers it.
+            # (Draft supersede-cancellation is handled on the pull_request side by the
+            # concurrency group.)
+            count=$(echo "$prs" | jq 'length' 2>/dev/null || echo 0)
+            if [ "${count:-0}" -gt 0 ]; then
+              echo "Upstream push for a branch with an open PR -> skip (pull_request build covers it)."
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Upstream push, no open PR -> build."
+              echo "should_build=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # Fork push: the fork build is complementary (latest commit only); skip it
+            # only while its PR is a draft, to silence noise during development.
+            draft=$(echo "$prs" | jq -r '[.[].draft] | first // false' 2>/dev/null || echo false)
+            if [ "$draft" = "true" ]; then
+              echo "Fork push for a draft PR (${{ github.ref_name }}) -> skip build."
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Fork push, PR not draft (or none) -> build."
+              echo "should_build=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
   prepare:

--- a/.github/workflows/draft-on-open.yml
+++ b/.github/workflows/draft-on-open.yml
@@ -1,0 +1,66 @@
+name: Draft on open
+
+# Open every pull request as a Draft; the author marks it ready once CI is green.
+#
+# Not a formality -- it is what build.yml keys on:
+#   - a Draft PR's builds share one concurrency group with cancel-in-progress, so a
+#     new push cancels the run the previous push started. A non-draft PR gets a
+#     unique per-run group: nothing is cancelled and every push queues behind the
+#     last, at a full matrix build each;
+#   - a fork's own push build is skipped while its PR is a Draft, because the
+#     authoritative build already runs on the PR.
+#
+# pull_request_target, not pull_request: the token a pull_request run gets for a PR
+# from a fork is read-only, and this needs pull-requests: write. That trigger is only
+# safe because nothing here checks out or runs the PR's code -- keep it that way.
+#
+# 'opened' only: reopening a PR that was deliberately marked ready should not send it
+# back to draft.
+#
+# The PR's first build has already started by the time this runs, and its concurrency
+# group was fixed at draft=false, so the conversion takes effect from the next push on.
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  convert:
+    name: Convert to draft
+    # Nothing to do when the author already opened it as a draft.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Mark the pull request as a draft
+        # Fail-open throughout: this is a convenience, it must never fail a PR.
+        run: |
+          if gh pr ready "${PR}" --undo --repo "${REPO}"; then
+            echo "PR #${PR} converted to draft."
+          else
+            echo "::warning::Could not convert PR #${PR} to draft; left as is."
+            exit 0
+          fi
+
+      - name: Say why, so it does not look arbitrary
+        run: |
+          cat > body.md <<'EOF'
+          This pull request was set to **Draft** automatically.
+
+          Draft is what our CI keys on: while a PR is a draft a new push cancels the build
+          the previous push started, and a fork's duplicate push build is skipped. On a
+          non-draft PR nothing is cancelled and every push queues behind the last -- a full
+          matrix build costs hours of runner time, shared with everyone else waiting.
+
+          Mark it **Ready for review** once CI is green: the button, or `gh pr ready`.
+
+          See [Open It as a Draft](https://docs.synocommunity.com/contributing/pull-requests/#open-it-as-a-draft).
+          EOF
+          gh pr comment "${PR}" --repo "${REPO}" --body-file body.md \
+            || echo "::warning::Could not post the explanatory comment."


### PR DESCRIPTION
Two changes that together give a pull request **one** build at a time, and cancel it when a new push supersedes it.

They are independent, but they answer the same question — why does iterating on a PR cost several full matrix builds — from opposite ends. The second is the larger of the two.

## 1. Skip the redundant push build for an upstream-hosted branch

A push to a PR branch fires **both** a `push` build and a `pull_request` build.

- On a **fork**, the push build runs on the fork and is complementary — only the latest commit, `git diff-tree`, not a duplicate — and #7238 already skips it while the PR is a draft.
- On a branch hosted **upstream**, both run in the same repo. The push build merely duplicates the `pull_request` build, which already covers the whole branch (`origin/master...HEAD`). And the concurrency block from #7268 gives a `push` run a **unique** per-run group, so it is never cancelled — even in draft.

So an upstream-hosted draft PR got two builds per push, one of them escaping supersede-cancellation entirely.

The `gate` job now decides on the **event** rather than on the repository:

| Event | Result |
|---|---|
| `pull_request` / `workflow_dispatch` | build |
| push to `master` | build |
| push, **upstream** branch **with** open PR | **skip** — the PR build covers it |
| push, **upstream** branch **without** PR | build (WIP) |
| push, **fork** branch, PR **draft** | skip (unchanged, #7238) |
| push, **fork** branch, PR **ready** / no PR | build (unchanged) |

Exactly one row changes. The concurrency block is untouched, and every lookup fails open to building.

Note this row does not occur in current practice: the branches it targets (`SynoCommunity/master-capability-vars`, `toolchain-fortran-probe`, …) were hosted upstream in July, while none of the last 60 PRs is. It closes the gate's blind spot rather than fixing a live symptom — which is why the second change matters more.

## 2. Open every pull request as a draft

`.github/workflows/draft-on-open.yml`, new.

This one applies to **every** PR, fork branches included. Draft is what `build.yml` keys on:

- a draft PR's builds share one concurrency group with `cancel-in-progress`, so a new push cancels the run the previous push started;
- a non-draft PR gets a unique per-run group: nothing is cancelled, and five pushes in a row mean five full matrix builds queued behind each other.

Opening as a draft is therefore not etiquette — it is the difference between one build and five. Authors mark it ready once CI is green, with the button or `gh pr ready <n>`.

`pull_request_target` rather than `pull_request`: the token a `pull_request` run gets for a PR from a fork is read-only, and converting needs `pull-requests: write`. That trigger is only safe because the workflow **does no checkout and runs none of the PR's code** — the file says so, to keep it that way.

Three deliberate limits:

- **`opened` only.** Reopening a PR that was consciously marked ready must not send it back to draft.
- **No-op** when the author already opened a draft.
- **Never fails.** Both steps fail open with a `::warning::` — a PR must not go red because a conversion or a comment did not go through.

It also posts one comment explaining the conversion, so a first-time contributor does not read it as a rejection. Say the word and that step goes.

**Known limit:** the PR's own first build has already started by the time this runs, with its concurrency group fixed at `draft=false`. The conversion takes effect from the next push on.

## Testing

`build.yml` and workflow files are not in the build workflow's `paths` filter, so **the Build workflow never runs on this PR** — only Lint does. Neither change can be exercised by CI here by construction; both were reviewed by reading, and the branch was rebased onto current master (`a8ff68177`) to be sure the reasoning still matches the file it patches.

The draft conversion is observable the moment this merges: the next PR opened against the repository is converted, or it is not.

cc @hgy59 @mreid-tt — follow-up to #7238 / #7268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd
