### PR TITLE
postgresql: fix dependency definition

### DIFF
--- a/spk/postgresql/Makefile
+++ b/spk/postgresql/Makefile
@@ -4,6 +4,10 @@ SPK_REV = 5
 SPK_ICON = src/postgresql.png
 
 DEPENDS = cross/postgresql
+OPTIONAL_DEPENDS = cross/postgis cross/pgvector
+
+# libicu-74.2 (used for GCC < 5 / DSM 6) doesn't support ARMv5
+UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
 MAINTAINER = DigitalBox98
 DESCRIPTION = PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development. This package includes PostGIS and pgvector extensions for DSM 7+.
@@ -21,9 +25,6 @@ SERVICE_PORT_TITLE = PostgreSQL
 NO_SERVICE_SHORTCUT = 1
 
 include ../../mk/spksrc.common.mk
-
-# libicu-74.2 (used for GCC < 5 / DSM 6) doesn't support ARMv5
-UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
 
 # Use ICU archive data packaging to avoid runtime libicudata shared library
 # loading issues observed on DSM ARMv7 systems.


### PR DESCRIPTION
## Description

- add OPTIONAL_DEPENDS for postgis and pgvector
- found that postresql was not built when only libproj has changed (#7417)

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [ ] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
