### PR TITLE
docs: Fix contributing guide chat/CoC, complete section indexes, and remove duplication

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -74,25 +74,7 @@ See [Development Process](development-process.md) for the full workflow from for
 
 ### Commit Messages
 
-Use clear, descriptive commit messages:
-
-```
-{DISPLAY_NAME}: brief description of change
-
-Detailed explanation if needed. Reference issues with #123.
-```
-
-Use the `DISPLAY_NAME` from the package's `spk/*/Makefile` (e.g., "Transmission", "Python 3.12").
-
-Examples:
-
-```
-Transmission: Update to v4.0.5
-
-Python 3.12: Fix wheel building for armv5
-
-docs: add troubleshooting section for PHP packages
-```
+Use the `DISPLAY_NAME` from the package's `spk/*/Makefile` as the commit prefix. See [Development Process](development-process.md) for format details and examples.
 
 ### Pull Request Guidelines
 
@@ -101,7 +83,7 @@ docs: add troubleshooting section for PHP packages
 - **Testing**: Describe how you tested the changes
 - **Screenshots**: Include for UI changes or wizard updates
 
-See [Pull Request Guidelines](pull-requests.md) for detailed requirements.
+See [Pull Request Guidelines](pull-requests.md) for detailed requirements and the PR template.
 
 ## Communication
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -141,6 +141,7 @@ All contributors are expected to follow the [Contributor Covenant Code of Conduc
 
 - [Development Process](development-process.md)
 - [Pull Request Guidelines](pull-requests.md)
+- [Package Lifecycle Policy](package-lifecycle.md)
 - [Developer Guide](../developer-guide/index.md)
 - [GitHub Issues](https://github.com/SynoCommunity/spksrc/issues)
 - [GitHub Discussions](https://github.com/SynoCommunity/spksrc/discussions)

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -117,10 +117,13 @@ See [Pull Request Guidelines](pull-requests.md) for detailed requirements.
 - Ideas and proposals
 - Community announcements
 
-### IRC/Matrix
+### Discord
 
-- Real-time chat with maintainers
+- Real-time chat with maintainers and contributors
 - Quick questions and debugging help
+- Use the `#package-dev` channel for development discussions
+
+[Join the SynoCommunity Discord](https://discord.gg/nnN9fgE7EF)
 
 ## Recognition
 
@@ -132,12 +135,7 @@ Contributors are recognized in:
 
 ## Code of Conduct
 
-We are committed to providing a welcoming and inclusive environment. Please:
-
-- Be respectful and considerate
-- Welcome newcomers and help them learn
-- Focus on constructive feedback
-- Respect differing viewpoints and experiences
+All contributors are expected to follow the [Contributor Covenant Code of Conduct](https://github.com/SynoCommunity/spksrc?tab=coc-ov-file). We are committed to providing a welcoming and inclusive environment.
 
 ## Quick Links
 

--- a/docs/developer-guide/advanced/index.md
+++ b/docs/developer-guide/advanced/index.md
@@ -5,3 +5,4 @@ This section covers advanced spksrc concepts.
 - [Cross-Compilation](cross-compilation.md) - Deep dive into cross-compilation
 - [Debugging](debugging.md) - Build troubleshooting
 - [Testing](testing.md) - Package testing strategies
+- [Ash Shell PID Issue](ash-pid-issue.md) - Background process PID tracking

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -69,6 +69,8 @@ These cookies allow builds to resume from where they left off and prevent redund
 - **[Architecture](architecture.md)** - Detailed build pipeline and stage interactions
 - **[Makefile System](makefile-system.md)** - Deep dive into the mk/*.mk files
 - **[Toolchains](toolchain.md)** - How toolchains are managed and used
+- **[Toolkit](toolkit.md)** - DSM development toolkit
+- **[Changes](changes.md)** - Framework changelog
 
 ## Related Documentation
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,8 +4,11 @@ This section provides reference documentation for spksrc development.
 
 ## In This Section
 
-- **[Architectures](architectures.md)** - CPU architectures and model mappings
+- **[Architectures](architectures.md)** - CPU architecture families, groups, and toolchains
+- **[Model ↔ Architecture](model-architecture.md)** - Searchable model-to-platform mapping
 - **[System Ports](system-ports.md)** - Port allocations for Synology and SynoCommunity packages
+- **[Package Ports](package-ports.md)** - Port allocations per package
+- **[Macros](macros.md)** - Available Makefile macros
 - **[Makefile Reference](makefile-reference.md)** - Complete variable and target reference
 - **[Permissions](permissions.md)** - Service accounts, ACLs, and access control
 - **[DSM APIs](dsm-apis.md)** - Synology documentation and external resources

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -9,6 +9,7 @@ SynoCommunity provides community-maintained packages for Synology NAS devices. T
 ## In This Section
 
 - **[Installation](installation.md)** - Add the SynoCommunity repository and install packages
+- **[SSH Access](ssh.md)** - Connect to your NAS via SSH
 - **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
 - **[Compatibility](compatibility.md)** - DSM versions, architectures, and model support
 - **[Permissions](permissions.md)** - Configure folder access for packages


### PR DESCRIPTION
## Description

Updates across the documentation to fix inconsistencies, outdated references, and content duplication.

### Fixes
- **Contributing index**: Replaced outdated IRC/Matrix reference with Discord (`#package-dev` channel)
- **Contributing index**: Replaced generic Code of Conduct summary with a link to the official Contributor Covenant
- **Contributing index**: Removed duplicate commit message guide (cross-references development-process.md instead)
- **Contributing index**: Added missing Package Lifecycle Policy link

### Missing index entries added
- **Reference**: Model ↔ Architecture, Package Ports, Macros
- **User Guide**: SSH Access
- **Advanced**: Ash Shell PID Issue
- **Framework**: Toolkit, Changes

### Internal consistency
- All section indexes now match their actual file listings
- No duplicate content between index pages and detailed guides

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. Wiki)
