### PR TITLE
MediaInfo: Update to v26.05 with MIN_GCC_VERSION capability floors

### DIFF
--- a/cross/libmediainfo-25.04/Makefile
+++ b/cross/libmediainfo-25.04/Makefile
@@ -9,7 +9,7 @@ PKG_DIR = MediaInfoLib-$(PKG_VERS)/Project/GNU/Library
 DEPENDS = cross/libzen cross/zlib
 
 # cross/libzen:
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+MIN_GCC_VERSION = 4.7
 
 HOMEPAGE = https://mediaarea.net/en/MediaInfo
 COMMENT  = MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.

--- a/cross/libmediainfo-latest/Makefile
+++ b/cross/libmediainfo-latest/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libmediainfo
-PKG_VERS = 26.01
+PKG_VERS = 26.05
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/MediaArea/MediaInfoLib/archive
@@ -8,7 +8,8 @@ PKG_DIR = MediaInfoLib-$(PKG_VERS)/Project/GNU/Library
 
 DEPENDS = cross/libzen cross/zlib
 
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# 26.x requires GCC >= 5 (selected by cross/mediainfo)
+MIN_GCC_VERSION = 5
 
 HOMEPAGE = https://mediaarea.net/en/MediaInfo
 COMMENT  = MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.

--- a/cross/libmediainfo-latest/digests
+++ b/cross/libmediainfo-latest/digests
@@ -1,3 +1,3 @@
-libmediainfo_26.01.tar.gz SHA1 cf799ca7e2fd026cfd1b4ea17723ab3c8e6b60fc
-libmediainfo_26.01.tar.gz SHA256 941daa01fce4595bd7b56c4d2db166f58e2bb2362dcb9636b952ee29b64db986
-libmediainfo_26.01.tar.gz MD5 4e5fd9b6377b7ca54dbfb0cbee5bcbd1
+libmediainfo_26.05.tar.gz SHA1 989c43c813ba06b91977995b7fb45ae3450ba525
+libmediainfo_26.05.tar.gz SHA256 f3fa9faa5623a5bacf6bed30c1d4c7434852be1654e655d458f964f597d98b8e
+libmediainfo_26.05.tar.gz MD5 814ca55547d56b787212f276a0b7d6e4

--- a/cross/libzen/Makefile
+++ b/cross/libzen/Makefile
@@ -8,8 +8,8 @@ PKG_DIR = ZenLib-$(PKG_VERS)/Project/GNU/Library
 
 DEPENDS =
 
-# compiler lacking support for -std=c++11
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# needs -std=c++11
+MIN_GCC_VERSION = 4.7
 
 HOMEPAGE = https://github.com/MediaArea/ZenLib
 COMMENT  = Small C++ derivate classes to have an easier life.

--- a/cross/mediainfo-25.04/Makefile
+++ b/cross/mediainfo-25.04/Makefile
@@ -9,7 +9,7 @@ PKG_DIR = MediaInfo-$(PKG_VERS)/Project/GNU/CLI
 DEPENDS = cross/libmediainfo-25.04
 
 # cross/libmediainfo-25.04:
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+MIN_GCC_VERSION = 4.7
 
 HOMEPAGE = https://mediaarea.net/en/MediaInfo
 COMMENT  = MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.

--- a/cross/mediainfo-latest/Makefile
+++ b/cross/mediainfo-latest/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = mediainfo
-PKG_VERS = 26.01
+PKG_VERS = 26.05
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/MediaArea/MediaInfo/archive
@@ -8,7 +8,8 @@ PKG_DIR = MediaInfo-$(PKG_VERS)/Project/GNU/CLI
 
 DEPENDS = cross/libmediainfo-latest
 
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# 26.x requires GCC >= 5 (selected by cross/mediainfo)
+MIN_GCC_VERSION = 5
 
 HOMEPAGE = https://mediaarea.net/en/MediaInfo
 COMMENT  = MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.

--- a/cross/mediainfo-latest/digests
+++ b/cross/mediainfo-latest/digests
@@ -1,3 +1,3 @@
-mediainfo_26.01.tar.gz SHA1 4f5c7a56616f9058e4ccea19fc85fcfb59c8f6d2
-mediainfo_26.01.tar.gz SHA256 cec53d8aa143376965d8da72cfaaed4e1e432e23a19ed26cbdf8e69a14e93365
-mediainfo_26.01.tar.gz MD5 eef97cecf806d353bbdd4529399a0ab4
+mediainfo_26.05.tar.gz SHA1 92c2072ccdb45696f04cd0724d1d5e4ce87d2ed7
+mediainfo_26.05.tar.gz SHA256 90dd67f5a70bb87158d7024456339f5062f59776188427d7158d07a43e6a46d1
+mediainfo_26.05.tar.gz MD5 ed2641967e67093ec8caf6a7e5c4dd71

--- a/cross/mediainfo/Makefile
+++ b/cross/mediainfo/Makefile
@@ -3,7 +3,8 @@ PKG_NAME = mediainfo-virtual
 OPTIONAL_DEPENDS  = cross/mediainfo-latest
 OPTIONAL_DEPENDS += cross/mediainfo-25.04
 
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# 25.04 fallback needs -std=c++11
+MIN_GCC_VERSION = 4.7
 
 include ../../mk/spksrc.common.mk
 

--- a/spk/mediainfo/Makefile
+++ b/spk/mediainfo/Makefile
@@ -1,19 +1,17 @@
 SPK_NAME = mediainfo
-SPK_VERS = 26.01
-SPK_REV = 15
+SPK_VERS = 26.05
+SPK_REV = 16
 SPK_ICON = src/mediainfo.png
 
 DEPENDS = cross/mediainfo
 
-# GCC >= 5 required for MediaInfo 26.01 (C++11)
-# comcerto2k uses GCC 4.9.3 even on DSM 7.x
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS) comcerto2k
-REQUIRED_MIN_DSM = 7.0
+# GCC >= 5 required for MediaInfo 26.05 (C++11)
+MIN_GCC_VERSION = 5
 
 MAINTAINER = ymartin59
 DESCRIPTION = "MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files."
 DISPLAY_NAME = MediaInfo
-CHANGELOG = "Update to version 26.01."
+CHANGELOG = "Update to version 26.05."
 
 HOMEPAGE = https://mediaarea.net/en/MediaInfo
 LICENSE = 2-Clause BSD


### PR DESCRIPTION
## Description

### Update
- MediaInfo / MediaInfoLib bumped from v26.01 to **v26.05**

### Cleanup: replace `UNSUPPORTED_ARCHS` with `MIN_GCC_VERSION`
Instead of hardcoding arch lists (`OLD_PPC_ARCHS ARMv5_ARCHS comcerto2k`),
each component now declares its compiler floor via the framework's
capability check:

| Component | `MIN_GCC_VERSION` | Reason |
|-----------|-------------------|--------|
| `cross/libzen` | 4.7 | needs `-std=c++11` |
| `cross/libmediainfo-25.04`, `cross/mediainfo-25.04` | 4.7 | `-std=c++11` |
| `cross/libmediainfo-latest`, `cross/mediainfo-latest` | 5 | 26.x line selected only for GCC ≥ 5 |
| `cross/mediainfo` (virtual) | 4.7 | floor of its 25.04 fallback |
| `spk/mediainfo` | 5 | excludes comcerto2k (GCC 4.9.3 on 7.x) |

- Removed the now-redundant `REQUIRED_MIN_DSM = 7.0` from the SPK:
  `MIN_GCC_VERSION = 5` alone rejects every sub-7.0 toolchain (all 5.2/6.x
  use GCC < 5).
- Dropped the stale `comcerto2k` comment — it is implied by the GCC floor.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
