### PR TITLE
Netdata: Update to v2.10.4

### DIFF
--- a/cross/netdata/Makefile
+++ b/cross/netdata/Makefile
@@ -13,6 +13,9 @@ HOMEPAGE = https://www.netdata.cloud
 COMMENT  = Real-time performance monitoring, done right
 LICENSE  = GPLv3
 
+# netdata compiles C++17 -- gcc 7.5 or newer (verified against the oldest DSM 7 toolchain)
+MIN_GCC_VERSION = 7.5
+
 ACLK_SCHEMAS_DIR = aclk-schemas-$(shell grep "^PKG_VERS " ../aclk-schemas/Makefile | sed 's/.*= //')
 
 CONFIGURE_ARGS  = -DENABLE_PLUGIN_GO=OFF

--- a/cross/netdata/Makefile
+++ b/cross/netdata/Makefile
@@ -29,7 +29,6 @@ CONFIGURE_ARGS += -DENABLE_PLUGIN_OTEL_SIGNAL_VIEWER=OFF
 CONFIGURE_ARGS += -DENABLE_PLUGIN_CUPS=OFF
 CONFIGURE_ARGS += -DENABLE_PLUGIN_FREEIPMI=OFF
 CONFIGURE_ARGS += -DENABLE_PLUGIN_EBPF=OFF
-CONFIGURE_ARGS += -DENABLE_PLUGIN_SYSTEMD_JOURNAL=OFF
 CONFIGURE_ARGS += -DENABLE_PLUGIN_SYSTEMD_UNITS=OFF
 CONFIGURE_ARGS += -DENABLE_PLUGIN_XENSTAT=OFF
 CONFIGURE_ARGS += -DENABLE_PLUGIN_NFACCT=OFF
@@ -41,11 +40,39 @@ CONFIGURE_ARGS += -DENABLE_PLUGIN_SLABINFO=OFF
 CONFIGURE_ARGS += -DENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE=OFF
 CONFIGURE_ARGS += -DENABLE_LIBBACKTRACE=OFF
 CONFIGURE_ARGS += -DENABLE_BUNDLED_PROTOBUF=ON
+# systemd journal log browsing, using netdata's own journal file reader
+# (the Rust journal_reader_ffi static library, see netdata_compile below)
+CONFIGURE_ARGS += -DENABLE_PLUGIN_SYSTEMD_JOURNAL=ON
+CONFIGURE_ARGS += -DENABLE_NETDATA_JOURNAL_FILE_READER=ON
 
 POST_PATCH_TARGET = netdata_post_patch
 COMPILE_TARGET = netdata_compile
 
 include ../../mk/spksrc.cross-cmake.mk
+# RUST_TARGET / TC_RUSTUP_TOOLCHAIN for cross-compiling the journal reader crate.
+# Defined here rather than including spksrc.cross/env-rust.mk, which can have
+# side effects on cmake-based builds (see cross/fish/Makefile).
+RUSTUP_QORIQ_TOOLCHAIN = 1.82.0
+ifeq ($(findstring $(ARCH), $(ARMv7_ARCHS)),$(ARCH))
+RUST_TARGET = armv7-unknown-linux-gnueabihf
+endif
+ifeq ($(findstring $(ARCH), $(ARMv7L_ARCHS)),$(ARCH))
+RUST_TARGET = armv7-unknown-linux-gnueabi
+endif
+ifeq ($(findstring $(ARCH), $(ARMv8_ARCHS)),$(ARCH))
+RUST_TARGET = aarch64-unknown-linux-gnu
+endif
+ifeq ($(findstring $(ARCH), $(PPC_ARCHS)),$(ARCH))
+RUST_TARGET = powerpc-unknown-linux-gnuspe
+TC_RUSTUP_TOOLCHAIN = stable-$(RUSTUP_QORIQ_TOOLCHAIN)-$(RUST_TARGET)
+endif
+ifeq ($(findstring $(ARCH), $(x64_ARCHS)),$(ARCH))
+RUST_TARGET = x86_64-unknown-linux-gnu
+endif
+ifeq ($(findstring $(ARCH), $(i686_ARCHS)),$(ARCH))
+RUST_TARGET = i686-unknown-linux-gnu
+endif
+TC_RUSTUP_TOOLCHAIN ?= stable
 
 .PHONY: netdata_post_patch
 netdata_post_patch:
@@ -74,4 +101,7 @@ netdata_compile:
 		sed -i '/protoc/s|--cpp_out=\([^ ]*\)/src/aclk/aclk-schemas[[:space:]]|--cpp_out=\1/src/aclk/aclk-schemas/proto |g' $$NINJA; \
 		sed -i '/INCLUDES.*src\/aclk\/aclk-schemas/s|\(-I[^ ]*src/aclk/aclk-schemas\)\([[:space:]]\)|\1\2\1/proto\2|g' $$NINJA; \
 	fi
+	@$(MSG) Building the netdata journal reader
+	@cd $(WORK_DIR)/$(PKG_DIR)/src/crates/jf && export PATH="$$HOME/.cargo/bin:$$PATH" && cargo +$(TC_RUSTUP_TOOLCHAIN) build --release --target $(RUST_TARGET) -p journal_reader_ffi
+	@cp $(WORK_DIR)/$(PKG_DIR)/src/crates/jf/target/$(RUST_TARGET)/release/libjournal_reader_ffi.a $(WORK_DIR)/$(PKG_DIR)/
 	$(RUN) cmake --build $(BUILD_DIR) -j $(NCPUS)

--- a/cross/netdata/Makefile
+++ b/cross/netdata/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = netdata
-PKG_VERS = 2.10.3
+PKG_VERS = 2.10.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/netdata/netdata/archive/refs/tags

--- a/cross/netdata/digests
+++ b/cross/netdata/digests
@@ -1,3 +1,3 @@
-netdata-2.10.3.tar.gz SHA1 e86d4f2ea47ec6465b6d92bc88db2621a826b863
-netdata-2.10.3.tar.gz SHA256 43db48647780e4ea38e39837715bc26ea019d3caf852170a2f038789fa144e86
-netdata-2.10.3.tar.gz MD5 6fd4e9afa978827d404aa96afcf9bc00
+netdata-2.10.4.tar.gz SHA1 2bbaead25ec3b9b7f5c84f07c036e4e14cad3f10
+netdata-2.10.4.tar.gz SHA256 4096ca1a3999254c511d02f140f2e02aa8781c79280a176cce53fa39b0a502ea
+netdata-2.10.4.tar.gz MD5 e1ba9437ee4763d79d0feb5d9f901dc5

--- a/cross/netdata/patches/001-link-prebuilt-journal-reader.patch
+++ b/cross/netdata/patches/001-link-prebuilt-journal-reader.patch
@@ -1,0 +1,75 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -193,65 +193,13 @@
+ 
+ cmake_dependent_option(ENABLE_NETDATA_JOURNAL_FILE_READER "Enable netdata's journal file reader implementation" False "ENABLE_PLUGIN_SYSTEMD_JOURNAL" False)
+ 
+-# Setup Rust/Corrosion for plugins that need it
+-if(ENABLE_NETDATA_JOURNAL_FILE_READER OR ENABLE_PLUGIN_OTEL OR ENABLE_PLUGIN_OTEL_SIGNAL_VIEWER)
+-    include(FetchContent)
+-    FetchContent_Declare(
+-        Corrosion
+-        GIT_REPOSITORY https://github.com/netdata/corrosion.git
+-        GIT_TAG f3b91559efca32c6b54837866ef35ba98ff5b2ca # stable/v0.5
+-    )
+-    FetchContent_MakeAvailable(Corrosion)
+-
+-    # Corrosion places cargo build artifacts under ${CMAKE_BINARY_DIR}/cargo/
+-    # (see Corrosion.cmake cargo_target_dir). Register it for cleanup so that
+-    # `ninja clean` removes it.  If a future Corrosion version changes this
+-    # path, this line must be updated to match.
+-    set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/cargo")
+-
+-    if(ENABLE_NETDATA_JOURNAL_FILE_READER)
+-        corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml
+-                               CRATES journal_reader_ffi)
+-    endif()
+-
+-    # Import crates from the main cargo workspace
+-    set(_WORKSPACE_CRATES "")
+-    if(ENABLE_PLUGIN_OTEL)
+-        list(APPEND _WORKSPACE_CRATES otel-plugin)
+-    endif()
+-    if(ENABLE_PLUGIN_OTEL_SIGNAL_VIEWER)
+-        list(APPEND _WORKSPACE_CRATES otel-signal-viewer-plugin)
+-    endif()
+-    if(_WORKSPACE_CRATES)
+-        corrosion_import_crate(MANIFEST_PATH src/crates/Cargo.toml
+-                               CRATES ${_WORKSPACE_CRATES})
+-    endif()
+-
+-    if(ENABLE_PLUGIN_OTEL)
+-      if(STATIC_BUILD)
+-        corrosion_add_target_rustflags(otel-plugin --cfg=tracing_unstable "-C" "target-feature=+crt-static")
+-      else()
+-        corrosion_add_target_rustflags(otel-plugin --cfg=tracing_unstable)
+-      endif()
+-    endif()
+-
+-    if(ENABLE_PLUGIN_OTEL_SIGNAL_VIEWER)
+-      set(OTEL_SIGNAL_VIEWER_RUSTFLAGS --cfg=tracing_unstable)
+-
+-      # We depend (transitively) on the `io-uring` crate which doesn't provide
+-      # prebuilt bindings for 32-bit arches. Considering this is a compile-time
+-      # and not a runtime dependency (because we don't use foyer's io-uring
+-      # engine), we can simply skip the check.
+-      if(CMAKE_SIZEOF_VOID_P EQUAL 4 AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-        list(APPEND OTEL_SIGNAL_VIEWER_RUSTFLAGS --cfg=io_uring_skip_arch_check)
+-      endif()
+-
+-      if(STATIC_BUILD)
+-        list(APPEND OTEL_SIGNAL_VIEWER_RUSTFLAGS "-C" "target-feature=+crt-static")
+-      endif()
+-
+-      corrosion_add_target_rustflags(otel-signal-viewer-plugin ${OTEL_SIGNAL_VIEWER_RUSTFLAGS})
+-    endif()
++# The journal reader is cross-compiled as a static library by the spksrc build
++# (see the netdata_compile target in cross/netdata/Makefile), so the Corrosion
++# cmake integration and its network fetch are not needed.
++if(ENABLE_NETDATA_JOURNAL_FILE_READER)
++    add_library(journal_reader_ffi STATIC IMPORTED)
++    set_target_properties(journal_reader_ffi PROPERTIES
++        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/libjournal_reader_ffi.a")
+ endif()
+ 
+ option(ENABLE_MIMALLOC "Enable mimalloc allocator" OFF)

--- a/cross/netdata/patches/002-systemd-journal-capabilities.patch
+++ b/cross/netdata/patches/002-systemd-journal-capabilities.patch
@@ -1,0 +1,11 @@
+--- src/collectors/systemd-journal.plugin/systemd-journal-annotations.c.orig	2026-08-09 16:07:39.979540345 +0000
++++ src/collectors/systemd-journal.plugin/systemd-journal-annotations.c	2026-08-09 16:07:39.983540276 +0000
+@@ -173,7 +173,7 @@
+     [CAP_MAC_ADMIN] = "MAC_ADMIN",
+     [CAP_SYSLOG] = "SYSLOG",
+     [CAP_WAKE_ALARM] = "WAKE_ALARM",
+-    [CAP_BLOCK_SUSPEND] = "BLOCK_SUSPEND",
++    [36 /*CAP_BLOCK_SUSPEND*/] = "BLOCK_SUSPEND",
+     [37 /*CAP_AUDIT_READ*/] = "AUDIT_READ",
+     [38 /*CAP_PERFMON*/] = "PERFMON",
+     [39 /*CAP_BPF*/] = "BPF",

--- a/docs/packages/netdata.md
+++ b/docs/packages/netdata.md
@@ -30,15 +30,17 @@ Install netdata from Package Center. The web dashboard is available at `http://y
 
 ## Post-Install
 
-### Enable Process Monitoring (Optional)
+### Enable Process Monitoring and System Logs (Optional)
 
-Per-process disk I/O monitoring requires `apps.plugin` to run with elevated privileges. DSM 7 blocks setuid binaries from unsigned packages, so this must be applied manually after install:
+Per-process disk I/O monitoring requires `apps.plugin` to run with elevated privileges, and browsing systemd journal logs requires the same for `systemd-journal.plugin`. DSM 7 blocks setuid binaries from unsigned packages, so this must be applied manually after install:
 
 ```bash
 netdata-fix
 ```
 
-This prompts for your DSM password, applies the fix, and tells you to restart the package. It only needs to be run once per install or upgrade.
+This prompts for your DSM password, grants root privileges to both plugins, and tells you to restart the package. It only needs to be run once per install or upgrade.
+
+After running it, process monitoring appears under **Metrics**, and system journal logs are browsable under **Logs** in the web UI.
 
 ### Verify It's Running
 
@@ -81,5 +83,9 @@ Netdata ships with a complete stock configuration at `/var/packages/netdata/targ
 ### Disk I/O not showing per process
 
 Run `netdata-fix` from SSH, then restart the package.
+
+### System logs not appearing
+
+Run `netdata-fix` from SSH, then restart the package. The `systemd-journal.plugin` needs root privileges (via setuid) to read the journal files, which DSM blocks for unsigned packages until the fix is applied.
 
 

--- a/docs/packages/netdata.md
+++ b/docs/packages/netdata.md
@@ -38,7 +38,7 @@ Per-process disk I/O monitoring requires `apps.plugin` to run with elevated priv
 netdata-fix
 ```
 
-This prompts for your DSM password, grants root privileges to both plugins, and tells you to restart the package. It only needs to be run once per install or upgrade.
+This prompts for your DSM password when needed, grants root privileges to both plugins, and restarts the package. It only needs to be run once per install or upgrade.
 
 After running it, process monitoring appears under **Metrics**, and system journal logs are browsable under **Logs** in the web UI.
 
@@ -82,10 +82,10 @@ Netdata ships with a complete stock configuration at `/var/packages/netdata/targ
 
 ### Disk I/O not showing per process
 
-Run `netdata-fix` from SSH, then restart the package.
+Run `netdata-fix` from SSH. It grants the needed root privileges and restarts the package for you.
 
 ### System logs not appearing
 
-Run `netdata-fix` from SSH, then restart the package. The `systemd-journal.plugin` needs root privileges (via setuid) to read the journal files, which DSM blocks for unsigned packages until the fix is applied.
+Run `netdata-fix` from SSH. The `systemd-journal.plugin` needs root privileges (via setuid) to read the journal files, which DSM blocks for unsigned packages until the fix is applied.
 
 

--- a/spk/netdata/Makefile
+++ b/spk/netdata/Makefile
@@ -11,7 +11,7 @@ UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS) comcerto2k
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = Netdata
 DESCRIPTION = Real-time performance monitoring, done right! Monitor your system with beautiful, interactive dashboards.
-CHANGELOG = "1. Update Netdata to v2.10.4."
+CHANGELOG = "1. Update Netdata to v2.10.4. <br/>2. Add systemd journal log viewing."
 
 HOMEPAGE = https://www.netdata.cloud
 LICENSE = GPLv3

--- a/spk/netdata/Makefile
+++ b/spk/netdata/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = netdata
-SPK_VERS = 2.10.3
-SPK_REV = 1
+SPK_VERS = 2.10.4
+SPK_REV = 2
 SPK_ICON = src/netdata.png
 
 DEPENDS = cross/netdata
@@ -11,7 +11,7 @@ UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS) comcerto2k
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = Netdata
 DESCRIPTION = Real-time performance monitoring, done right! Monitor your system with beautiful, interactive dashboards.
-CHANGELOG = "1. Initial release of Netdata v2.10.3."
+CHANGELOG = "1. Update Netdata to v2.10.4."
 
 HOMEPAGE = https://www.netdata.cloud
 LICENSE = GPLv3

--- a/spk/netdata/Makefile
+++ b/spk/netdata/Makefile
@@ -36,3 +36,6 @@ netdata_extra_install:
 	@$(MSG) Install netdata fix script
 	install -m 755 -d $(STAGING_DIR)/bin
 	install -m 755 src/bin/netdata-fix $(STAGING_DIR)/bin/netdata-fix
+	@$(MSG) Install default netdata configuration
+	install -m 755 -d $(STAGING_DIR)/var/etc/netdata
+	install -m 644 src/var/etc/netdata/netdata.conf $(STAGING_DIR)/var/etc/netdata/

--- a/spk/netdata/Makefile
+++ b/spk/netdata/Makefile
@@ -14,6 +14,7 @@ DESCRIPTION = Real-time performance monitoring, done right! Monitor your system 
 CHANGELOG = "1. Update Netdata to v2.10.4. <br/>2. Add systemd journal log viewing."
 
 HOMEPAGE = https://www.netdata.cloud
+HELPURL = https://docs.synocommunity.com/packages/netdata/
 LICENSE = GPLv3
 
 STARTABLE = yes

--- a/spk/netdata/Makefile
+++ b/spk/netdata/Makefile
@@ -5,8 +5,10 @@ SPK_ICON = src/netdata.png
 
 DEPENDS = cross/netdata
 
+# netdata compiles C++17 -- gcc 7.5 or newer (verified against the oldest DSM 7 toolchain)
+MIN_GCC_VERSION = 7.5
+
 REQUIRED_MIN_DSM = 7.0
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS) comcerto2k
 
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = Netdata

--- a/spk/netdata/src/bin/netdata-fix
+++ b/spk/netdata/src/bin/netdata-fix
@@ -1,21 +1,24 @@
 #!/bin/sh
 PKG_NAME="netdata"
 PKG_DIR="/var/packages/${PKG_NAME}"
-PLUGIN="${PKG_DIR}/target/usr/libexec/netdata/plugins.d/apps.plugin"
-
-if [ ! -f "${PLUGIN}" ]; then
-    echo "Error: Cannot find ${PLUGIN}" >&2
-    exit 1
-fi
+PLUGIN_DIR="${PKG_DIR}/target/usr/libexec/netdata/plugins.d"
+PLUGINS="apps.plugin systemd-journal.plugin"
 
 if ! sudo -n true 2>/dev/null; then
     echo "This operation requires administrator privileges."
     echo "Enter your DSM password when prompted."
 fi
 
-sudo chown root:synocommunity "${PLUGIN}" 2>/dev/null
-sudo chmod 4750 "${PLUGIN}"
+for PLUGIN in ${PLUGINS}; do
+    if [ -f "${PLUGIN_DIR}/${PLUGIN}" ]; then
+        sudo chown root:synocommunity "${PLUGIN_DIR}/${PLUGIN}" 2>/dev/null
+        sudo chmod 4750 "${PLUGIN_DIR}/${PLUGIN}"
+        echo "Granted root privileges to ${PLUGIN}"
+    else
+        echo "Warning: ${PLUGIN} not found in ${PLUGIN_DIR}" >&2
+    fi
+done
 
 echo ""
-echo "Done. Restart netdata to enable full process monitoring."
+echo "Done. Restart netdata to enable full process and system log monitoring."
 echo "Run: sudo synopkg restart ${PKG_NAME}"

--- a/spk/netdata/src/bin/netdata-fix
+++ b/spk/netdata/src/bin/netdata-fix
@@ -20,5 +20,6 @@ for PLUGIN in ${PLUGINS}; do
 done
 
 echo ""
-echo "Done. Restart netdata to enable full process and system log monitoring."
-echo "Run: sudo synopkg restart ${PKG_NAME}"
+# Restart netdata to apply the changes
+sudo synopkg restart "${PKG_NAME}"
+echo "Netdata restarted. Process monitoring and system log browsing are enabled."

--- a/spk/netdata/src/service-setup.sh
+++ b/spk/netdata/src/service-setup.sh
@@ -8,6 +8,10 @@ service_postinst ()
              "${SYNOPKG_PKGVAR}/log/netdata" \
              "${SYNOPKG_PKGVAR}/cache/netdata" \
              "${SYNOPKG_PKGVAR}/etc/netdata"
+    # ensure the shipped default config is writable by the service user
+    if [ -f "${SYNOPKG_PKGVAR}/etc/netdata/netdata.conf" ]; then
+        chown "${EFF_USER}:synocommunity" "${SYNOPKG_PKGVAR}/etc/netdata/netdata.conf"
+    fi
 }
 
 service_postupgrade () { service_postinst; }

--- a/spk/netdata/src/var/etc/netdata/netdata.conf
+++ b/spk/netdata/src/var/etc/netdata/netdata.conf
@@ -1,0 +1,9 @@
+# Netdata user configuration file.
+#
+# This file is created by the SynoCommunity package so Netdata finds a user
+# configuration on first start. It overrides the stock configuration shipped
+# in /var/packages/netdata/target/usr/lib/netdata/conf.d/.
+#
+# You can edit it directly via SSH, or let the Netdata web UI manage it:
+# settings saved from the web UI are written back to this file. Anything left
+# out here falls back to the stock defaults.

--- a/spk/netdata/src/wizard/install_uifile
+++ b/spk/netdata/src/wizard/install_uifile
@@ -3,10 +3,10 @@
     "step_title": "Post-Installation Instructions",
     "items": [
       {
-        "desc": "Netdata's <strong>apps.plugin</strong> needs <strong>root privileges</strong> to collect disk I/O and process metrics, but Synology blocks this for unsigned packages."
+        "desc": "Netdata's <strong>apps.plugin</strong> (per-process metrics) and <strong>systemd-journal.plugin</strong> (system log browsing) need <strong>root privileges</strong>, but Synology blocks this for unsigned packages."
       },
       {
-        "desc": "After the package starts, you can enable full process monitoring by running this command in SSH:<br/><br/><code>netdata-fix</code><br/><br/>It will prompt for your DSM password, apply the fix, and tell you to restart the package."
+        "desc": "After the package starts, enable them by running this command in SSH:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, apply the fix, and tell you to restart the package."
       }
     ]
   }

--- a/spk/netdata/src/wizard/install_uifile
+++ b/spk/netdata/src/wizard/install_uifile
@@ -6,7 +6,7 @@
         "desc": "Netdata's <strong>apps.plugin</strong> (per-process metrics) and <strong>systemd-journal.plugin</strong> (system log browsing) need <strong>root privileges</strong>, but Synology blocks this for unsigned packages."
       },
       {
-        "desc": "After the package starts, enable them by running this command in SSH:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, apply the fix, and tell you to restart the package."
+        "desc": "After the package starts, enable them by running this command in SSH:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, apply the fix, and restart the package."
       }
     ]
   }

--- a/spk/netdata/src/wizard/install_uifile
+++ b/spk/netdata/src/wizard/install_uifile
@@ -7,6 +7,9 @@
       },
       {
         "desc": "After the package starts, enable them by running this command in SSH:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, apply the fix, and restart the package."
+      },
+      {
+        "desc": "For full documentation, see: <a target=\"_blank\" href=\"https://docs.synocommunity.com/packages/netdata/\">docs.synocommunity.com/packages/netdata</a>"
       }
     ]
   }

--- a/spk/netdata/src/wizard/upgrade_uifile
+++ b/spk/netdata/src/wizard/upgrade_uifile
@@ -3,7 +3,7 @@
     "step_title": "Upgrade Instructions",
     "items": [
       {
-        "desc": "If you see \"Permission denied\" for <code>/proc/*/io</code> in the logs after upgrading, or system logs are not visible in the UI, run:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, re-apply the fix, and tell you to restart the package."
+        "desc": "If you see \"Permission denied\" for <code>/proc/*/io</code> in the logs after upgrading, or system logs are not visible in the UI, run:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, re-apply the fix, and restart the package."
       }
     ]
   }

--- a/spk/netdata/src/wizard/upgrade_uifile
+++ b/spk/netdata/src/wizard/upgrade_uifile
@@ -3,7 +3,7 @@
     "step_title": "Upgrade Instructions",
     "items": [
       {
-        "desc": "If you see \"Permission denied\" for <code>/proc/*/io</code> in the logs after upgrading, run:<br/><br/><code>netdata-fix</code><br/><br/>It will prompt for your DSM password, re-apply the fix, and tell you to restart the package."
+        "desc": "If you see \"Permission denied\" for <code>/proc/*/io</code> in the logs after upgrading, or system logs are not visible in the UI, run:<br/><br/><code style=\"user-select: all\">netdata-fix</code><br/><br/>It will prompt for your DSM password, re-apply the fix, and tell you to restart the package."
       }
     ]
   }


### PR DESCRIPTION
## Description

Updates Netdata from v2.10.3 to v2.10.4 and adds systemd journal log viewing, using Netdata's own Rust-based journal file reader cross-compiled for each target. Also includes packaging polish: a single self-contained `netdata-fix` helper, a shipped default config to silence the first-start warning, a docs link, and a declared GCC capability floor replacing the hardcoded unsupported-arch list.

## Changes

- **Update to v2.10.4** — `PKG_VERS`/`SPK_VERS` to 2.10.4, regenerated checksums, `SPK_REV` to 2, changelog entry.
- **Systemd journal log viewing** — cross-compile the `journal_reader_ffi` static library (Rust) with `cargo` and link it through an imported target in `CMakeLists.txt`, replacing the Corrosion/`FetchContent` network build; enable `ENABLE_PLUGIN_SYSTEMD_JOURNAL` + `ENABLE_NETDATA_JOURNAL_FILE_READER`; `netdata-fix` now grants root (setuid) privileges to both `apps.plugin` and `systemd-journal.plugin`.
- **`netdata-fix` self-contained** — after applying the fix it restarts the package automatically; the wizard command is now selectable and the docs were updated.
- **Default config** — ship a comment-only `netdata.conf` so the first-start "configuration file not found" warning is silenced; the file is owned by the service user so web-UI settings are writable and preserved across upgrades.
- **Docs links** — added `HELPURL` to the `INFO` file and a documentation link (opens in a new window) in the install wizard.
- **GCC capability floor** — declared `MIN_GCC_VERSION = 7.5` (netdata compiles C++17) in both `cross/netdata` and `spk/netdata`, replacing `UNSUPPORTED_ARCHS`.
- **Documentation** — updated `docs/packages/netdata.md`.


Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
