### PR TITLE
Navidrome: Use MkDocs admonition for lyrics note

### DIFF
--- a/docs/packages/navidrome.md
+++ b/docs/packages/navidrome.md
@@ -64,8 +64,8 @@ Navidrome uses FFmpeg for transcoding. Configuration in web UI under Settings �
 
 Navidrome displays synchronized lyrics from embedded tags, `.lrc` sidecar files next to your music, or (for synced lyrics fetched from external providers) a lyrics plugin.
 
-> [!NOTE]
-> The web UI does not display lyrics fetched by plugins — use a third-party client such as Symfonium or DSub. If you only use the web UI, place `.lrc` files next to your music files instead (Navidrome reads them natively).
+!!! note
+    The web UI does not display lyrics fetched by plugins — use a third-party client such as Symfonium or DSub. If you only use the web UI, place `.lrc` files next to your music files instead (Navidrome reads them natively).
 
 ### Installing a Lyrics Plugin
 
@@ -83,6 +83,7 @@ The package data lives in `/var/packages/navidrome/var`, so the plugin folder is
    ```sh
    sudo -u sc-navidrome vi /var/packages/navidrome/var/navidrome.toml
    ```
+
    ```toml
    LyricsPriority = ".ttml,.yaml,.yml,.elrc,.lrc,.srt,.txt,embedded,nd-lyrics"
    ```


### PR DESCRIPTION
## Description

Fixes the note in the Navidrome "Synced Lyrics" section added in #7375, which wasn't rendering as an admonition on the docs site.

## Problem

The note used GitHub-flavored blockquote syntax (`> [!NOTE]`), but the repo's MkDocs build enables the `admonition` extension and uses `!!! note` style everywhere else — so the note rendered as a plain quote with a literal `[!NOTE]` label.

## Fix

- `docs/packages/navidrome.md`: converted the note to the MkDocs `admonition` syntax:

  ```markdown
  !!! note
      The web UI does not display lyrics fetched by plugins — use a third-party client such as Symfonium or DSub. If you only use the web UI, place `.lrc` files next to your music files instead (Navidrome reads them natively).
  ```

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
