### PR TITLE
Vaultwarden: Update to v1.37.2

### DIFF
--- a/cross/vaultwarden/Makefile
+++ b/cross/vaultwarden/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = vaultwarden
-PKG_VERS = 1.37.0
+PKG_VERS = 1.37.2
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/dani-garcia/vaultwarden/archive

--- a/cross/vaultwarden/Makefile
+++ b/cross/vaultwarden/Makefile
@@ -8,19 +8,13 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/openssl3 cross/mariadb-connector-c cross/libpq
 
-# issue with dependent component "ring"
-# https://github.com/briansmith/ring/issues/1424
-UNSUPPORTED_ARCHS = $(PPC_ARCHS)
+# rust edition 2024 required (see rust-version in Cargo.toml)
+MIN_RUSTC_VERSION = 1.95
 
-# issue with dependent component "governor"
-# https://github.com/antifuchs/governor/issues/89
-UNSUPPORTED_ARCHS += $(ARMv5_ARCHS)
-
-# OLD_PPC_ARCHS, ARMv5_ARCHS and ARMv7L_ARCHS
 # issue with dependent component "libmimalloc-sys"
 # error: failed to run custom build command for `libmimalloc-sys v0.1.30`
 # c_src/mimalloc/include/mimalloc-atomic.h:39:23: fatal error: stdatomic.h: No such file or directory
-UNSUPPORTED_ARCHS += $(ARMv7L_ARCHS)
+UNSUPPORTED_ARCHS = $(ARMv7L_ARCHS)
 
 HOMEPAGE = https://github.com/dani-garcia/vaultwarden/wiki
 COMMENT = Alternative implementation of the Bitwarden server API written in Rust and compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.
@@ -45,10 +39,8 @@ ENV += VW_VERSION="$(PKG_VERS) (SynoCommunity-$(ARCH))"
 
 include ../../mk/spksrc.common.mk
 
-ifeq ($(call version_lt, ${TCVERSION}, 7.0),1)
+ifeq ($(call version_lt, $(TC_GCC), 5),1)
 # fix for build of "libmimalloc-sys v0.1.30"
-ADDITIONAL_CFLAGS = -std=c99
-else ifeq ($(findstring $(ARCH),comcerto2k),$(ARCH))
 ADDITIONAL_CFLAGS = -std=c99
 endif
 

--- a/cross/vaultwarden/digests
+++ b/cross/vaultwarden/digests
@@ -1,3 +1,3 @@
-vaultwarden-1.37.0.tar.gz SHA1 4999da8a94d91de6b77c95243a2c162e17ace9ae
-vaultwarden-1.37.0.tar.gz SHA256 f8a9bd9a31b30c2a5e196d875d458bcac987175ffa6c1ce3f56a5920e70aef16
-vaultwarden-1.37.0.tar.gz MD5 810ebbb2aaee8485a80a943c9cce6d6a
+vaultwarden-1.37.2.tar.gz SHA1 1c820388d598e547a341f12529cd2645e3f7e6ce
+vaultwarden-1.37.2.tar.gz SHA256 d607cc00066f7ea62b27a3c198e0259955fd5591adabccb8d3414d1f3d91ecd7
+vaultwarden-1.37.2.tar.gz MD5 367326ce1de2da9cdb4aebc7fc8f5ba7

--- a/spk/vaultwarden/Makefile
+++ b/spk/vaultwarden/Makefile
@@ -5,7 +5,9 @@ SPK_ICON = src/vaultwarden.png
 
 DEPENDS = cross/vaultwarden cross/vaultwarden_web
 
-UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS)
+# issue with dependent component "libmimalloc-sys" (stdatomic.h missing)
+# PPC and ARMv5 are gated by MIN_RUSTC_VERSION in cross/vaultwarden
+UNSUPPORTED_ARCHS = $(ARMv7L_ARCHS)
 
 MAINTAINER = Hylen
 DESCRIPTION = Alternative implementation of the Bitwarden server API written in Rust and compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.

--- a/spk/vaultwarden/Makefile
+++ b/spk/vaultwarden/Makefile
@@ -5,9 +5,6 @@ SPK_ICON = src/vaultwarden.png
 
 DEPENDS = cross/vaultwarden cross/vaultwarden_web
 
-# PPC/ARMv5 are additionally gated by MIN_RUSTC_VERSION in cross/vaultwarden, but
-# listed here so `all-supported` does not attempt to build them
-# issue with dependent component "libmimalloc-sys" (stdatomic.h missing)
 # rust edition 2024 required (see rust-version in vaultwarden Cargo.toml)
 MIN_RUSTC_VERSION = 1.95
 # issue with dependent component "libmimalloc-sys" (stdatomic.h missing)

--- a/spk/vaultwarden/Makefile
+++ b/spk/vaultwarden/Makefile
@@ -8,7 +8,10 @@ DEPENDS = cross/vaultwarden cross/vaultwarden_web
 # PPC/ARMv5 are additionally gated by MIN_RUSTC_VERSION in cross/vaultwarden, but
 # listed here so `all-supported` does not attempt to build them
 # issue with dependent component "libmimalloc-sys" (stdatomic.h missing)
-UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS)
+# rust edition 2024 required (see rust-version in vaultwarden Cargo.toml)
+MIN_RUSTC_VERSION = 1.95
+# issue with dependent component "libmimalloc-sys" (stdatomic.h missing)
+UNSUPPORTED_ARCHS = $(ARMv7L_ARCHS)
 
 MAINTAINER = Hylen
 DESCRIPTION = Alternative implementation of the Bitwarden server API written in Rust and compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.

--- a/spk/vaultwarden/Makefile
+++ b/spk/vaultwarden/Makefile
@@ -5,9 +5,10 @@ SPK_ICON = src/vaultwarden.png
 
 DEPENDS = cross/vaultwarden cross/vaultwarden_web
 
+# PPC/ARMv5 are additionally gated by MIN_RUSTC_VERSION in cross/vaultwarden, but
+# listed here so `all-supported` does not attempt to build them
 # issue with dependent component "libmimalloc-sys" (stdatomic.h missing)
-# PPC and ARMv5 are gated by MIN_RUSTC_VERSION in cross/vaultwarden
-UNSUPPORTED_ARCHS = $(ARMv7L_ARCHS)
+UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS)
 
 MAINTAINER = Hylen
 DESCRIPTION = Alternative implementation of the Bitwarden server API written in Rust and compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.

--- a/spk/vaultwarden/Makefile
+++ b/spk/vaultwarden/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = vaultwarden
-SPK_VERS = 1.37.0
-SPK_REV = 4
+SPK_VERS = 1.37.2
+SPK_REV = 5
 SPK_ICON = src/vaultwarden.png
 
 DEPENDS = cross/vaultwarden cross/vaultwarden_web
@@ -10,7 +10,7 @@ UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS)
 MAINTAINER = Hylen
 DESCRIPTION = Alternative implementation of the Bitwarden server API written in Rust and compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.
 DISPLAY_NAME = Vaultwarden
-CHANGELOG = "Update to v1.37.0 with web vault v2026.6.4."
+CHANGELOG = "1. Update Vaultwarden to v1.37.2. <br/>2. Fixes the invite issue and compatibility with the latest Bitwarden clients."
 
 HOMEPAGE = https://github.com/dani-garcia/vaultwarden
 LICENSE  = GPLv3


### PR DESCRIPTION
## Description

Updates Vaultwarden to v1.37.2. This is a patch release covering two important fixes: v1.37.1 resolves a broken invite flow, and v1.37.2 is required for compatibility with Bitwarden clients v2026.8.0+.

The web vault remains at v2026.6.4 (the latest `bw_web_builds` release).

## Changes

- Update Vaultwarden from 1.37.0 to 1.37.2 (SPK_REV 4 → 5)
- Changelog updated: invite fix and compatibility with the latest Bitwarden clients
- Replace the hard-coded PPC/ARMv5 `UNSUPPORTED_ARCHS` with a `MIN_RUSTC_VERSION = 1.95` capability gate (vaultwarden's declared MSRV); `ARMv7L` remains unsupported (libmimalloc-sys `stdatomic.h`). The `-std=c99` workaround is now gated on `TC_GCC < 5`, and the spk's arch list is aligned accordingly.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
