### PR TITLE
Docs: Add patch creation guide

### DIFF
--- a/docs/developer-guide/basics/package-anatomy.md
+++ b/docs/developer-guide/basics/package-anatomy.md
@@ -40,7 +40,7 @@ cross/curl/
 ├── Makefile         # Build configuration
 ├── digests          # Checksums for source files
 ├── PLIST            # List of installed files (optional)
-└── patches/         # Source code patches (optional)
+└── patches/         # Source code patches (optional, see [Patches](../packaging/patches.md))
     └── 001-fix-something.patch
 ```
 

--- a/docs/developer-guide/package-types/python.md
+++ b/docs/developer-guide/package-types/python.md
@@ -17,9 +17,9 @@ third-party modules the application needs. Those modules are distributed as
   time and bundled into the SPK's `share/wheelhouse`.
 
 Most packages describe their wheels with plain `requirements-*.txt` files. The
-few wheels that the default `pip` build cannot handle (they need meson, patches,
-or other cross packages) live as standalone packages under `python/` and are
-pulled in with `DEPENDS += python/<module>`.
+few wheels that the default `pip` build cannot handle (they need meson,
+[patches](../packaging/patches.md), or other cross packages) live as standalone
+packages under `python/` and are pulled in with `DEPENDS += python/<module>`.
 
 ## Wheel types
 
@@ -43,7 +43,8 @@ limited API (`--py-limited-api`), producing a single wheel usable across Python
 
 **Exception wheels** are the hard cases the default `pip` build does not handle
 well — a wheel that must be built with **meson**, one that depends on other
-cross packages at build time, or one that needs patches. These live under
+cross packages at build time, or one that needs [patches](../packaging/patches.md).
+These live under
 `python/` (see [The `python/` tree](#the-python-tree-exception-wheels)); you
 never edit `requirements-cross.txt` by hand — the framework writes each
 `python/<module>` into it automatically.

--- a/docs/developer-guide/packaging/index.md
+++ b/docs/developer-guide/packaging/index.md
@@ -43,6 +43,7 @@ Tools built for the build host:
 
 - **[Makefile Variables](makefile-variables.md)** - Common variables and their meanings
 - **[Build Rules](build-rules.md)** - Build targets and customization
+- **[Patches](patches.md)** - When and how to create source patches
 - **[PLIST Files](plist.md)** - Defining package contents
 - **[Service Scripts](service-scripts.md)** - Daemons and services
 - **[Wizards](wizards.md)** - Installation wizards
@@ -140,7 +141,9 @@ cross/mypackage/
     └── 002-add-feature.patch
 ```
 
-Patches are applied in alphabetical order.
+Patches are applied in alphabetical order, so use numeric prefixes to fix the
+order. See **[Patches](patches.md)** for when to use a patch, naming
+conventions, and how to create one.
 
 ### Custom Build Steps
 

--- a/docs/developer-guide/packaging/patches.md
+++ b/docs/developer-guide/packaging/patches.md
@@ -1,0 +1,139 @@
+# Patches
+
+This page explains when and how to create source patches for spksrc packages.
+
+## When to Use a Patch
+
+A patch modifies the upstream source before it is configured and compiled.
+Prefer Makefile-level solutions first — a patch should only be used when the
+change cannot be expressed any other way:
+
+- Use `CONFIGURE_ARGS`, `ADDITIONAL_CFLAGS`, or other Makefile variables when the
+  project exposes the needed option
+- Set environment variables with `ENV` when the build honors them
+- Only fall back to a patch when the upstream code itself must change (a
+  cross-compilation fix, a missing include, a hardcoded path, etc.)
+
+Keeping the change in the Makefile documents *what* it does; a patch documents
+*how* the source was edited. Prefer the former when possible.
+
+## Location and Naming
+
+Patches live in the `patches/` directory of the package that owns the source:
+
+| Package type | Patch location |
+|--------------|----------------|
+| `cross/<pkg>/patches/` | For the library/tool's source |
+| `native/<pkg>/patches/` | For host-build tools |
+| `spk/<pkg>/patches/` | For files shipped with the SPK (scripts, config) |
+
+Name patches sequentially with a numeric prefix and a short description:
+
+```
+patches/
+├── 001-fix-cross-build.patch
+└── 002-add-feature.patch
+```
+
+The numeric prefix fixes the application order. Without it, patches are applied
+in alphabetical order, which is rarely what you want for related changes.
+
+## How Patches Are Discovered
+
+The framework auto-discovers patches from the package's `patches/` directory
+(in `mk/spksrc.build/patch.mk`):
+
+- `patches/*.patch` — applied for every architecture
+- `patches/kernel-<KERNEL>/*.patch` — for a specific kernel
+- `patches/DSM-<TCVERSION>/*.patch` and `patches/DSM-<major>/*.patch` — for a
+  specific DSM/SRM version
+- `patches/<arch>-<TCVERSION>/*.patch` and `patches/<arch>/*.patch` — for one
+  architecture
+- Group directories such as `patches/arm/`, `patches/x64/`,
+  `patches/armv7-<TCVERSION>/`, … — for an architecture group
+
+Use these subdirectories to keep generic fixes in `patches/` and
+architecture- or version-specific fixes in their matching subdirectory.
+
+You can also add explicit files from the Makefile:
+
+```makefile
+PATCHES += my-special.patch
+```
+
+## Patch Size
+
+Keep each patch small and self-contained — one logical change per patch. A
+large patch that mixes unrelated fixes is hard to review, hard to drop when
+upstream fixes part of it, and prone to conflicts on version bumps. If you find
+yourself writing a huge diff, split it into several numbered patches.
+
+## Patch Level
+
+Patches are applied with `patch -p$(PATCHES_LEVEL)`. The framework default is
+`PATCHES_LEVEL = 0`, which matches diffs generated with `diff -Naur` against
+the extracted source (as shown below). Do not override `PATCHES_LEVEL` unless
+you have a specific reason (for example, importing a patch from upstream that
+already uses `-p1` paths):
+
+```makefile
+PATCHES_LEVEL = 1
+```
+
+## Creating a Patch
+
+The following walks through creating a patch for `cross/mypackage`:
+
+### 1. Extract the source
+
+Build the package once so the source is extracted (the build will likely fail —
+that is fine):
+
+```bash
+cd cross/mypackage
+mkdir -p patches
+make clean
+make arch-x64-7.2
+```
+
+The extracted source is in `$(WORK_DIR)/$(PKG_DIR)`, e.g.
+`work-x64-7.2/mypackage-1.0.0/`.
+
+### 2. Edit the source
+
+Copy the file you need to change, edit the copy, then generate the diff:
+
+```bash
+cd work-x64-7.2/mypackage-1.0.0/
+cp src/build.c src/build.c.org
+# ... edit src/build.c with your changes ...
+diff -Naur src/build.c.org src/build.c > ../../patches/001-fix-cross-build.patch
+```
+
+`diff -Naur` produces a unified diff with no directory prefixes — exactly what
+`patch -p0` expects.
+
+### 3. Clean and test
+
+```bash
+cd ../..
+make clean
+make arch-x64-7.2
+```
+
+Confirm the build now succeeds and the behavior is correct. Keep `patches/`
+empty of anything that is not a patch (the `diff -Naur` target and `.org`
+backup files must not be committed).
+
+## Verifying Patches Apply Cleanly
+
+Before submitting a PR, ensure every patch applies without fuzz or offset
+warnings (the CI treats those as failures):
+
+```bash
+make clean
+make arch-x64-7.2
+```
+
+If a patch no longer applies after a source version bump, update it against the
+new extraction following the steps above.

--- a/docs/reference/makefile-reference.md
+++ b/docs/reference/makefile-reference.md
@@ -110,6 +110,8 @@ This is a comprehensive reference for all Makefile variables and targets in spks
 | `PRE_COMPILE_TARGET` | Target to run before compile |
 | `POST_COMPILE_TARGET` | Target to run after compile |
 | `DISABLE_PARALLEL_MAKE` | Set to 1 to disable parallel build |
+| `PATCHES` | Additional patch files to apply (in addition to the auto-discovered `patches/` ones) |
+| `PATCHES_LEVEL` | Patch level for `patch -p<level>` (default `0`; see [Patches](../developer-guide/packaging/patches.md)) |
 
 ### Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - developer-guide/packaging/index.md
       - Makefile Variables: developer-guide/packaging/makefile-variables.md
       - Build Rules: developer-guide/packaging/build-rules.md
+      - Patches: developer-guide/packaging/patches.md
       - PLIST Files: developer-guide/packaging/plist.md
       - Service Scripts: developer-guide/packaging/service-scripts.md
       - Wizards: developer-guide/packaging/wizards.md


### PR DESCRIPTION
## Description

Add a patch-creation guide to the developer documentation, closing #2664.

- **New**: `docs/developer-guide/packaging/patches.md` — when to use a patch (vs Makefile/config options), location and naming, patch ordering and the framework's auto-discovery (`patches/*.patch`, `kernel-*/`, `DSM-<ver>/`, arch-specific, and arch-group directories), keeping patches small and self-contained, `PATCHES_LEVEL` guidance (default `0`, matching `diff -Naur`), and a step-by-step creation walkthrough.
- **Cross-links**: added to the packaging index, the package-anatomy tree, the Python package-types page (exception wheels), and the Makefile reference (`PATCHES` / `PATCHES_LEVEL` in the Compilation table).
- **Nav**: `mkdocs.yml` packaging section entry.

Verified with `mkdocs build --strict` (no warnings or broken links).

Fixes #2664

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] This change requires a documentation update (e.g. [docs.synocommunity.com](https://docs.synocommunity.com))
