### PR TITLE
postgresql: fix build of libproj

### DIFF
--- a/cross/libproj/Makefile
+++ b/cross/libproj/Makefile
@@ -9,7 +9,7 @@ DEPENDS = cross/sqlite cross/libtiff cross/curl
 BUILD_DEPENDS = native/sqlite
 
 HOMEPAGE = https://proj.org/
-COMMENT = PROJ is a generic coordinate transformation software
+COMMENT = PROJ is a Cartographic Projections and Coordinate Transformations Library.
 LICENSE = MIT
 
 # PROJ uses CMake
@@ -18,5 +18,6 @@ CONFIGURE_ARGS += -DBUILD_TESTING=OFF
 CONFIGURE_ARGS += -DENABLE_CURL=ON
 CONFIGURE_ARGS += -DENABLE_TIFF=ON
 CONFIGURE_ARGS += -DEXE_SQLITE3=$(NATIVE_SQLITE_DIR)/bin/sqlite3
+CONFIGURE_ARGS += -DCURL_NO_CURL_CMAKE=ON
 
 include ../../mk/spksrc.cross-cmake.mk


### PR DESCRIPTION
## Description

- fix build of libproj for postgis (supported in postgresql with GCC > 5)
- fix to find curl libraries since curl is built with cmake (#7399)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
