### PR TITLE
DNSACME: Update to v1.0.9

### DIFF
--- a/cross/dnsacme/Makefile
+++ b/cross/dnsacme/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = dnsacme
-PKG_VERS = 1.0.8
+PKG_VERS = 1.0.9
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/mritd/dnsacme/archive/refs/tags

--- a/cross/dnsacme/digests
+++ b/cross/dnsacme/digests
@@ -1,3 +1,3 @@
-dnsacme-1.0.8.tar.gz SHA1 fce20dbc9ff4c53b3e25407769a17400a1b10837
-dnsacme-1.0.8.tar.gz SHA256 4f54f75975b3e674c0e58ab180721e70407618606222e02bd25bfc1e7a4da6ae
-dnsacme-1.0.8.tar.gz MD5 b64fe276a77c9d27e2c8b28af63c30f8
+dnsacme-1.0.9.tar.gz SHA1 b81d8c3d3b92c629c7c10d1e38ea7e0d8a5a5e55
+dnsacme-1.0.9.tar.gz SHA256 e1103ec1851f706cd592cb822a2bd38f9c7293ab959e11fa3119230d3a8fb66e
+dnsacme-1.0.9.tar.gz MD5 e022b71a79522bc386fc8d64ea5f6080

--- a/spk/dnsacme/Makefile
+++ b/spk/dnsacme/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = dnsacme
-SPK_VERS = 1.0.8
-SPK_REV = 1
+SPK_VERS = 1.0.9
+SPK_REV = 2
 SPK_ICON = src/dnsacme.png
 
 DEPENDS = cross/dnsacme
@@ -12,7 +12,7 @@ UNSUPPORTED_ARCHS = $(PPC_ARCHS)
 MAINTAINER = mritd
 DESCRIPTION = DNS-01 ACME certificate manager with Synology DSM certificate deployment.
 DISPLAY_NAME = DNSACME
-CHANGELOG = "Initial package release."
+CHANGELOG = "Update DNSACME to v1.0.9."
 
 HOMEPAGE = https://github.com/mritd/dnsacme
 LICENSE = Apache-2.0


### PR DESCRIPTION
## Description

Update DNSACME from v1.0.8 to v1.0.9 and bump the SynoCommunity package revision to 2.

The upstream release adds ACME-DNS support with automatic account registration, manual credential entry, CNAME setup guidance, configurable recursive DNS checks, and delegated challenge handling. It also adds Hetzner Cloud support and includes DSM setup wizard and log display fixes.

Upstream release: [v1.0.9](https://github.com/mritd/dnsacme/releases/tag/v1.0.9)

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created

### Type of change

- [x] Package update
