### PR TITLE
Navidrome: Document synced lyrics plugin setup

### DIFF
--- a/docs/packages/navidrome.md
+++ b/docs/packages/navidrome.md
@@ -60,6 +60,45 @@ ImageCacheSize = "100MB"
 
 Navidrome uses FFmpeg for transcoding. Configuration in web UI under Settings → Transcoding.
 
+## Synced Lyrics
+
+Navidrome displays synchronized lyrics from embedded tags, `.lrc` sidecar files next to your music, or (for synced lyrics fetched from external providers) a lyrics plugin.
+
+> [!NOTE]
+> The web UI does not display lyrics fetched by plugins — use a third-party client such as Symfonium or DSub. If you only use the web UI, place `.lrc` files next to your music files instead (Navidrome reads them natively).
+
+### Installing a Lyrics Plugin
+
+The package data lives in `/var/packages/navidrome/var`, so the plugin folder is `/var/packages/navidrome/var/plugins`. The package runs as user `sc-navidrome`.
+
+1. Download the plugin into the plugins folder (run as the package user to avoid permission issues):
+
+   ```sh
+   sudo -u sc-navidrome curl -L -o /var/packages/navidrome/var/plugins/nd-lyrics.ndp \
+     https://github.com/J0R6IT0/navidrome-lyrics-plugin/releases/latest/download/nd-lyrics.ndp
+   ```
+
+2. Add `nd-lyrics` to `LyricsPriority` in the configuration file:
+
+   ```sh
+   sudo -u sc-navidrome vi /var/packages/navidrome/var/navidrome.toml
+   ```
+   ```toml
+   LyricsPriority = ".ttml,.yaml,.yml,.elrc,.lrc,.srt,.txt,embedded,nd-lyrics"
+   ```
+
+3. In the web UI (Administration → Plugins), open **nd-lyrics**, enable the **Library** permission (Allow all libraries and write access), save, then enable the plugin.
+
+4. Restart Navidrome for the plugin to be picked up:
+
+   ```sh
+   synopkg restart navidrome
+   ```
+
+5. Connect with a third-party client (Symfonium, DSub, etc.) — lyrics are fetched on demand.
+
+The [Navidrome Lyrics Plugin](https://github.com/J0R6IT0/navidrome-lyrics-plugin) fetches synced lyrics (LRC/ELRC) from providers such as LRCLIB, NetEase, QQ Music and KuGou.
+
 ## Mobile Apps
 
 Subsonic-compatible apps:


### PR DESCRIPTION
## Description

Adds a "Synced Lyrics" section to the Navidrome package docs explaining how to get synchronized lyrics, based on a user's verified working setup.

## What changed

- `docs/packages/navidrome.md`: new **Synced Lyrics** section covering:
  - How Navidrome displays lyrics (embedded tags, `.lrc` sidecar files, or a lyrics plugin)
  - The caveat that the web UI doesn't show plugin-fetched lyrics — a third-party client (Symfonium, DSub) is needed; for web-UI-only users, `.lrc` sidecar files are the simpler path
  - Step-by-step install of the `nd-lyrics` plugin: `sudo -u sc-navidrome curl` into `/var/packages/navidrome/var/plugins`, adding `nd-lyrics` to `LyricsPriority`, enabling the Library permission in Administration → Plugins, restarting via `synopkg restart navidrome`


Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
