### PR TITLE
docs(immich): Add advanced guide for changing media location

### DIFF
--- a/docs/packages/immich.md
+++ b/docs/packages/immich.md
@@ -62,3 +62,105 @@ For package-related issues, please open a ticket with SynoCommunity first. The m
 - [SynoCommunity issues](https://github.com/SynoCommunity/spksrc/issues)
 - [Upstream issues](https://github.com/immich-app/immich/issues)
 - [Immich documentation](https://immich.app/docs)
+
+## Advanced: Changing the Media Location
+
+If you need to move Immich's media storage to a new location (e.g., renaming a DSM shared folder, migrating to a new volume), the following steps are required to keep everything in sync.
+
+### Before You Start
+
+- Stop the Immich package in Package Center (or `sudo synopkg stop immich`)
+- Ensure the new location exists and is accessible
+
+### Step 1 — Update Database Paths
+
+Run the `immich-admin` CLI to update stored file paths in the database:
+
+```bash
+sudo /var/packages/immich/target/bin/immich-admin change-media-location
+```
+
+You will be prompted for:
+
+- **Previous value** — the old media location (e.g., `/volume1/immich-media`)
+- **New value** — the new media location (e.g., `/volume1/Photos`)
+
+The tool updates paths in the `asset`, `asset_file`, `person`, and `user` tables.
+
+### Step 2 — Update System Metadata
+
+The CLI does not update the `system_metadata` table, so this must be done manually via `psql`. You will be prompted for the Immich database password (set during installation):
+
+```bash
+/usr/local/bin/psql -h localhost -p 5433 -U immich -d immich -c \
+  "UPDATE system_metadata SET value = '{\"location\":\"/volume1/Photos\"}' WHERE key = 'MediaLocation';"
+```
+
+Verify the change:
+
+```bash
+/usr/local/bin/psql -h localhost -p 5433 -U immich -d immich -c \
+  "SELECT * FROM system_metadata WHERE key = 'MediaLocation';"
+```
+
+Expected output:
+
+```
+      key      |              value              
+---------------+---------------------------------
+ MediaLocation | {"location": "/volume1/Photos"}
+(1 row)
+```
+
+!!! tip "Alternative: interactive psql"
+    If you prefer an interactive session: `/usr/local/bin/psql -h localhost -p 5433 -U immich -d immich` then paste the SQL without the shell escaping:
+    ```sql
+    UPDATE system_metadata SET value = '{"location":"/volume1/Photos"}' WHERE key = 'MediaLocation';
+    ```
+
+### Step 3 — Update Immich Configuration
+
+Edit the runtime config and change `IMMICH_MEDIA_LOCATION` to the new path:
+
+```bash
+sudo vi /var/packages/immich/etc/immich.conf
+```
+
+For example, change:
+
+```
+IMMICH_MEDIA_LOCATION=/volume1/immich-media
+```
+
+to:
+
+```
+IMMICH_MEDIA_LOCATION=/volume1/Photos
+```
+
+### Step 4 — Update DSM Share (if applicable)
+
+If you renamed the DSM shared folder, update the installer variables and share symlink:
+
+```bash
+sudo vi /var/packages/immich/etc/installer-variables
+```
+
+Update `SHARE_PATH` and `SHARE_NAME` to match the new location and name. For example:
+
+```
+SHARE_PATH=/volume1/Photos
+SHARE_NAME=Photos
+```
+
+Then update the symlink in the shares directory:
+
+```bash
+cd /var/packages/immich/shares
+sudo ln -sf /volume1/Photos Photos
+sudo rm -f immich-media
+```
+
+### Step 5 — Restart
+
+Start the Immich package in Package Center (or `sudo synopkg start immich`). The server should detect that the media location is consistent and start normally.


### PR DESCRIPTION
## Description

Adds a new "Advanced: Changing the Media Location" section to the Immich documentation covering the complete process of moving Immich's media storage to a new path:

1. **Update database paths** — using the `immich-admin change-media-location` CLI
2. **Update system metadata** — manually updating the `system_metadata` table in PostgreSQL (the CLI doesn't do this)
3. **Update Immich configuration** — changing `IMMICH_MEDIA_LOCATION` in `immich.conf`
4. **Update DSM share** — updating installer variables and share symlinks (if the shared folder was renamed)
5. **Restart** — verifying the server starts cleanly

Includes practical tips for `psql` usage, expected command output, and `synopkg` alternatives to the Package Center UI.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. Wiki)
