### PR TITLE
Fix spk command link creation

### DIFF
--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -251,9 +251,11 @@ ifneq ($(strip $(SPK_COMMANDS)),)
 		'."usr-local-linker" = {"bin": $$binaries | split(" ")}' $@ | sponge $@
 endif
 ifneq ($(strip $(SPK_USR_LOCAL_LINKS)),)
-# e.g. SPK_USR_LOCAL_LINKS=etc:var/foo lib:libs/bar
-	@jq --arg links_str '${SPK_USR_LOCAL_LINKS}' \
-		'."usr-local-linker" += ($$links_str | split (" ") | map(split(":")) | group_by(.[0]) | map({(.[0][0]) : map(.[1])}) | add )' $@ | sponge $@
+# e.g. SPK_USR_LOCAL_LINKS=etc:var/foo bin:sbin/bars
+# REMARKS: SPK_USR_LOCAL_LINKS must not overwrite existing entries created by SPK_COMMANDS
+	@jq --arg links_str '$(SPK_USR_LOCAL_LINKS)' \
+		'($$links_str | split(" ") | map(split(":")) | group_by(.[0]) | map({(.[0][0]): map(.[1])}) | add) as $$links | ."usr-local-linker" |= (to_entries + ($$links | to_entries) | group_by(.key) | map({key: .[0].key, value: map(.value) | add}) | from_entries)' \
+		$@ | sponge $@
 endif
 ifneq ($(strip $(SERVICE_WIZARD_SHARE)),)
 # e.g. SERVICE_WIZARD_SHARE=wizard_download_dir, for DSM 6 with USE_DATA_SHARE_WORKER = yes

--- a/spk/synocli-file/Makefile
+++ b/spk/synocli-file/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = synocli-file
 SPK_VERS = 4.0.3
-SPK_REV = 30
+SPK_REV = 31
 SPK_ICON = src/synocli-file.png
 
 # cross/libblkid must be built before cross/e2fsprogs or cross/libext2fs


### PR DESCRIPTION
## Description

- fix for packages that define both SPK_COMMANDS and SPK_USR_LOCAL_LINKS
- SPK_USR_LOCAL_LINKS must not overwrite existing entries created by SPK_COMMANDS
- this is a fix for #7119

So far only two packages are affected
- duplicity
- synocli-file (since #7119)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [x] Package update
