### PR TITLE
cross/libdaemon, libvpx: Gentoo download fallback + fix stale gcc-gate comment

### DIFF
--- a/cross/libdaemon/Makefile
+++ b/cross/libdaemon/Makefile
@@ -3,6 +3,9 @@ PKG_VERS = 0.14
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = http://0pointer.de/lennart/projects/$(PKG_NAME)
+# 0pointer.de is unreachable from CI; fall back to the Gentoo mirror. Subdir = first
+# two hex of blake2b of the file name (recompute on a version bump).
+PKG_DIST_MIRRORS = https://distfiles.gentoo.org/distfiles/66
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/cross/libvpx/Makefile
+++ b/cross/libvpx/Makefile
@@ -7,7 +7,7 @@ MIN_GCC_VERSION = 4.6
 
 include ../../mk/spksrc.common.mk
 
-# GCC >= 5 (DSM >= 7.0)
+# GCC >= 7.5 (DSM >= 7.0)
 ifeq ($(call version_ge, $(TC_GCC), 7.5),1)
 DEPENDS = cross/libvpx-latest
 else


### PR DESCRIPTION
Two small, independent fixes split out of #7324 to keep it focused on the gcc-8 overlay.

- **cross/libdaemon**: upstream 0pointer.de is unreachable from CI (IPv6 network-unreachable, then IPv4 connection-refused) and serves only plain http. Fall back to the Gentoo distfiles mirror (same tarball name, subdir = first two hex of blake2b of the file name = `66`, verified HTTP 200), same shape as cross/znc.
- **cross/libvpx**: #7313 raised the libvpx-latest gcc gate from 5 to 7.5 (its `MIN_GCC_VERSION = 7.5`, DSM >= 7.0) but left the comment reading "GCC >= 5". Match the comment to the test; libaom already matches. Addresses @hgy59's review on #7313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8