### PR TITLE
Fix spk-clean target in global Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ all: $(SUPPORTED_SPKS)  ## Build every supported SPK (long; usually build one <s
 endif
 
 all-noarch:  ## Build every noarch (override ARCH) SPK
-	@for spk in $(filter-out $(dir $(wildcard spk/*/BROKEN)),$(dir $(wildcard spk/*/Makefile))) ; \
+	@for spk in $(filter-out $(dir $(wildcard spk/*/BROKEN)) $(dir $(wildcard spk/*/DISABLED)),$(dir $(wildcard spk/*/Makefile))) ; \
 	do \
 	   grep -q "override ARCH" "$${spk}/Makefile" && $(MAKE) -C $${spk} ; \
 	done
@@ -103,7 +103,7 @@ cross-clean:  ## Clean all cross/ work dirs
 	done
 
 spk-clean:  ## Clean all spk/ work dirs
-	@for spk in $(filter-out $(dir $(wildcard spk/*/BROKEN)),$(dir $(wildcard spk/*/Makefile))) ; \
+	@for spk in $(filter-out $(dir $(wildcard spk/*/BROKEN)) $(dir $(wildcard spk/*/DISABLED)),$(dir $(wildcard spk/*/Makefile))) ; \
 	do \
 	    $(MAKE) -C $${spk} clean ; \
 	done


### PR DESCRIPTION
## Description

- skip DISABLED packages
- with introduction of DISABLED packages in #7283, "make spk-clean" did not work anymore

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
