### PR TITLE
uMurmur: Harden certificate generation and config migration

### DIFF
--- a/spk/umurmur/src/service-setup.sh
+++ b/spk/umurmur/src/service-setup.sh
@@ -10,7 +10,7 @@ PUBLIC_KEY="${SYNOPKG_PKGVAR}/umurmur.crt"
 
 create_certificate ()
 {
-    if [ -f "${PRIVATE_KEY}" ] && [ -f "${PUBLIC_KEY}" ]; then
+    if [ -s "${PRIVATE_KEY}" ] && [ -s "${PUBLIC_KEY}" ]; then
         echo "Found uMurmur certificate. To create a new certificate upon package update you have to delete the existing certificate before."
         return 0
     fi
@@ -37,8 +37,6 @@ service_postinst ()
     # Certificate generation
     create_certificate 2>&1
     if [ $? -ne 0 ]; then
-        touch ${PRIVATE_KEY}
-        touch ${PUBLIC_KEY}
         return 1
     fi
 }
@@ -47,7 +45,7 @@ service_preupgrade ()
 {
     # Migrate to DSM 7 compatible var folder
     if [ -e "${CFG_FILE}" ]; then
-        if $(grep -q "/usr/local/umurmur/var/" "${CFG_FILE}"); then
+        if grep -q "/usr/local/umurmur/var/" "${CFG_FILE}"; then
             echo "Update var folder for DSM 7 compatibility in configuration file."
             sed -e "s,/usr/local/umurmur/var/,/var/packages/umurmur/var/,g" -i "${CFG_FILE}"
         fi
@@ -55,7 +53,7 @@ service_preupgrade ()
 
     # Update log-file name to package name
     if [ -e "${CFG_FILE}" ]; then
-        if $(grep -q "umurmurd.log" "${CFG_FILE}"); then
+        if grep -q "umurmurd.log" "${CFG_FILE}"; then
             echo "Update log file name in configuration file."
             sed -e "s,umurmurd.log,umurmur.log,g" -i "${CFG_FILE}"
         fi

--- a/spk/umurmur/src/service-setup.sh
+++ b/spk/umurmur/src/service-setup.sh
@@ -12,24 +12,24 @@ create_certificate ()
 {
     if [ -f "${PRIVATE_KEY}" ] && [ -f "${PUBLIC_KEY}" ]; then
         echo "Found uMurmur certificate. To create a new certificate upon package update you have to delete the existing certificate before."
-        exit 0
+        return 0
     fi
 
     if [ -z "${OPENSSL}" ]; then
         echo "missing openssl to create certificate for uMurmur."
-        exit 2
+        return 2
     fi
 
     # create certificate (use openssl of DSM)
     ${OPENSSL} req -x509 -newkey rsa:4096 -keyout ${PRIVATE_KEY} -nodes -sha256 -days 3653 -out ${PUBLIC_KEY} -batch -config /etc/ssl/openssl.cnf > /dev/null 2>&1
 
-    # Exit with the right code and an explicit message
+    # Return with the right code and an explicit message
     if [ $? -ne 0 ]; then
-        exit 1
+        return 1
     fi
 
     echo "Certificate for uMurmur successfully created."
-    exit 0
+    return 0
 }
 
 service_postinst ()
@@ -39,7 +39,7 @@ service_postinst ()
     if [ $? -ne 0 ]; then
         touch ${PRIVATE_KEY}
         touch ${PUBLIC_KEY}
-        exit 1
+        return 1
     fi
 }
 


### PR DESCRIPTION
## Description

Follow-on to the unpublished [#7399](https://github.com/SynoCommunity/spksrc/pull/7399) (which updated uMurmur to v0.4.1 and pinned mbedtls at 3.6.7 for compatibility). Fixes issues in the uMurmur package's `service-setup.sh`: the certificate-generation fallback was dead code (an in-function `exit` short-circuited `service_postinst`), empty certificate files could be accepted as valid on a retried install, and the config migration used a fragile `if $(grep -q ...)` idiom. No `SPK_REV` bump — the package (0.4.1) was never published, so this fixes it before release.

## Changes

- **Fix the certificate fallback** — `create_certificate()` and `service_postinst()` used `exit` inside functions, which terminated the rest of `service_postinst` (the `touch` fallback never ran). Converted to `return` so the intended control flow works.
- **Harden certificate checks** — `[ -f ]` → `[ -s ]` (non-empty) so empty/placeholder key and certificate files are not accepted as valid; dropped the `touch ${PRIVATE_KEY}/${PUBLIC_KEY}` fallback so a failed install fails cleanly without leaving misleading empty files behind (which would have passed the old `-f` check on a retry).
- **Config migration cleanup** — replaced `if $(grep -q ...)` with `if grep -q ...` (the command-substitution form would break if the pattern output anything).

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
