### PR TITLE
uMurmur: Test mbedtls 4.x support

### DIFF
--- a/cross/mbedtls-4.2/Makefile
+++ b/cross/mbedtls-4.2/Makefile
@@ -1,0 +1,42 @@
+PKG_NAME = mbedtls
+PKG_VERS = 4.2.0
+PKG_EXT = tar.bz2
+PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
+PKG_DIST_SITE = https://github.com/Mbed-TLS/mbedtls/releases/download/$(PKG_NAME)-$(PKG_VERS)
+PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
+
+DEPENDS =
+
+HOMEPAGE = https://www.trustedfirmware.org/projects/mbed-tls/
+COMMENT  = Mbed TLS implements cryptographic primitives, X.509 certificate manipulation and the SSL/TLS and DTLS protocols. Its small code footprint makes it suitable for embedded systems.
+LICENSE  = Apache 2.0 or GPLv2+
+
+CONFIGURE_ARGS  = -DUSE_SHARED_MBEDTLS_LIBRARY=ON
+CONFIGURE_ARGS += -DUSE_STATIC_MBEDTLS_LIBRARY=OFF
+CONFIGURE_ARGS += -DENABLE_TESTING=OFF
+CONFIGURE_ARGS += -DENABLE_PROGRAMS=OFF
+
+include ../../mk/spksrc.common.mk
+
+# Avoid definition of MBEDTLS_AESCE_C for aarch64 with gcc < 6
+ifeq ($(call version_lt, $(TC_GCC), 5),1)
+ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
+POST_EXTRACT_TARGET = disable_mbedtls_target
+MBEDTLS_DISABLE = MBEDTLS_AESCE_C
+endif
+
+# Disable ASM for x86 archs with gcc < 5
+# Note: Only MBEDTLS_HAVE_ASM needs disabling with version 4.x
+ifeq ($(findstring $(ARCH),$(i686_ARCHS)),$(ARCH))
+POST_EXTRACT_TARGET = disable_mbedtls_target
+MBEDTLS_DISABLE  = MBEDTLS_HAVE_ASM
+MBEDTLS_DISABLE += MBEDTLS_AESNI_C
+MBEDTLS_DISABLE += MBEDTLS_PADLOCK_C
+endif
+endif
+
+include ../../mk/spksrc.cross-cmake.mk
+
+disable_mbedtls_target:
+	@$(foreach var,$(MBEDTLS_DISABLE),$(RUN) find $(WORK_DIR) -type f -exec sed -i \
+		's|^[[:space:]]*#define[[:space:]]\+$(var)|// #define $(var)|' {} +;)

--- a/cross/mbedtls-4.2/PLIST
+++ b/cross/mbedtls-4.2/PLIST
@@ -1,0 +1,12 @@
+lnk:lib/libmbedcrypto.so
+lnk:lib/libmbedcrypto.so.18
+lib:lib/libmbedcrypto.so.4.2.0
+lnk:lib/libmbedtls.so
+lnk:lib/libmbedtls.so.23
+lib:lib/libmbedtls.so.4.2.0
+lnk:lib/libmbedx509.so
+lnk:lib/libmbedx509.so.9
+lib:lib/libmbedx509.so.4.2.0
+lnk:lib/libtfpsacrypto.so
+lnk:lib/libtfpsacrypto.so.2
+lib:lib/libtfpsacrypto.so.1.2.0

--- a/cross/mbedtls-4.2/digests
+++ b/cross/mbedtls-4.2/digests
@@ -1,0 +1,3 @@
+mbedtls-4.2.0.tar.bz2 SHA1 d492092bdca908975afbce04b651bcbef0bd9ea2
+mbedtls-4.2.0.tar.bz2 SHA256 2bed9d713b4668f76553b097e72b8aa30bc8f112a940d7ae228d524bbde6ffea
+mbedtls-4.2.0.tar.bz2 MD5 4d2956835f099e374e64589f09addd28

--- a/cross/umurmur/Makefile
+++ b/cross/umurmur/Makefile
@@ -6,7 +6,7 @@ PKG_DIST_SITE = https://github.com/umurmur/umurmur/archive
 PKG_DIST_FILE = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
-DEPENDS = cross/libconfig cross/protobuf-c cross/mbedtls
+DEPENDS = cross/libconfig cross/protobuf-c cross/mbedtls-4.2
 
 HOMEPAGE = https://github.com/umurmur/umurmur
 COMMENT  = uMurmur is a minimalistic Mumble server.

--- a/cross/umurmur/patches/002-mbedtls-4x.patch
+++ b/cross/umurmur/patches/002-mbedtls-4x.patch
@@ -1,0 +1,753 @@
+diff --git a/cmake/Modules/FindMbedTLS.cmake b/cmake/Modules/FindMbedTLS.cmake
+index 2a62124f..269a175f 100644
+--- cmake/Modules/FindMbedTLS.cmake
++++ cmake/Modules/FindMbedTLS.cmake
+@@ -2,73 +2,30 @@
+ # (c) Azamat Hackimov <azamat.hackimov@gmail.com>
+ 
+ #[=======================================================================[.rst:
+-FindMbedTLS v1.0
+---------
++FindMbedTLS
++-----------
+ 
+-Find MbedTLS library and include files.
+-
+-This module is a compatibility layer for the library version below 3.6.0,
+-where full support of cmake configuration modules appeared. It is recommended
+-to use the library 3.6 and higher, for which this module is redundant.
+-
+-The module provides the same targets as the MbedTLS 3.6 modules, due to which
+-the migration process to 3.6 will be very simple - just delete the local copy
+-of this file and reinitialize the project.
++Find Mbed TLS 4.x library and include files.
+ 
+ IMPORTED Targets
+ ^^^^^^^^^^^^^^^^
+ 
+-This module defines the :prop_tgt:`IMPORTED` targets:
+-
+ ``MbedTLS::mbedtls``
+ 
+-``MbedTLS::mbedcrypto``
+-
+ ``MbedTLS::mbedx509``
+ 
+-Result Variables
+-^^^^^^^^^^^^^^^^
+-
+-This module defines the following variables:
+-
+-``MbedTLS_FOUND``
+-  True if ``MbedTLS`` was found.
+-
+-``MbedTLS_INCLUDE_DIRS``
+-
+-  Where to find mbedtls/version.h, etc.
+-
+-``MbedTLS_LIBRARIES``
+-  List of libraries for using ``mbedtls``.
+-
+-Cache Variables
+-^^^^^^^^^^^^^^^
+-
+-This module may set the following variables depending on platform.
+-These variables may optionally be set to help this module find the
+-correct files, but clients should not use these as results:
+-
+-``MbedTLS_INCLUDE_DIR``
+-  The full path to the directory containing ``mbedtls/version.h``.
++``MbedTLS::tfpsacrypto``
+ 
+-``MbedTLS_mbedtls_LIBRARY``
+-  The full path to the mbedtls library.
+-
+-``MbedTLS_mbedcrypto_LIBRARY``
+-  The full path to the mbedcrypto library.
+-
+-``MbedTLS_mbedx509_LIBRARY``
+-  The full path to the mbedx509 library.
++``MbedTLS::mbedcrypto`` (alias of ``MbedTLS::tfpsacrypto`` on 4.x)
+ 
+ #]=======================================================================]
+ 
+ include(FindPackageHandleStandardArgs)
+ 
+-list(APPEND _MBEDTLS_COMPONENTS mbedtls mbedcrypto mbedx509)
+-
++# find_path returns the directory containing mbedtls/ (e.g. /usr/include),
++# which is the correct -I path for #include <mbedtls/...>.
+ find_path(MbedTLS_INCLUDE_DIR mbedtls/version.h
+-  HINTS /usr/pkg/include /usr/local/include /usr/include
+-  PATH_SUFFIXES "mbedtls3"
++  HINTS /usr/pkg/include
+ )
+ 
+ mark_as_advanced(MbedTLS_INCLUDE_DIR)
+@@ -79,60 +36,58 @@ if(MbedTLS_INCLUDE_DIR AND EXISTS "${MbedTLS_INCLUDE_DIR}/mbedtls/build_info.h")
+   string(REGEX REPLACE "^.*MBEDTLS_VERSION_STRING[\t ]+\"([0-9]+\\.[0-9]+\\.[0-9]+)\".*$"
+     "\\1" MBEDTLS_VERSION_STR "${MBEDTLS_VERSION_STR}")
+   set(MbedTLS_VERSION "${MBEDTLS_VERSION_STR}")
+-
+-  # ZLIB support was removed in 3.0.0
+-  if(MbedTLS_VERSION VERSION_LESS "3.0.0")
+-    include(CheckSymbolExists)
+-    check_symbol_exists(MBEDTLS_ZLIB_SUPPORT "${MbedTLS_INCLUDE_DIR}/mbedtls/version.h" HAVE_ZLIB_SUPPORT)
+-    if(HAVE_ZLIB_SUPPORT)
+-      find_package(ZLIB REQUIRED)
+-    endif(HAVE_ZLIB_SUPPORT)
+-  endif()
+ else()
+   message(WARNING "No Mbed TLS version information could be parsed from the source headers")
+ endif()
+ 
++if(MbedTLS_VERSION AND MbedTLS_VERSION VERSION_LESS "4.0.0")
++  message(FATAL_ERROR "Mbed TLS 4.0 or greater is required (found ${MbedTLS_VERSION})")
++endif()
++
++list(APPEND _MBEDTLS_COMPONENTS mbedtls mbedx509 tfpsacrypto)
++
+ foreach(v ${_MBEDTLS_COMPONENTS})
+-  if(v STREQUAL "mbedcrypto")
+-    # Mbed TLS 4.x ships libtfpsacrypto; some distros omit the libmbedcrypto.so symlink
++  if(v STREQUAL "tfpsacrypto")
+     find_library(MbedTLS_${v}_LIBRARY
+-      NAMES ${v}-3 ${v} tfpsacrypto tfpsacrypto-1
+-      PATHS /usr/pkg /usr/local /usr
++      NAMES tfpsacrypto tfpsacrypto-1 mbedcrypto-3 mbedcrypto
++      PATHS /usr/pkg
+     )
+   else()
+     find_library(MbedTLS_${v}_LIBRARY
+-      NAMES ${v}-3 ${v}   # Some Linux distributions offers mbedtls-2 and mbedtls-3 simultaneously, prefer mbedtls-3
+-      PATHS /usr/pkg /usr/local /usr
++      NAMES ${v}-3 ${v}
++      PATHS /usr/pkg
+     )
+   endif()
+   mark_as_advanced(MbedTLS_${v}_LIBRARY)
+ endforeach()
+ 
+-find_package_handle_standard_args(MbedTLS REQUIRED_VARS MbedTLS_mbedtls_LIBRARY MbedTLS_INCLUDE_DIR)
++find_package_handle_standard_args(MbedTLS REQUIRED_VARS
++  MbedTLS_mbedtls_LIBRARY
++  MbedTLS_mbedx509_LIBRARY
++  MbedTLS_tfpsacrypto_LIBRARY
++  MbedTLS_INCLUDE_DIR
++)
+ 
+ foreach(v ${_MBEDTLS_COMPONENTS})
+   if(MbedTLS_${v}_LIBRARY AND NOT TARGET MbedTLS::${v})
+     add_library(MbedTLS::${v} UNKNOWN IMPORTED)
+     set_target_properties(MbedTLS::${v} PROPERTIES
+       IMPORTED_LOCATION "${MbedTLS_${v}_LIBRARY}"
+-      INTERFACE_INCLUDE_DIRECTORIES ${MbedTLS_INCLUDE_DIR}
++      INTERFACE_INCLUDE_DIRECTORIES "${MbedTLS_INCLUDE_DIR}"
+     )
+-    if(HAVE_ZLIB_SUPPORT)
+-      set_target_properties(MbedTLS::${v} PROPERTIES
+-        LINK_INTERFACE_LIBRARIES ZLIB::ZLIB
+-      )
+-    endif()
+   endif()
+ endforeach()
+ 
++if(MbedTLS_FOUND AND TARGET MbedTLS::tfpsacrypto AND NOT TARGET MbedTLS::mbedcrypto)
++  add_library(MbedTLS::mbedcrypto ALIAS MbedTLS::tfpsacrypto)
++endif()
++
+ if(MbedTLS_FOUND)
+-  set(MbedTLS_INCLUDE_DIRS
+-    ${MbedTLS_INCLUDE_DIR}
+-  )
++  set(MbedTLS_INCLUDE_DIRS ${MbedTLS_INCLUDE_DIR})
+   set(MbedTLS_LIBRARIES
+     ${MbedTLS_mbedtls_LIBRARY}
+-    ${MbedTLS_mbedcrypto_LIBRARY}
+     ${MbedTLS_mbedx509_LIBRARY}
++    ${MbedTLS_tfpsacrypto_LIBRARY}
+   )
+ endif()
+ 
+
+diff --git a/cmake/Modules/Options.cmake b/cmake/Modules/Options.cmake
+index 3bdc3caa..707960ad 100644
+--- cmake/Modules/Options.cmake
++++ cmake/Modules/Options.cmake
+@@ -5,11 +5,10 @@ set_property(CACHE SSL PROPERTY STRINGS "openssl" "mbedtls" "gnutls")
+ 
+ # mbedTLS
+ option(USE_MBEDTLS_TESTCERT "Link to the mbedTLS test certificate and key." OFF)
+-option(USE_MBEDTLS_HAVEGE "Use the mbedTLS HAVEGE random generator key." OFF)
+ 
+-if(USE_MBEDTLS_TESTCERT OR USE_MBEDTLS_HAVEGE)
++if(USE_MBEDTLS_TESTCERT)
+   if(NOT SSL MATCHES "mbedtls")
+-    message(FATAL_ERROR "Selecting USE_MBEDTLS_TESTCERT or USE_MBEDTLS_HAVEGE implies SSL=mbedtls")
++    message(FATAL_ERROR "Selecting USE_MBEDTLS_TESTCERT implies SSL=mbedtls")
+   endif()
+ endif()
+ 
+
+diff --git a/cmake/Modules/SelectTLSBackend.cmake b/cmake/Modules/SelectTLSBackend.cmake
+index f280c1a5..1e4323e1 100644
+--- cmake/Modules/SelectTLSBackend.cmake
++++ cmake/Modules/SelectTLSBackend.cmake
+@@ -27,7 +27,7 @@ function(SelectTLSBackend SSL)
+     set(SSL_VERSION "MbedTLS ${MbedTLS_VERSION}")
+ 
+     set(USE_MBEDTLS ON PARENT_SCOPE)
+-    set(LIBRARIES MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
++    set(LIBRARIES MbedTLS::mbedtls MbedTLS::mbedx509 MbedTLS::tfpsacrypto)
+ 
+   elseif("${SSL}" STREQUAL "gnutls")
+     find_package(GnuTLS 3 REQUIRED)
+
+diff --git a/src/config.h.in b/src/config.h.in
+index af982950..f72fb807 100644
+--- src/config.h.in
++++ src/config.h.in
+@@ -4,7 +4,6 @@
+ #cmakedefine USE_GNUTLS
+ #cmakedefine USE_MBEDTLS
+ #cmakedefine USE_MBEDTLS_TESTCERT
+-#cmakedefine USE_MBEDTLS_HAVEGE
+ 
+ #cmakedefine USE_SHAREDMEMORY_API
+ 
+
+diff --git a/src/crypt.c b/src/crypt.c
+index fdb3bc16..e773deb1 100644
+--- src/crypt.c
++++ src/crypt.c
+@@ -38,14 +38,74 @@
+  * OCB with something else or get yourself a license.
+  */
+ 
+-#include "crypt.h"
+-#include <string.h>
+-#include <arpa/inet.h>
+ #include "log.h"
+-#include "ssl.h"
++#include "crypt.h"
++
++#if defined(USE_MBEDTLS)
++#include <psa/crypto.h>
++
++static psa_key_id_t CryptState_importAesKey(const unsigned char *source)
++{
++	psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
++	psa_key_id_t key_id;
++	psa_status_t status;
++
++	psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT);
++	psa_set_key_algorithm(&attributes, PSA_ALG_ECB_NO_PADDING);
++	psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
++	psa_set_key_bits(&attributes, 128);
++
++	status = psa_import_key(&attributes, source, AES_BLOCK_SIZE, &key_id);
++	psa_reset_key_attributes(&attributes);
++	if (status != PSA_SUCCESS)
++		Log_fatal("Failed to import AES key: %d", (int)status);
++
++	return key_id;
++}
++
++static void CryptState_destroyAesKey(psa_key_id_t *key_id)
++{
++	if (*key_id != PSA_KEY_ID_NULL) {
++		psa_destroy_key(*key_id);
++		*key_id = PSA_KEY_ID_NULL;
++	}
++}
++
++void CryptState_setEncryptKey(CRYPT_AES_KEY *dest, const unsigned char *source, int size)
++{
++	(void)size;
++	CryptState_destroyAesKey(dest);
++	*dest = CryptState_importAesKey(source);
++}
++
++void CryptState_setDecryptKey(CRYPT_AES_KEY *dest, const unsigned char *source, int size)
++{
++	(void)size;
++	CryptState_destroyAesKey(dest);
++	*dest = CryptState_importAesKey(source);
++}
++
++void CryptState_aesEncrypt(const unsigned char *src, unsigned char *dst, cryptState_t *cs)
++{
++	size_t out_len;
++	psa_status_t status;
+ 
+-#if defined(USE_MBEDTLS_HAVEGE)
+-extern mbedtls_havege_state hs;
++	status = psa_cipher_encrypt(cs->encrypt_key, PSA_ALG_ECB_NO_PADDING,
++				    src, AES_BLOCK_SIZE, dst, AES_BLOCK_SIZE, &out_len);
++	if (status != PSA_SUCCESS || out_len != AES_BLOCK_SIZE)
++		Log_fatal("AES encryption failed: %d", (int)status);
++}
++
++void CryptState_aesDecrypt(const unsigned char *src, unsigned char *dst, cryptState_t *cs)
++{
++	size_t out_len;
++	psa_status_t status;
++
++	status = psa_cipher_decrypt(cs->decrypt_key, PSA_ALG_ECB_NO_PADDING,
++				    src, AES_BLOCK_SIZE, dst, AES_BLOCK_SIZE, &out_len);
++	if (status != PSA_SUCCESS || out_len != AES_BLOCK_SIZE)
++		Log_fatal("AES decryption failed: %d", (int)status);
++}
+ #endif
+ 
+ static void CryptState_ocb_encrypt(cryptState_t *cs, const unsigned char *plain, unsigned char *encrypted, unsigned int len, const unsigned char *nonce, unsigned char *tag);
+@@ -107,8 +167,10 @@ void CryptState_init(cryptState_t *cs)
+ 	memset(cs->raw_key, 0, AES_BLOCK_SIZE);
+ 	memset(cs->encrypt_iv, 0, AES_BLOCK_SIZE);
+ 	memset(cs->decrypt_iv, 0, AES_BLOCK_SIZE);
+-	/* OpenSSL-only context state initialization. */
+-#if !defined(USE_MBEDTLS) && !defined(USE_GNUTLS)
++#if defined(USE_MBEDTLS)
++	cs->encrypt_key = PSA_KEY_ID_NULL;
++	cs->decrypt_key = PSA_KEY_ID_NULL;
++#elif !defined(USE_GNUTLS)
+ 	cs->encrypt_key = NULL;
+ 	cs->decrypt_key = NULL;
+ #endif
+@@ -155,8 +217,14 @@ void CryptState_setDecryptIV(cryptState_t *cs, const unsigned char *iv)
+ 
+ void CryptState_cleanup(cryptState_t *cs)
+ {
+-	/* OpenSSL-only EVP context cleanup. */
+-#if !defined(USE_MBEDTLS) && !defined(USE_GNUTLS)
++#if defined(USE_MBEDTLS)
++	if (cs->encrypt_key != PSA_KEY_ID_NULL)
++		psa_destroy_key(cs->encrypt_key);
++	if (cs->decrypt_key != PSA_KEY_ID_NULL)
++		psa_destroy_key(cs->decrypt_key);
++	cs->encrypt_key = PSA_KEY_ID_NULL;
++	cs->decrypt_key = PSA_KEY_ID_NULL;
++#elif !defined(USE_GNUTLS)
+ 	if (cs->encrypt_key) {
+ 		EVP_CIPHER_CTX_free(cs->encrypt_key);
+ 		cs->encrypt_key = NULL;
+
+diff --git a/src/crypt.h b/src/crypt.h
+index 8c4a142d..c651ae49 100644
+--- src/crypt.h
++++ src/crypt.h
+@@ -46,16 +46,24 @@ typedef struct CryptState cryptState_t;
+ /* Crypto backend: mbedTLS */
+ #if defined(USE_MBEDTLS)
+ 
+-#include <mbedtls/aes.h>
++#include <psa/crypto.h>
+ 
+-#define CRYPT_AES_KEY mbedtls_aes_context
++#define CRYPT_AES_KEY psa_key_id_t
+ 
+-#define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((unsigned char *)(dest), (size))
+-#define CRYPT_SET_ENC_KEY(dest, source, size) mbedtls_aes_setkey_enc((dest), (source), (size));
+-#define CRYPT_SET_DEC_KEY(dest, source, size) mbedtls_aes_setkey_dec((dest), (source), (size));
++#define CRYPT_RANDOM_BYTES(dest, size) do { \
++	if (psa_generate_random((unsigned char *)(dest), (size)) != PSA_SUCCESS) \
++		Log_fatal("psa_generate_random failed"); \
++} while (0)
++
++void CryptState_setEncryptKey(CRYPT_AES_KEY *dest, const unsigned char *source, int size);
++void CryptState_setDecryptKey(CRYPT_AES_KEY *dest, const unsigned char *source, int size);
++void CryptState_aesEncrypt(const unsigned char *src, unsigned char *dst, cryptState_t *cs);
++void CryptState_aesDecrypt(const unsigned char *src, unsigned char *dst, cryptState_t *cs);
+ 
+-#define CRYPT_AES_ENCRYPT(src, dst, cryptstate) mbedtls_aes_crypt_ecb(&(cryptstate)->encrypt_key, MBEDTLS_AES_ENCRYPT, (unsigned char *)(src), (unsigned char *)(dst));
+-#define CRYPT_AES_DECRYPT(src, dst, cryptstate) mbedtls_aes_crypt_ecb(&(cryptstate)->decrypt_key, MBEDTLS_AES_DECRYPT, (unsigned char *)(src), (unsigned char *)(dst));
++#define CRYPT_SET_ENC_KEY(dest, source, size) CryptState_setEncryptKey((dest), (source), (size))
++#define CRYPT_SET_DEC_KEY(dest, source, size) CryptState_setDecryptKey((dest), (source), (size))
++#define CRYPT_AES_ENCRYPT(src, dst, cryptstate) CryptState_aesEncrypt((const unsigned char *)(src), (unsigned char *)(dst), (cryptstate))
++#define CRYPT_AES_DECRYPT(src, dst, cryptstate) CryptState_aesDecrypt((const unsigned char *)(src), (unsigned char *)(dst), (cryptstate))
+ 
+ /* Crypto backend: GnuTLS/nettle */
+ #elif defined(USE_GNUTLS)
+
+diff --git a/src/ssl.h b/src/ssl.h
+index 53114975..36581220 100644
+--- src/ssl.h
++++ src/ssl.h
+@@ -43,31 +43,12 @@
+ #if defined(USE_MBEDTLS)
+ #include <mbedtls/version.h>
+ 
+-#if !defined(MBEDTLS_VERSION_MAJOR) || (MBEDTLS_VERSION_MAJOR < 2)
+-#error mbedTLS version 2.0.0 or greater is required!
++#if MBEDTLS_VERSION_MAJOR < 4
++#error Mbed TLS 4.0 or greater is required!
+ #endif
+ 
+ #include <mbedtls/ssl.h>
+-#if (MBEDTLS_VERSION_MINOR > 3)
+ #include <mbedtls/net_sockets.h>
+-#else
+-#include <mbedtls/net.h>
+-#endif
+-
+-#if (MBEDTLS_VERSION_MAJOR >= 3)
+-#undef USE_MBEDTLS_HAVEGE
+-#endif
+-
+-#if defined(USE_MBEDTLS_HAVEGE)
+-#include <mbedtls/havege.h>
+-#define HAVEGE_RAND (mbedtls_havege_random)
+-#define RAND_bytes(_dst_, _size_) do { \
+-        mbedtls_havege_random(&hs, _dst_, _size_); \
+-	} while (0)
+-#else
+-#define RAND_bytes(_dst_, _size_) do { urandom_bytes(NULL, _dst_, _size_); } while (0)
+-int urandom_bytes(void *ctx, unsigned char *dest, size_t len);
+-#endif
+ 
+ #define SSLI_ERROR_WANT_READ -0x0F300
+ #define SSLI_ERROR_WANT_WRITE -0x0F310
+@@ -76,7 +57,7 @@ int urandom_bytes(void *ctx, unsigned char *dest, size_t len);
+ #define SSLI_ERROR_CONNRESET MBEDTLS_ERR_NET_CONN_RESET
+ #define SSLI_ERROR_SYSCALL MBEDTLS_ERR_NET_RECV_FAILED
+ 
+-typedef	mbedtls_ssl_context SSL_handle_t;
++typedef mbedtls_ssl_context SSL_handle_t;
+ 
+ /* TLS backend: GnuTLS */
+ #elif defined(USE_GNUTLS)
+@@ -141,4 +122,3 @@ static inline void SSLi_hex2hash(char *in, uint8_t *hash)
+ 	}
+ }
+ #endif
+-
+
+diff --git a/src/ssli_mbedtls.c b/src/ssli_mbedtls.c
+index 1c90e7d3..95029bb8 100644
+--- src/ssli_mbedtls.c
++++ src/ssli_mbedtls.c
+@@ -35,28 +35,12 @@
+ #include "memory.h"
+ 
+ #include <stdlib.h>
+-#include <fcntl.h>
+-
+-#include <mbedtls/version.h>
+-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+-#include <mbedtls/psa_util.h>
+-#else
+-#include <mbedtls/ctr_drbg.h>
+-#include <mbedtls/entropy.h>
+-#endif
+-#if MBEDTLS_VERSION_MAJOR < 3
+-#include <mbedtls/certs.h>
+-#endif
++
++#include <psa/crypto.h>
++#include <psa/crypto_extra.h>
+ #include <mbedtls/x509.h>
+ #include <mbedtls/ssl.h>
+-
+-#if MBEDTLS_VERSION_NUMBER < 0x02060000L
+-#include <mbedtls/net.h>
+-#else
+ #include <mbedtls/net_sockets.h>
+-#endif
+-
+-#include <mbedtls/sha1.h>
+ #include <mbedtls/error.h>
+ 
+ const int ciphers[] =
+@@ -68,58 +52,22 @@ const int ciphers[] =
+ 	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+ 	MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+ 	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+-	MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA,
+-	MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA,
+-    0
++	0
+ };
+ 
+-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
+-#ifdef MBEDTLS_ENTROPY_C
+-static mbedtls_entropy_context entropy;
+-#ifdef MBEDTLS_CTR_DRBG_C
+-static mbedtls_ctr_drbg_context ctr_drbg;
+-#endif
+-#endif
+-#endif
+-#endif
+-
+ static mbedtls_x509_crt certificate;
+-static inline int x509parse_keyfile(mbedtls_pk_context *pk, const char *path, const char *pwd)
+-{
+-    int ret;
+-
+-    mbedtls_pk_init(pk);
+-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+-    ret = mbedtls_pk_parse_keyfile(pk, path, pwd, mbedtls_psa_get_random, MBEDTLS_PSA_RANDOM_STATE);
+-#else
+-    ret = mbedtls_pk_parse_keyfile(pk, path, pwd, mbedtls_ctr_drbg_random, &ctr_drbg);
+-#endif
+-#else
+-    ret = mbedtls_pk_parse_keyfile(pk, path, pwd);
+-#endif
+-    if (ret == 0 && !mbedtls_pk_can_do(pk, MBEDTLS_PK_ECDSA) && !mbedtls_pk_can_do(pk, MBEDTLS_PK_RSA))
+-	{
+-        ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
+-	}
+-
+-    return ret;
+-}
+-
+ static mbedtls_pk_context key;
+ bool_t builtInTestCertificate;
+ 
+-#ifdef USE_MBEDTLS_HAVEGE
+-mbedtls_havege_state hs;
+-#else
+-int urandom_fd;
+-#endif
++static inline int x509parse_keyfile(mbedtls_pk_context *pk, const char *path, const char *pwd)
++{
++	mbedtls_pk_init(pk);
++	return mbedtls_pk_parse_keyfile(pk, path, pwd);
++}
+ 
+ static void initCert()
+ {
+ 	int rc;
+-	
+ 	char *crtfile = (char *)getStrConf(CERTIFICATE);
+ 
+ 	if (crtfile == NULL) {
+@@ -128,12 +76,10 @@ static void initCert()
+ 	}
+ 
+ 	rc = mbedtls_x509_crt_parse_file(&certificate, crtfile);
+-
+ 	if (rc != 0) {
+-	    char buffer[128];
+-	    mbedtls_strerror(rc, buffer, 128);
+-	    Log_fatal("Could not parse certificate file %s: %s", crtfile, buffer);
+-		return;
++		char buffer[128];
++		mbedtls_strerror(rc, buffer, sizeof(buffer));
++		Log_fatal("Could not parse certificate file %s: %s", crtfile, buffer);
+ 	}
+ }
+ 
+@@ -144,45 +90,22 @@ static void initKey()
+ 
+ 	if (keyfile == NULL)
+ 		Log_fatal("No key file specified");
++
+ 	rc = x509parse_keyfile(&key, keyfile, NULL);
+ 	if (rc != 0) {
+ 		char buffer[128];
+-		mbedtls_strerror(rc, buffer, 128);
++		mbedtls_strerror(rc, buffer, sizeof(buffer));
+ 		Log_fatal("Could not read private key file %s: %s", keyfile, buffer);
+ 	}
+ }
+ 
+-#ifndef USE_MBEDTLS_HAVEGE
+-int urandom_bytes(void *ctx, unsigned char *dest, size_t len)
+-{
+-	(void)ctx;
+-#if (MBEDTLS_VERSION_MAJOR >= 3)
+-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+-	mbedtls_psa_get_random(MBEDTLS_PSA_RANDOM_STATE, dest, len);
+-#else
+-	mbedtls_ctr_drbg_random(&ctr_drbg, dest, len);
+-#endif
+-#else
+-	int cur;
+-
+-	while (len) {
+-		cur = read(urandom_fd, dest, len);
+-		if (cur < 0)
+-			continue;
+-		len -= cur;
+-	}
+-#endif
+-	return 0;
+-}
+-#endif
+-
+ #define DEBUG_LEVEL 3
+ static void pssl_debug(void *ctx, int level, const char *file, int line, const char *str)
+ {
+ 	(void)ctx;
+ 	(void)file;
+ 	(void)line;
+-    if (level <= DEBUG_LEVEL)
++	if (level <= DEBUG_LEVEL)
+ 		Log_info("mbedTLS [level %d]: %s", level, str);
+ }
+ 
+@@ -192,61 +115,31 @@ void SSLi_init(void)
+ {
+ 	int rc;
+ 
++	if (psa_crypto_init() != PSA_SUCCESS)
++		Log_fatal("psa_crypto_init failed");
++
+ 	initCert();
+ 	initKey();
+ 
+-	/* Initialize random number generator */
+-#ifdef USE_MBEDTLS_HAVEGE
+-	mbedtls_havege_init(&hs);
+-#else
+-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+-	psa_crypto_init();
+-#else
+-	mbedtls_ctr_drbg_init(&ctr_drbg);
+-	mbedtls_entropy_init(&entropy);
+-	mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0);
+-#endif
+-#else
+-	urandom_fd = open("/dev/urandom", O_RDONLY);
+-	if (urandom_fd < 0)
+-		Log_fatal("Cannot open /dev/urandom");
+-#endif
+-#endif
+-
+-	/* Initialize config */
+ 	conf = Memory_safeCalloc(1, sizeof(mbedtls_ssl_config));
+-
+ 	if (!conf)
+ 		Log_fatal("Out of memory");
+ 
+ 	mbedtls_ssl_config_init(conf);
+ 
+-	if((rc = mbedtls_ssl_config_defaults(conf,
++	if ((rc = mbedtls_ssl_config_defaults(conf,
+ 			MBEDTLS_SSL_IS_SERVER,
+ 			MBEDTLS_SSL_TRANSPORT_STREAM,
+ 			MBEDTLS_SSL_PRESET_DEFAULT)) != 0)
+ 		Log_fatal("mbedtls_ssl_config_defaults returned %d", rc);
+ 
+ 	mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+-#ifdef USE_MBEDTLS_HAVEGE
+-	mbedtls_ssl_conf_rng(conf, HAVEGE_RAND, &hs);
+-#else
+-	mbedtls_ssl_conf_rng(conf, urandom_bytes, NULL);
+-#endif
+ 	mbedtls_ssl_conf_dbg(conf, pssl_debug, NULL);
+-
+-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-	mbedtls_ssl_conf_min_version(conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+-#else
+-	mbedtls_ssl_conf_min_version(conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_1);
+-#endif
+-
+-	mbedtls_ssl_conf_ciphersuites(conf, (const int*)&ciphers);
+-
++	mbedtls_ssl_conf_min_tls_version(conf, MBEDTLS_SSL_VERSION_TLS1_2);
++	mbedtls_ssl_conf_ciphersuites(conf, (const int *)&ciphers);
+ 	mbedtls_ssl_conf_ca_chain(conf, &certificate, NULL);
+ 
+-	if((rc = mbedtls_ssl_conf_own_cert(conf, &certificate, &key)) != 0)
++	if ((rc = mbedtls_ssl_conf_own_cert(conf, &certificate, &key)) != 0)
+ 		Log_fatal("mbedtls_ssl_conf_own_cert returned %d", rc);
+ 
+ 	Log_info("Mbed TLS library initialized (version: %s)", MBEDTLS_VERSION_STRING);
+@@ -258,42 +151,24 @@ void SSLi_deinit(void)
+ 	free(conf);
+ 	mbedtls_x509_crt_free(&certificate);
+ 	mbedtls_pk_free(&key);
+-	
+-#ifdef USE_MBEDTLS_HAVEGE
+-	mbedtls_havege_free(&hs);
+-#else
+-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
+-	mbedtls_ctr_drbg_free(&ctr_drbg);
+-	mbedtls_entropy_free(&entropy);
+-#endif
+-#else
+-	close(urandom_fd);
+-#endif
+-#endif
++	mbedtls_psa_crypto_free();
+ }
+ 
+ bool_t SSLi_getSHA1Hash(SSL_handle_t *ssl, uint8_t *hash)
+ {
+ 	mbedtls_x509_crt const *cert;
++	size_t hash_length;
++
+ 	cert = mbedtls_ssl_get_peer_cert(ssl);
++	if (!cert)
++		return false;
+ 
+-	if (!cert) {
++	if (psa_hash_compute(
++		    PSA_ALG_SHA_1, cert->raw.p, cert->raw.len, hash,
++		    20, &hash_length) != PSA_SUCCESS)
+ 		return false;
+-	}
+-#if MBEDTLS_VERSION_NUMBER < 0x02070000L
+-	mbedtls_sha1(cert->raw.p, cert->raw.len, hash);
+-#elif MBEDTLS_VERSION_NUMBER < 0x03000000L
+-	mbedtls_sha1_ret(cert->raw.p, cert->raw.len, hash);
+-#elif !defined(MBEDTLS_USE_PSA_CRYPTO)
+-	mbedtls_sha1(cert->raw.p, cert->raw.len, hash);
+-#else
+-	size_t hash_length;
+-	mbedtls_psa_hash_compute(
+-		PSA_ALG_SHA_1, cert->raw.p, cert->raw.len, hash,
+-		20 /* client_t member uint8_t hash[20] */, &hash_length);
+-#endif
+-	return true;
++
++	return hash_length == 20;
+ }
+ 
+ SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready)
+@@ -305,7 +180,6 @@ SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready)
+ 
+ 	ssl = Memory_safeCalloc(1, sizeof(mbedtls_ssl_context));
+ 	ssn = Memory_safeCalloc(1, sizeof(mbedtls_ssl_session));
+-
+ 	if (!ssl || !ssn)
+ 		Log_fatal("Out of memory");
+ 
+@@ -313,7 +187,7 @@ SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready)
+ 	mbedtls_ssl_set_bio(ssl, fd, mbedtls_net_send, mbedtls_net_recv, NULL);
+ 	mbedtls_ssl_set_session(ssl, ssn);
+ 
+-	if((rc = mbedtls_ssl_setup(ssl, conf)) != 0)
++	if ((rc = mbedtls_ssl_setup(ssl, conf)) != 0)
+ 		Log_fatal("mbedtls_ssl_setup returned %d", rc);
+ 
+ 	return ssl;
+@@ -325,14 +199,12 @@ int SSLi_nonblockaccept(SSL_handle_t *ssl, bool_t *SSLready)
+ 
+ 	rc = mbedtls_ssl_handshake(ssl);
+ 	if (rc != 0) {
+-		if (rc == MBEDTLS_ERR_SSL_WANT_READ || rc == MBEDTLS_ERR_SSL_WANT_WRITE) {
++		if (rc == MBEDTLS_ERR_SSL_WANT_READ || rc == MBEDTLS_ERR_SSL_WANT_WRITE)
+ 			return 0;
+-		} else if (rc == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) { /* Allow this (selfsigned etc) */
++		if (rc == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED)
+ 			return 0;
+-		} else {
+-			Log_warn("SSL handshake failed: %d", rc);
+-			return -1;
+-		}
++		Log_warn("SSL handshake failed: %d", rc);
++		return -1;
+ 	}
+ 	*SSLready = true;
+ 	return 0;
+@@ -380,4 +252,3 @@ void SSLi_free(SSL_handle_t *ssl)
+ 	mbedtls_ssl_free(ssl);
+ 	free(ssl);
+ }
+-


### PR DESCRIPTION
> **DRAFT** — testing the upstream [umurmur PR #240](https://github.com/umurmur/umurmur/pull/240) ("Update to Mbed TLS 4.x and PSA Crypto API"). Not for publication; a follow-on to #7404's discussion with @th0ma7.

## Description

Tests whether uMurmur 0.4.1 can build against mbedtls 4.x using the upstream draft patch. mbedtls 4.x removed the legacy `mbedtls_sha1()` / HAVEGE APIs and moved headers; the patch rewrites the Mumble cert-fingerprint path to use the PSA Crypto API (`psa_hash_compute(PSA_ALG_SHA_1, ...)`), preserving Mumble client compatibility.

## Changes

- **Add `cross/mbedtls-4.2`** — an isolated mbedtls 4.2.0 package (TF-PSA-Crypto split: `libmbedtls`, `libmbedx509`, `libtfpsacrypto` + `libmbedcrypto` compat). Kept separate from `cross/mbedtls` (3.6.7) so `cross/curl` is unaffected.
- **Apply [upstream PR #240](https://github.com/umurmur/umurmur/pull/240)** as `cross/umurmur/patches/002-mbedtls-4x.patch` (source + CMake finder changes; Dockerfile changes excluded).
- **Point `cross/umurmur` at `cross/mbedtls-4.2`** for the test.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [ ] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [ ] Package update
