### PR TITLE
Docs: Migrate wiki URLs to docs.synocommunity.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
   id: arch
   attributes:
     label: Device Architecture
-    description: Which CPU Architecture does your NAS have? [You can look up the Architecture for your NAS here](https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures)
+    description: Which CPU Architecture does your NAS have? [You can look up the Architecture for your NAS here](https://docs.synocommunity.com/reference/architectures/)
     options:
       - x86_64
       - AArch64 (ARMv8)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@ Fixes # <!--Optionally, add links to existing issues or other PR's-->
 - [ ] Build rule `all-supported` completed successfully
 - [ ] New installation of package completed successfully
 - [ ] Package upgrade completed successfully (Manually install the package again)
-- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
-- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created
+- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
+- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created
 
 
 ### Type of change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@ Fixes # <!--Optionally, add links to existing issues or other PR's-->
 - [ ] New Package
 - [ ] Package update
 - [ ] Includes small framework changes
-- [ ] This change requires a documentation update (e.g. Wiki)
+- [ ] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ make setup              # Basic setup with default toolchains
 make setup-synocommunity  # Setup with SynoCommunity defaults (publish URL, distributor info)
 ```
 
-For detailed Docker setup and LXC/LXD alternatives, see the [Developers HOW-TO](https://github.com/SynoCommunity/spksrc/wiki/Developers-HOW-TO).
+For detailed Docker setup and LXC/LXD alternatives, see the [Developer Guide](https://docs.synocommunity.com/developer-guide/).
 
 > **Note:** Native Linux builds are not officially supported. Use Docker or LXC/LXD with Debian to match the build environment.
 
@@ -484,8 +484,8 @@ grep -r "cross/openssl" spk/*/Makefile
 
 ## References
 
-- [SynoCommunity Wiki](https://github.com/SynoCommunity/spksrc/wiki)
-- [Developers HOW-TO](https://github.com/SynoCommunity/spksrc/wiki/Developers-HOW-TO)
-- [Using Python Wheels](https://github.com/SynoCommunity/spksrc/wiki/Using-wheels-to-distribute-Python-packages)
-- [Architecture Reference](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model)
-- [FAQ](https://github.com/SynoCommunity/spksrc/wiki/Frequently-Asked-Questions)
+- [SynoCommunity Docs](https://docs.synocommunity.com)
+- [Developer Guide](https://docs.synocommunity.com/developer-guide/)
+- [Python Packages](https://docs.synocommunity.com/developer-guide/package-types/python/)
+- [Architectures](https://docs.synocommunity.com/reference/architectures/)
+- [Troubleshooting](https://docs.synocommunity.com/user-guide/troubleshooting/)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -554,7 +554,7 @@ jobs:
           PUBLISH: ${{ github.event.inputs.publish }}
           API_KEY: ${{ secrets.PUBLISH_API_KEY }}
           PACKAGE_TO_PUBLISH: ${{ github.event.inputs.package }}
-          # https://github.com/SynoCommunity/spksrc/wiki/Compile-and-build-rules
+          # https://docs.synocommunity.com/developer-guide/packaging/build-rules/
           GH_ARCH: ${{ matrix.arch }}
           BUILD_ERROR_FILE: /github/workspace/build_errors.txt
           BUILD_ERROR_LOGFILE: /github/workspace/build_log_errors.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ If you have questions, suggestions or you believe you have found a bug, we'd lik
 
 Do:
 
-* Check the [FAQ](https://github.com/SynoCommunity/spksrc/wiki/Frequently-Asked-Questions);
+* Check the [Troubleshooting guide](https://docs.synocommunity.com/user-guide/troubleshooting/);
 * Search the [bug tracker](https://github.com/SynoCommunity/spksrc/issues) to see if the issue has not already been reported;
-* Check if the package has specific documentation related to it via the [Package Documentation Index](https://github.com/SynoCommunity/spksrc/wiki/Package-Documentation-Index);
+* Check if the package has specific documentation related to it via the [Package Catalog](https://docs.synocommunity.com/packages/);
 * if you're reporting a bug, make sure you include sufficient information. See [Issue Content](https://github.com/SynoCommunity/spksrc/blob/master/CONTRIBUTING.md#issue-content).
 
 Don't:
@@ -34,10 +34,10 @@ Content:
 
 * Describe what you did, what you expected to happen and what actually happened;
 * Which steps to perform to reproduce what happened;
-* Model, arch and DSM version of your NAS. See [Architecture per Synology model](https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model);
+* Model, arch and DSM version of your NAS. See [Architectures](https://docs.synocommunity.com/reference/architectures/);
 * Provide log files if available. Sometimes a log is shown in Package Center for that package. There might be a log available at `/usr/local/{package}/var/`;
 * Wrap larger logs between triple backticks (```). Log files over ten lines should be placed on gist.github.com, Pastebin etc., and linked in the issue;
-* If the package doesn't start, try to start the package [via the command line](https://github.com/SynoCommunity/spksrc/wiki/Frequently-Asked-Questions#how-to-query-package-status-or-start-from-command-line)  and provide the output.
+* If the package doesn't start, try to start the package [via the command line](https://docs.synocommunity.com/user-guide/troubleshooting/#package-wont-start)  and provide the output.
 
 
 Package Requests
@@ -70,7 +70,7 @@ Pull requests to add packages to the [SynoCommunity repository](https://synocomm
 
 Please create a new branch before pulling your request and avoid using the master branch. Pay attention on [How to make a clean pull request](https://github.com/MarcDiethelm/contributing/blob/master/README.md).
 
-Once you have a development environment set up, you can start building packages, create new ones, or improve upon existing packages while making your changes available to other people. See the [Developers HOW-TO](https://github.com/SynoCommunity/spksrc/wiki/Developers-HOW-TO) for information on how to use spksrc.
+Once you have a development environment set up, you can start building packages, create new ones, or improve upon existing packages while making your changes available to other people. See the [Developer Guide](https://docs.synocommunity.com/developer-guide/) for information on how to use spksrc.
 
 #### When creating a Pull Request you get a description from a template like this:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ DSM 7 was released on June 29 2021 as Version 7.0.41890.
 
 ## Contributing
 Before opening a new issue, check the [Troubleshooting guide](https://docs.synocommunity.com/user-guide/troubleshooting/) and search open issues.
-If you can't find an answer, or if you want to open a package request, read [CONTRIBUTING](https://github.com/SynoCommunity/spksrc/blob/master/CONTRIBUTING.md) to make sure you include all the information needed for contributors to handle your request.
+If you can't find an answer, or if you want to open a package request, read [CONTRIBUTING](https://docs.synocommunity.com/contributing/) to make sure you include all the information needed for contributors to handle your request.
 
 
 ## Setup Development Environment

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DSM 7 was released on June 29 2021 as Version 7.0.41890.
 
 
 ## Contributing
-Before opening a new issue, check the [FAQ] and search open issues.
+Before opening a new issue, check the [Troubleshooting guide] and search open issues.
 If you can't find an answer, or if you want to open a package request, read [CONTRIBUTING] to make sure you include all the information needed for contributors to handle your request.
 
 
@@ -42,7 +42,7 @@ docker run -it --platform=linux/amd64 -v $(pwd):/spksrc -w /spksrc ghcr.io/synoc
 # If running on macOS:
 docker run -it --platform=linux/amd64 -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
 ```
-5. From there, follow the instructions in the [Developers HOW TO].
+5. From there, follow the instructions in the [Developer Guide].
 
 
 
@@ -75,7 +75,7 @@ sudo apt install --no-install-recommends -y \
                  python3 python3-mako python3-pip python3-setuptools \
                  python3-virtualenv python3-yaml
 ```
-From there, follow the instructions in the [Developers HOW TO].
+From there, follow the instructions in the [Developer Guide].
 
 
 ### LXC
@@ -125,7 +125,7 @@ lxc exec spksrc -- /usr/sbin/adduser --uid 1001 spksrc
 lxc exec spksrc --user 1001 -- cp /etc/skel/.profile /etc/skel/.bashrc ~spksrc/.
 ```
 
-From there you can connect to your container as `spksrc` and follow the instructions in the [Developers HOW TO].
+From there you can connect to your container as `spksrc` and follow the instructions in the [Developer Guide].
 ```bash
 lxc exec spksrc -- su --login spksrc
 spksrc@spksrc:~$
@@ -175,7 +175,7 @@ EOF"
 
 ## Usage
 Once you have a development environment set up, you can start building packages, create new ones, or improve upon existing packages while making your changes available to other people.
-See the [Developers HOW TO] for information on how to use spksrc.
+See the [Developer Guide] for information on how to use spksrc.
 
 
 ## License
@@ -186,8 +186,8 @@ When not explicitly set, files are placed under a [3 clause BSD license]
 [bug tracker]: https://github.com/SynoCommunity/spksrc/issues
 [CONTRIBUTING]: https://github.com/SynoCommunity/spksrc/blob/master/CONTRIBUTING.md
 [Fork and clone]: https://docs.github.com/en/github/getting-started-with-github/fork-a-repo
-[Developers HOW TO]: https://github.com/SynoCommunity/spksrc/wiki/Developers-HOW-TO
+[Developer Guide]: https://docs.synocommunity.com/developer-guide/
 [Docker installation]: https://docs.docker.com/engine/installation
-[FAQ]: https://github.com/SynoCommunity/spksrc/wiki/Frequently-Asked-Questions
+[Troubleshooting guide]: https://docs.synocommunity.com/user-guide/troubleshooting/
 [Install Docker with wget]: https://docs.docker.com/linux/step_one
 [SynoCommunity repository]: http://www.synocommunity.com

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SynoCommunity is now on Discord!
 [![Discord](https://img.shields.io/discord/732558169863225384?color=7289DA&label=Discord&logo=Discord&logoColor=white&style=for-the-badge)](https://discord.gg/nnN9fgE7EF)
 
 # spksrc
-spksrc is a cross compilation framework intended to compile and package software for Synology NAS devices. Packages are made available via the [SynoCommunity repository].
+spksrc is a cross compilation framework intended to compile and package software for Synology NAS devices. Packages are made available via the [SynoCommunity repository](http://www.synocommunity.com).
 
 
 # DSM 7
@@ -14,22 +14,22 @@ DSM 7 was released on June 29 2021 as Version 7.0.41890.
   - before the repository deliverd DSM 6 packages for Systems with DSM 7, when no DSM 7 package was available
   - this gave errors like "invalid file format" (or "package requires root privileges")
   - you still get this error when manually installing a DSM 6 package on DSM 7
-* You find the status of the former packages in the issue [#4524] **Meta: DSM7 package status**
+* You find the status of the former packages in the issue [#4524](https://github.com/SynoCommunity/spksrc/issues/4524) **Meta: DSM7 package status**
 * New packages support DSM 7 from initial package version (and some require at least DSM 7).
 * **ATTENTION**: As reported, package configuration settings may be lost following the upgrade to DSM 7 and the execution of a Package repair. Make sure to backup your settings and configuration for your SynoCommunity packages before installation of DSM 7 to facilitate restoration if needed.
 
 
 ## Contributing
-Before opening a new issue, check the [Troubleshooting guide] and search open issues.
-If you can't find an answer, or if you want to open a package request, read [CONTRIBUTING] to make sure you include all the information needed for contributors to handle your request.
+Before opening a new issue, check the [Troubleshooting guide](https://docs.synocommunity.com/user-guide/troubleshooting/) and search open issues.
+If you can't find an answer, or if you want to open a package request, read [CONTRIBUTING](https://github.com/SynoCommunity/spksrc/blob/master/CONTRIBUTING.md) to make sure you include all the information needed for contributors to handle your request.
 
 
 ## Setup Development Environment
 ### Docker
 *The Docker development environment supports Linux and macOS systems, but not Windows due to limitations of the underlying file system.*
 
-1. [Fork and clone] spksrc: `git clone https://github.com/YOUR-USERNAME/spksrc`
-2. Install Docker on your host OS (see [Docker installation], or use a `wget`-based alternative for linux [Install Docker with wget]).
+1. [Fork and clone](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) spksrc: `git clone https://github.com/YOUR-USERNAME/spksrc`
+2. Install Docker on your host OS (see [Docker installation](https://docs.docker.com/engine/installation), or use a `wget`-based alternative for linux [Install Docker with wget](https://docs.docker.com/linux/step_one)).
 3. Download the spksrc Docker container: `docker pull ghcr.io/synocommunity/spksrc`
 4. Run the container with the repository mounted into the `/spksrc` directory with the appropriate command for your host Operating System:
 
@@ -42,7 +42,7 @@ docker run -it --platform=linux/amd64 -v $(pwd):/spksrc -w /spksrc ghcr.io/synoc
 # If running on macOS:
 docker run -it --platform=linux/amd64 -v $(pwd):/spksrc -w /spksrc -e TAR_CMD="fakeroot tar" ghcr.io/synocommunity/spksrc /bin/bash
 ```
-5. From there, follow the instructions in the [Developer Guide].
+5. From there, follow the instructions in the [Developer Guide](https://docs.synocommunity.com/developer-guide/).
 
 
 
@@ -75,7 +75,7 @@ sudo apt install --no-install-recommends -y \
                  python3 python3-mako python3-pip python3-setuptools \
                  python3-virtualenv python3-yaml
 ```
-From there, follow the instructions in the [Developer Guide].
+From there, follow the instructions in the [Developer Guide](https://docs.synocommunity.com/developer-guide/).
 
 
 ### LXC
@@ -125,7 +125,7 @@ lxc exec spksrc -- /usr/sbin/adduser --uid 1001 spksrc
 lxc exec spksrc --user 1001 -- cp /etc/skel/.profile /etc/skel/.bashrc ~spksrc/.
 ```
 
-From there you can connect to your container as `spksrc` and follow the instructions in the [Developer Guide].
+From there you can connect to your container as `spksrc` and follow the instructions in the [Developer Guide](https://docs.synocommunity.com/developer-guide/).
 ```bash
 lxc exec spksrc -- su --login spksrc
 spksrc@spksrc:~$
@@ -175,19 +175,9 @@ EOF"
 
 ## Usage
 Once you have a development environment set up, you can start building packages, create new ones, or improve upon existing packages while making your changes available to other people.
-See the [Developer Guide] for information on how to use spksrc.
+See the [Developer Guide](https://docs.synocommunity.com/developer-guide/) for information on how to use spksrc.
 
 
 ## License
-When not explicitly set, files are placed under a [3 clause BSD license]
+When not explicitly set, files are placed under a [3 clause BSD license](http://www.opensource.org/licenses/BSD-3-Clause)
 
-[3 clause BSD license]: http://www.opensource.org/licenses/BSD-3-Clause
-[#4524]: https://github.com/SynoCommunity/spksrc/issues/4524
-[bug tracker]: https://github.com/SynoCommunity/spksrc/issues
-[CONTRIBUTING]: https://github.com/SynoCommunity/spksrc/blob/master/CONTRIBUTING.md
-[Fork and clone]: https://docs.github.com/en/github/getting-started-with-github/fork-a-repo
-[Developer Guide]: https://docs.synocommunity.com/developer-guide/
-[Docker installation]: https://docs.docker.com/engine/installation
-[Troubleshooting guide]: https://docs.synocommunity.com/user-guide/troubleshooting/
-[Install Docker with wget]: https://docs.docker.com/linux/step_one
-[SynoCommunity repository]: http://www.synocommunity.com

--- a/docs/developer-guide/advanced/testing.md
+++ b/docs/developer-guide/advanced/testing.md
@@ -2,6 +2,12 @@
 
 Strategies for testing spksrc packages.
 
+## Regression Checks
+
+If the issue being fixed was reported for a previous version, reproduce the
+original problem first, then verify the fix resolves it with an appropriate
+test case before submitting.
+
 ## Build Testing
 
 ```bash
@@ -15,11 +21,39 @@ make -C spk/<package> arch-x64-7.2 arch-aarch64-7.2 arch-armv7-7.1
 make -C spk/<package> all-supported
 ```
 
+Build at least the primary architecture plus one representative per CPU family
+(e.g. x64, aarch64, armv7) — ideally matching what CI runs.
+
+## Package Features
+
+- [ ] Description translations are correct
+- [ ] Wizard pages and process work for both install and upgrade
+- [ ] Wizard translations are complete
+
+## Service Operation
+
+- [ ] Service starts from Package Center; confirm with `ps`
+- [ ] Service stops from Package Center; confirm with `ps`
+- [ ] "View log" in Package Center works
+- [ ] Log files exist in the package data directory
+      (`/var/packages/<package>/var/` on DSM < 7, `/volume1/@appdata/<package>/`
+      on DSM 7)
+- [ ] DSM shortcut opens the interface
+- [ ] Application port is declared in Firewall Services
+
+## Command Line Tools
+
+- [ ] Expected binaries appear in PATH (via `/usr/local/bin` links)
+- [ ] Run binaries with version and verbose options (`--version`, `-v`)
+
 ## Device Testing
 
 1. Install via Package Center > Manual Install (upload SPK from local computer)
-3. Check `/var/packages/<pkg>/var/*.log`
-4. Verify service starts correctly
+2. Check the package log in the data directory
+   (`/var/packages/<pkg>/var/` on DSM < 7, `/volume1/@appdata/<pkg>/` on DSM 7)
+3. Verify service starts correctly
+4. For a fresh install, confirm the service account is created and config is
+   initialized in the package data directory
 
 ## Upgrade Testing
 
@@ -27,6 +61,20 @@ make -C spk/<package> all-supported
 2. Configure and add data
 3. Upgrade to new version
 4. Verify data preserved
+5. Verify the service account and permissions are unchanged after upgrade
+
+## Uninstall Testing
+
+- [ ] Package removes cleanly from `/var/packages/<package>/`
+- [ ] On DSM < 7: service account is removed from `/etc/passwd`
+- [ ] On DSM 7: confirm the package data directory is removed when "delete
+  data" is selected in the uninstall wizard
+
+!!! note
+    On DSM 5/6 the installer explicitly removes the service account
+    (`syno_remove_user`). On DSM 7 the account is managed by the DSM package
+    framework (via `conf/privilege`) and **persists after uninstall** — the
+    installer no longer removes it.
 
 ## Checklist Before PR
 
@@ -36,3 +84,9 @@ make -C spk/<package> all-supported
 - [ ] Service starts automatically
 - [ ] Core features work
 - [ ] Upgrades from previous version
+- [ ] Uninstalls cleanly
+
+## See Also
+
+- [Update Policy and Process](../publishing/update-policy.md) - The testing
+  checklist used before publishing, including supported DSM versions

--- a/docs/developer-guide/packaging/help-pages.md
+++ b/docs/developer-guide/packaging/help-pages.md
@@ -1,0 +1,93 @@
+# Help Pages
+
+Packages can ship an in-DSM help system that guides the user through the
+package step by step: installation, configuration, and basic usage. Help pages
+are plain HTML files rendered inside DSM (under the package's "Help" link),
+with the same styling as DSM's own help.
+
+## Overview
+
+- Help files are HTML pages placed under `spk/<package>/src/app/help/`.
+- There is one main page (`index.html`) plus optional sub-pages, one per topic
+  (e.g. *Installation*, *Configuration*, *Usage*, *Service feature*).
+- Each language gets its own subdirectory (e.g. `enu/` for English, `fre/` for
+  French).
+- The package must set `DSM_UI_DIR = app` so the `app/` tree (including
+  `help/`) is packaged and served by DSM.
+
+`debian-chroot` is the reference package: it ships a main page with
+*Installation*, *Configuration* and *Usage* topics plus a page explaining the
+*Service feature*.
+
+## File Structure
+
+```
+spk/<package>/src/app/help/
+├── enu/
+│   ├── index.html      # Main help page
+│   └── services.html   # Optional sub-page
+├── fre/
+│   ├── index.html
+│   └── services.html
+└── ...
+```
+
+## Example
+
+```html
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Package Name</title>
+        <link href="/webman/help/help.css" rel="stylesheet" type="text/css" />
+    </head>
+    <body>
+        <h1>Package Name</h1>
+        <h3>Installation</h3>
+        <p>Once installed via Package Center, ...</p>
+        <h3>Usage</h3>
+        <p>Connect via SSH (root) and run: <b>/var/packages/package/scripts/start-stop-status</b>.</p>
+    </body>
+</html>
+```
+
+Use the same HTML markup as the `debian-chroot` help files. Synology applies
+the standard `help.css` stylesheet so the pages match DSM's look and feel.
+
+## Linking Help
+
+Set `HELPURL` in the SPK Makefile to an external fallback documentation URL.
+When set, it is written to the package `INFO` file as `helpurl` and used by
+Package Center:
+
+```makefile
+HELPURL = https://docs.synocommunity.com/packages/<package>/
+```
+
+## Localization
+
+Create a subdirectory per language, mirroring the wizard translation suffixes:
+
+| Suffix | Language |
+|--------|----------|
+| `enu` | English |
+| `fre` | French |
+| `ger` | German |
+| `chs` | Chinese (Simplified) |
+| ... | (same set as wizard translations) |
+
+Each language directory contains its own set of HTML pages.
+
+## Best Practices
+
+1. Cover the main topics: **Installation**, **Configuration**, **Basic Usage**
+2. Keep a single main page plus focused sub-pages
+3. Provide at least English (`enu/`) HTML
+4. Reference the package data directory (`/var/packages/<package>/var/`) where
+   configuration lives
+5. Match the `debian-chroot` HTML structure and use `help.css` classes
+
+## See Also
+
+- [Wizards](wizards.md) - Installation/upgrade wizard pages
+- [Resource Files](resource-files.md) - Other files packaged with the SPK

--- a/docs/developer-guide/packaging/index.md
+++ b/docs/developer-guide/packaging/index.md
@@ -46,6 +46,7 @@ Tools built for the build host:
 - **[PLIST Files](plist.md)** - Defining package contents
 - **[Service Scripts](service-scripts.md)** - Daemons and services
 - **[Wizards](wizards.md)** - Installation wizards
+- **[Help Pages](help-pages.md)** - In-DSM help pages
 - **[Resource Files](resource-files.md)** - DSM 7 resource configuration
 
 ## Quick Start: Creating a Package

--- a/docs/developer-guide/publishing/update-policy.md
+++ b/docs/developer-guide/publishing/update-policy.md
@@ -30,7 +30,9 @@ Before publishing, verify:
 
 - [ ] Service starts from Package Center
 - [ ] Service stops from Package Center
-- [ ] Log files exist in `/var/packages/{package}/var/`
+- [ ] Log files exist in the package data directory
+      (`/var/packages/{package}/var/` on DSM < 7, `/volume1/@appdata/{package}/`
+      on DSM 7)
 - [ ] DSM shortcut opens the interface
 
 ### Command Line Tools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - PLIST Files: developer-guide/packaging/plist.md
       - Service Scripts: developer-guide/packaging/service-scripts.md
       - Wizards: developer-guide/packaging/wizards.md
+      - Help Pages: developer-guide/packaging/help-pages.md
       - Resource Files: developer-guide/packaging/resource-files.md
     - Package Types:
       - developer-guide/package-types/index.md


### PR DESCRIPTION
## Description

Migrates all documentation references in the repo from the legacy GitHub wiki
(`github.com/SynoCommunity/spksrc/wiki`) to the docs site
(`docs.synocommunity.com`), which is now the canonical home for
SynoCommunity documentation.

### What changed

**Documentation links migrated** (README, CONTRIBUTING, `.github/`, `docs/`):
- Wiki page URLs mapped to their docs-site equivalents (Permission Management →
  `/user-guide/permissions/`, FAQ → `/user-guide/troubleshooting/`, Developers
  HOW-TO → `/developer-guide/`, Architecture per Synology model →
  `/reference/architectures/`, etc.)
- Link text updated to match destination page titles ("Developers HOW-TO" →
  "Developer Guide", "FAQ" → "Troubleshooting", etc.)
- Fixed a broken anchor in CONTRIBUTING (`#package-wont-start`)
- README reference-style links converted to inline URLs
- CONTRIBUTING link now points to the docs site (`/contributing/`)

**New content:**
- `docs/developer-guide/packaging/help-pages.md` — documents the in-DSM help
  page pattern (previously only on the wiki's "Create documentation" page),
  registered in `mkdocs.yml`
- Enriched `docs/developer-guide/advanced/testing.md` with the package feature,
  service, command-line, and uninstall checks from the wiki's "Tests Checks"
  section, and made it DSM-version-accurate (service account removal is
  DSM < 7 only; data dir is `@appdata` on DSM 7)

**Cleanup:**
- Removed stale "wiki" wording from PR template and link text
- The intentional "Legacy documentation" link back to the GitHub wiki is kept

### Notes
- `mkdocs build --strict` passes
- No package files touched — separate PR covers the `spk/` wizard/Makefile URL
  updates (which trigger CI rebuilds)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks)
- [x] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. Wiki)
