### PR TITLE
mesa: take the source from gitlab, archive.mesa3d.org is unreachable

### DIFF
--- a/cross/mesa/Makefile
+++ b/cross/mesa/Makefile
@@ -1,9 +1,10 @@
 PKG_NAME = mesa
 PKG_VERS = 23.3.6
-PKG_EXT = tar.xz
-PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = https://archive.mesa3d.org
-PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+PKG_EXT = tar.bz2
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://gitlab.freedesktop.org/mesa/mesa/-/archive/$(PKG_NAME)-$(PKG_VERS)
+PKG_DIR = $(PKG_NAME)-$(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS  = cross/libdrm
 DEPENDS += cross/libexpat

--- a/cross/mesa/digests
+++ b/cross/mesa/digests
@@ -1,3 +1,3 @@
-mesa-23.3.6.tar.xz SHA1 ff5e312cfef31a4c7142eb479aa9fb747a62ec4f
-mesa-23.3.6.tar.xz SHA256 cd3d6c60121dea73abbae99d399dc2facaecde1a8c6bd647e6d85410ff4b577b
-mesa-23.3.6.tar.xz MD5 6395410694f654b12934cec957b51714
+mesa-23.3.6.tar.bz2 SHA1 a545bae6171850071fde8ab2fb90ecd88c3ee68b
+mesa-23.3.6.tar.bz2 SHA256 227fc2726c44eb47bb8f8368ed7b61402c917deee8104aca258aab43170b7dae
+mesa-23.3.6.tar.bz2 MD5 297e59e796d66d3019c911af17cb6c49


### PR DESCRIPTION
`archive.mesa3d.org` times out and is blocking every build that needs mesa.

## No mirror has 23.3.6

Probed, all 404 or unreachable:

```
osuosl BLFS          keeps 25.3.1 → 26.1.7 only
distfiles.macports   404
Debian pool          keeps 25.0.7 → 26.2.1 only
Debian snapshot      404, searched by the SHA1 in our digests
Gentoo · Arch · kernel.org · Slackware · Lysator    404
mesa.freedesktop.org 200, but 308s straight back to the dead mesa3d.org
```

They all keep only current versions, and 23.3.6 is from February 2024.

## gitlab.freedesktop.org is the one host that stays up

It survived the previous freedesktop outage too, and it is already where `libpciaccess`, `intel-gpu-tools` and `pkg-config` (#7401) get their sources.

The tag archive is a git archive, not a repack of the release tarball — so it deserved checking rather than assuming. It carries the same tree:

```
paths in the released tarball   9877
paths in the gitlab archive     9877
present in one but not the other    0  and  0
VERSION                         23.3.6 on both sides
```

mesa generates nothing extra at release time, so nothing is lost. No `autogen` step is needed either — the build is meson, which works straight from the sources.

## Format

`tar.bz2` rather than gitlab's default `tar.gz`:

```
tar.gz    31.3 MB
tar.bz2   22.8 MB
tar.xz    19.5 MB   (the original, currently unreachable)
```

3 MB more than the original instead of 12. It is also the format `libpciaccess` already uses for gitlab.

## Caveats

A gitlab auto-generated archive has no contractual guarantee that its checksum stays stable, unlike a released tarball. The other gitlab packages in the tree already carry that risk.

**Built locally on x64-7.1 since opening this**, from the gitlab archive, and it produces exactly what the PLIST expects:

```
lib/libvulkan_intel.so                 present   (ELF DYN, x86-64)
etc/vulkan/icd.d                       present
share/drirc.d/00-mesa-defaults.conf    present
```

No errors, LLVM and glslang dependencies included. So the git archive is not missing anything the release tarball generated — which was the one real risk here.
