### PR TITLE
Pin rust for aarch64-6.2.4

### DIFF
--- a/mk/spksrc.cross/env-rust.mk
+++ b/mk/spksrc.cross/env-rust.mk
@@ -39,6 +39,13 @@ endif
 
 ifeq ($(findstring $(RUST_ARCH), $(ARMv8_ARCHS)),$(RUST_ARCH))
 RUST_TARGET = aarch64-unknown-linux-gnu
+ifeq ($(call version_lt, ${TC_GCC}, 5),1)
+ifeq ($(TC_RUSTC),stable)
+# Rust 1.98 breaks the build with gcc 4.9.4
+# see: https://github.com/rust-lang/rust/issues/161486
+TC_RUSTC = 1.97.1
+endif
+endif
 endif
 
 ifeq ($(findstring $(RUST_ARCH), $(PPC_ARCHS)),$(RUST_ARCH))


### PR DESCRIPTION
## Description

Rust 1.98 breaks the build for aarch64 with gcc 4.9.4
see: https://github.com/rust-lang/rust/issues/161486

- limit rust to 1.97.1 since 1.98 breaks the build for aarch64-6.2.4


This can be reverted when we once have gcc8 for DSM 6 toolchains available (see #7391 )

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully (locally verified the rust tools)
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
