### PR TITLE
cairo, pixman: add mirrors, cairographics.org is unreliable

### DIFF
--- a/cross/cairo-1.16/Makefile
+++ b/cross/cairo-1.16/Makefile
@@ -3,6 +3,7 @@ PKG_VERS = 1.16.0
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.cairographics.org/releases/
+PKG_DIST_MIRRORS = https://ftp.osuosl.org/pub/blfs/conglomeration/cairo https://distfiles.macports.org/cairo
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libpng cross/freetype cross/pixman cross/fontconfig cross/glib

--- a/cross/cairo-latest/Makefile
+++ b/cross/cairo-latest/Makefile
@@ -3,6 +3,7 @@ PKG_VERS = 1.18.4
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.cairographics.org/releases/
+PKG_DIST_MIRRORS = https://ftp.osuosl.org/pub/blfs/conglomeration/cairo https://distfiles.macports.org/cairo
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libpng cross/freetype cross/pixman cross/fontconfig cross/glib

--- a/cross/pixman/Makefile
+++ b/cross/pixman/Makefile
@@ -3,6 +3,7 @@ PKG_VERS = 0.46.4
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.cairographics.org/releases/
+PKG_DIST_MIRRORS = https://ftp.osuosl.org/pub/blfs/conglomeration/pixman https://distfiles.macports.org/pixman
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libpng


### PR DESCRIPTION
`cairographics.org` is the only upstream home for cairo and pixman, and it answers intermittently. Measured just now, five probes for the same file:

```
1: timeout at 25s      2: 200 in 3.3s      3: 200 in 1.2s
4: 200 in 0.2s         5: timeout at 25s
```

The host resolves (131.252.210.176) — connections simply hang. `wget` retries twice per candidate, so one build usually gets through; twenty parallel arch jobs do not, and CI stalls on downloads rather than on anything real.

## Change

`PKG_DIST_MIRRORS` on the three packages that use that host — the existing per-package mechanism, already used by `libdaemon`, `lua-5.3` and `znc`.

| package | mirrors added |
|---|---|
| `cross/cairo-latest` (1.18.4) | osuosl BLFS, macports |
| `cross/cairo-1.16` (1.16.0) | osuosl BLFS, macports |
| `cross/pixman` (0.46.4) | osuosl BLFS, macports |

## Verified, not assumed

Each mirror was downloaded and hashed against the package's own `digests`:

```
cairo-1.18.4    445ed820…c32ccb   osuosl ✓   macports ✓
cairo-1.16.0    5e7b29b3…052331   osuosl ✓   macports ✓
pixman-0.46.4   d09c44eb…6a591c   osuosl ✓   macports 404
```

No digest changes — the mirrors carry the same files. macports has no `pixman-0.46.4` today, but the `pixman/` directory exists there, so it is kept as a second chance for later versions; a mirror that 404s just falls through to the next candidate.

The primary stays first in the list, so nothing changes when upstream is healthy.
