### PR TITLE
Packages: Update wiki URLs in wizards and Makefiles to docs.synocommunity.com

### DIFF
--- a/spk/comskip/Makefile
+++ b/spk/comskip/Makefile
@@ -19,7 +19,7 @@ CHANGELOG = "1. Update to FFMPEG 8.1.2"
 
 HOMEPAGE = https://www.kaashoek.com/comskip/
 LICENSE = LGPL
-HELPURL = https://github.com/SynoCommunity/spksrc/wiki/Comskip
+HELPURL = https://docs.synocommunity.com/packages/comskip/
 
 SPK_COMMANDS = bin/comskip
 

--- a/spk/cops/src/wizard_templates/install_uifile.yml
+++ b/spk/cops/src/wizard_templates/install_uifile.yml
@@ -11,4 +11,4 @@ DO_YOU_WANT_TO_USE_COPS_WITH_A_KOBO_DESCRIPTION: "Do you want to use COPS with a
 DO_YOU_WANT_TO_USE_COPS_WITH_A_KOBO_LABEL: "Kobo"
 
 DSM_PERMISSIONS_TITLE: "Attention! DSM Permissions"
-DSM_PERMISSIONS_TEXT: "Package user and group will not appear on most UI settings. Please read <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\\\">Permission Management</a> for details."
+DSM_PERMISSIONS_TEXT: "Package user and group will not appear on most UI settings. Please read <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/user-guide/permissions/\\\">Permission Management</a> for details."

--- a/spk/cops/src/wizard_templates/install_uifile_fre.yml
+++ b/spk/cops/src/wizard_templates/install_uifile_fre.yml
@@ -11,4 +11,4 @@ DO_YOU_WANT_TO_USE_COPS_WITH_A_KOBO_DESCRIPTION: "Voulez vous utiliser COPS avec
 DO_YOU_WANT_TO_USE_COPS_WITH_A_KOBO_LABEL: "Kobo"
 
 DSM_PERMISSIONS_TITLE: "Attention! DSM Permissions"
-DSM_PERMISSIONS_TEXT: "L'utilisateur et le group du package n'apparaîtront pas sur la plupart des UI réglages. Veuillez vous référrer à <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\\\">Permission Management</a> pour plus de détails."
+DSM_PERMISSIONS_TEXT: "L'utilisateur et le group du package n'apparaîtront pas sur la plupart des UI réglages. Veuillez vous référrer à <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/user-guide/permissions/\\\">Permission Management</a> pour plus de détails."

--- a/spk/couchpotatoserver-custom/src/wizard/upgrade_uifile
+++ b/spk/couchpotatoserver-custom/src/wizard/upgrade_uifile
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within CouchPotato, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."

--- a/spk/couchpotatoserver-custom/src/wizard/upgrade_uifile_fre
+++ b/spk/couchpotatoserver-custom/src/wizard/upgrade_uifile_fre
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans CouchPotato, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."

--- a/spk/couchpotatoserver/src/wizard/install_uifile
+++ b/spk/couchpotatoserver/src/wizard/install_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/couchpotatoserver/src/wizard/install_uifile_fre
+++ b/spk/couchpotatoserver/src/wizard/install_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/couchpotatoserver/src/wizard/upgrade_uifile
+++ b/spk/couchpotatoserver/src/wizard/upgrade_uifile
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within CouchPotato, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."

--- a/spk/couchpotatoserver/src/wizard/upgrade_uifile_fre
+++ b/spk/couchpotatoserver/src/wizard/upgrade_uifile_fre
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans CouchPotato, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -18,7 +18,6 @@ CHANGELOG = "1. Update to 8.4<br>2. Use amd64 for x86-64 archs"
 
 HOMEPAGE = https://www.debian.org
 LICENSE  = https://www.debian.org/legal/licenses
-HELPURL  = https://docs.synocommunity.com/developer-guide/setup/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh

--- a/spk/debian-chroot/Makefile
+++ b/spk/debian-chroot/Makefile
@@ -18,7 +18,7 @@ CHANGELOG = "1. Update to 8.4<br>2. Use amd64 for x86-64 archs"
 
 HOMEPAGE = https://www.debian.org
 LICENSE  = https://www.debian.org/legal/licenses
-HELPURL  = https://github.com/SynoCommunity/spksrc/wiki/Debian-Chroot
+HELPURL  = https://docs.synocommunity.com/developer-guide/setup/
 
 INSTALLER_SCRIPT = src/installer.sh
 SSS_SCRIPT       = src/dsm-control.sh

--- a/spk/deluge/src/wizard/6.1/upgrade_uifile
+++ b/spk/deluge/src/wizard/6.1/upgrade_uifile
@@ -61,7 +61,7 @@
   {
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within Deluge, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."

--- a/spk/deluge/src/wizard/6.1/upgrade_uifile_fre
+++ b/spk/deluge/src/wizard/6.1/upgrade_uifile_fre
@@ -61,7 +61,7 @@
   {
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans Deluge, donner les droits de Lecture/Écriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."

--- a/spk/deluge/src/wizard/install_uifile
+++ b/spk/deluge/src/wizard/install_uifile
@@ -57,7 +57,7 @@
         "desc": "If the specified share does not exist, it will be created. You can use an existing share by specifying the name of the folder."
       },
       {
-        "desc": "Package user and group will not appear on most UI settings. Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Package user and group will not appear on most UI settings. Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
       }
     ]
   }

--- a/spk/deluge/src/wizard/install_uifile_fre
+++ b/spk/deluge/src/wizard/install_uifile_fre
@@ -57,7 +57,7 @@
         "desc": "Si le répertoire partagé est inexistant, il sera créé.  Vous pouvez utiliser un partage existant en spécifiant le nom du répertoire destination."
       },
       {
-        "desc": "Le nom d'utilisateur et groupe n'apparaîteront pas dans la plupart des options de configuration de l'interface utilisateur. Prière de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour d'avantage de détails."
+        "desc": "Le nom d'utilisateur et groupe n'apparaîteront pas dans la plupart des options de configuration de l'interface utilisateur. Prière de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour d'avantage de détails."
       }
     ]
   }

--- a/spk/demoservice/src/wizard/install_uifile
+++ b/spk/demoservice/src/wizard/install_uifile
@@ -25,7 +25,7 @@
       }, {
         "desc": ""
       }, {
-        "desc": "This package runs as internal service user <b>'sc-demoservice'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user.<p>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "This package runs as internal service user <b>'sc-demoservice'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user.<p>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
       }
     ]
   }

--- a/spk/demoservice/src/wizard/install_uifile_fre
+++ b/spk/demoservice/src/wizard/install_uifile_fre
@@ -25,7 +25,7 @@
       }, {
         "desc": ""
       }, {
-         "desc": "Ce package s'exécute en tant qu'utilisateur de service interne <b>'sc-demoservice'</b> dans DSM. Le dossier partagé ci-dessus est configuré au moment de l'installation pour être accessible par cet utilisateur.<p>Veuillez lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+         "desc": "Ce package s'exécute en tant qu'utilisateur de service interne <b>'sc-demoservice'</b> dans DSM. Le dossier partagé ci-dessus est configuré au moment de l'installation pour être accessible par cet utilisateur.<p>Veuillez lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
       }
     ]
   }

--- a/spk/demowebservice/src/wizard/install_uifile
+++ b/spk/demowebservice/src/wizard/install_uifile
@@ -24,7 +24,7 @@
         "desc": ""
       },
       {
-        "desc": "This package runs as internal service user <b>'sc-demowebservice'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user.<p>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "This package runs as internal service user <b>'sc-demowebservice'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user.<p>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
       }
     ]
   },

--- a/spk/ffsync/src/wizard/install_uifile.sh
+++ b/spk/ffsync/src/wizard/install_uifile.sh
@@ -78,7 +78,7 @@ PAGE_FFSYNC_SETUP=$(/bin/cat<<EOF
             "desc": "Desktop Config"
         }]
     }, {
-        "desc": "<b>Additional Configuration:</b> For SSL setup with a reverse proxy and Firefox mobile configuration, visit our <a href=\"https://github.com/SynoCommunity/spksrc/wiki/Mozilla-Sync-Server\" target=\"_blank\">Mozilla Sync Server wiki</a>."
+        "desc": "<b>Additional Configuration:</b> For SSL setup with a reverse proxy and Firefox mobile configuration, visit our <a href=\"https://docs.synocommunity.com/packages/mozilla-sync/\" target=\"_blank\">Mozilla Sync package</a>."
     }]
 }
 EOF

--- a/spk/flexget/src/wizard/install_uifile
+++ b/spk/flexget/src/wizard/install_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "FlexGet Documentation",
     "items": [{
-        "desc": "Your need to configure FlexGet after fresh install. Please refer to <a target=\"_blank\" href=\"https://flexget.com/Configuration\">documentation</a> for FlexGet configuration.<br><br>In order to setup your default password please refer to <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Flexget\">SynoCommunity wiki</a>"
+        "desc": "Your need to configure FlexGet after fresh install. Please refer to <a target=\"_blank\" href=\"https://flexget.com/Configuration\">documentation</a> for FlexGet configuration.<br><br>In order to setup your default password please refer to <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/flexget/\">Flexget package</a>"
     }]
 }]

--- a/spk/flexget/src/wizard/upgrade_uifile
+++ b/spk/flexget/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "FlexGet Documentation",
     "items": [{
-        "desc": "Warning: your configuration may require changes after update. Please refer to <a target=\"_blank\" href=\"https://flexget.com/Configuration\">documentation</a> for FlexGet configuration.<br><br>In order to setup your default password please refer to <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Flexget\">SynoCommunity wiki</a>"
+        "desc": "Warning: your configuration may require changes after update. Please refer to <a target=\"_blank\" href=\"https://flexget.com/Configuration\">documentation</a> for FlexGet configuration.<br><br>In order to setup your default password please refer to <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/flexget/\">Flexget package</a>"
     }]
 }]

--- a/spk/forgejo/src/wizard/install_uifile
+++ b/spk/forgejo/src/wizard/install_uifile
@@ -24,7 +24,7 @@
                 }, {
                     "desc": ""
                 }, {
-                    "desc": "This package runs as internal service user <b>'sc-forgejo'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user. Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+                    "desc": "This package runs as internal service user <b>'sc-forgejo'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user. Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
                 }
         ]
     }

--- a/spk/gitea/src/wizard/install_uifile
+++ b/spk/gitea/src/wizard/install_uifile
@@ -24,7 +24,7 @@
                 }, {
                     "desc": ""
                 }, {
-                    "desc": "This package runs as internal service user <b>'sc-gitea'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user. Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+                    "desc": "This package runs as internal service user <b>'sc-gitea'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user. Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
                 }
         ]
     }

--- a/spk/gitea/src/wizard/install_uifile_plk
+++ b/spk/gitea/src/wizard/install_uifile_plk
@@ -24,7 +24,7 @@
                 }, {
                     "desc": ""
                 }, {
-                    "desc": "Ten pakiet uruchamia się jako użytkownik usługi wewnętrznej <b>'sc-gitea'</b> w DSM. Powyższy folder współdzielony jest skonfigurowany podczas instalacji tak, aby był dostępny dla tego użytkownika. Przeczytaj <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Zarządzanie uprawnieniami</a>, aby uzyskać szczegółowe informacje."
+                    "desc": "Ten pakiet uruchamia się jako użytkownik usługi wewnętrznej <b>'sc-gitea'</b> w DSM. Powyższy folder współdzielony jest skonfigurowany podczas instalacji tak, aby był dostępny dla tego użytkownika. Przeczytaj <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Zarządzanie uprawnieniami</a>, aby uzyskać szczegółowe informacje."
                 }
         ]
     }

--- a/spk/google-authenticator-libpam/Makefile
+++ b/spk/google-authenticator-libpam/Makefile
@@ -12,7 +12,7 @@ STARTABLE = no
 CHANGELOG = "Initial package release."
 
 HOMEPAGE = https://github.com/google/google-authenticator-libpam
-SUPPORTURL = https://github.com/SynoCommunity/spksrc/wiki/Google-Authenticator-PAM
+SUPPORTURL = https://docs.synocommunity.com/packages/google-authenticator/
 LICENSE = Apache-2.0
 LICENSE_FILE = $(WORK_DIR)/$(SPK_NAME)-$(SPK_VERS)/LICENSE
 

--- a/spk/google-authenticator-libpam/src/wizard/install_uifile
+++ b/spk/google-authenticator-libpam/src/wizard/install_uifile
@@ -3,7 +3,7 @@
         "step_title": "How to use this package",
         "items": [
             {
-                "desc": "For instructions on how to use this package with your device, please visit our wiki page <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Google-Authenticator-PAM\">Google-Authenticator-PAM</a>."
+                "desc": "For instructions on how to use this package with your device, please visit our <a target="_blank" href="https://docs.synocommunity.com/packages/google-authenticator/">Google Authenticator package</a>."
             }
         ]
     }

--- a/spk/google-authenticator-libpam/src/wizard/install_uifile
+++ b/spk/google-authenticator-libpam/src/wizard/install_uifile
@@ -3,7 +3,7 @@
         "step_title": "How to use this package",
         "items": [
             {
-                "desc": "For instructions on how to use this package with your device, please visit our <a target="_blank" href="https://docs.synocommunity.com/packages/google-authenticator/">Google Authenticator package</a>."
+                "desc": "For instructions on how to use this package with your device, please visit our <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/google-authenticator/\">Google Authenticator package</a>."
             }
         ]
     }

--- a/spk/google-fonts/src/wizard/install_uifile
+++ b/spk/google-fonts/src/wizard/install_uifile
@@ -60,7 +60,7 @@
           }
         ]
       }, {
-        "desc": "To give applications access to the Google Fonts in the shared folder, please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a>."
+        "desc": "To give applications access to the Google Fonts in the shared folder, please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a>."
       }
     ]
   }

--- a/spk/headphones-custom/src/wizard/install_uifile
+++ b/spk/headphones-custom/src/wizard/install_uifile
@@ -22,6 +22,6 @@
 }, {
     "step_title": "Attention! DSM6 Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/headphones-custom/src/wizard/install_uifile_fre
+++ b/spk/headphones-custom/src/wizard/install_uifile_fre
@@ -22,6 +22,6 @@
 }, {
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/headphones-custom/src/wizard/upgrade_uifile
+++ b/spk/headphones-custom/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! DSM6 Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/headphones-custom/src/wizard/upgrade_uifile_fre
+++ b/spk/headphones-custom/src/wizard/upgrade_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/headphones/src/wizard/install_uifile
+++ b/spk/headphones/src/wizard/install_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Permissions for download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>Internal package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>Internal package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/headphones/src/wizard/install_uifile_fre
+++ b/spk/headphones/src/wizard/install_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Les permissions des applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions des applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/headphones/src/wizard/upgrade_uifile
+++ b/spk/headphones/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Permissions for download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>Internal package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>Internal package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/headphones/src/wizard/upgrade_uifile_fre
+++ b/spk/headphones/src/wizard/upgrade_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Les permissions des applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions des applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/homeassistant/src/wizard/install_uifile
+++ b/spk/homeassistant/src/wizard/install_uifile
@@ -3,7 +3,7 @@
     "items": [{
         "desc": "<b>This package includes most of the default Home Assistant integrations.</b>"
     },{
-        "desc": "Please refer to <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-HomeAssistant\">SynoCommunity package Home Assistant Core</a> for further details."
+        "desc": "Please refer to <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/homeassistant/\">Home Assistant package</a> for further details."
     },{
         "desc": "<b>WARNING:</b><p>This is a huge package and installation may take some time and display an error. In this case please press abort and do not retry installation. The package installer will display \"Installing...\" and finally \"Running\". For systems with low resources it may take up to 60 minutes until the web frontend is running and does not display \"Home Assistant is starting...\" anymore."
     }]

--- a/spk/homeassistant/src/wizard/install_uifile_fre
+++ b/spk/homeassistant/src/wizard/install_uifile_fre
@@ -3,7 +3,7 @@
     "items": [{
         "desc": "<b>Ce package contient la plupart des intégrations par défaut de Home Assistant.</b>"
     },{
-        "desc": "Veuillez consulter <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-HomeAssistant\">SynoCommunity package Home Assistant Core</a> pour plus de détails."
+        "desc": "Veuillez consulter <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/homeassistant/\">Home Assistant package</a> pour plus de détails."
     },{
         "desc": "<b>ATTENTION:</b><p>Ce package prend beaucoup de place et l'installation peut prendre du temps et afficher une erreur. Si c'est le cas, veuillez annuler et ne pas réessayer l'installation. L'installeur du package affichera \"Mise à jour en cours...\" et enfin \"En cours d'exécution\". Pour les systèmes disposant de peu de resources il peut s'écouler jusqu'à 60 avant que la façade web ne soit opérationnelle et n'affiche plus \"Home Assistant is starting...\"."
     }]

--- a/spk/homeassistant/src/wizard/upgrade_uifile
+++ b/spk/homeassistant/src/wizard/upgrade_uifile
@@ -3,7 +3,7 @@
     "items": [{
         "desc": "<b>This update includes most of the default Home Assistant integrations.</b>"
     },{
-        "desc": "Please refer to <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-HomeAssistant\">SynoCommunity package Home Assistant Core</a> for further details."
+        "desc": "Please refer to <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/homeassistant/\">Home Assistant package</a> for further details."
     },{
         "desc": "<b>WARNING:</b><p>This is a huge package and installation may take some time and display an error. In this case please press abort and do not retry installation. The package installer will display \"Installing...\" and finally \"Running\". For systems with low resources it may take up to 60 minutes until the web frontend is running and does not display \"Home Assistant is starting...\" anymore."
     }]

--- a/spk/homeassistant/src/wizard/upgrade_uifile_fre
+++ b/spk/homeassistant/src/wizard/upgrade_uifile_fre
@@ -3,7 +3,7 @@
     "items": [{
         "desc": "<b>Ce mettre à jour contient la plupart des intégrations par défaut de Home Assistant.</b>"
     },{
-        "desc": "Veuillez consulter <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-HomeAssistant\">SynoCommunity package Home Assistant Core</a> pour plus de détails."
+        "desc": "Veuillez consulter <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/homeassistant/\">Home Assistant package</a> pour plus de détails."
     },{
         "desc": "<b>ATTENTION:</b><p>Ce package prend beaucoup de place et l'installation peut prendre du temps et afficher une erreur. Si c'est le cas, veuillez annuler et ne pas réessayer l'installation. L'installeur du package affichera \"Mise à jour en cours...\" et enfin \"En cours d'exécution\". Pour les systèmes disposant de peu de resources il peut s'écouler jusqu'à 60 avant que la façade web ne soit opérationnelle et n'affiche plus \"Home Assistant is starting...\"."
     }]

--- a/spk/jellyfin/src/wizard/install_uifile
+++ b/spk/jellyfin/src/wizard/install_uifile
@@ -3,10 +3,10 @@
     "step_title": "Important information",
     "items": [
       {
-        "desc": "Permissions for the package are managed by a \"System internal user\" named <b>sc-jellyfin</b>.<br>For DSM 7 you may need to give <b>sc-ffmpeg</b> the same permissions as sc-jellyfin.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for the package are managed by a \"System internal user\" named <b>sc-jellyfin</b>.<br>For DSM 7 you may need to give <b>sc-ffmpeg</b> the same permissions as sc-jellyfin.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
       },
       {
-        "desc": "Information regarding Jellyfin troubleshooting and hardware acceleration support for your NAS can be found <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Jellyfin\">here</a>"
+        "desc": "Information regarding Jellyfin troubleshooting and hardware acceleration support for your NAS can be found <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/jellyfin/\">here</a>"
       }
     ]
   }

--- a/spk/kavita/src/wizard/install_uifile
+++ b/spk/kavita/src/wizard/install_uifile
@@ -3,6 +3,6 @@
     "items": [{
         "desc": "The first time Kavita is started it might take a few moments for the interface to become available!"
     }, {
-        "desc": "Before adding a library, ensure permissions are granted to the internal user <b>'sc-kavita'</b> in DSM. Refer to the <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> guide for details."
+        "desc": "Before adding a library, ensure permissions are granted to the internal user <b>'sc-kavita'</b> in DSM. Refer to the <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> guide for details."
     }]
 }]

--- a/spk/kavita/src/wizard/install_uifile_fre
+++ b/spk/kavita/src/wizard/install_uifile_fre
@@ -3,6 +3,6 @@
     "items": [{
         "desc": "La première fois que Kavita est lancée, il peut falloir quelques instants avant que l'interface ne soit disponible !"
     }, {
-        "desc": "Avant d'ajouter une bibliothèque, assurez-vous d'accorder les permissions à l'utilisateur interne <b>'sc-kavita'</b> dans DSM. Consultez le guide de <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Gestion des autorisations</a> pour plus de détails."
+        "desc": "Avant d'ajouter une bibliothèque, assurez-vous d'accorder les permissions à l'utilisateur interne <b>'sc-kavita'</b> dans DSM. Consultez le guide de <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Gestion des autorisations</a> pour plus de détails."
     }]
 }]

--- a/spk/kiwix/src/wizard/install_uifile
+++ b/spk/kiwix/src/wizard/install_uifile
@@ -21,7 +21,7 @@
       }, {
         "desc": ""
       }, {
-        "desc": "The web server <b>kiwix-serve</b> runs as internal service user <b>'sc-kiwix'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user.<p>If you add content with <b>kiwix-manage</b>, make sure 'sc-kiwix' has permissions to access library.xml and *.zim files in this folder.<p>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "The web server <b>kiwix-serve</b> runs as internal service user <b>'sc-kiwix'</b> in DSM. The shared folder above is configured at installation time to be accessible by this user.<p>If you add content with <b>kiwix-manage</b>, make sure 'sc-kiwix' has permissions to access library.xml and *.zim files in this folder.<p>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
       }
     ]
   }

--- a/spk/kopia/src/wizard/install_uifile
+++ b/spk/kopia/src/wizard/install_uifile
@@ -4,7 +4,7 @@
     "invalid_next_disabled": true,
     "items": [
       {
-        "desc": "Permissions for the package are managed by a \"System internal user\" named <b>sc-kopia</b>.Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for the package are managed by a \"System internal user\" named <b>sc-kopia</b>.Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
       },
       {
         "type": "textfield",

--- a/spk/lazylibrarian/src/wizard/install_uifile
+++ b/spk/lazylibrarian/src/wizard/install_uifile
@@ -22,6 +22,6 @@
 }, {
     "step_title": "Attention! DSM6 Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/lazylibrarian/src/wizard/install_uifile_fre
+++ b/spk/lazylibrarian/src/wizard/install_uifile_fre
@@ -22,6 +22,6 @@
 }, {
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/lazylibrarian/src/wizard/upgrade_uifile
+++ b/spk/lazylibrarian/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! DSM6 Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/lazylibrarian/src/wizard/upgrade_uifile_fre
+++ b/spk/lazylibrarian/src/wizard/upgrade_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/lidarr/src/wizard/install_uifile
+++ b/spk/lidarr/src/wizard/install_uifile
@@ -6,6 +6,6 @@
 }, {
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]

--- a/spk/lidarr/src/wizard/install_uifile_fre
+++ b/spk/lidarr/src/wizard/install_uifile_fre
@@ -6,6 +6,6 @@
 }, {
 	"step_title": "Permissions DSM",
 	"items": [{
-		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
 	}]
 }]

--- a/spk/lidarr/src/wizard/upgrade_uifile
+++ b/spk/lidarr/src/wizard/upgrade_uifile
@@ -8,6 +8,6 @@
 }, {
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]

--- a/spk/lidarr/src/wizard/upgrade_uifile_fre
+++ b/spk/lidarr/src/wizard/upgrade_uifile_fre
@@ -8,6 +8,6 @@
 }, {
 	"step_title": "Permissions DSM",
 	"items": [{
-		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
 	}]
 }]

--- a/spk/mpd/src/wizards/install_uifile
+++ b/spk/mpd/src/wizards/install_uifile
@@ -21,7 +21,7 @@
       }, {
         "desc": ""
       }, {
-        "desc": "The folder will be created on demand as regular DSM shared folder for the service user <b>sc-mpd</b>. For details about the DSM permissions see <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a>.<p/>"
+        "desc": "The folder will be created on demand as regular DSM shared folder for the service user <b>sc-mpd</b>. For details about the DSM permissions see <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a>.<p/>"
       }
     ]
   }

--- a/spk/mylar/src/wizard/install_uifile
+++ b/spk/mylar/src/wizard/install_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/mylar/src/wizard/install_uifile_fre
+++ b/spk/mylar/src/wizard/install_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/mylar/src/wizard/upgrade_uifile
+++ b/spk/mylar/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/mylar/src/wizard/upgrade_uifile_fre
+++ b/spk/mylar/src/wizard/upgrade_uifile_fre
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/mympd/src/wizard/install_uifile
+++ b/spk/mympd/src/wizard/install_uifile
@@ -21,7 +21,7 @@
       "desc": ""
     },
     {
-      "desc": "myMPD runs as internal service user <b>'sc-mympd'</b>. Read access to the music folder is required for cover art, lyrics, and other metadata features.<br><br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+      "desc": "myMPD runs as internal service user <b>'sc-mympd'</b>. Read access to the music folder is required for cover art, lyrics, and other metadata features.<br><br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }
   ]
 }]

--- a/spk/nzbget/src/wizard/install_uifile
+++ b/spk/nzbget/src/wizard/install_uifile
@@ -50,7 +50,7 @@
           }
         ]
       }, {
-        "desc": "Permissions for download-related packages are managed with the group <b>'synocommunity'</b> in DSM. Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for further information."
+        "desc": "Permissions for download-related packages are managed with the group <b>'synocommunity'</b> in DSM. Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for further information."
       }
     ]
   }, {

--- a/spk/nzbget/src/wizard/install_uifile_fre
+++ b/spk/nzbget/src/wizard/install_uifile_fre
@@ -50,7 +50,7 @@
           }
         ]
       }, {
-        "desc": "Permissions for download-related packages are managed with the group <b>'synocommunity'</b> in DSM. Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for further information."
+        "desc": "Permissions for download-related packages are managed with the group <b>'synocommunity'</b> in DSM. Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for further information."
       }
     ]
   }, {

--- a/spk/openlist/src/wizard_templates/install_uifile.yml
+++ b/spk/openlist/src/wizard_templates/install_uifile.yml
@@ -6,4 +6,4 @@ ADMIN_PASSWORD_DESCRIPTION: "Initial Password for user 'admin'"
 ADMIN_PASSWORD_LABEL:       "Password (default: admin)"
 
 INSTALLATION_NOTES_TITLE: "<b>Notes</b><br/>"
-INSTALLATION_NOTES_TEXT1: "See <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/OpenList\\\">OpenList package</a> for additional information and links to the official documentation."
+INSTALLATION_NOTES_TEXT1: "See <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/packages/openlist/\\\">OpenList package</a> for additional information and links to the official documentation."

--- a/spk/openlist/src/wizard_templates/install_uifile_chs.yml
+++ b/spk/openlist/src/wizard_templates/install_uifile_chs.yml
@@ -6,4 +6,4 @@ ADMIN_PASSWORD_DESCRIPTION: "默认用户 \\\"admin\\\" 的初始密码"
 ADMIN_PASSWORD_LABEL:       "密码 (默认: admin)"
 
 INSTALLATION_NOTES_TITLE: "<b>安装说明</b><br/>"
-INSTALLATION_NOTES_TEXT1: "请参阅 <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/OpenList\\\">SynoCommunity OpenList wiki 页面</a>以获取更多信息及官方文档的链接。"
+INSTALLATION_NOTES_TEXT1: "请参阅 <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/packages/openlist/\\\">SynoCommunity OpenList 包页面</a>以获取更多信息及官方文档的链接。"

--- a/spk/owncloud/src/wizard_templates/upgrade_uifile.yml
+++ b/spk/owncloud/src/wizard_templates/upgrade_uifile.yml
@@ -3,7 +3,7 @@ OWNCLOUD_INCOMPATIBLE_UPGRADE_DESCRIPTION: "<strong>NOTICE:</strong> Version ${O
 
 OWNCLOUD_MIGRATE_DATABASE_STEP_TITLE: "Migrate database to MariaDB"
 OWNCLOUD_MIGRATE_DATABASE_DESCRIPTION: "<strong>NOTICE:</strong> The upgrade process only supports MariaDB (MySQL) databases. Please migrate your current database to MariaDB before proceeding with the upgrade, and then try again."
-OWNCLOUD_MIGRATE_DATABASE_DETAILS: "Please follow the manual steps provided on this webpage: <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/ownCloud-Database-Migration\\\">ownCloud Database Migration</a>."
+OWNCLOUD_MIGRATE_DATABASE_DETAILS: "Please follow the manual steps provided on this webpage: <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/packages/owncloud/\\\">ownCloud Database Migration</a>."
 
 OWNCLOUD_UPGRADE_LIMITATIONS_STEP_TITLE: "Upgrade limitations"
 OWNCLOUD_UPGRADE_LIMITATIONS_DESCRIPTION: "Please note the following limitations when upgrading the ownCloud package:"

--- a/spk/owncloud/src/wizard_templates/upgrade_uifile_fre.yml
+++ b/spk/owncloud/src/wizard_templates/upgrade_uifile_fre.yml
@@ -3,7 +3,7 @@ OWNCLOUD_INCOMPATIBLE_UPGRADE_DESCRIPTION: "<strong>AVIS:</strong> La version ${
 
 OWNCLOUD_MIGRATE_DATABASE_STEP_TITLE: "Migrer la base de données vers MariaDB"
 OWNCLOUD_MIGRATE_DATABASE_DESCRIPTION: "<strong>AVIS:</strong> le processus de mise à niveau ne prend en charge que les bases de données MariaDB (MySQL). Veuillez migrer votre base de données actuelle vers MariaDB avant de procéder à la mise à niveau, puis réessayez."
-OWNCLOUD_MIGRATE_DATABASE_DETAILS: "Veuillez suivre les étapes manuelles fournies sur cette page Web: <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/ownCloud-Database-Migration\\\">Migration de base de données ownCloud</a>."
+OWNCLOUD_MIGRATE_DATABASE_DETAILS: "Veuillez suivre les étapes manuelles fournies sur cette page Web: <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/packages/owncloud/\\\">Migration de base de données ownCloud</a>."
 
 OWNCLOUD_UPGRADE_LIMITATIONS_STEP_TITLE: "Limitations de la mise à niveau"
 OWNCLOUD_UPGRADE_LIMITATIONS_DESCRIPTION: "Veuillez noter les limitations suivantes lors de la mise à jour du package ownCloud:"

--- a/spk/pyload/src/wizard/install_uifile
+++ b/spk/pyload/src/wizard/install_uifile
@@ -32,6 +32,6 @@
 }, {
     "step_title": "DSM6 Permissions",
     "items": [{
-    "desc": "DSM access permissions for this package are managed with the group <b>'sc-download'</b>.<br><br>Package installation will ensure, the group exists and the permissions are set for the chosen directory.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+    "desc": "DSM access permissions for this package are managed with the group <b>'sc-download'</b>.<br><br>Package installation will ensure, the group exists and the permissions are set for the chosen directory.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/pyload/src/wizard/upgrade_uifile
+++ b/spk/pyload/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "DSM6 Permissions",
     "items": [{
-    "desc": "DSM access permissions for this package are managed with the group <b>'sc-download'</b>.<br><br>Package installation will ensure, the group exists and the permissions are set for the chosen directory.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+    "desc": "DSM access permissions for this package are managed with the group <b>'sc-download'</b>.<br><br>Package installation will ensure, the group exists and the permissions are set for the chosen directory.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/qbittorrent/src/wizard/install_uifile.sh
+++ b/spk/qbittorrent/src/wizard/install_uifile.sh
@@ -82,7 +82,7 @@ PAGE_INFO=$(/bin/cat<<EOF
         "desc": "<b>Web Interface</b><br>qBittorrent will be accessible at <b>http://${INTERNAL_IP}:8095</b><br>Downloads will be saved to <b>complete</b> and <b>incomplete</b> subfolders in your selected shared folder."
     },
     {
-        "desc": "<b>Permissions</b><br>Permissions are managed via the <b>'synocommunity'</b> group on DSM 7, and the <b>'sc-download'</b> group on DSM 6.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "<b>Permissions</b><br>Permissions are managed via the <b>'synocommunity'</b> group on DSM 7, and the <b>'sc-download'</b> group on DSM 6.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }
 EOF

--- a/spk/radarr/src/wizard/install_uifile
+++ b/spk/radarr/src/wizard/install_uifile
@@ -6,6 +6,6 @@
 },{
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/radarr/src/wizard/install_uifile_fre
+++ b/spk/radarr/src/wizard/install_uifile_fre
@@ -6,6 +6,6 @@
 },{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/radarr/src/wizard/upgrade_uifile
+++ b/spk/radarr/src/wizard/upgrade_uifile
@@ -8,6 +8,6 @@
 }, {
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/radarr/src/wizard/upgrade_uifile_fre
+++ b/spk/radarr/src/wizard/upgrade_uifile_fre
@@ -8,6 +8,6 @@
 },{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/readarr/src/wizard/install_uifile
+++ b/spk/readarr/src/wizard/install_uifile
@@ -6,6 +6,6 @@
 },{
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/readarr/src/wizard/install_uifile_fre
+++ b/spk/readarr/src/wizard/install_uifile_fre
@@ -6,6 +6,6 @@
 },{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/readarr/src/wizard/upgrade_uifile
+++ b/spk/readarr/src/wizard/upgrade_uifile
@@ -8,6 +8,6 @@
 }, {
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/readarr/src/wizard/upgrade_uifile_fre
+++ b/spk/readarr/src/wizard/upgrade_uifile_fre
@@ -8,6 +8,6 @@
 },{
     "step_title": "Permissions DSM",
     "items": [{
-        "desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/rutorrent/src/wizard_templates/install_uifile.yml
+++ b/spk/rutorrent/src/wizard_templates/install_uifile.yml
@@ -7,4 +7,4 @@ DOWNLOAD_SHARE_VALIDATION_ERROR: "Subdirectories are not supported."
 WATCH_DIR_DESC: "Optional: Watch a directory for torrent files and add them automatically. The path is relative to the downloads folder. Leave empty to disable."
 WATCH_DIR_LABEL: "Watch directory"
 
-DSM_PERMISSIONS_TEXT: "ruTorrent runs as internal service user <b>sc-rutorrent</b> in DSM. The downloads folder is configured at installation to be accessible by this user. Please read <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\\\">Permission Management</a> for details."
+DSM_PERMISSIONS_TEXT: "ruTorrent runs as internal service user <b>sc-rutorrent</b> in DSM. The downloads folder is configured at installation to be accessible by this user. Please read <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/user-guide/permissions/\\\">Permission Management</a> for details."

--- a/spk/rutorrent/src/wizard_templates/install_uifile_fre.yml
+++ b/spk/rutorrent/src/wizard_templates/install_uifile_fre.yml
@@ -7,4 +7,4 @@ DOWNLOAD_SHARE_VALIDATION_ERROR: "Les sous-répertoires ne sont pas pris en char
 WATCH_DIR_DESC: "Optionnel: Surveiller un répertoire pour les fichiers torrent et les ajouter automatiquement. Le chemin est relatif au dossier de téléchargements. Laisser vide pour désactiver."
 WATCH_DIR_LABEL: "Répertoire surveillé"
 
-DSM_PERMISSIONS_TEXT: "ruTorrent s'exécute en tant qu'utilisateur de service interne <b>sc-rutorrent</b> dans DSM. Le dossier de téléchargements est configuré lors de l'installation pour être accessible par cet utilisateur. Veuillez lire <a target=\\\"_blank\\\" href=\\\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\\\">Permission Management</a> pour plus de détails."
+DSM_PERMISSIONS_TEXT: "ruTorrent s'exécute en tant qu'utilisateur de service interne <b>sc-rutorrent</b> dans DSM. Le dossier de téléchargements est configuré lors de l'installation pour être accessible par cet utilisateur. Veuillez lire <a target=\\\"_blank\\\" href=\\\"https://docs.synocommunity.com/user-guide/permissions/\\\">Permission Management</a> pour plus de détails."

--- a/spk/sabnzbd/src/wizard/install_uifile
+++ b/spk/sabnzbd/src/wizard/install_uifile
@@ -24,7 +24,7 @@
       }, {
         "desc": ""
       }, {
-        "desc": "This package utilizes the internal service user <b>'sc-sabnzbd'</b> in DSM. The shared folder mentioned is set up during installation to be accessible specifically by this user. For more detailed information, please consult the <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> guide."
+        "desc": "This package utilizes the internal service user <b>'sc-sabnzbd'</b> in DSM. The shared folder mentioned is set up during installation to be accessible specifically by this user. For more detailed information, please consult the <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> guide."
       }
     ]
   }

--- a/spk/sabnzbd/src/wizard/upgrade_uifile.sh
+++ b/spk/sabnzbd/src/wizard/upgrade_uifile.sh
@@ -71,7 +71,7 @@ PAGE_DSM_PERMISSIONS=$(/bin/cat<<EOF
 {
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     },{
         "type": "textfield",
         "subitems": [{

--- a/spk/sickbeard-custom/Makefile
+++ b/spk/sickbeard-custom/Makefile
@@ -14,7 +14,7 @@ CHANGELOG = "Integrate with DSM5+6 Generic Service support for correct permissio
 
 HOMEPAGE   = https://sickbeard.com
 LICENSE    = GPL
-HELPURL    = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SickBeard-custom
+HELPURL    = https://docs.synocommunity.com/packages/sickbeard-custom/
 
 SERVICE_USER = auto
 SERVICE_SETUP = src/service-setup.sh

--- a/spk/sickbeard-custom/src/wizard/install_uifile
+++ b/spk/sickbeard-custom/src/wizard/install_uifile
@@ -20,6 +20,6 @@
         }]
     },
     {
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }]

--- a/spk/sickbeard-custom/src/wizard/install_uifile_fre
+++ b/spk/sickbeard-custom/src/wizard/install_uifile_fre
@@ -20,6 +20,6 @@
         }]
     },
     {
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     }]
 }]

--- a/spk/sickbeard-custom/src/wizard/upgrade_uifile
+++ b/spk/sickbeard-custom/src/wizard/upgrade_uifile
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! DSM Permissions",
     "items": [{
-        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for all download-related packages are managed with the group <b>'sc-download'</b> in DSM.<br>The group 'users' is no longer used as of DSM 6.<br>Package user will not appear on most UI settings.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> The package upgrade will try to set the correct permissions on your folders. If you get permission errors within SickBeard, manually set Read/Write permissions for the 'sc-download' group on the reported folders using File Station."

--- a/spk/sickbeard-custom/src/wizard/upgrade_uifile_fre
+++ b/spk/sickbeard-custom/src/wizard/upgrade_uifile_fre
@@ -1,7 +1,7 @@
 [{
     "step_title": "Attention! Permissions DSM",
     "items": [{
-        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+        "desc": "Les permissions de toutes les applications de téléchargement sont gérées par le groupe <b>'sc-download'</b> dans DSM.<br>Le groupe 'users' n'est plus utilisé depuis DSM 6.<br>L'utilisateur spécifique à l'application n'apparaît plus dans la plupart des interfaces de configuration.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
     },
     {
         "desc": "<strong style='color:red'>NOTE:</strong> La mise à jour de l'application va tenter de corriger les permissions des répertoires. En cas d'erreur de permission dans SickBeard, donner les droits de Lecture/Ecriture au groupe 'sc-download' sur les répertoires mentionnés depuis File Station."

--- a/spk/sickchill/src/wizard/install_uifile
+++ b/spk/sickchill/src/wizard/install_uifile
@@ -23,6 +23,6 @@
         }]
     },
     {
-        "desc": "<p>The first time SickChill is started it will take a few moments for the interface to become available!</p><p>Permissions for SickChill are user <b>'sc-sickchill'</b> all download-related packages are managed with the group <b>'sc-download (DSM6) and synocommunity (DSM7)'</b>.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details.</p>"
+        "desc": "<p>The first time SickChill is started it will take a few moments for the interface to become available!</p><p>Permissions for SickChill are user <b>'sc-sickchill'</b> all download-related packages are managed with the group <b>'sc-download (DSM6) and synocommunity (DSM7)'</b>.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details.</p>"
     }]
 }]

--- a/spk/sickchill/src/wizard/upgrade_uifile
+++ b/spk/sickchill/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
     "step_title": "Attention!",
     "items": [{
-        "desc": "<p>The first time SickChill is started it will take a few moments for the interface to become available!</p><p>Permissions for SickChill are user <b>'sc-sickchill'</b> all download-related packages are managed with the group <b>'sc-download (DSM6) and synocommunity (DSM7)'</b>.<br>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details.</p>"
+        "desc": "<p>The first time SickChill is started it will take a few moments for the interface to become available!</p><p>Permissions for SickChill are user <b>'sc-sickchill'</b> all download-related packages are managed with the group <b>'sc-download (DSM6) and synocommunity (DSM7)'</b>.<br>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details.</p>"
     }]
 }]

--- a/spk/sonarr/src/wizard/install_uifile
+++ b/spk/sonarr/src/wizard/install_uifile
@@ -6,6 +6,6 @@
 }, {
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]

--- a/spk/sonarr/src/wizard/install_uifile_fre
+++ b/spk/sonarr/src/wizard/install_uifile_fre
@@ -6,6 +6,6 @@
 }, {
 	"step_title": "Permissions DSM",
 	"items": [{
-		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
 	}]
 }]

--- a/spk/sonarr/src/wizard/upgrade_uifile
+++ b/spk/sonarr/src/wizard/upgrade_uifile
@@ -8,6 +8,6 @@
 }, {
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]

--- a/spk/sonarr/src/wizard/upgrade_uifile_fre
+++ b/spk/sonarr/src/wizard/upgrade_uifile_fre
@@ -8,6 +8,6 @@
 }, {
 	"step_title": "Permissions DSM",
 	"items": [{
-		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
 	}]
 }]

--- a/spk/sonarr3/src/wizard/install_uifile
+++ b/spk/sonarr3/src/wizard/install_uifile
@@ -6,6 +6,6 @@
 }, {
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]

--- a/spk/sonarr3/src/wizard/install_uifile_fre
+++ b/spk/sonarr3/src/wizard/install_uifile_fre
@@ -6,6 +6,6 @@
 }, {
 	"step_title": "Permissions DSM",
 	"items": [{
-		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
 	}]
 }]

--- a/spk/sonarr3/src/wizard/upgrade_uifile
+++ b/spk/sonarr3/src/wizard/upgrade_uifile
@@ -8,6 +8,6 @@
 }, {
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]

--- a/spk/sonarr3/src/wizard/upgrade_uifile_fre
+++ b/spk/sonarr3/src/wizard/upgrade_uifile_fre
@@ -8,6 +8,6 @@
 }, {
 	"step_title": "Permissions DSM",
 	"items": [{
-		"desc": "Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+		"desc": "Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
 	}]
 }]

--- a/spk/syncthing/src/wizard/install_uifile
+++ b/spk/syncthing/src/wizard/install_uifile
@@ -48,7 +48,7 @@
                 "desc": "<b>Permissions</b>"
             },
             {
-                "desc": "Permissions for this package are handled by the <b>'sc-syncthing'</b> group. <br>Using File Station, add this group to every folder Syncthing should be allowed to access. <br/>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+                "desc": "Permissions for this package are handled by the <b>'sc-syncthing'</b> group. <br>Using File Station, add this group to every folder Syncthing should be allowed to access. <br/>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
             },
             {
                 "desc": "<b>Customization</b>"

--- a/spk/syncthing/src/wizard/install_uifile_fre
+++ b/spk/syncthing/src/wizard/install_uifile_fre
@@ -48,7 +48,7 @@
                 "desc": "<b>Permissions</b>"
             },
             {
-                "desc": "Les permissions pour cette application sont gérées par le groupe <b>'sc-syncthing'</b>.<br>Depuis File Station, ajouter ce groupe à tout répertoire auquel Syncthing doit avoir accès.<br>Merci de lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> pour plus de détails."
+                "desc": "Les permissions pour cette application sont gérées par le groupe <b>'sc-syncthing'</b>.<br>Depuis File Station, ajouter ce groupe à tout répertoire auquel Syncthing doit avoir accès.<br>Merci de lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> pour plus de détails."
             },
             {
                 "desc": "<b>Personnalisation</b>"

--- a/spk/syncthing/src/wizard/upgrade_uifile.sh
+++ b/spk/syncthing/src/wizard/upgrade_uifile.sh
@@ -45,7 +45,7 @@ PAGE_PERMISSIONS=$(/bin/cat<<EOF
     "items": [{
         "desc": "<b>Permissions</b>"
     },{
-        "desc": "Permissions for this package are handled by the <b>'sc-syncthing'</b> group. <br>Using File Station, add this group to every folder Syncthing should be allowed to access. <br/>Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Permissions for this package are handled by the <b>'sc-syncthing'</b> group. <br>Using File Station, add this group to every folder Syncthing should be allowed to access. <br/>Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     },{
         "desc": "<b>Customization</b>"
     },{

--- a/spk/syncthing/src/wizard/upgrade_uifile_fre.sh
+++ b/spk/syncthing/src/wizard/upgrade_uifile_fre.sh
@@ -45,7 +45,7 @@ PAGE_PERMISSIONS=$(/bin/cat<<EOF
     "items": [{
         "desc": "<b>Permissions</b>"
     },{
-        "desc": "Les permissions pour ce paquet sont gérées par le groupe <b>'sc-syncthing'</b>. <br>En utilisant File Station, ajoutez ce groupe à chaque dossier auquel Syncthing devrait avoir accès. <br/>Veuillez lire <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Gestion des Permissions</a> pour plus de détails."
+        "desc": "Les permissions pour ce paquet sont gérées par le groupe <b>'sc-syncthing'</b>. <br>En utilisant File Station, ajoutez ce groupe à chaque dossier auquel Syncthing devrait avoir accès. <br/>Veuillez lire <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Gestion des Permissions</a> pour plus de détails."
     },{
         "desc": "<b>Personnalisation</b>"
     },{

--- a/spk/synocli-devel/Makefile
+++ b/spk/synocli-devel/Makefile
@@ -9,7 +9,7 @@ DESCRIPTION = SynoCli Development Tools provides a set of command-line utilities
 DISPLAY_NAME = SynoCli Development Tools
 STARTABLE = no
 
-HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliDevel
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-devel/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
 SPK_DEPENDS = "Perl"

--- a/spk/synocli-disk/Makefile
+++ b/spk/synocli-disk/Makefile
@@ -72,7 +72,7 @@ endif
 HOMEPAGE = https://docs.synocommunity.com/packages/synocli-disk/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
-DOCS_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliDisk\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>SynoCli Disk Tools\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = "SynoCli Disk Tools provides a number of small command-line utilities: e2fsprogs, ntfs-3g/ntfsprogs, testdisk, ncdu, davfs2, lsscsi, ddrescure$(OPTIONAL_DESC)."

--- a/spk/synocli-disk/Makefile
+++ b/spk/synocli-disk/Makefile
@@ -72,7 +72,7 @@ endif
 HOMEPAGE = https://docs.synocommunity.com/packages/synocli-disk/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
-WIKI_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliDisk\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliDisk\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = "SynoCli Disk Tools provides a number of small command-line utilities: e2fsprogs, ntfs-3g/ntfsprogs, testdisk, ncdu, davfs2, lsscsi, ddrescure$(OPTIONAL_DESC)."
@@ -82,7 +82,7 @@ CHANGELOG += "2. Update davfs2 from v1.7.1 to v1.7.2. <br/>"
 CHANGELOG += "3. Update dua from v2.31.0 to v2.32.0 (except for ARMv5 and qoriq). <br/>"
 CHANGELOG += "4. Update duf from v0.8.1 to v0.9.1. <br/>"
 CHANGELOG += "5. Update s3backer from v2.1.5 to v2.1.6. <br/>"
-CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
+CHANGELOG += "<br/>For package details and specific licences see $(DOCS_URL)".
 
 
 SPK_COMMANDS += bin/chattr bin/compile_et bin/lsattr bin/mk_cmds

--- a/spk/synocli-disk/Makefile
+++ b/spk/synocli-disk/Makefile
@@ -69,7 +69,7 @@ OPTIONAL_DESC := $(OPTIONAL_DESC)", fuse"
 SPK_COMMANDS += bin/fusermount bin/ulockmgr_server
 endif
 
-HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliDisk
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-disk/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
 WIKI_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliDisk\</a\>"

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -91,7 +91,7 @@ endif
 PCRE2_CLI_FULL = 1
 export PCRE2_CLI_FULL
 
-WIKI_URL = "\<a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliFile\"\>FAQ SynoCliFile\</a\>"
+WIKI_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-file/\"\>FAQ SynoCliFile\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = "SynoCli File Tools provide a set of small command-line utilities: \
@@ -118,7 +118,7 @@ CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
 
 SERVICE_SETUP = src/service-setup.sh
 
-HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliFile
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-file/
 LICENSE  = Each tool is licensed under it's respective license.
 
 SPK_COMMANDS  = bin/less bin/lessecho bin/lesskey

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -91,7 +91,7 @@ endif
 PCRE2_CLI_FULL = 1
 export PCRE2_CLI_FULL
 
-WIKI_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-file/\"\>FAQ SynoCliFile\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-file/\"\>FAQ SynoCliFile\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = "SynoCli File Tools provide a set of small command-line utilities: \
@@ -114,7 +114,7 @@ CHANGELOG += "5. Update less from v679 to v685. <br/>"
 CHANGELOG += "6. Update lsd from v1.1.5 to v1.2.0 (except for ARMv5). <br/>"
 CHANGELOG += "7. Update nano from v8.6 to v8.7. <br/>"
 CHANGELOG += "8. Update ripgrep from v14.1.1 to v15.1.0 (except for ARMv5 and qoriq). <br/>"
-CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
+CHANGELOG += "<br/>For package details and specific licences see $(DOCS_URL)".
 
 SERVICE_SETUP = src/service-setup.sh
 

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -91,7 +91,7 @@ endif
 PCRE2_CLI_FULL = 1
 export PCRE2_CLI_FULL
 
-DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-file/\"\>FAQ SynoCliFile\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-file/\"\>SynoCli File Tools\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = "SynoCli File Tools provide a set of small command-line utilities: \

--- a/spk/synocli-kernel/Makefile
+++ b/spk/synocli-kernel/Makefile
@@ -11,7 +11,7 @@ DISPLAY_NAME  = SynoCli Kernel Tools
 STARTABLE     = no
 CHANGELOG     = "1. Publish for newer x25 models<br/>2. Updates to libusb 1.0.29 and usbutils 019"
 
-HOMEPAGE = https://synocommunity.com/
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-kernel/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
 SPK_LINKS     = /usr/local/bin/synocli-kernelmodule:bin/synocli-kernelmodule.sh

--- a/spk/synocli-misc/Makefile
+++ b/spk/synocli-misc/Makefile
@@ -13,14 +13,14 @@ DEPENDS += cross/dialog
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = SynoCli misc. Tools
 
-WIKI_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-misc/\"\>FAQ SynoCliFile\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-misc/\"\>FAQ SynoCliMisc\</a\>"
 
 DESCRIPTION = "SynoCli misc. Tools provide a set of miscellaneous small command-line utilities: bc, errno, expect, ifdata, ifne, isutf8, lckdo, mispipe, parallel, pee, sponge, ts, cal, col, colcrt, colrm, column, hardlink, findmnt, hexdump, lsblk, lscpu, lsipc, lsirq, rev, wall, whereis, zramctl, uhubctl."
 STARTABLE = no
 
 CHANGELOG  = "1. Add dialog. <br/>"
 CHANGELOG += "2. Update util-linux to v2.41.4. <br/>"
-CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
+CHANGELOG += "<br/>For package details and specific licences see $(DOCS_URL)".
 
 HOMEPAGE = https://docs.synocommunity.com/packages/synocli-misc/
 LICENSE  = Each tool is licensed under it's respective license.

--- a/spk/synocli-misc/Makefile
+++ b/spk/synocli-misc/Makefile
@@ -13,7 +13,7 @@ DEPENDS += cross/dialog
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = SynoCli misc. Tools
 
-WIKI_URL = "\<a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliMisc\"\>FAQ SynoCliFile\</a\>"
+WIKI_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-misc/\"\>FAQ SynoCliFile\</a\>"
 
 DESCRIPTION = "SynoCli misc. Tools provide a set of miscellaneous small command-line utilities: bc, errno, expect, ifdata, ifne, isutf8, lckdo, mispipe, parallel, pee, sponge, ts, cal, col, colcrt, colrm, column, hardlink, findmnt, hexdump, lsblk, lscpu, lsipc, lsirq, rev, wall, whereis, zramctl, uhubctl."
 STARTABLE = no
@@ -22,7 +22,7 @@ CHANGELOG  = "1. Add dialog. <br/>"
 CHANGELOG += "2. Update util-linux to v2.41.4. <br/>"
 CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
 
-HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliMisc
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-misc/
 LICENSE  = Each tool is licensed under it's respective license.
 
 # gnu:

--- a/spk/synocli-misc/Makefile
+++ b/spk/synocli-misc/Makefile
@@ -13,7 +13,7 @@ DEPENDS += cross/dialog
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = SynoCli misc. Tools
 
-DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-misc/\"\>FAQ SynoCliMisc\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-misc/\"\>SynoCli Misc Tools\</a\>"
 
 DESCRIPTION = "SynoCli misc. Tools provide a set of miscellaneous small command-line utilities: bc, errno, expect, ifdata, ifne, isutf8, lckdo, mispipe, parallel, pee, sponge, ts, cal, col, colcrt, colrm, column, hardlink, findmnt, hexdump, lsblk, lscpu, lsipc, lsirq, rev, wall, whereis, zramctl, uhubctl."
 STARTABLE = no

--- a/spk/synocli-monitor/Makefile
+++ b/spk/synocli-monitor/Makefile
@@ -47,7 +47,7 @@ MAINTAINER = hgy59
 HOMEPAGE = https://docs.synocommunity.com/packages/synocli-monitor/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
-WIKI_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliMonitor\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliMonitor\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = SynoCli Monitor Tools provides a set of command-line utilities for system monitoring: nmon, njmon, iperf2, iperf3, htop, ionice, cpulimit, net-snmp tools$(OPTIONAL_DESC).
@@ -58,7 +58,7 @@ CHANGELOG += "2. Update bottom to v0.11.4. </br>"
 CHANGELOG += "3. Update iperf3 to v3.20. </br>"
 CHANGELOG += "4. Update njmon to v90. </br>"
 CHANGELOG += "5. Update nmon v16s. </br>"
-CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
+CHANGELOG += "<br/>For package details and specific licences see $(DOCS_URL)".
 
 SERVICE_SETUP = src/service-setup.sh
 

--- a/spk/synocli-monitor/Makefile
+++ b/spk/synocli-monitor/Makefile
@@ -47,7 +47,7 @@ MAINTAINER = hgy59
 HOMEPAGE = https://docs.synocommunity.com/packages/synocli-monitor/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
-DOCS_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliMonitor\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>SynoCli Monitor Tools\</a\>"
 
 # Remarks: html in DESCRIPTION is not supported
 DESCRIPTION = SynoCli Monitor Tools provides a set of command-line utilities for system monitoring: nmon, njmon, iperf2, iperf3, htop, ionice, cpulimit, net-snmp tools$(OPTIONAL_DESC).

--- a/spk/synocli-monitor/Makefile
+++ b/spk/synocli-monitor/Makefile
@@ -44,7 +44,7 @@ endif
 
 MAINTAINER = hgy59
 
-HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliMonitor
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-monitor/
 LICENSE  = Each tool is licensed under it\'s respective license.
 
 WIKI_URL = "\<a target=\"_blank\" href=\"$(HOMEPAGE)\"\>FAQ SynoCliMonitor\</a\>"

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -76,7 +76,7 @@ DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilit
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
 
-WIKI_URL = "\<a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliNet\"\>FAQ SynoCliFile\</a\>"
+WIKI_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-net/\"\>FAQ SynoCliFile\</a\>"
 
 CHANGELOG  = "1. Update bind v9.18.38 to v9.18.50 and v9.20.11 to v9.20.24. <br/>"
 CHANGELOG += "2. Update inetutils from v2.6 to v2.7. <br/>"
@@ -89,7 +89,7 @@ CHANGELOG += "8. Update tmux from v3.5a to v3.6b. <br/>"
 CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
 
 
-HOMEPAGE = https://github.com/SynoCommunity/spksrc/wiki/FAQ-SynoCliNet
+HOMEPAGE = https://docs.synocommunity.com/packages/synocli-net/
 LICENSE = Each tool is licensed under it\'s respective license.
 
 SPK_COMMANDS  = bin/screen

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -76,7 +76,7 @@ DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilit
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
 
-WIKI_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-net/\"\>FAQ SynoCliFile\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-net/\"\>FAQ SynoCliNet\</a\>"
 
 CHANGELOG  = "1. Update bind v9.18.38 to v9.18.50 and v9.20.11 to v9.20.24. <br/>"
 CHANGELOG += "2. Update inetutils from v2.6 to v2.7. <br/>"
@@ -86,7 +86,7 @@ CHANGELOG += "5. Update ser2net from v4.6.5 to v4.6.6 and add gensio tools. <br/
 CHANGELOG += "6. Update socat from v1.8.0.3 to v1.8.1.1. <br/>"
 CHANGELOG += "7. Update sshfs3 from v3.7.3 to v3.7.6. <br/>"
 CHANGELOG += "8. Update tmux from v3.5a to v3.6b. <br/>"
-CHANGELOG += "<br/>For package details and specific licences see $(WIKI_URL)".
+CHANGELOG += "<br/>For package details and specific licences see $(DOCS_URL)".
 
 
 HOMEPAGE = https://docs.synocommunity.com/packages/synocli-net/

--- a/spk/synocli-net/Makefile
+++ b/spk/synocli-net/Makefile
@@ -76,7 +76,7 @@ DESCRIPTION = "SynoCli Network Tools provides a set of small command-line utilit
 DISPLAY_NAME = SynoCli Network Tools
 STARTABLE = no
 
-DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-net/\"\>FAQ SynoCliNet\</a\>"
+DOCS_URL = "\<a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/synocli-net/\"\>SynoCli Network Tools\</a\>"
 
 CHANGELOG  = "1. Update bind v9.18.38 to v9.18.50 and v9.20.11 to v9.20.24. <br/>"
 CHANGELOG += "2. Update inetutils from v2.6 to v2.7. <br/>"

--- a/spk/transmission/src/wizard/install_uifile.sh
+++ b/spk/transmission/src/wizard/install_uifile.sh
@@ -61,7 +61,7 @@ PAGE_BASE_CONFIG=$(/bin/cat<<EOF
 {
     "step_title": "DSM Permissions",
     "items": [{
-        "desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+        "desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
     }]
 }
 EOF

--- a/spk/transmission/src/wizard/upgrade_uifile
+++ b/spk/transmission/src/wizard/upgrade_uifile
@@ -1,6 +1,6 @@
 [{
 	"step_title": "DSM Permissions",
 	"items": [{
-		"desc": "Please read <a target=\"_blank\" href=\"https://github.com/SynoCommunity/spksrc/wiki/Permission-Management\">Permission Management</a> for details."
+		"desc": "Please read <a target=\"_blank\" href=\"https://docs.synocommunity.com/user-guide/permissions/\">Permission Management</a> for details."
 	}]
 }]


### PR DESCRIPTION
## Description

Migrates all package-level references to the legacy GitHub wiki
(`github.com/SynoCommunity/spksrc/wiki`) to the docs site
(`docs.synocommunity.com`) — the companion PR to the docs-side migration (#7364).

### What changed

**Wizard files** (~95 files): updated URL links in install/upgrade wizard
templates across all packages, mapping wiki pages to their docs equivalents
(e.g. Permission-Management → `/user-guide/permissions/`, package FAQ pages →
`/packages/<name>/`). Updated link display text where it referenced the "wiki".

**SPK Makefiles** (~10 files): updated `HOMEPAGE` / `SUPPORTURL` / `HELPURL` /
custom `WIKI_URL` references to point to the docs site:
- `synocli-*`: renamed the custom `WIKI_URL` variable to `DOCS_URL`, fixed
  copy-paste display-text errors ("FAQ SynoCliFile" on the wrong packages), and
  aligned link text with the docs page titles (dropped the "FAQ" prefix)
- `synocli-kernel`: HOMEPAGE now points to its docs page instead of the generic
  `synocommunity.com/`
- `debian-chroot`, `comskip`, `sickbeard-custom`, `google-authenticator-libpam`:
  HOMEPAGE/HELPURL/SUPPORTURL → docs equivalents

### Notes
- This is the package-side half of the wiki→docs migration; the docs-side half
  was merged in #7364
- All docs links verified to resolve (HTTP 200); `WIKI_URL` no longer appears
  anywhere in the repo
- Will trigger CI rebuilds for the affected packages

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
