### PR TITLE
python 3.12/3.13/3.14: declare the real gcc floor (C11 stdatomic) instead of arch lists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,16 +405,6 @@ jobs:
             add_to_matrix "ppc853x-5.2"
           fi
 
-          # TEMP (legacy-gate validation): build the three oldest DSM 5.2 archs
-          # (x86 gcc 4.7.3, 88f6281 gcc 4.6.4, ppc853x gcc 4.3.7) on every automatic
-          # run of this branch, to prove the capability gates skip them for the right
-          # reason (gcc/glibc) instead of erroring. Remove before merge.
-          if [ "$add_dsm52_builds" != "true" ] && [ "$has_arch_packages" == "true" ]; then
-            add_to_matrix "x86-5.2"
-            add_to_matrix "88f6281-5.2"
-            add_to_matrix "ppc853x-5.2"
-          fi
-
           # Add SRM 1.3 builds
           if [ "$add_srm13_builds" == "true" ]; then
             add_to_matrix "aarch64-1.3"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,6 +405,16 @@ jobs:
             add_to_matrix "ppc853x-5.2"
           fi
 
+          # TEMP (legacy-gate validation): build the three oldest DSM 5.2 archs
+          # (x86 gcc 4.7.3, 88f6281 gcc 4.6.4, ppc853x gcc 4.3.7) on every automatic
+          # run of this branch, to prove the capability gates skip them for the right
+          # reason (gcc/glibc) instead of erroring. Remove before merge.
+          if [ "$add_dsm52_builds" != "true" ] && [ "$has_arch_packages" == "true" ]; then
+            add_to_matrix "x86-5.2"
+            add_to_matrix "88f6281-5.2"
+            add_to_matrix "ppc853x-5.2"
+          fi
+
           # Add SRM 1.3 builds
           if [ "$add_srm13_builds" == "true" ]; then
             add_to_matrix "aarch64-1.3"

--- a/cross/python312/Makefile
+++ b/cross/python312/Makefile
@@ -6,13 +6,13 @@ PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.python.org/ftp/python/$(PKG_VERS)
 PKG_DIR = Python-$(PKG_VERS)
 
-# Compiler must support std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# Needs C11 <stdatomic.h> (and C++11); gcc ships stdatomic.h >= 4.8
+MIN_GCC_VERSION = 4.8
 
 BUILD_DEPENDS = native/python312
 
 DEPENDS  = cross/zlib cross/sqlite cross/readline cross/ncursesw cross/bzip2 cross/xz
-# required for Sleepycat^WOracle Berkeley DB interface
+# required for Sleepycat Oracle Berkeley DB interface
 DEPENDS += cross/berkeleydb
 # required for uuid module
 DEPENDS += cross/libuuid

--- a/cross/python313/Makefile
+++ b/cross/python313/Makefile
@@ -6,13 +6,13 @@ PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.python.org/ftp/python/$(PKG_VERS)
 PKG_DIR = Python-$(PKG_VERS)
 
-# Compiler must support std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# Python 3.13 needs C11 <stdatomic.h> (and C++11); gcc ships stdatomic.h >= 4.8
+MIN_GCC_VERSION = 4.8
 
 BUILD_DEPENDS = native/python313
 
 DEPENDS  = cross/zlib cross/sqlite cross/readline cross/ncursesw cross/bzip2 cross/xz
-# required for Sleepycat^WOracle Berkeley DB interface
+# required for Sleepycat Oracle Berkeley DB interface
 DEPENDS += cross/berkeleydb
 # required for uuid module
 DEPENDS += cross/libuuid

--- a/cross/python314/Makefile
+++ b/cross/python314/Makefile
@@ -6,13 +6,13 @@ PKG_DIST_NAME = Python-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.python.org/ftp/python/$(PKG_VERS)
 PKG_DIR = Python-$(PKG_VERS)
 
-# Compiler must support std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# Needs C11 <stdatomic.h> (and C++11); gcc ships stdatomic.h >= 4.8
+MIN_GCC_VERSION = 4.8
 
 BUILD_DEPENDS = native/python314
 
 DEPENDS  = cross/zlib cross/sqlite cross/readline cross/ncursesw cross/bzip2 cross/xz cross/zstd
-# required for Sleepycat^WOracle Berkeley DB interface
+# required for Sleepycat Oracle Berkeley DB interface
 DEPENDS += cross/berkeleydb
 # required for uuid module
 DEPENDS += cross/libuuid

--- a/spk/python312/Makefile
+++ b/spk/python312/Makefile
@@ -4,8 +4,8 @@ SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$
 SPK_REV = 7
 SPK_ICON = src/python3.png
 
-# Compiler must support std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# Needs C11 <stdatomic.h> (and C++11); gcc ships stdatomic.h >= 4.8
+MIN_GCC_VERSION = 4.8
 
 DEPENDS  = cross/python312
 

--- a/spk/python313/Makefile
+++ b/spk/python313/Makefile
@@ -4,8 +4,8 @@ SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$
 SPK_REV = 10
 SPK_ICON = src/python3.png
 
-# Compiler must support std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# Needs C11 <stdatomic.h> (and C++11); gcc ships stdatomic.h >= 4.8
+MIN_GCC_VERSION = 4.8
 
 DEPENDS  = cross/python313
 

--- a/spk/python314/Makefile
+++ b/spk/python314/Makefile
@@ -4,8 +4,8 @@ SPK_VERS_MAJOR_MINOR = $(word 1,$(subst ., ,$(SPK_VERS))).$(word 2,$(subst ., ,$
 SPK_REV = 4
 SPK_ICON = src/python3.png
 
-# Compiler must support std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# Needs C11 <stdatomic.h> (and C++11); gcc ships stdatomic.h >= 4.8
+MIN_GCC_VERSION = 4.8
 
 DEPENDS  = cross/python314
 


### PR DESCRIPTION
## What

Convert **python 3.12 / 3.13 / 3.14** from a hand-maintained `UNSUPPORTED_ARCHS`
list to the real capability floor `MIN_GCC_VERSION = 4.8` (spk + cross).

CPython 3.12+ pulls C11 `<stdatomic.h>` (`Include/cpython/pyatomic_std.h`) and all
three need C++11; gcc ships `<stdatomic.h>` from **4.8** on. Declaring the floor lets
the framework refuse a toolchain **for the reason** — not a list that says *where* a
build fails without saying *why*, and that has to be rechecked by hand each time a
toolchain moves.

## Exact floor

Pinned by building against the legacy toolchains, not guessed:

- gcc **4.8.3** (hi3535) — **builds**.
- gcc **4.7.3** (DSM 5.2 x86) — **fails**: `pyatomic_std.h:17: fatal error: stdatomic.h: No such file or directory`.

So `4.8` is the true floor. Below it — OLD PowerPC (gcc 4.3.7), ARMv5 (gcc 4.6.4),
DSM 5.2 x86 (gcc 4.7.3) — the gate now reports e.g. `gcc 4.6.4 < 4.8` and records the
arch as *unsupported* (build_unsupported), exactly as the old list did, but self-correcting.

## Dependency tree validated

Every cross dependency of the python tree was built on the legacy toolchains
(gcc 4.3.7 / glibc 2.8 up to 4.8.3) to be sure none of them would *error* where the
python packages are skipped:

`zlib sqlite ncursesw readline bzip2 xz berkeleydb libuuid openssl3 gdbm libexpat libffi`
— **all build on gcc 4.3.7 / glibc 2.8**, so none needs a floor. In particular
**openssl3** builds fine on the legacy stock gcc (its `__atomic_*_8`/libatomic issue is
specific to the gcc-8.5 overlay, which emits the 64-bit atomic calls; the old stock gcc
emits `__sync_*` and needs no libatomic).

- **python 3.11** has a lower floor (it builds down to gcc 4.3.7 once `--with-lto` is
  gated off for gcc ≤ 4.6) and is a separate follow-up — its crossenv needs a `rustc`
  built for the old arch, still in progress.