### PR TITLE
download: mirror the freedesktop.org family from the framework

### DIFF
--- a/cross/fontconfig/Makefile
+++ b/cross/fontconfig/Makefile
@@ -3,6 +3,7 @@ PKG_VERS = 2.16.0
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.freedesktop.org/software/fontconfig/release
+PKG_DIST_MIRRORS = https://ftp.osuosl.org/pub/blfs/conglomeration/fontconfig
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libexpat cross/freetype cross/libuuid

--- a/cross/libX11/Makefile
+++ b/cross/libX11/Makefile
@@ -3,6 +3,8 @@ PKG_VERS = 1.8.10
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://xorg.freedesktop.org/archive/individual/lib
+PKG_DIST_MIRRORS = https://distfiles.macports.org/xorg-libX11
+PKG_DIST_MIRRORS = https://distfiles.macports.org/xorg-libX11
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/xorgproto cross/libxcb cross/xtrans cross/xorg-sgml-doctools cross/libICE cross/libSM

--- a/cross/libdrm/Makefile
+++ b/cross/libdrm/Makefile
@@ -3,6 +3,7 @@ PKG_VERS = 2.4.131
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://dri.freedesktop.org/libdrm
+PKG_DIST_MIRRORS = https://ftp.osuosl.org/pub/blfs/conglomeration/libdrm
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libpciaccess

--- a/cross/pkg-config/Makefile
+++ b/cross/pkg-config/Makefile
@@ -3,6 +3,8 @@ PKG_VERS = 0.29.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://pkgconfig.freedesktop.org/releases/
+PKG_DIST_MIRRORS = https://distfiles.macports.org/pkgconfig
+PKG_DIST_MIRRORS = https://distfiles.macports.org/pkgconfig
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/glib

--- a/cross/uchardet/Makefile
+++ b/cross/uchardet/Makefile
@@ -3,6 +3,7 @@ PKG_VERS = 0.0.6
 PKG_EXT = tar.xz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://www.freedesktop.org/software/uchardet/releases
+PKG_DIST_MIRRORS = https://ftp.osuosl.org/pub/blfs/conglomeration/uchardet https://distfiles.macports.org/uchardet
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =

--- a/mk/spksrc.build/download.mk
+++ b/mk/spksrc.build/download.mk
@@ -124,6 +124,12 @@ MIRROR_GNOME       ?= https://download.gnome.org/sources https://mirror.csclub.u
 MIRROR_KERNEL      ?= https://cdn.kernel.org/pub https://mirrors.kernel.org/pub https://www.kernel.org/pub
 MIRROR_SAVANNAH    ?= https://download.savannah.gnu.org/releases https://download-mirror.savannah.gnu.org/releases
 MIRROR_GNUPG       ?= https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt https://mirrors.dotsrc.org/gcrypt
+# freedesktop.org hosts each project under its own path shape, so there is no common
+# tree-root marker to replace. Its mirrors instead file everything by package name, so
+# these bases carry $(PKG_NAME) and take the file name appended, like PKG_DIST_MIRRORS.
+# A base that does not have the file simply 404s and the next candidate is tried, so a
+# package whose mirror name differs (libX11 -> xorg-libX11) just adds its own.
+MIRROR_FREEDESKTOP ?= https://ftp.osuosl.org/pub/blfs/conglomeration/$(PKG_NAME) https://distfiles.macports.org/$(PKG_NAME)
 PKG_DIST_MIRRORS   ?=
 
 # ---------------------------------------------------------------------------
@@ -229,7 +235,7 @@ define DOWNLOAD_HTTP
 	      else \
 	        rm -f $${localFile}.part ; \
 	        mirrorUrls="$${url}" ; \
-	        marker="" ; mirrorBases="" ; \
+	        marker="" ; mirrorBases="" ; namedBases="" ; \
 	        case "$${url}" in \
 	          *//ftpmirror.gnu.org/gnu/*|*//ftp.gnu.org/gnu/*)  marker="/gnu/" ;     mirrorBases="$(MIRROR_GNU)" ;; \
 	          *//downloads.sourceforge.net/project/*)           marker="/project/" ; mirrorBases="$(MIRROR_SOURCEFORGE)" ;; \
@@ -237,11 +243,13 @@ define DOWNLOAD_HTTP
 	          *//www.kernel.org/pub/*|*//cdn.kernel.org/pub/*)  marker="/pub/" ;     mirrorBases="$(MIRROR_KERNEL)" ;; \
 	          *//download.savannah.gnu.org/releases/*)          marker="/releases/" ; mirrorBases="$(MIRROR_SAVANNAH)" ;; \
 	          *//gnupg.org/ftp/gcrypt/*|*//www.gnupg.org/ftp/gcrypt/*) marker="/gcrypt/" ; mirrorBases="$(MIRROR_GNUPG)" ;; \
+	          *//*.freedesktop.org/*)                          namedBases="$(MIRROR_FREEDESKTOP)" ;; \
 	        esac ; \
 	        if [ -n "$${marker}" ]; then \
 	          tail=$${url#*$${marker}} ; \
 	          for b in $${mirrorBases} ; do mirrorUrls="$${mirrorUrls} $${b%/}/$${tail}" ; done ; \
 	        fi ; \
+	        for b in $${namedBases} ; do mirrorUrls="$${mirrorUrls} $${b%/}/$${localFile}" ; done ; \
 	        for m in $(PKG_DIST_MIRRORS) ; do mirrorUrls="$${mirrorUrls} $${m%/}/$${localFile}" ; done ; \
 	        uniqUrls="" ; \
 	        for u in $${mirrorUrls} ; do case " $${uniqUrls} " in *" $${u} "*) ;; *) uniqUrls="$${uniqUrls} $${u}" ;; esac ; done ; \


### PR DESCRIPTION
freedesktop.org is down — `dri.`, `www.`, `xorg.` and `pkgconfig.` all time out, and CI stalls on the downloads. Only `gitlab.freedesktop.org` answers, which is why `intel-gpu-tools` and `libpciaccess` are unaffected.

Six packages come from that host, so the fix goes in the mirror table rather than in six Makefiles.

## Why a new shape of entry

The existing family mechanism swaps everything up to a **tree-root marker**:

```
*//download.gnome.org/sources/*)   marker="/sources/"   mirrorBases="$(MIRROR_GNOME)"
```

That does not fit freedesktop: each project sits under its own path shape — `dri./libdrm/`, `www./software/fontconfig/release/`, `xorg./archive/individual/lib/`, `pkgconfig./releases/` — so there is no common marker to strip.

Its mirrors, though, file everything **by package name**. So `MIRROR_FREEDESKTOP` carries `$(PKG_NAME)` in the base and has the file name appended, exactly the way `PKG_DIST_MIRRORS` already works. One extra loop beside the existing one:

```make
MIRROR_FREEDESKTOP ?= https://ftp.osuosl.org/pub/blfs/conglomeration/$(PKG_NAME) \
                      https://distfiles.macports.org/$(PKG_NAME)
```

## Coverage

| | |
|---|---|
| `dbus` `fontconfig` `libdrm` `uchardet` | covered by the table alone |
| `libX11` `pkg-config` | mirrored under a different name, so one `PKG_DIST_MIRRORS` line each |

macports files things under its **port** name — `xorg-libX11`, `pkgconfig` — not the package name. A base that lacks the file simply 404s and the next candidate is tried, which is what keeps those two exceptions to a single line instead of a special case. Any freedesktop package added later gets the mirror for nothing.

## Verified against the live outage

Not probed for a 200 — actually downloaded, with the primary genuinely unreachable:

```
libdrm    dri.freedesktop.org        failed
          osuosl/libdrm              ok, sha256 matches digests

libX11    xorg.freedesktop.org       failed
          osuosl/libX11              failed
          macports/libX11            failed
          macports/xorg-libX11       ok, sha256 matches digests
```

The second one walks the whole cascade, which is the case worth seeing work.

No digest changes; the primary stays first, so nothing changes once upstream recovers.

## dbus

`cross/dbus` is covered by the table here, but it is stuck on **1.13.22** — a development release that no mirror carries. #7401 moves it to 1.14.10, at which point this entry starts working for it too.
