### PR TITLE
docs: Convert Stage Pipeline to a mermaid diagram

### DIFF
--- a/docs/framework/architecture.md
+++ b/docs/framework/architecture.md
@@ -69,11 +69,11 @@ block
   columns 1
   s0["Stage 0 — parse time (mk/spksrc.common/stage0.mk)<br>Bootstrap the toolchain in its own work dir, load its tc_vars.mk<br>→ TC_GCC known, so version_ge($(TC_GCC),...) DEPENDS parse right<br>cookie: .stage0-bootstrap_done &nbsp; (does NOT write package tc_vars)"]
   space
-  s1["Stage 1 — recipe time (cross-cc.mk / spk.mk)<br>make -C toolchain/&lt;TC&gt; toolchain &nbsp; (MANDATORY)<br>make -C toolchain/&lt;TC&gt; toolkit &nbsp; (OPTIONAL, REQUIRE_TOOLKIT)<br>generate the package work-dir tc_vars* (needs INSTALL_PREFIX)<br>[spk only] spk-meta-source: build the meta sources<br>cookies: .stage1-tcvars_done / .stage1-tkvars_done &nbsp; (idempotent)"]
+  s1["Stage 1 — recipe time (recipes run after parse; cross-cc.mk / spk.mk)<br>make -C toolchain/&lt;TC&gt; toolchain &nbsp; (MANDATORY)<br>make -C toolchain/&lt;TC&gt; toolkit &nbsp; (OPTIONAL, REQUIRE_TOOLKIT)<br>generate the package work-dir tc_vars* (needs INSTALL_PREFIX)<br>[spk only] spk-meta-source: build the meta sources<br>cookies: .stage1-tcvars_done / .stage1-tkvars_done &nbsp; (idempotent)"]
   space
   s2["Stage 2 — recipe time<br>cross: see Build Pipeline Overview<br>spk: see SPK Package Assembly"]
 
-  s0 -->|recipes run after parse| s1
+  s0 --> s1
   s1 --> s2
 ```
 

--- a/docs/framework/architecture.md
+++ b/docs/framework/architecture.md
@@ -64,26 +64,17 @@ Stage 2 builds the actual package using the cross-compilation environment:
 
 The same three-stage model drives both `cross/` and `spk/` builds (mirrors the diagrams in `mk/spksrc.cross-cc.mk` and `mk/spksrc.spk.mk`):
 
-```text
-┌─ stage 0 ── parse time (mk/spksrc.common/stage0.mk) ───────────────┐
-│  bootstrap the toolchain in its own work dir, load its tc_vars.mk  │
-│  → TC_GCC known, so version_ge($(TC_GCC),...) DEPENDS parse right  │
-│  cookie: .stage0-bootstrap_done   (does NOT write package tc_vars) │
-└────────────────────────────────────────────────────────────────────┘
-                              │  (recipes run after parse)
-┌─ stage 1 ── recipe time (cross-cc.mk / spk.mk) ────────────────────┐
-│  make -C toolchain/<TC> toolchain    (MANDATORY)                   │
-│  make -C toolchain/<TC> toolkit      (OPTIONAL, REQUIRE_TOOLKIT)   │
-│  generate the package work-dir tc_vars* (needs INSTALL_PREFIX)     │
-│  [spk only] spk-meta-source: build the meta sources                │
-│  cookies: .stage1-tcvars_done / .stage1-tkvars_done   (idempotent) │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-┌─ stage 2 ── recipe time ───────────────────────────────────────────┐
-│  cross: download → extract → patch → configure → compile →         │
-│         install → plist                                            │
-│  spk:   depend → copy → strip → icon → wizards → package           │
-└────────────────────────────────────────────────────────────────────┘
+```mermaid
+block
+  columns 1
+  s0["Stage 0 — parse time (mk/spksrc.common/stage0.mk)<br>Bootstrap the toolchain in its own work dir, load its tc_vars.mk<br>→ TC_GCC known, so version_ge($(TC_GCC),...) DEPENDS parse right<br>cookie: .stage0-bootstrap_done &nbsp; (does NOT write package tc_vars)"]
+  space
+  s1["Stage 1 — recipe time (cross-cc.mk / spk.mk)<br>make -C toolchain/&lt;TC&gt; toolchain &nbsp; (MANDATORY)<br>make -C toolchain/&lt;TC&gt; toolkit &nbsp; (OPTIONAL, REQUIRE_TOOLKIT)<br>generate the package work-dir tc_vars* (needs INSTALL_PREFIX)<br>[spk only] spk-meta-source: build the meta sources<br>cookies: .stage1-tcvars_done / .stage1-tkvars_done &nbsp; (idempotent)"]
+  space
+  s2["Stage 2 — recipe time<br>cross: download → extract → patch → configure → compile → install → plist<br>spk: &nbsp; depend → copy → strip → icon → wizards → package"]
+
+  s0 -->|recipes run after parse| s1
+  s1 --> s2
 ```
 
 ## SPK Package Assembly

--- a/docs/framework/architecture.md
+++ b/docs/framework/architecture.md
@@ -71,7 +71,7 @@ block
   space
   s1["Stage 1 — recipe time (cross-cc.mk / spk.mk)<br>make -C toolchain/&lt;TC&gt; toolchain &nbsp; (MANDATORY)<br>make -C toolchain/&lt;TC&gt; toolkit &nbsp; (OPTIONAL, REQUIRE_TOOLKIT)<br>generate the package work-dir tc_vars* (needs INSTALL_PREFIX)<br>[spk only] spk-meta-source: build the meta sources<br>cookies: .stage1-tcvars_done / .stage1-tkvars_done &nbsp; (idempotent)"]
   space
-  s2["Stage 2 — recipe time<br>cross: download → extract → patch → configure → compile → install → plist<br>spk: &nbsp; depend → copy → strip → icon → wizards → package"]
+  s2["Stage 2 — recipe time<br>cross: see Build Pipeline Overview<br>spk: see SPK Package Assembly"]
 
   s0 -->|recipes run after parse| s1
   s1 --> s2


### PR DESCRIPTION
## Description

Converts the "Stage Pipeline" section in `docs/framework/architecture.md` from ASCII box art to a mermaid `block` diagram, for consistency with the other two diagrams on the same page (Build Pipeline Overview, SPK Package Assembly). The section content is unchanged.

## Changes

- **Convert to mermaid** — replaced the ASCII `┌─ stage 0 ── ...` box drawing with a mermaid `block` diagram (`columns 1`), matching the style of the other diagrams in `docs/framework/architecture.md`.
- **De-duplicate pipeline flows** — the stage-2 node now references the same-page "Build Pipeline Overview" (cross flow) and "SPK Package Assembly" (spk flow) diagrams instead of repeating the step lists a third time.
- **Avoid edge label** — used plain `s0 --> s1` edges; mermaid's `-->|label|` edge labels do not render in block-diagram previews (each token is split into separate blocks on GitHub). The "recipes run after parse" note was folded into the stage-1 label.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
