### PR TITLE
Navidrome: Update to v0.63.2

### DIFF
--- a/cross/navidrome/Makefile
+++ b/cross/navidrome/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = navidrome
-PKG_VERS = 0.62.0
+PKG_VERS = 0.63.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/navidrome/navidrome/archive

--- a/cross/navidrome/digests
+++ b/cross/navidrome/digests
@@ -1,3 +1,3 @@
-navidrome-0.62.0.tar.gz SHA1 5a560596083137db1a9f3f1f99eb21706fbd7439
-navidrome-0.62.0.tar.gz SHA256 4e1d3c8cdb5b16deadbe2e7b29f6cc147aadc466a771eb929daec95153ac1cb0
-navidrome-0.62.0.tar.gz MD5 f08ecbbad30241b05fc2de8e2856b9c9
+navidrome-0.63.2.tar.gz SHA1 55b795c22f2a2e20839bec353d36661cc04fec29
+navidrome-0.63.2.tar.gz SHA256 a2602f00b429325f37efedba5e67918269f5ad2687266629dad23b740135cd4c
+navidrome-0.63.2.tar.gz MD5 333ec5a1148f3cb28179a3e0b6297725

--- a/spk/navidrome/Makefile
+++ b/spk/navidrome/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = navidrome
-SPK_VERS = 0.62.0
-SPK_REV = 10
+SPK_VERS = 0.63.2
+SPK_REV = 11
 SPK_ICON = src/navidrome.png
 
 DEPENDS = cross/navidrome
@@ -14,7 +14,7 @@ HOMEPAGE = https://www.navidrome.org/
 DESCRIPTION = 🎧☁ Modern Music Server and Streamer compatible with Subsonic/Airsonic. It gives you freedom to listen to your music collection from any browser or mobile device.
 LICENSE = GPLv3
 DISPLAY_NAME = Navidrome
-CHANGELOG = "1. Update Navidrome to v0.62.0."
+CHANGELOG = "1. Update Navidrome to v0.63.2."
 
 STARTABLE = yes
 SERVICE_SETUP = src/service-setup.sh

--- a/spk/navidrome/src/wizard/install_uifile
+++ b/spk/navidrome/src/wizard/install_uifile
@@ -18,6 +18,6 @@
     }, {
       "desc": "Navidrome runs as internal service user <b>sc-navidrome</b> in DSM. The shared music folder above is configured at installation time to be accessible by this user."
     }, {
-      "desc": "If you manually change the music folder, make sure <b>sc-navidrome</b> has read permissions. Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+      "desc": "If you manually change the music folder, make sure <b>sc-navidrome</b> has read permissions. Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]


### PR DESCRIPTION
## Description

### What changed
- Update Navidrome to v0.63.2
- Update wizard permission link to new docs page

### Highlights of this release
- Full support for synced sidecar lyrics (TTML, ELRC, SRT, YAML, LRC) via OpenSubsonic v2 extensions
- Smarter search: exact matches rank above prefix matches; short/non-ASCII artist names now findable
- Large-library performance gains: search3 full-library sync ~20x faster, getRandomSongs ~13x faster
- Sharing now enabled by default (`EnableSharing=false` to disable)
- Security: per-library access enforced on playlist import and sharing paths

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
