### PR TITLE
Syncthing: Update to v2.1.3

### DIFF
--- a/cross/syncthing/Makefile
+++ b/cross/syncthing/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = syncthing
-PKG_VERS = 2.0.16
+PKG_VERS = 2.1.3
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-source-v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERS)

--- a/cross/syncthing/digests
+++ b/cross/syncthing/digests
@@ -1,3 +1,3 @@
-syncthing-source-v2.0.16.tar.gz SHA1 ee8e4de9606805388a14fffa80d26caf4492d0ea
-syncthing-source-v2.0.16.tar.gz SHA256 f93836f943967c8fe608e90fd6dc2c419ce00cfa0ca5266caa86c22ae290f169
-syncthing-source-v2.0.16.tar.gz MD5 3264925246c814eb46dfdf6ecb43f524
+syncthing-source-v2.1.3.tar.gz SHA1 2abe3bd4c8e334992b6bc802d746a721d83f7907
+syncthing-source-v2.1.3.tar.gz SHA256 f34bc1b3219e02ac1eca0b1446f582af8fe13f789da5f8c679ba9cac0396bf81
+syncthing-source-v2.1.3.tar.gz MD5 5689e93eff86d278252c69b260a3b182

--- a/docs/packages/syncthing.md
+++ b/docs/packages/syncthing.md
@@ -18,7 +18,7 @@ Syncthing is a continuous file synchronization program that syncs files between 
 | Package Name | syncthing |
 | Upstream | [syncthing.net](https://syncthing.net/) |
 | License | MPL-2.0 |
-| Default Port | 8384 (Web UI), 22000 (Sync) |
+| Default Port | 8384 (Web UI), 21027 (Discovery), 22000 (Sync) |
 
 ## Features
 
@@ -64,8 +64,13 @@ Enable file versioning in folder settings:
 
 ## Data Locations
 
-- Configuration: `/var/packages/syncthing/var/config/`
-- Index database: `/var/packages/syncthing/var/index/`
+- Configuration: `/var/packages/syncthing/var/config.xml`
+- Certificates: `/var/packages/syncthing/var/cert.pem` and `key.pem`
+- Index database: `/var/packages/syncthing/var/index-v2/`
+
+## Self-updates
+
+Syncthing automatically checks for and installs updates (every 12 hours). Because of this, the installed binary may be newer than the version shown in Package Center. The package preserves a newer self-updated binary on package upgrades, so updating the package will never downgrade Syncthing.
 
 ## Troubleshooting
 

--- a/docs/reference/package-ports.md
+++ b/docs/reference/package-ports.md
@@ -119,6 +119,8 @@ The following ports are used by SynoCommunity packages.
     <tr data-category="Development"><td>18888</td><td>Demo Service</td><td>Development</td><td>Demo</td></tr>
     <tr data-category="Development"><td>18889</td><td>Demo Web Service</td><td>Development</td><td>Demo</td></tr>
     <tr data-category="Monitoring"><td>19999</td><td>Netdata</td><td>Monitoring</td><td>Dashboard</td></tr>
+    <tr data-category="Sync"><td>21027</td><td>Syncthing</td><td>Sync</td><td>Local discovery</td></tr>
+    <tr data-category="Sync"><td>22000</td><td>Syncthing</td><td>Sync</td><td>BEP (sync)</td></tr>
     <tr data-category="Backup"><td>51515</td><td>Kopia</td><td>Backup</td><td>Web interface</td></tr>
 
   </tbody>

--- a/spk/syncthing/Makefile
+++ b/spk/syncthing/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = syncthing
-SPK_VERS = 2.0.16
-SPK_REV = 35
+SPK_VERS = 2.1.3
+SPK_REV = 36
 SPK_ICON = src/syncthing.png
 DSM_UI_DIR = app
 
@@ -13,7 +13,7 @@ MAINTAINER = acolomb
 DESCRIPTION = Automatically sync files via secure, distributed technology.
 DESCRIPTION_FRE = Synchronisation automatique de fichiers via une technologie sécurisée et distribuée.
 DISPLAY_NAME = Syncthing
-CHANGELOG = "1. Update Syncthing to v2.0.16 (built with Go 1.26). <br/>2. Fix for ARMv7 builds."
+CHANGELOG = "1. Update Syncthing to v2.1.3 (built with Go 1.26)."
 HOMEPAGE = https://www.syncthing.net
 LICENSE = MPLv2.0
 STARTABLE = yes

--- a/spk/syncthing/src/config.xml
+++ b/spk/syncthing/src/config.xml
@@ -1,4 +1,4 @@
-<configuration version="35">
+<configuration version="52">
     <gui enabled="true" tls="false" debugging="false">
         <address>0.0.0.0:8384</address>
         <theme>default</theme>
@@ -26,7 +26,6 @@
         <autoUpgradeIntervalH>12</autoUpgradeIntervalH>
         <upgradeToPreReleases>false</upgradeToPreReleases>
         <keepTemporariesH>24</keepTemporariesH>
-        <cacheIgnoredFiles>false</cacheIgnoredFiles>
         <progressUpdateIntervalS>5</progressUpdateIntervalS>
         <limitBandwidthInLan>false</limitBandwidthInLan>
         <minHomeDiskFree unit="%">1</minHomeDiskFree>
@@ -42,7 +41,6 @@
         <stunKeepaliveStartS>180</stunKeepaliveStartS>
         <stunKeepaliveMinS>20</stunKeepaliveMinS>
         <stunServer>default</stunServer>
-        <databaseTuning>auto</databaseTuning>
         <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
         <announceLANAddresses>true</announceLANAddresses>
         <sendFullIndexOnUpgrade>false</sendFullIndexOnUpgrade>

--- a/spk/syncthing/src/service-setup.sh
+++ b/spk/syncthing/src/service-setup.sh
@@ -10,9 +10,6 @@ SVC_WRITE_PID=y
 
 GROUP="sc-syncthing"
 
-# include next gen gui
-export STGUIASSETS=${SYNOPKG_PKGDEST}/gui
-
 set_credentials() {
     if [ -n "${wizard_username}" -a -n "${wizard_password}" ]; then
         echo "set user name ${wizard_username} for syncthing Web GUI access"

--- a/spk/syncthing/src/wizard/install_uifile
+++ b/spk/syncthing/src/wizard/install_uifile
@@ -4,7 +4,7 @@
         "invalid_next_disabled": true,
         "items": [
             {
-                "desc": "The Syncthing Web GUI should not be accessible without authentication.  That would be dangerous because with access to the Web GUI, any folder can be configured for sharing by a malicious third-party.<br/>Please provide a user name and password to protect from unauthorized logins.  It will be required every time the Syncthing Web GUI is opened.<br/><br/>(Leaving either field empty disables authentication.)"
+                "desc": "The Syncthing Web GUI should not be accessible without authentication.  That would be dangerous because with access to the Web GUI, any folder can be configured for sharing by a malicious third-party.<br/><br/>Please provide a user name and password to protect from unauthorized logins.  It will be required every time the Syncthing Web GUI is opened.<br/><br/>(Leaving either field empty disables authentication.)"
             },
             {
                 "type": "textfield",
@@ -54,7 +54,7 @@
                 "desc": "<b>Customization</b>"
             },
             {
-                "desc": "For advanced customization you can edit the file <code>/var/packages/syncthing/var/options.conf</code>. For example, you can define a custom <code>HOME</code> folder or additional parameters to start Syncthing with. <br/>To modify the options file, you need <code>SSH</code> access with a privileged user account. To apply your modifications, you have to restart Syncthing in the Package Center."
+                "desc": "For advanced customization you can edit the file <code style=\"user-select: all\">/var/packages/syncthing/var/options.conf</code>. For example, you can define a custom <code>HOME</code> folder or additional parameters to start Syncthing with. <br/>To modify the options file, you need <code>SSH</code> access with a privileged user account. To apply your modifications, you have to restart Syncthing in the Package Center."
             }
         ]
     }

--- a/spk/syncthing/src/wizard/install_uifile_fre
+++ b/spk/syncthing/src/wizard/install_uifile_fre
@@ -4,7 +4,7 @@
         "invalid_next_disabled": true,
         "items": [
             {
-                "desc": "L'interface graphique Syncthing ne doit pas être accessible sans authentification. Ce serait dangereux car avec l'accès à l'interface graphique Web, n'importe quel dossier peut être configuré pour être partagé par un tiers malveillant.<br/>Veuillez fournir un nom d'utilisateur et un mot de passe pour vous protéger contre les connexions non autorisées. Il sera requis à chaque ouverture de l'interface graphique de Syncthing.<br/><br/>(Laisser l'un ou l'autre des champs vide désactive l'authentification.)"
+                "desc": "L'interface graphique Syncthing ne doit pas être accessible sans authentification. Ce serait dangereux car avec l'accès à l'interface graphique Web, n'importe quel dossier peut être configuré pour être partagé par un tiers malveillant.<br/><br/>Veuillez fournir un nom d'utilisateur et un mot de passe pour vous protéger contre les connexions non autorisées. Il sera requis à chaque ouverture de l'interface graphique de Syncthing.<br/><br/>(Laisser l'un ou l'autre des champs vide désactive l'authentification.)"
             },
             {
                 "type": "textfield",
@@ -54,7 +54,7 @@
                 "desc": "<b>Personnalisation</b>"
             },
             {
-                "desc": "Pour une personnalisation avancée, vous pouvez modifier le fichier <code>/var/packages/syncthing/var/options.conf</code>. Par exemple, vous pouvez définir un dossier <code>HOME</code> personnalisé ou des paramètres supplémentaires avec lesquels démarrer Syncthing. <br/>Pour modifier le fichier d'options, vous avez besoin d'un accès <code>SSH</code> avec un compte utilisateur privilégié. <br/>Pour appliquer vos modifications, vous devez redémarrer Syncthing dans le Centre de paquets."            }
+                "desc": "Pour une personnalisation avancée, vous pouvez modifier le fichier <code style=\"user-select: all\">/var/packages/syncthing/var/options.conf</code>. Par exemple, vous pouvez définir un dossier <code>HOME</code> personnalisé ou des paramètres supplémentaires avec lesquels démarrer Syncthing. <br/>Pour modifier le fichier d'options, vous avez besoin d'un accès <code>SSH</code> avec un compte utilisateur privilégié. <br/>Pour appliquer vos modifications, vous devez redémarrer Syncthing dans le Centre de paquets."            }
         ]
     }
 ]

--- a/spk/syncthing/src/wizard/upgrade_uifile.sh
+++ b/spk/syncthing/src/wizard/upgrade_uifile.sh
@@ -49,7 +49,7 @@ PAGE_PERMISSIONS=$(/bin/cat<<EOF
     },{
         "desc": "<b>Customization</b>"
     },{
-        "desc": "For advanced customization you can edit the file <code>/var/packages/syncthing/var/options.conf</code>. For example, you can define a custom <code>HOME</code> folder or additional parameters to start Syncthing with. <br/>To modify the options file, you need <code>SSH</code> access with a privileged user. To apply your modifications, you have to restart Syncthing in the Package Center."
+        "desc": "For advanced customization you can edit the file <code style=\"user-select: all\">/var/packages/syncthing/var/options.conf</code>. For example, you can define a custom <code>HOME</code> folder or additional parameters to start Syncthing with. <br/>To modify the options file, you need <code>SSH</code> access with a privileged user. To apply your modifications, you have to restart Syncthing in the Package Center."
     },{
         "desc": "<b>This update does not modify your existing <code>options.conf</code> file. Please find additional examples in the provided file <code>options.conf.new</code> in the same folder.</b>"
     }]

--- a/spk/syncthing/src/wizard/upgrade_uifile_fre.sh
+++ b/spk/syncthing/src/wizard/upgrade_uifile_fre.sh
@@ -49,7 +49,7 @@ PAGE_PERMISSIONS=$(/bin/cat<<EOF
     },{
         "desc": "<b>Personnalisation</b>"
     },{
-        "desc": "Pour une personnalisation avancée, vous pouvez modifier le fichier <code>/var/packages/syncthing/var/options.conf</code>. Par exemple, vous pouvez définir un dossier <code>HOME</code> personnalisé ou des paramètres supplémentaires pour démarrer Syncthing. <br/>Pour modifier le fichier options, vous avez besoin d'un accès <code>SSH</code> avec un utilisateur privilégié. Pour appliquer vos modifications, vous devez redémarrer Syncthing dans le Centre de Paquets."
+        "desc": "Pour une personnalisation avancée, vous pouvez modifier le fichier <code style=\"user-select: all\">/var/packages/syncthing/var/options.conf</code>. Par exemple, vous pouvez définir un dossier <code>HOME</code> personnalisé ou des paramètres supplémentaires pour démarrer Syncthing. <br/>Pour modifier le fichier options, vous avez besoin d'un accès <code>SSH</code> avec un utilisateur privilégié. Pour appliquer vos modifications, vous devez redémarrer Syncthing dans le Centre de Paquets."
     },{
         "desc": "<b>Cette mise à jour ne modifie pas votre fichier <code>options.conf</code> existant. Veuillez trouver des exemples supplémentaires dans le fichier fourni <code>options.conf.new</code> dans le même dossier.</b>"
     }]


### PR DESCRIPTION
## Description

Updates Syncthing from v2.0.16 to v2.1.3, plus related cleanups and documentation.

### What changed

- **Update to v2.1.3** — minor release; changes are additive (folder/device grouping in the GUI, HTTP/HTTPS CONNECT proxy support, optional `blockIndexing` folder attribute, configurable GUI session cookie). No breaking changes; Syncthing migrates its config/database automatically.
- **`config.xml` cleanups for 2.1**
  - Config `version="35" → "52"` (2.1.3's current config version, avoids first-run migration)
  - Removed `<cacheIgnoredFiles>` (removed upstream in 2.1)
  - Removed `<databaseTuning>` (obsolete since the SQLite database switch)
- **Removed vestigial `STGUIASSETS` export** from `service-setup.sh` — points at a `gui/` directory that was never shipped; the GUI is embedded in the binary since the v1.23-era "next-gen GUI" became standard.
- **Wizard polish** — blank line between the intro paragraphs and `user-select: all` on the full `options.conf` path for easy copying (install + upgrade, EN + FR).
- **Docs** — documented the self-update behavior (Syncthing auto-updates every 12 h, so Package Center's version may lag the running binary; the package preserves a newer binary on upgrade), corrected the data locations, and added the missing 21027/22000 ports to both the package page and `docs/reference/package-ports.md`.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
