### PR TITLE
cairo and glib: gate on the toolchain, not the arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,10 +281,7 @@ jobs:
           add_dsm70_builds=${{ github.event.inputs.add_dsm70_builds || 'false' }}
           add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'false' }}
           add_dsm61_builds=${{ github.event.inputs.add_dsm61_builds || 'false' }}
-          # TEMP (revert before merge): activate DSM 5.2 so the archs these floors newly
-          # exclude are actually exercised. Every arch whose behaviour changes here is a
-          # 5.2 one; DSM 6.x and 7.x are untouched by this PR.
-          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'true' }}
+          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}
           add_srm13_builds=${{ github.event.inputs.add_srm13_builds || 'false' }}
           add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}
           add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'false' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,10 @@ jobs:
           add_dsm70_builds=${{ github.event.inputs.add_dsm70_builds || 'false' }}
           add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'false' }}
           add_dsm61_builds=${{ github.event.inputs.add_dsm61_builds || 'false' }}
-          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}
+          # TEMP (revert before merge): activate DSM 5.2 so the archs these floors newly
+          # exclude are actually exercised. Every arch whose behaviour changes here is a
+          # 5.2 one; DSM 6.x and 7.x are untouched by this PR.
+          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'true' }}
           add_srm13_builds=${{ github.event.inputs.add_srm13_builds || 'false' }}
           add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}
           add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'false' }}

--- a/cross/cairo-latest/Makefile
+++ b/cross/cairo-latest/Makefile
@@ -8,8 +8,11 @@ PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/libpng cross/freetype cross/pixman cross/fontconfig cross/glib
 
-# ERROR: Could not get define '__FLOAT_WORD_ORDER__'
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+# gcc only defines __FLOAT_WORD_ORDER__ from 4.8 on these toolchains; without it meson
+# stops at "Could not get define '__FLOAT_WORD_ORDER__'". Stated as a floor rather than an
+# arch list so a newer compiler lifts it, and so archs nobody tried are covered too:
+# x86-5.2 and x64-5.2 (4.7.3) lack the define just as ppc853x (4.3.7) does.
+MIN_GCC_VERSION = 4.8
 
 HOMEPAGE = https://www.cairographics.org
 COMMENT  = Cairo is a 2D graphics library with support for multiple output devices.

--- a/cross/cairo/Makefile
+++ b/cross/cairo/Makefile
@@ -5,10 +5,10 @@ OPTIONAL_DEPENDS += cross/cairo-1.16
 
 include ../../mk/spksrc.common.mk
 
-ifeq ($(findstring $(ARCH),$(OLD_PPC_ARCHS) $(ARMv5_ARCHS)),$(ARCH))
-DEPENDS = cross/cairo-1.16
-else
+ifeq ($(call version_ge, $(TC_GCC), 4.8),1)
 DEPENDS = cross/cairo-latest
+else
+DEPENDS = cross/cairo-1.16
 endif
 
 include ../../mk/spksrc.cross-virtual.mk

--- a/cross/glib-2.66/Makefile
+++ b/cross/glib-2.66/Makefile
@@ -11,7 +11,8 @@ HOMEPAGE = https://developer.gnome.org/glib/
 COMMENT  = General-purpose utility library.
 LICENSE  = LGPLv2.1+
 
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+# Only the 2008 PowerPC compiler (4.3.7) was ever excluded here; ARMv5's 4.6.4 builds it.
+MIN_GCC_VERSION = 4.6
 
 # https://docs.gtk.org/glib/building.html
 CONFIGURE_ARGS += -Dlibmount=disabled

--- a/cross/glib-latest/Makefile
+++ b/cross/glib-latest/Makefile
@@ -11,7 +11,10 @@ HOMEPAGE = https://developer.gnome.org/glib/
 COMMENT  = General-purpose utility library.
 LICENSE  = LGPLv2.1+
 
-UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS)
+# Only the 2008 PowerPC compiler (4.3.7) was ever excluded here. The real floor for
+# glib 2.84 is far higher -- cross/glib only ever selects it from gcc 7.5 -- but that
+# is the selector's business; this restates the exclusion that was here, nothing more.
+MIN_GCC_VERSION = 4.6
 
 # https://docs.gtk.org/glib/building.html
 CONFIGURE_ARGS += -Dgtk_doc=false -Dman=false

--- a/cross/glib/Makefile
+++ b/cross/glib/Makefile
@@ -10,7 +10,7 @@ include ../../mk/spksrc.common.mk
 ifeq ($(call version_ge, $(TC_KERNEL), 3.2)$(call version_ge, $(TC_GCC), 7.5),11)
 DEPENDS = cross/glib-latest
 else
-ifneq ($(findstring $(ARCH),$(OLD_PPC_ARCHS)),$(ARCH))
+ifeq ($(call version_ge, $(TC_GCC), 4.6),1)
 DEPENDS = cross/glib-2.66
 else
 # old compilers do not support glib with meson build

--- a/cross/libmaxminddb/Makefile
+++ b/cross/libmaxminddb/Makefile
@@ -13,10 +13,15 @@ LICENSE  = Apache-2.0
 
 GNU_CONFIGURE = 1
 
-# define missing MAP_ANONYMOUS for older gcc (for test functions in libtap only)
-ifneq ($(findstring $(ARCH), 88f6281 ppc853x),)
+include ../../mk/spksrc.common.mk
+
+# The bundled libtap uses MAP_ANONYMOUS, which the glibc headers shipped with the
+# pre-4.8 toolchains only expose under _DEFAULT_SOURCE -- and libmaxminddb builds
+# with -std=c99, which turns that off. Keyed on the compiler rather than an arch
+# list so x86-5.2 and x64-5.2 (gcc 4.7.3) are covered too; they failed the same
+# way on "MAP_ANONYMOUS undeclared" and were simply never built.
+ifeq ($(call version_lt,$(TC_GCC),4.8),1)
 ADDITIONAL_CFLAGS = -DMAP_ANONYMOUS=0x20
 endif
-
 
 include ../../mk/spksrc.cross-cc.mk

--- a/cross/libzmq/Makefile
+++ b/cross/libzmq/Makefile
@@ -12,6 +12,14 @@ HOMEPAGE = https://zeromq.org/
 COMMENT  = ZeroMQ (also known as ØMQ, 0MQ, or zmq) looks like an embeddable networking library but acts like a concurrency framework. It gives you sockets that carry atomic messages across various transports like in-process, inter-process, TCP, and multicast. 
 LICENSE  = GPLv3
 
+include ../../mk/spksrc.common.mk
+
+# CMakeLists.txt adds -std=c++11 once the compiler merely ACCEPTS the flag: gcc 4.7 does,
+# without implicit noexcept on destructors. Pin it instead -- 4.6 and older already build.
+ifeq ($(call version_lt,$(TC_GCC),4.8),1)
+ADDITIONAL_CXXFLAGS += -std=gnu++98
+endif
+
 include ../../mk/spksrc.cross-cmake.mk
 
 # Flags to be added to CMake toolchain file

--- a/cross/m4/patches/001-in-function-pragma-needs-gcc-4.6.patch
+++ b/cross/m4/patches/001-in-function-pragma-needs-gcc-4.6.patch
@@ -1,0 +1,32 @@
+Guard the in-function diagnostic pragmas with the right gcc version.
+
+format.c wraps its xasprintf calls in `#pragma GCC diagnostic push/ignored/pop`
+to silence -Wformat-nonliteral, guarded by _GL_GNUC_PREREQ (4, 3). gcc accepted
+`#pragma GCC diagnostic` at file scope from 4.2, but only gained push/pop and
+in-function placement in 4.6, so 4.3 to 4.5 reject it outright:
+
+  format.c:355: error: #pragma GCC diagnostic not allowed inside functions
+
+Raise the guard to 4.6. On ppc853x-5.2 (gcc 4.3.7) the pragmas are then skipped
+along with the warning they suppress; every other toolchain is unaffected.
+
+--- src/format.c
++++ src/format.c
+@@ -351,7 +351,7 @@
+       *p = '\0';
+ 
+       /* Our constructed format string in fstart is safe.  */
+-#if _GL_GNUC_PREREQ (4, 3) || defined __clang__
++#if _GL_GNUC_PREREQ (4, 6) || defined __clang__
+ # pragma GCC diagnostic push
+ # pragma GCC diagnostic ignored "-Wformat-nonliteral"
+ #endif
+@@ -381,7 +381,7 @@
+         default:
+           abort ();
+         }
+-#if _GL_GNUC_PREREQ (4, 3) || defined __clang__
++#if _GL_GNUC_PREREQ (4, 6) || defined __clang__
+ # pragma GCC diagnostic pop
+ #endif
+ 

--- a/spk/ntopng/Makefile
+++ b/spk/ntopng/Makefile
@@ -8,6 +8,7 @@ DEPENDS = cross/ntopng
 SPK_DEPENDS = "redis"
 
 UNSUPPORTED_ARCHS = $(OLD_PPC_ARCHS) $(ARMv5_ARCHS)
+REQUIRED_MIN_DSM = 6
 
 MAINTAINER = hgy59
 DESCRIPTION = High-Speed Web-based Traffic Analysis and Flow Collection. ntopng is a network traffic probe that provides 360° Network visibility, with its ability to gather traffic information from traffic mirrors, NetFlow exporters, SNMP devices, Firewall logs, Intrusion Detection systems.  To run ntopng on DSM 7, the installed privileges file must be manually patched after installation or update.


### PR DESCRIPTION
Split out of #7397, which was doing too much at once. This half is `cairo` and `glib`; the other half — the meson `c_std` overrides, the `openexr` / `pngquant3` floors, the `ffmpeg5` / `ffmpeg6` floors, the tvheadend ffmpeg bump and the `libsrt` / `svt-hevc` / `ffmpeg4` DSM 5.2 work — stays in #7397 and will rebase onto this once it lands.

Groundwork for #7391. These packages refused work by naming architectures. The reason was never the architecture — it was the compiler those architectures happen to ship — and an arch list cannot be lifted by a newer compiler, which is exactly what `OVERLAY_GCC` will offer.

| package | was | now |
|---|---|---|
| `cairo-latest` | `$(OLD_PPC_ARCHS) $(ARMv5_ARCHS)` | `MIN_GCC_VERSION = 4.8` |
| `glib-2.66` | `$(OLD_PPC_ARCHS)` | `MIN_GCC_VERSION = 4.6` |
| `glib-latest` | `$(OLD_PPC_ARCHS)` | `MIN_GCC_VERSION = 4.6` |

The two virtuals, `cross/cairo` and `cross/glib`, now pick their version by comparing `TC_GCC` instead of matching an architecture, so the selection follows the same line the floors draw.

## Where 4.8 comes from

Measured on the Synology toolchains rather than taken from upstream gcc release notes. Core C++11 — `unique_ptr` brace-init, `std::mutex`, lambdas, `-std=c++11`:

```
gcc 4.3.7  no      gcc 4.6.4  no      gcc 4.7.3  no      gcc 4.8.3  yes      gcc 4.9.3  yes
```

cairo's `__FLOAT_WORD_ORDER__` follows the same line — absent on 4.3.7 and 4.7.3, present from 4.8, and without it meson stops at *"Could not get define '__FLOAT_WORD_ORDER__'"*.

4.6 is where the two glib packages already sat: only the 2008 PowerPC compiler was excluded, ARMv5's 4.6.4 builds them. `glib-latest`'s real requirement is far higher — `cross/glib` only ever selects it from gcc 7.5 — but that is the selector's business; the floor here restates the exclusion that was there, nothing more.

## Blast radius

No architecture is freed. Every newly excluded one is a DSM 5.2 arch below the floor:

```
alpine  armada370  armada375  armadaxp  avoton  braswell  bromolow
cedarview  comcerto2k  evansport  qoriq  x64  x86         (all -5.2, gcc 4.3.7 … 4.7.3)
```

They were never named because DSM 5.2 is not built in CI, so nobody hit them. DSM 6.x and 7.x are untouched.

`build.yml` turns DSM 5.2 on temporarily so CI exercises exactly those archs. **That commit reverts before merge.**

## The DSM 5.2 commit

Switching 5.2 on surfaced three failures the 5.2 toolchains have carried for as long as CI has not built them. None is about a capability floor; they are here because nothing else in this branch can be exercised on 5.2 until they are fixed. Each is verified by an actual build, not by inspection.

- **`cross/m4`** (ppc853x-5.2, gcc 4.3.7) — `format.c` guards its in-function `#pragma GCC diagnostic push/ignored/pop` with `_GL_GNUC_PREREQ (4, 3)`. gcc took `#pragma GCC diagnostic` at file scope from 4.2 but only allowed push/pop *inside a function* from 4.6, so 4.3 stops at *"#pragma GCC diagnostic not allowed inside functions"*. Patched to ask for 4.6. Verified: `cross/m4` builds for ppc853x-5.2.
- **`cross/libmaxminddb`** (x86-5.2 and x64-5.2, gcc 4.7.3) — the bundled libtap needs `MAP_ANONYMOUS`, which the pre-4.8 toolchains' headers only expose under `_DEFAULT_SOURCE`, and the package compiles with `-std=c99`, which turns that off. The `-DMAP_ANONYMOUS=0x20` workaround was already there, behind an arch list naming `88f6281 ppc853x`; x86 and x64 at 5.2 need it just as much and were simply never built. Keyed on `gcc < 4.8` instead, which is exactly those four toolchains and nothing else — the same substitution this PR makes everywhere else. Verified: `cross/libmaxminddb` builds for x86-5.2.
- **`spksrc.spk-meta/videodriver.mk`** (x86-5.2) — the meta is selected by architecture alone, and `x64_ARCHS` contains the 5.2 archs, so every consumer pulled `spk/synocli-videodriver` into `spk-stage1` on DSM 5.2, where that package can only stop at *"DSM Toolchain 5.2 is lower than 6.2.4"*, failing the consumer with it (`ffmpeg6` did). `synocli-videodriver` declares `REQUIRED_MIN_DSM = 6.2.4`; the selector now asks for the same. Verified: `ffmpeg6` `spk-stage1` pulls no meta at x86-5.2 and still pulls it at apollolake-7.1.

## About the `-7.1` builds

Touching `cross/glib` selects 21 SPK packages, and the four slowest DSM 7.1 archs do not finish them inside the 20700 s build budget. Those jobs report `ERRORS: none` and a partial build, not a failure — the same signature as #7399 and #7412, both merged that way. Splitting does not help here: `cairo`'s package set is a subset of `glib`'s, so this half is 21 packages however it is sliced.

## ffmpeg5 and ffmpeg6

Both `cross/` and `spk/` Makefiles carried

```
# requires c11 and proper atomic using gcc-4.9+ support
UNSUPPORTED_ARCHS = $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(OLD_PPC_ARCHS)
```

— a comment naming 4.9 above a list that does not say 4.9. `ffmpeg7` and `ffmpeg8` already declare `MIN_GCC_VERSION = 4.9`; all four versions now express it the same way.

Nothing is freed: every arch the list named is below 4.9 at every DSM it has a toolchain for (88f6281 4.6.4, hi3535 4.8.3, ppc853x 4.3.7), and `powerpc`, `ppc824x`, `ppc854x` have no toolchain at all. What the floor adds is the fourteen toolchains the list silently admitted — `qoriq-5.2` 4.3.7, `evansport-5.2` 4.6.3, `alpine/armada370/armada375/armadaxp/comcerto2k-5.2` 4.6.4, `avoton/braswell/bromolow/cedarview/x64/x86-5.2` 4.7.3, `monaco-5.2` 4.8.3. All DSM 5.2, all below the stated requirement, none ever built. `qoriq` is the one that could have been hit outside 5.2: it is a PowerPC arch but not in `OLD_PPC_ARCHS`, so the list never covered it.

This lands here rather than separately because the videodriver-meta fix lets `ffmpeg6` get past `spk-stage1` on x86-5.2, where it would then reach the compiler its own comment says it cannot use.

## Also carried here

Two commits shared with #7397, because `cross/ntopng` depends on `cross/glib` and so lands in this PR's package set too:

- **`libzmq`** pins `-std=gnu++98` below gcc 4.8. `CMakeLists.txt` adds `-std=c++11` as soon as the compiler *accepts* the flag; gcc 4.7 accepts it without giving destructors their implicit `noexcept`, so x86-5.2 and x64-5.2 failed on *"looser throw specifier"*. An override rather than a floor: 4.6 and older build this package today and keep building it.
- **`ntopng`** declares `REQUIRED_MIN_DSM = 6` — its installation services are not compatible with DSM 5.

Both are identical to the commits in #7397 and will be absorbed when that branch rebases onto this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBhJxRTbjD6HWSEjzE41g

