### PR TITLE
download: add Savannah, group/clean the built-in mirror tables (MIRROR_*), and update libpciaccess to 0.19 (GitLab)

### DIFF
--- a/cross/libpciaccess/Makefile
+++ b/cross/libpciaccess/Makefile
@@ -1,9 +1,10 @@
 PKG_NAME = libpciaccess
-PKG_VERS = 0.18.1
-PKG_EXT = tar.xz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://xorg.freedesktop.org/archive/individual/lib
-PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+PKG_VERS = 0.19
+PKG_EXT = tar.bz2
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/$(PKG_NAME)-$(PKG_VERS)
+PKG_DIR = $(PKG_NAME)-$(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =
 
@@ -14,3 +15,8 @@ LICENSE  = https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/blob/master/CO
 ADDITIONAL_CFLAGS = -O
 
 include ../../mk/spksrc.cross-meson.mk
+
+# 0.19 uses a C99 for-loop init; pin gnu99 (gcc 4.x defaults to gnu89).
+ifeq ($(call version_ge,$(TC_GCC),4.9),1)
+CONFIGURE_ARGS += -Dc_std=gnu99
+endif

--- a/cross/libpciaccess/digests
+++ b/cross/libpciaccess/digests
@@ -1,3 +1,3 @@
-libpciaccess-0.18.1.tar.xz SHA1 0f06bb9579544e6b18cb28514a5f77cb7fdd10a7
-libpciaccess-0.18.1.tar.xz SHA256 4af43444b38adb5545d0ed1c2ce46d9608cc47b31c2387fc5181656765a6fa76
-libpciaccess-0.18.1.tar.xz MD5 57c7efbeceedefde006123a77a7bc825
+libpciaccess-0.19.tar.bz2 SHA1 843d1010de22f5a9935b692104dd4a75cee7100c
+libpciaccess-0.19.tar.bz2 SHA256 a595ae61e57f4c3ddb26fbc89567212efbf477b43eda8500f36e00a259f03527
+libpciaccess-0.19.tar.bz2 MD5 edb7531ff489dd5b959764a0b0061cfa

--- a/docs/developer-guide/packaging/makefile-variables.md
+++ b/docs/developer-guide/packaging/makefile-variables.md
@@ -47,11 +47,11 @@ them without any declaration on your part:
 
 | If the URL is hosted on | Fallbacks are taken from |
 |-------------------------|--------------------------|
-| GNU (`ftp.gnu.org`, `ftpmirror.gnu.org`) | `GNU_MIRRORS` |
-| SourceForge (`downloads.sourceforge.net`) | `SOURCEFORGE_MIRRORS` |
-| GNOME (`download.gnome.org`) | `GNOME_MIRRORS` |
-| X.Org (`www.x.org`) | `XORG_MIRRORS` |
-| kernel.org (`cdn.kernel.org`) | `KERNEL_MIRRORS` |
+| GNU (`ftp.gnu.org`, `ftpmirror.gnu.org`) | `MIRROR_GNU` |
+| SourceForge (`downloads.sourceforge.net`) | `MIRROR_SOURCEFORGE` |
+| GNOME (`download.gnome.org`) | `MIRROR_GNOME` |
+| kernel.org (`cdn.kernel.org`) | `MIRROR_KERNEL` |
+| Savannah (`download.savannah.gnu.org`) | `MIRROR_SAVANNAH` |
 
 A candidate is built by replacing everything up to and including the family's
 tree-root marker (`/gnu/`, `/project/`, `/sources/`, ...) with the mirror base,

--- a/mk/spksrc.build/download.mk
+++ b/mk/spksrc.build/download.mk
@@ -117,13 +117,13 @@ pre_download_target: download_msg
 # (number of mirror candidates) x DOWNLOAD_TRIES attempts, and the candidate
 # list is finite (primary URL + the family mirrors + PKG_DIST_MIRRORS, then
 # de-duplicated), so a failing download can never loop indefinitely.
-DOWNLOAD_TRIES      ?= 2
-GNU_MIRRORS         ?= https://ftpmirror.gnu.org/gnu https://ftp.gnu.org/gnu https://mirrors.kernel.org/gnu https://mirror.csclub.uwaterloo.ca/gnu
-SOURCEFORGE_MIRRORS ?= https://downloads.sourceforge.net/project https://netcologne.dl.sourceforge.net/project https://phoenixnap.dl.sourceforge.net/project
-GNOME_MIRRORS       ?= https://download.gnome.org/sources https://mirror.csclub.uwaterloo.ca/gnome/sources
-XORG_MIRRORS        ?= https://www.x.org/releases https://mirror.csclub.uwaterloo.ca/x.org/releases
-KERNEL_MIRRORS      ?= https://cdn.kernel.org/pub https://mirrors.kernel.org/pub https://www.kernel.org/pub
-PKG_DIST_MIRRORS    ?=
+DOWNLOAD_TRIES     ?= 2
+MIRROR_GNU         ?= https://ftpmirror.gnu.org/gnu https://ftp.gnu.org/gnu https://mirrors.kernel.org/gnu https://mirror.csclub.uwaterloo.ca/gnu
+MIRROR_SOURCEFORGE ?= https://downloads.sourceforge.net/project https://netcologne.dl.sourceforge.net/project https://phoenixnap.dl.sourceforge.net/project
+MIRROR_GNOME       ?= https://download.gnome.org/sources https://mirror.csclub.uwaterloo.ca/gnome/sources
+MIRROR_KERNEL      ?= https://cdn.kernel.org/pub https://mirrors.kernel.org/pub https://www.kernel.org/pub
+MIRROR_SAVANNAH    ?= https://download.savannah.gnu.org/releases https://download-mirror.savannah.gnu.org/releases
+PKG_DIST_MIRRORS   ?=
 
 # ---------------------------------------------------------------------------
 # Per-method download macros, spliced into download_target's case below.
@@ -230,11 +230,11 @@ define DOWNLOAD_HTTP
 	        mirrorUrls="$${url}" ; \
 	        marker="" ; mirrorBases="" ; \
 	        case "$${url}" in \
-	          *//ftpmirror.gnu.org/gnu/*|*//ftp.gnu.org/gnu/*)  marker="/gnu/" ;     mirrorBases="$(GNU_MIRRORS)" ;; \
-	          *//downloads.sourceforge.net/project/*)           marker="/project/" ; mirrorBases="$(SOURCEFORGE_MIRRORS)" ;; \
-	          *//download.gnome.org/sources/*)                  marker="/sources/" ; mirrorBases="$(GNOME_MIRRORS)" ;; \
-	          *//www.x.org/releases/*|*//x.org/releases/*)      marker="/releases/" ; mirrorBases="$(XORG_MIRRORS)" ;; \
-	          *//www.kernel.org/pub/*|*//cdn.kernel.org/pub/*)  marker="/pub/" ;     mirrorBases="$(KERNEL_MIRRORS)" ;; \
+	          *//ftpmirror.gnu.org/gnu/*|*//ftp.gnu.org/gnu/*)  marker="/gnu/" ;     mirrorBases="$(MIRROR_GNU)" ;; \
+	          *//downloads.sourceforge.net/project/*)           marker="/project/" ; mirrorBases="$(MIRROR_SOURCEFORGE)" ;; \
+	          *//download.gnome.org/sources/*)                  marker="/sources/" ; mirrorBases="$(MIRROR_GNOME)" ;; \
+	          *//www.kernel.org/pub/*|*//cdn.kernel.org/pub/*)  marker="/pub/" ;     mirrorBases="$(MIRROR_KERNEL)" ;; \
+	          *//download.savannah.gnu.org/releases/*)          marker="/releases/" ; mirrorBases="$(MIRROR_SAVANNAH)" ;; \
 	        esac ; \
 	        if [ -n "$${marker}" ]; then \
 	          tail=$${url#*$${marker}} ; \


### PR DESCRIPTION
Follow-ups to #7254 (generic mirror fallback), plus a related X.Org download breakage.

### Add Savannah to the auto-mirror families

From the #7254 discussion: a failing download from `download.savannah.gnu.org` had no fallback — Savannah was not in the mirror table (reported for `attr-2.5.2.tar.xz`). The primary 302-redirects to a geo-mirror that can time out, while `download-mirror.savannah.gnu.org` serves the same `/releases/` tree directly. Adds `MIRROR_SAVANNAH` + a case arm keyed on the host. Covers `acl`, `attr`, `ddrescue`, `lzip`, `plzip`.

### Group the built-in tables under `MIRROR_*`, and drop the dead X.Org one

Rename `GNU_MIRRORS` → `MIRROR_GNU`, `SOURCEFORGE_MIRRORS` → `MIRROR_SOURCEFORGE`, etc., so the built-in host tables share one discoverable prefix. `PKG_DIST_MIRRORS` stays as-is — it is the per-package interface in the `PKG_DIST_*` family, not a built-in host table.

The X.Org table is **removed**: the modern per-package `individual/` tarballs live only on `xorg.freedesktop.org`, no public mirror carries them (the official x.org mirrors carry just the legacy X11R* FTP tree), and the entry only ever pointed at hosts that redirect back to it — it never actually worked.

### `cross/libpciaccess`: update to 0.19, fetch from upstream GitLab

`xorg.freedesktop.org` (and its `www.x.org` redirect — the same host) had an **expired TLS cert on 2026-07-28**, which blocked the whole *Prepare for Build* stage on a libpciaccess download, with no mirror to fall back to. Fetch the source from the **upstream GitLab tag archive** — the authoritative, cert-independent host. Requesting the archive under its `<project>-<tag>` name keeps GitLab from stamping the commit hash into the extracted tree, so `PKG_DIR` needs no per-release SHA; `PKG_DIST_FILE` restores the normal local name. It builds with meson, so the snapshot needs no pre-generated configure. This bump also exercises the download changes above in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEH1b4ASNYSrZFQnEeroj8
