### PR TITLE
ossp-uuid: Disable getentropy for kernel 3.10 compatibility

### DIFF
--- a/cross/ossp-uuid/Makefile
+++ b/cross/ossp-uuid/Makefile
@@ -16,6 +16,9 @@ GNU_CONFIGURE = 1
 CONFIGURE_ARGS = --disable-shared --enable-static --with-pic
 CONFIGURE_ARGS += LIBS="-lcrypto"
 ENV += ac_cv_func_SHA1Final=yes
+# Disable getentropy detection (requires kernel 3.17+). Braswell uses kernel
+# 3.10 where the getrandom syscall is unavailable. Fall back to /dev/urandom.
+ENV += ac_cv_func_getentropy=no
 PRE_CONFIGURE_TARGET = ossp_uuid_pre_configure
 
 include ../../mk/spksrc.cross-cc.mk

--- a/spk/postgresql/Makefile
+++ b/spk/postgresql/Makefile
@@ -1,13 +1,13 @@
 SPK_NAME = postgresql
 SPK_VERS = 17.10
-SPK_REV = 4
+SPK_REV = 5
 SPK_ICON = src/postgresql.png
 
 DEPENDS = cross/postgresql
 
 MAINTAINER = DigitalBox98
 DESCRIPTION = PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development. This package includes PostGIS and pgvector extensions for DSM 7+.
-CHANGELOG = "1. Update PostgreSQL to 17.10. <br/>2. Add pgvector extension."
+CHANGELOG = "1. Update PostgreSQL to 17.10. <br/>2. Add pgvector extension. <br/>3. Fix uuid-ossp on kernel 3.10."
 DISPLAY_NAME = PostgreSQL
 STARTABLE = yes
 


### PR DESCRIPTION
## Description

The `getentropy()` function requires the `getrandom` syscall (kernel 3.17+). Braswell platforms ship kernel 3.10.108, causing `uuid-ossp` to fail with `OSSP uuid library failure: internal error` at runtime.

Disabling `getentropy` detection makes ossp-uuid fall back to `/dev/urandom`, which works on all kernel versions.

- `cross/ossp-uuid/Makefile` — added `ac_cv_func_getentropy=no`
- `spk/postgresql/Makefile` — bumped `SPK_REV` to 5, updated changelog

Fixes #7326

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
