### PR TITLE
Borg: Update to v1.4.5 with borgmatic v2.1.6

### DIFF
--- a/spk/borgbackup/Makefile
+++ b/spk/borgbackup/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = borgbackup
-SPK_VERS = 1.4.4
+SPK_VERS = 1.4.5
 SPK_REV = 23
 SPK_ICON = src/borgbackup.png
 
@@ -59,7 +59,7 @@ DESCRIPTION = BorgBackup \(short: Borg\) is a deduplicating backup program. Opti
 
 DISPLAY_NAME = Borg
 STARTABLE = no
-CHANGELOG = "1. Update Borg to v1.4.4. <br/>2. Update borgmatic to v2.1.5. <br/>3. Refresh Python dependencies. <br/>4. Fix jsonschema/rpds-py dependency conflict."
+CHANGELOG = "1. Update Borg to v1.4.5. <br/>2. Update borgmatic to v2.1.6. <br/>3. Fix jsonschema/rpds-py dependency conflict."
 
 HOMEPAGE = https://borgbackup.readthedocs.io
 LICENSE  = 3-Clause BSD
@@ -105,12 +105,8 @@ ifeq ($(call version_lt, $(TC_GCC), 5.0),1)
 WHEELS_CFLAGS += [msgpack] -std=gnu99
 endif
 
-# [rpds-py]
-# Version = 0.21 requires rustc >= 1.77 (armv5)
-# Version = 0.24 requires rustc >= 1.82 (qoriq)
-# Version = 0.25 requires rustc >= 1.85
-# jsonschema is pinned to match — 4.26+ requires rpds-py>=0.25.0
-ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
+# [rpds-py] — capped by Rust toolchain version per architecture.
+# jsonschema >= 4.26 requires rpds-py >= 0.25 — pinned to match.
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
 WHEELS += rpds_py==0.21.0
 WHEELS += jsonschema==4.25.1
@@ -121,7 +117,6 @@ WHEELS += jsonschema==4.25.1
 else
 WHEELS += rpds_py==0.30.0
 WHEELS += jsonschema==4.26.0
-endif
 endif
 
 include ../../mk/spksrc.spk-meta.mk

--- a/spk/borgbackup/Makefile
+++ b/spk/borgbackup/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = borgbackup
 SPK_VERS = 1.4.4
-SPK_REV = 22
+SPK_REV = 23
 SPK_ICON = src/borgbackup.png
 
 # Include common.mk first to get ARCH definitions
@@ -59,7 +59,7 @@ DESCRIPTION = BorgBackup \(short: Borg\) is a deduplicating backup program. Opti
 
 DISPLAY_NAME = Borg
 STARTABLE = no
-CHANGELOG = "1. Update Borg to v1.4.4. <br/>2. Update borgmatic to v2.1.5. <br/>3. Refresh Python dependencies."
+CHANGELOG = "1. Update Borg to v1.4.4. <br/>2. Update borgmatic to v2.1.5. <br/>3. Refresh Python dependencies. <br/>4. Fix jsonschema/rpds-py dependency conflict."
 
 HOMEPAGE = https://borgbackup.readthedocs.io
 LICENSE  = 3-Clause BSD
@@ -109,14 +109,18 @@ endif
 # Version = 0.21 requires rustc >= 1.77 (armv5)
 # Version = 0.24 requires rustc >= 1.82 (qoriq)
 # Version = 0.25 requires rustc >= 1.85
+# jsonschema is pinned to match — 4.26+ requires rpds-py>=0.25.0
 ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
 ifeq ($(findstring $(ARCH),$(ARMv5_ARCHS)),$(ARCH))
 WHEELS += rpds_py==0.21.0
+WHEELS += jsonschema==4.25.1
 else ifeq ($(findstring $(ARCH),$(PPC_ARCHS)),$(ARCH))
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 WHEELS += rpds_py==0.24.0
+WHEELS += jsonschema==4.25.1
 else
 WHEELS += rpds_py==0.30.0
+WHEELS += jsonschema==4.26.0
 endif
 endif
 

--- a/spk/borgbackup/src/requirements-crossenv-armv5.txt
+++ b/spk/borgbackup/src/requirements-crossenv-armv5.txt
@@ -1,8 +1,10 @@
 # ARMv5-specific cross-compiled requirements (Python 3.11)
+# Generated on 2026-07-30
+# Command: borgbackup[llfuse]==1.4.5 borgmatic==2.1.6 emborg rpds-py==0.21.0
 # rpds_py pinned to 0.21.0 for Cargo.lock v3 compatibility with Rust 1.77.2
 
-borgbackup==1.4.4
-charset_normalizer==3.4.7
+borgbackup==1.4.5
+charset_normalizer==3.4.9
 llfuse==1.5.2
-msgpack==1.1.2
-#rpds_py==0.21.0                ==> supported version depends on rust version
+msgpack==1.2.1
+#rpds_py==0.21.0                        ==> supported version depends on rust version

--- a/spk/borgbackup/src/requirements-crossenv.txt
+++ b/spk/borgbackup/src/requirements-crossenv.txt
@@ -1,7 +1,9 @@
 # Cross-compiled requirements for borgbackup (Python 3.14)
+# Generated on 2026-07-30
+# Command: borgbackup[llfuse]==1.4.5 borgmatic==2.1.6 emborg
 
-borgbackup==1.4.4
-charset_normalizer==3.4.7
+borgbackup==1.4.5
+charset_normalizer==3.4.9
 llfuse==1.5.2
-msgpack==1.1.2
-#rpds_py==0.30.0                ==> supported version depends on rust version
+msgpack==1.2.1
+#rpds_py==0.30.0                        ==> supported version depends on rust version

--- a/spk/borgbackup/src/requirements-pure-armv5.txt
+++ b/spk/borgbackup/src/requirements-pure-armv5.txt
@@ -1,26 +1,28 @@
 # ARMv5-specific pure-python requirements (Python 3.11)
+# Generated on 2026-07-30
+# Command: borgbackup[llfuse]==1.4.5 borgmatic==2.1.6 emborg rpds-py==0.21.0
 
 appdirs==1.4.4
 arrow==1.4.0
 attrs==26.1.0
-borgmatic==2.1.5
-#certifi==2026.5.20                     ==> python311
+borgmatic==2.1.6
+#certifi==2026.7.22                     ==> python311
 docopt==0.6.2
-emborg==1.42
-idna==3.16
-inform==1.36
-jsonschema==4.25.1
+emborg==1.43
+idna==3.18
+inform==1.37
+#jsonschema==4.25.1                     ==> per-arch version in WHEELS (4.25.1 for armv5/PPC)
 jsonschema_specifications==2025.9.1
 nestedtext==3.8
 packaging==26.2
 #pip==24.0                              ==> python311
 python_dateutil==2.9.0.post0
-quantiphy==2.21
+quantiphy==2.22.1
 referencing==0.37.0
 requests==2.34.2
 ruamel_yaml==0.19.1
 #setuptools==79.0.1                     ==> python311
 #six==1.17.0                            ==> python311
-typing_extensions==4.15.0
-tzdata==2026.2
+typing_extensions==4.16.0
+tzdata==2026.3
 urllib3==2.7.0

--- a/spk/borgbackup/src/requirements-pure.txt
+++ b/spk/borgbackup/src/requirements-pure.txt
@@ -9,7 +9,7 @@ docopt==0.6.2
 emborg==1.42
 idna==3.16
 inform==1.36
-jsonschema==4.26.0
+#jsonschema==4.26.0                     ==> per-arch version in WHEELS (4.25.1 for armv5/PPC)
 jsonschema_specifications==2025.9.1
 nestedtext==3.8
 packaging==26.2

--- a/spk/borgbackup/src/requirements-pure.txt
+++ b/spk/borgbackup/src/requirements-pure.txt
@@ -1,24 +1,25 @@
 # Pure-python requirements for borgbackup (Python 3.14)
+# Generated on 2026-07-30
+# Command: borgbackup[llfuse]==1.4.5 borgmatic==2.1.6 emborg
 
 appdirs==1.4.4
 arrow==1.4.0
 attrs==26.1.0
-borgmatic==2.1.5
-#certifi==2026.5.20                     ==> python314
+borgmatic==2.1.6
+#certifi==2026.7.22                     ==> python314
 docopt==0.6.2
-emborg==1.42
-idna==3.16
-inform==1.36
+emborg==1.43
+idna==3.18
+inform==1.37
 #jsonschema==4.26.0                     ==> per-arch version in WHEELS (4.25.1 for armv5/PPC)
 jsonschema_specifications==2025.9.1
 nestedtext==3.8
-packaging==26.2
-#pip==25.3                              ==> python314
+#pip==26.1.1                            ==> python314
 python_dateutil==2.9.0.post0
-quantiphy==2.21
+quantiphy==2.22.1
 referencing==0.37.0
 requests==2.34.2
 ruamel_yaml==0.19.1
 #six==1.17.0                            ==> python314
-tzdata==2026.2
+tzdata==2026.3
 urllib3==2.7.0


### PR DESCRIPTION
## Description

- Update Borg to v1.4.5, borgmatic to v2.1.6, emborg to v1.43
- Refresh Python dependencies across all requirement files (mainline + ARMv5)
- Fix jsonschema/rpds-py dependency conflict on PPC and ARMv5 (jsonschema 4.26+ requires rpds-py>=0.25, but older archs are pinned to 0.21/0.24 due to Rust toolchain limits)
- Simplify rpds-py/jsonschema conditional block (removed redundant OLD_PPC wrapper, consistent comment style across all files)

Fixes #7341

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
