### PR TITLE
mk: relocate archive.mk from spksrc.native to spksrc.build

### DIFF
--- a/docs/developer-guide/packaging/build-rules.md
+++ b/docs/developer-guide/packaging/build-rules.md
@@ -54,7 +54,7 @@ Run from `native/<package>/` directory (host tools built once, then reused via
 |--------|-------------|
 | `all` | Build everything (default): download → … → install, then `archive` |
 | `download` `checksum` `extract` `patch` `configure` `compile` `install` | Individual build lifecycle steps, in order |
-| `build-archive` / `print-archive-name` | Create the reusable archive on demand / print its filename (opt-in via `ARCHIVE_NAME`, see `spksrc.native/archive.mk`) |
+| `build-archive` / `print-archive-name` | Create the reusable archive on demand / print its filename (opt-in via `ARCHIVE_NAME`, see `spksrc.build/archive.mk`) |
 | `nativeclean` | Drop **this** package's build cookies so every step re-runs next `make`, keeping the work dir (source, install, archive). The native counterpart of `spkclean`; leaves dependencies' cookies alone |
 | `clean` / `smart-clean` | Remove all work directories / this package's source and cookies |
 

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -73,7 +73,7 @@ If you only read one thing, read this. The details are in the dated log below.
 ---
 
 ??? note "July 24th 2026 — Host a native build's output as a reusable archive (#7327)"
-    - **What:** a new opt-in step, `spksrc.native/archive.mk` (included by
+    - **What:** a new opt-in step, `spksrc.build/archive.mk` (included by
       `spksrc.native-cc.mk`), tars a native package's install tree into a release
       archive after `install`, so an expensive tool is built once and re-consumed
       via `DEPENDS` instead of rebuilt from source. A package enables it with a

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -72,7 +72,7 @@ If you only read one thing, read this. The details are in the dated log below.
 
 ---
 
-??? note "July 24th 2026 — Host a native build's output as a reusable archive (#7327)"
+??? note "July 24th 2026 — Host a native build's output as a reusable archive (#7327, #7386)"
     - **What:** a new opt-in step, `spksrc.build/archive.mk` (included by
       `spksrc.native-cc.mk`), tars a native package's install tree into a release
       archive after `install`, so an expensive tool is built once and re-consumed
@@ -100,7 +100,11 @@ If you only read one thing, read this. The details are in the dated log below.
       carried its own `build-archive` recipe); this factors it into one shared,
       defaulted helper. `native/llvm-14.0-build` adopts it here; the gcc-8.5
       overlays reuse it in #7324.
-    - Pull request: [#7327](https://github.com/SynoCommunity/spksrc/pull/7327)
+    - **Relocated (#7386):** moved `spksrc.native/archive.mk` →
+      `spksrc.build/archive.mk` — the helper is a shared build step, not native-only
+      (a from-source rustc reuses it in #7353). No behaviour change.
+    - Pull requests: [#7327](https://github.com/SynoCommunity/spksrc/pull/7327),
+      [#7386](https://github.com/SynoCommunity/spksrc/pull/7386)
 
 ??? note "July 23rd 2026 — Carry the runtime library the binary asks for, by symbol version (#7322)"
     - **What:** the strip step copies the runtime libraries DSM does not ship

--- a/docs/framework/makefile-system.md
+++ b/docs/framework/makefile-system.md
@@ -39,6 +39,7 @@ The `mk/` directory contains all makefile includes, organized by function:
 | `spksrc.build/compile.mk` | Compilation orchestration |
 | `spksrc.build/install.mk` | Installation to staging |
 | `spksrc.build/plist.mk` | Package list generation |
+| `spksrc.build/archive.mk` | Optional post-install archive of the build output, for hosting/reuse (opt-in via `ARCHIVE_NAME`) |
 
 ### Cross-Compilation
 
@@ -82,7 +83,6 @@ The `mk/` directory contains all makefile includes, organized by function:
 | `spksrc.native-cmake.mk` | Native CMake builds |
 | `spksrc.native-meson.mk` | Native Meson builds |
 | `spksrc.native-install.mk` | Install-only native build (skip configure/compile) |
-| `spksrc.native/archive.mk` | Optional post-install archive of the build output, for hosting/reuse (opt-in via `ARCHIVE_NAME`) |
 
 ### Python/Wheel System
 
@@ -148,7 +148,8 @@ spksrc.build/
 ├── compile.mk                # compile
 ├── install.mk                # install to staging
 ├── plist.mk                  # package list generation (cross/kernel/cross-virtual; not in build.mk)
-└── ninja.mk                  # ninja helper (cmake/meson)
+├── ninja.mk                  # ninja helper (cmake/meson)
+└── archive.mk                # optional post-install archive (ARCHIVE_NAME)
 
 # Rules — shared targets / orchestration, included by the entry points
 spksrc.rules.mk               # rules entry point: clean/changelog targets,
@@ -185,7 +186,6 @@ spksrc.native-cmake.mk
 spksrc.native-install.mk
 spksrc.native-meson.mk
 spksrc.native/
-├── archive.mk                # optional post-install archive (ARCHIVE_NAME)
 ├── env-cmake.mk
 ├── env-default.mk            # base native env
 └── env-meson.mk

--- a/mk/spksrc.build/archive.mk
+++ b/mk/spksrc.build/archive.mk
@@ -1,11 +1,12 @@
 ###############################################################################
-# spksrc.native/archive.mk
+# spksrc.build/archive.mk
 #
-# Optional packaging step for native packages: tar a subset of the install tree
-# into a hosted archive, so an expensive native tool (llvm, the gcc-8.5 overlays,
-# ...) is built once and then re-consumed via DEPENDS instead of rebuilt from
-# source. Included by spksrc.native-cc.mk and run automatically after 'install'
-# (see _all there), idempotently, with an optional debug-symbol strip.
+# Optional packaging step: tar a subset of a build tree into a hosted archive, so
+# an expensive artefact (llvm, the gcc-8.5 overlays, a from-source rustc, ...) is
+# built once and then re-consumed via DEPENDS instead of rebuilt from source.
+# Included by spksrc.native-cc.mk and run automatically after 'install' (see _all
+# there); consumed by the native producers (llvm-14.0-build, rustc-1.82, gcc-8.5
+# overlays). Idempotent via a status cookie, with an optional debug-symbol strip.
 #
 # A pure no-op unless the package declares ARCHIVE_NAME; when it does, the
 # other variables default so a package usually needs that one line only:
@@ -98,15 +99,9 @@ ARCHIVE_STRIP_HOST_DIRS ?= bin libexec
 print-archive-name:
 	@echo $(ARCHIVE)
 
-# The packaging work: an optional debug-symbol strip, then the tar. It lives in
-# archive_target so PRE_/POST_ARCHIVE_TARGET wrap it like every other step's hooks,
-# and so idempotency is the cookie below -- WORK_DIR/.$(COOKIE_PREFIX)archive_done,
-# the same shape as extract/patch/compile/install -- instead of the archive file's
-# presence. No pre-build guard, like every other step: it just runs, and the tar
-# fails (with a "build it first" note) if there is nothing to archive yet.
-# --strip-debug keeps the symbol tables the tools need and only drops the (large)
-# debug sections. Target objects need the arch's OWN strip (the host strip cannot
-# touch them); host binaries use the host strip.
+# Optional debug-symbol strip, then the tar; wrapped by PRE_/POST hooks and made idempotent
+# by the cookie below (like extract/patch/compile/install). --strip-debug drops only debug
+# sections; target objects need the arch's OWN strip (host strip can't touch them).
 archive_target: $(PRE_ARCHIVE_TARGET)
 	@if [ -n "$(strip $(ARCHIVE_STRIP))" ]; then \
 	  $(MSG) "archive: stripping debug symbols -> $(ARCHIVE)" ; \
@@ -122,10 +117,8 @@ archive_target: $(PRE_ARCHIVE_TARGET)
 	@$(ARCHIVE_CMD) $(ARCHIVE) -C $(ARCHIVE_DIR) $(ARCHIVE_EXCLUDES) $(ARCHIVE_KEEP) || \
 	  { $(MSG) "$(PKG_NAME): nothing to archive under $(ARCHIVE_DIR)/$(firstword $(ARCHIVE_KEEP)) -- build it first" ; exit 1 ; }
 
-# Cookie-guarded like every other build step: 'archive' runs in the native _all
-# pipeline (after install), 'build-archive' is the on-demand entry point for
-# generators; both share one cookie, so whichever runs first does the work and the
-# other is a no-op. Remove $(ARCHIVE_COOKIE) to force a rebuild.
+# Cookie-guarded: 'archive' runs in the native _all pipeline (after install), 'build-archive'
+# is the on-demand entry point; both share one cookie. Remove $(ARCHIVE_COOKIE) to force a rebuild.
 ifeq ($(wildcard $(ARCHIVE_COOKIE)),)
 archive build-archive: $(ARCHIVE_COOKIE)
 

--- a/mk/spksrc.native-cc.mk
+++ b/mk/spksrc.native-cc.mk
@@ -48,7 +48,7 @@ cat_PLIST:
 
 # Define _all as a real target that does the work. 'archive' runs after install
 # and is a no-op unless the package declares ARCHIVE_NAME (see
-# spksrc.native/archive.mk).
+# spksrc.build/archive.mk).
 .PHONY: _all
 _all: install archive
 
@@ -75,6 +75,6 @@ nativeclean:
 	      $(STATUS_COOKIE) $(ARCHIVE_COOKIE)
 
 ### Optional archive packaging (build-archive); no-op unless ARCHIVE is set
-include ../../mk/spksrc.native/archive.mk
+include ../../mk/spksrc.build/archive.mk
 
 ###

--- a/native/llvm-14.0-build/Makefile
+++ b/native/llvm-14.0-build/Makefile
@@ -41,8 +41,8 @@ NATIVE_DEPENDS += native/intel-opencl-clang-140
 
 # -----------------------------------------------------------------------------
 # Host the build output as a release archive, reused via DEPENDS = native/llvm-14.0
-# instead of rebuilt from source. The shared native-archive helper (included by
-# native-cc.mk) archives it automatically after install; everything else defaults
+# instead of rebuilt from source. The shared archive helper (spksrc.build/archive.mk,
+# included by native-cc.mk) archives it automatically after install; else defaults
 # (txz of ./install from work-native, gated on the install bin/), so only the name
 # is declared. Declared before the front-end so the helper sees it.
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Relocate the optional archive-packaging helper from `mk/spksrc.native/archive.mk` to `mk/spksrc.build/archive.mk`.

## Why

The helper (added in #7327) tars a subset of a build tree into a hosted archive so an expensive artefact is built once and re-consumed via `DEPENDS` instead of rebuilt from source. It is **not native-specific** — from-source producers (e.g. a Tier-3 rustc, in the upcoming #7353) reuse the exact same tar-and-host step. Living under `spksrc.native/` misrepresents it as native-only. Moving it under `spksrc.build/` (the per-package build pipeline, alongside `download.mk`/`install.mk`/…) makes it read as the shared build helper it already is, and lets #7353 consume it without duplicating the file.

## How

- `git mv mk/spksrc.native/archive.mk mk/spksrc.build/archive.mk` (rename, history preserved).
- Generalize the header comment (shared helper wording; no longer "native packages" only).
- Repoint the single `include` in `mk/spksrc.native-cc.mk`.
- Update docs: `makefile-system.md`, `build-rules.md`, `changes.md`.
- Update the `native/llvm-14.0-build` comment referencing the helper.

## No behaviour change

Same recipe, same cookie, same targets (`archive` / `build-archive` / `print-archive-name`). The only consumer path is unchanged: `native-cc.mk` still includes it, so `native/llvm-14.0-build` archives identically — `make -C native/llvm-14.0-build print-archive-name` verified.
