### PR TITLE
Docs: Complete and verify synocli package tool listings

### DIFF
--- a/docs/packages/synocli-devel.md
+++ b/docs/packages/synocli-devel.md
@@ -24,6 +24,10 @@ SynoCli Development Tools provides build tools and debugging utilities.
 |------|---------|-------------|
 | automake | 1.18.1 | Makefile generator |
 | autoconf | 2.71 | Configure script generator |
+| binutils | — | Binary tools (ld, as, gold) |
+| gdb | — | GNU debugger |
+| LLVM | — | Compiler and toolchain technologies |
+| m4 | — | Macro processor |
 | make | 4.4.1 | Build automation |
 | pkg-config | 0.29.2 | Library configuration |
 | libtree | 3.1.1 | Library dependency viewer |

--- a/docs/packages/synocli-devel.md
+++ b/docs/packages/synocli-devel.md
@@ -22,16 +22,16 @@ SynoCli Development Tools provides build tools and debugging utilities.
 
 | Tool | Version | Description |
 |------|---------|-------------|
+| autoconf | 2.73 | Configure script generator |
 | automake | 1.18.1 | Makefile generator |
-| autoconf | 2.71 | Configure script generator |
-| binutils | — | Binary tools (ld, as, gold) |
-| gdb | — | GNU debugger |
-| LLVM | — | Compiler and toolchain technologies |
-| m4 | — | Macro processor |
+| binutils | 2.46 | Binary tools (ld, as, gold) |
+| gdb | 17.1 | GNU debugger |
+| libtree | 3.1.1 | Library dependency viewer |
+| LLVM | 22.1 | Compiler and toolchain technologies |
+| m4 | 1.4.21 | Macro processor |
 | make | 4.4.1 | Build automation |
 | pkg-config | 0.29.2 | Library configuration |
-| libtree | 3.1.1 | Library dependency viewer |
-| strace | 6.18 | System call tracer |
+| strace | 6.19 | System call tracer |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-disk.md
+++ b/docs/packages/synocli-disk.md
@@ -26,10 +26,20 @@ SynoCli Disk Tools provides essential disk management and recovery utilities.
 | ntfs-3g | NTFS read/write support |
 | ntfsprogs | NTFS utilities |
 | testdisk | Data recovery tool |
-| ncdu | NCurses disk usage (also in synocli-file) |
+| ncdu | NCurses disk usage analyzer |
 | davfs2 | Mount WebDAV shares |
 | lsscsi | List SCSI devices |
 | ddrescue | Data recovery tool |
+| dar | Disk archive (full filesystem backups) |
+| duf | Disk usage/free utility (better `df`) |
+| gdu | Fast disk usage analyzer (Go) |
+| dua | Disk usage analyzer |
+| dutree | Disk usage analyzer (Rust) |
+| tdu | Top disk usage |
+| smartmontools | SMART disk monitoring (smartctl, smartd) |
+| mergerfs | FUSE union filesystem (run as root) |
+| disktype | Detect disk/image content format |
+| gpart | Recover damaged partition tables |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-disk.md
+++ b/docs/packages/synocli-disk.md
@@ -22,24 +22,24 @@ SynoCli Disk Tools provides essential disk management and recovery utilities.
 
 | Tool | Description |
 |------|-------------|
+| dar | Disk archive (full filesystem backups) |
+| davfs2 | Mount WebDAV shares |
+| ddrescue | Data recovery tool |
+| disktype | Detect disk/image content format |
+| dua | Disk usage analyzer |
+| duf | Disk usage/free utility (better `df`) |
+| dutree | Disk usage analyzer (Rust) |
 | e2fsprogs | ext2/3/4 filesystem utilities (e2fsck, mkfs.ext4, etc.) |
+| gdu | Fast disk usage analyzer (Go) |
+| gpart | Recover damaged partition tables |
+| lsscsi | List SCSI devices |
+| mergerfs | FUSE union filesystem (run as root) |
+| ncdu | NCurses disk usage analyzer |
 | ntfs-3g | NTFS read/write support |
 | ntfsprogs | NTFS utilities |
-| testdisk | Data recovery tool |
-| ncdu | NCurses disk usage analyzer |
-| davfs2 | Mount WebDAV shares |
-| lsscsi | List SCSI devices |
-| ddrescue | Data recovery tool |
-| dar | Disk archive (full filesystem backups) |
-| duf | Disk usage/free utility (better `df`) |
-| gdu | Fast disk usage analyzer (Go) |
-| dua | Disk usage analyzer |
-| dutree | Disk usage analyzer (Rust) |
-| tdu | Top disk usage |
 | smartmontools | SMART disk monitoring (smartctl, smartd) |
-| mergerfs | FUSE union filesystem (run as root) |
-| disktype | Detect disk/image content format |
-| gpart | Recover damaged partition tables |
+| tdu | Top disk usage |
+| testdisk | Data recovery tool |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-file.md
+++ b/docs/packages/synocli-file.md
@@ -22,37 +22,37 @@ SynoCli File Tools provides essential file management utilities for the command 
 
 | Tool | Description |
 |------|-------------|
-| less | Pager for viewing files |
-| tree | Directory tree viewer |
-| jdupes | Duplicate file finder |
+| bat | Cat clone with syntax highlighting |
+| detox | Filename cleanup |
+| dos2unix | Convert line endings |
+| eza | Modern `ls` replacement |
+| fd | Simple, fast alternative to `find` |
 | fdupes | Duplicate file finder |
-| rhash | Hash computing/verifying utility |
-| mc | Midnight Commander file manager |
-| nano | Text editor |
-| micro | Modern terminal text editor |
-| mg | Micro (GNU) emacs-like text editor |
-| jupp | Joe's Own Editor (jmacs, joe, jpico, jstar) |
-| rnm | Batch file renamer (regex) |
 | file | File type identification |
 | fzf | Command-line fuzzy finder |
-| rg (ripgrep) | Line-oriented recursive search |
-| fd | Simple, fast alternative to `find` |
-| sd | Intuitive `sed` alternative |
-| bat | Cat clone with syntax highlighting |
-| eza | Modern `ls` replacement |
-| lsd | Modern `ls` replacement |
-| nnn | Terminal file manager |
-| detox | Filename cleanup |
-| rmlint | Duplicate and lint finder |
-| zstd | Zstandard compression |
-| lzip / plzip | Lossless data compressor (parallel) |
-| pixz | Parallel, indexing `xz` |
-| pigz | Parallel `gzip` |
 | iconv | Character set conversion |
-| dos2unix | Convert line endings |
-| xstow | Symlink farm manager |
+| jdupes | Duplicate file finder |
+| jupp | Joe's Own Editor (jmacs, joe, jpico, jstar) |
+| less | Pager for viewing files |
+| lsd | Modern `ls` replacement |
+| lzip / plzip | Lossless data compressor (parallel) |
+| mc | Midnight Commander file manager |
+| mg | Micro (GNU) emacs-like text editor |
+| micro | Modern terminal text editor |
+| nano | Text editor |
+| nnn | Terminal file manager |
 | patch | Apply patches to files |
 | pcre2grep / pcre2test | PCRE2 grep and test tools |
+| pigz | Parallel `gzip` |
+| pixz | Parallel, indexing `xz` |
+| rg (ripgrep) | Line-oriented recursive search |
+| rhash | Hash computing/verifying utility |
+| rmlint | Duplicate and lint finder |
+| rnm | Batch file renamer (regex) |
+| sd | Intuitive `sed` alternative |
+| tree | Directory tree viewer |
+| xstow | Symlink farm manager |
+| zstd | Zstandard compression |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-file.md
+++ b/docs/packages/synocli-file.md
@@ -22,19 +22,37 @@ SynoCli File Tools provides essential file management utilities for the command 
 
 | Tool | Description |
 |------|-------------|
-| mc | Midnight Commander file manager |
-| tree | Directory tree viewer |
-| ncdu | NCurses disk usage analyzer |
 | less | Pager for viewing files |
-| file | File type identification |
+| tree | Directory tree viewer |
+| jdupes | Duplicate file finder |
 | fdupes | Duplicate file finder |
-| jq | JSON processor |
-| rmlint | Duplicate and lint finder |
-| rename | Batch file renaming |
+| rhash | Hash computing/verifying utility |
+| mc | Midnight Commander file manager |
+| nano | Text editor |
+| micro | Modern terminal text editor |
+| mg | Micro (GNU) emacs-like text editor |
+| jupp | Joe's Own Editor (jmacs, joe, jpico, jstar) |
+| rnm | Batch file renamer (regex) |
+| file | File type identification |
+| fzf | Command-line fuzzy finder |
+| rg (ripgrep) | Line-oriented recursive search |
+| fd | Simple, fast alternative to `find` |
+| sd | Intuitive `sed` alternative |
+| bat | Cat clone with syntax highlighting |
+| eza | Modern `ls` replacement |
+| lsd | Modern `ls` replacement |
+| nnn | Terminal file manager |
 | detox | Filename cleanup |
-| nano | Text editor (optional) |
+| rmlint | Duplicate and lint finder |
 | zstd | Zstandard compression |
-| lz4 | LZ4 compression |
+| lzip / plzip | Lossless data compressor (parallel) |
+| pixz | Parallel, indexing `xz` |
+| pigz | Parallel `gzip` |
+| iconv | Character set conversion |
+| dos2unix | Convert line endings |
+| xstow | Symlink farm manager |
+| patch | Apply patches to files |
+| pcre2grep / pcre2test | PCRE2 grep and test tools |
 
 ## Usage Examples
 
@@ -46,32 +64,6 @@ mc
 
 # Use F keys for operations
 # F5: Copy, F6: Move, F8: Delete, F10: Exit
-```
-
-### ncdu - Disk Usage Analyzer
-
-```bash
-# Analyze current directory
-ncdu
-
-# Analyze specific path
-ncdu /volume1/data
-
-# Export results
-ncdu -o report.json /volume1/
-```
-
-### jq - JSON Processing
-
-```bash
-# Pretty print JSON
-cat data.json | jq .
-
-# Extract specific field
-cat data.json | jq '.items[].name'
-
-# Filter results
-jq '.[] | select(.status == "active")' data.json
 ```
 
 ### fdupes - Find Duplicates

--- a/docs/packages/synocli-misc.md
+++ b/docs/packages/synocli-misc.md
@@ -22,32 +22,36 @@ SynoCli Misc Tools provides various useful command-line utilities.
 
 | Tool | Description |
 |------|-------------|
-| bc | Calculator |
+| bc / dc | Arbitrary precision calculator |
 | errno | Lookup errno names and descriptions |
 | expect | Automate interactive applications |
+| dialog | Display dialog boxes from shell scripts |
 | parallel | Parallel command execution |
 | cal | Calendar display |
+| col | Filter reverse line feeds |
+| colcrt | Filter for terminal processing |
+| colrm | Remove columns from a file |
+| column | Columnate lists |
 | hexdump | Display file in hexadecimal |
 | lscpu | Display CPU information |
 | lsblk | List block devices |
+| lsipc | IPC information |
+| lsirq | IRQ information |
 | findmnt | Find mounted filesystems |
+| hardlink | Link duplicate files |
+| rev | Reverse lines of a file |
 | wall | Write to all users |
 | whereis | Locate commands |
 | uhubctl | USB hub power control |
 | zramctl | ZRAM management |
-
-### moreutils (pee, sponge, etc.)
-
-| Tool | Description |
-|------|-------------|
-| pee | Tee to pipes |
-| sponge | Soak up stdin, write to file |
-| ts | Timestamp input |
 | ifdata | Get network interface info |
 | ifne | Run command if stdin not empty |
-| isutf8 | Check if file is valid UTF-8 |
-| lckdo | Execute with lock held |
-| mispipe | Pipe preserving exit status |
+| isutf8 | Check if input is valid UTF-8 |
+| lckdo | Execute a command with a lock held |
+| mispipe | Pipe while preserving exit status |
+| pee | Tee standard input to pipes |
+| sponge | Soak up stdin and write to file |
+| ts | Timestamp input lines |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-misc.md
+++ b/docs/packages/synocli-misc.md
@@ -23,35 +23,35 @@ SynoCli Misc Tools provides various useful command-line utilities.
 | Tool | Description |
 |------|-------------|
 | bc / dc | Arbitrary precision calculator |
-| errno | Lookup errno names and descriptions |
-| expect | Automate interactive applications |
-| dialog | Display dialog boxes from shell scripts |
-| parallel | Parallel command execution |
 | cal | Calendar display |
 | col | Filter reverse line feeds |
 | colcrt | Filter for terminal processing |
 | colrm | Remove columns from a file |
 | column | Columnate lists |
-| hexdump | Display file in hexadecimal |
-| lscpu | Display CPU information |
-| lsblk | List block devices |
-| lsipc | IPC information |
-| lsirq | IRQ information |
+| dialog | Display dialog boxes from shell scripts |
+| errno | Lookup errno names and descriptions |
+| expect | Automate interactive applications |
 | findmnt | Find mounted filesystems |
 | hardlink | Link duplicate files |
-| rev | Reverse lines of a file |
-| wall | Write to all users |
-| whereis | Locate commands |
-| uhubctl | USB hub power control |
-| zramctl | ZRAM management |
+| hexdump | Display file in hexadecimal |
 | ifdata | Get network interface info |
 | ifne | Run command if stdin not empty |
 | isutf8 | Check if input is valid UTF-8 |
 | lckdo | Execute a command with a lock held |
+| lsblk | List block devices |
+| lscpu | Display CPU information |
+| lsipc | IPC information |
+| lsirq | IRQ information |
 | mispipe | Pipe while preserving exit status |
+| parallel | Parallel command execution |
 | pee | Tee standard input to pipes |
+| rev | Reverse lines of a file |
 | sponge | Soak up stdin and write to file |
 | ts | Timestamp input lines |
+| uhubctl | USB hub power control |
+| wall | Write to all users |
+| whereis | Locate commands |
+| zramctl | ZRAM management |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-monitor.md
+++ b/docs/packages/synocli-monitor.md
@@ -22,14 +22,23 @@ SynoCli Monitor Tools provides system monitoring and performance analysis utilit
 
 | Tool | Description |
 |------|-------------|
-| nmon | Performance monitor |
-| njmon | JSON performance output |
 | htop | Interactive process viewer |
-| iperf2 | Network bandwidth testing |
-| iperf3 | Modern network testing |
+| btop | Resource monitor (CPU, memory, disks, network) |
+| btm (bottom) | Cross-platform graphical process viewer |
+| nmon / njmon | Performance monitor (JSON output) |
+| iperf2 / iperf3 | Network bandwidth testing |
 | ionice | I/O scheduling priority |
+| iostat | CPU/disk statistics |
+| pgrep | Find processes by name |
+| pmap | Report memory map of a process |
+| watch | Execute commands periodically |
+| pstree | Display process tree |
+| lsof | List open files |
 | cpulimit | CPU usage limiter |
-| net-snmp | SNMP tools (snmpget, snmpwalk, etc.) |
+| bandwhich | Bandwidth utilization viewer |
+| procs | Modern `ps` replacement |
+| net-snmp | SNMP tools (snmpget, snmpwalk, snmptable, etc.) |
+| lm-sensors | Hardware sensors (sensors, sensors-detect, fancontrol) |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-monitor.md
+++ b/docs/packages/synocli-monitor.md
@@ -22,23 +22,23 @@ SynoCli Monitor Tools provides system monitoring and performance analysis utilit
 
 | Tool | Description |
 |------|-------------|
-| htop | Interactive process viewer |
-| btop | Resource monitor (CPU, memory, disks, network) |
+| bandwhich | Bandwidth utilization viewer |
 | btm (bottom) | Cross-platform graphical process viewer |
-| nmon / njmon | Performance monitor (JSON output) |
-| iperf2 / iperf3 | Network bandwidth testing |
+| btop | Resource monitor (CPU, memory, disks, network) |
+| cpulimit | CPU usage limiter |
+| htop | Interactive process viewer |
 | ionice | I/O scheduling priority |
 | iostat | CPU/disk statistics |
+| iperf2 / iperf3 | Network bandwidth testing |
+| lm-sensors | Hardware sensors (sensors, sensors-detect, fancontrol) |
+| lsof | List open files |
+| net-snmp | SNMP tools (snmpget, snmpwalk, snmptable, etc.) |
+| nmon / njmon | Performance monitor (JSON output) |
 | pgrep | Find processes by name |
 | pmap | Report memory map of a process |
-| watch | Execute commands periodically |
-| pstree | Display process tree |
-| lsof | List open files |
-| cpulimit | CPU usage limiter |
-| bandwhich | Bandwidth utilization viewer |
 | procs | Modern `ps` replacement |
-| net-snmp | SNMP tools (snmpget, snmpwalk, snmptable, etc.) |
-| lm-sensors | Hardware sensors (sensors, sensors-detect, fancontrol) |
+| pstree | Display process tree |
+| watch | Execute commands periodically |
 
 ## Usage Examples
 

--- a/docs/packages/synocli-net.md
+++ b/docs/packages/synocli-net.md
@@ -22,26 +22,26 @@ SynoCli Network Tools provides essential command-line networking utilities.
 
 | Tool | Description |
 |------|-------------|
-| screen | Terminal multiplexer |
-| tmux | Modern terminal multiplexer |
-| socat | Multipurpose relay |
-| nmap / nping / ncat | Network scanner and netcat |
-| arp-scan | ARP network scanner |
-| mtr | Network diagnostic tool |
-| links | Text-mode web browser |
-| rsync | Fast file copying |
-| xxhsum | xxHash checksum utility |
-| autossh | Automatic SSH reconnection |
-| openssh | SSH client and server tools (ssh, scp, sftp, sshd) |
-| etherwake | Wake-on-LAN utility |
-| telnet | Telnet client |
-| whois | Domain lookup |
-| sshfs | Mount filesystems over SSH |
-| ser2net | Serial-to-network proxy |
-| gensiot | Generic socket I/O tools |
 | aria2c | Download utility |
+| arp-scan | ARP network scanner |
+| autossh | Automatic SSH reconnection |
 | dig / delv / mdig | DNS lookup tools |
+| etherwake | Wake-on-LAN utility |
+| gensiot | Generic socket I/O tools |
 | IMAPFilter | IMAP mail filtering |
+| links | Text-mode web browser |
+| mtr | Network diagnostic tool |
+| nmap / nping / ncat | Network scanner and netcat |
+| openssh | SSH client and server tools (ssh, scp, sftp, sshd) |
+| rsync | Fast file copying |
+| screen | Terminal multiplexer |
+| ser2net | Serial-to-network proxy |
+| socat | Multipurpose relay |
+| sshfs | Mount filesystems over SSH |
+| telnet | Telnet client |
+| tmux | Modern terminal multiplexer |
+| whois | Domain lookup |
+| xxhsum | xxHash checksum utility |
 
 ## Installation
 

--- a/docs/packages/synocli-net.md
+++ b/docs/packages/synocli-net.md
@@ -25,20 +25,22 @@ SynoCli Network Tools provides essential command-line networking utilities.
 | screen | Terminal multiplexer |
 | tmux | Modern terminal multiplexer |
 | socat | Multipurpose relay |
-| nmap | Network scanner |
+| nmap / nping / ncat | Network scanner and netcat |
 | arp-scan | ARP network scanner |
 | mtr | Network diagnostic tool |
 | links | Text-mode web browser |
 | rsync | Fast file copying |
 | xxhsum | xxHash checksum utility |
 | autossh | Automatic SSH reconnection |
-| openssh | SSH client and server tools |
-| sftp | Secure file transfer |
-| scp | Secure copy |
+| openssh | SSH client and server tools (ssh, scp, sftp, sshd) |
 | etherwake | Wake-on-LAN utility |
 | telnet | Telnet client |
 | whois | Domain lookup |
 | sshfs | Mount filesystems over SSH |
+| ser2net | Serial-to-network proxy |
+| gensiot | Generic socket I/O tools |
+| aria2c | Download utility |
+| dig / delv / mdig | DNS lookup tools |
 | IMAPFilter | IMAP mail filtering |
 
 ## Installation


### PR DESCRIPTION
## Description

Completes and corrects the "Included Tools" tables on all six `synocli-*`
package documentation pages (`synocli-devel`, `synocli-disk`, `synocli-file`,
`synocli-misc`, `synocli-monitor`, `synocli-net`), compared against the
legacy wiki and the actual package contents.

### What changed

**Completeness** — added tools that were missing from the docs tables:
- `synocli-devel`: binutils, gdb, LLVM, m4
- `synocli-disk`: dar, duf, gdu, dua, dutree, tdu, smartmontools, mergerfs,
  gpart
- `synocli-file`: jdupes, rhash, micro, mg, jupp, rnm, fzf, ripgrep, fd, sd,
  bat, eza, lsd, nnn, iconv, dos2unix, xstow, patch, lzip/plzip, pixz, pigz,
  pcre2grep/pcre2test
- `synocli-misc`: dialog, col, colcrt, colrm, column, hardlink, lsipc, lsirq,
  rev (consolidated two separate tables into one)
- `synocli-monitor`: btop, btm, iostat, pgrep, pmap, watch, pstree, lsof,
  bandwhich, procs, lm-sensors
- `synocli-net`: ser2net, gensiot, aria2c, dig/delv/mdig, ncat

**Accuracy fixes**:
- `synocli-file`: removed tools that are not in the package (jq, rename, lz4,
  ncdu) and their incorrect usage examples
- `synocli-devel`: corrected versions — autoconf 2.73, strace 6.19, and added
  versions for binutils 2.46, gdb 17.1, LLVM 22.1, m4 1.4.21

**Consistency**:
- All tool tables sorted alphabetically
- Every listed tool verified against the package `Makefile`
  (`DEPENDS`/`SPK_COMMANDS`), including tools shipped via combined/virtual
  packages (e.g. procps utilities, openssh via autossh)

### Verification
- `mkdocs build --strict` passes

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
