### PR TITLE
ImageMagick: Disable OpenMP on toolchains with gcc < 4.4

### DIFF
--- a/cross/imagemagick/Makefile
+++ b/cross/imagemagick/Makefile
@@ -44,6 +44,12 @@ else ifeq ($(call version_lt, $(TCVERSION), 6.0)$(call version_ge, $(TCVERSION),
 SUPPORT_CPP11 = 0
 endif
 
+# libgomp from gcc < 4.4 lacks omp_set_max_active_levels (OpenMP 3.0), which
+# ImageMagick >= 7.1.2-29 calls unconditionally when OpenMP is enabled
+ifeq ($(call version_lt, $(TC_GCC), 4.4),1)
+CONFIGURE_ARGS += --disable-openmp
+endif
+
 ifeq ($(SUPPORT_CPP11),1)
 DEPENDS += cross/libheif
 DEPENDS += cross/libraw


### PR DESCRIPTION
## Description

Fixes the `all-supported` build failure for `ppc853x-5.2` (and `qoriq-5.2`) after the v7.1.2-29 update (#7372).

## Problem

ImageMagick 7.1.2-29 calls `omp_set_max_active_levels` (an OpenMP 3.0 API) in `MagickCore/thread-private.h` whenever OpenMP is enabled. The DSM 5.2 PPC toolchains ship **gcc 4.3.7**, whose libgomp predates OpenMP 3.0 and lacks that symbol, so linking `utilities/magick` fails with `undefined reference to omp_set_max_active_levels`.

Only toolchains with gcc < 4.4 are affected (`ppc853x-5.2`, `qoriq-5.2`).

## Fix

Conditionally disable OpenMP when the toolchain gcc is older than 4.4:

```make
ifeq ($(call version_lt, $(TC_GCC), 4.4),1)
CONFIGURE_ARGS += --disable-openmp
endif
```

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
