### PR TITLE
archs: keep toolchain overlay consumers out of the architecture lists

### DIFF
--- a/mk/spksrc.common/archs.mk
+++ b/mk/spksrc.common/archs.mk
@@ -29,7 +29,16 @@
 ###############################################################################
 
 # Available toolchains formatted as '{ARCH}-{TC}'
-AVAILABLE_TOOLCHAINS = $(subst syno-,,$(filter-out %-rust,$(sort $(notdir $(wildcard $(BASEDIR)/toolchain/syno-*)))))
+#
+# A toolchain OVERLAY CONSUMER (syno-<arch>-<dsm>_<component>-<vers>) lives beside the
+# base toolchains but is not one: it installs a compiler component, and nothing can be
+# built "for" it. It is told apart by the '_' in its name, which no base toolchain has --
+# the same rule the consumer generators use. The '%-rust' filter this replaces was
+# written for an earlier naming and matches none of the current directories, so every
+# consumer was reaching SUPPORTED_ARCHS and 'make all-supported' was emitting a
+# supported-arch-<consumer-dir> target for each.
+_AVAILABLE_TC_DIRS = $(sort $(notdir $(wildcard $(BASEDIR)/toolchain/syno-*)))
+AVAILABLE_TOOLCHAINS = $(subst syno-,,$(foreach d,$(_AVAILABLE_TC_DIRS),$(if $(findstring _,$(d)),,$(d))))
 AVAILABLE_TCVERSIONS = $(sort $(foreach arch,$(AVAILABLE_TOOLCHAINS),$(shell echo ${arch} | cut -f2 -d'-')))
 
 # Available toolchains formatted as '{ARCH}-{TC}'


### PR DESCRIPTION
`AVAILABLE_TOOLCHAINS` globs `toolchain/syno-*` and filters out `%-rust`. That pattern was written for an earlier naming and matches **none** of the overlay consumer directories #7353 settled on, so every one of them reaches the architecture lists.

## On master today, in any package

```
$ make all-supported
... supported-arch-88f6281-5.2_binutils-2.30_gcc-4.6.4
    supported-arch-88f6281-5.2_rust-1.82_gcc-4.6.4
    supported-arch-88f6281-6.2.4_binutils-2.30_gcc-4.6.4
    supported-arch-88f6281-6.2.4_rust-1.82_gcc-4.6.4
    supported-arch-qoriq-6.2.4_binutils-2.30_gcc-4.9.3
    supported-arch-qoriq-6.2.4_rust-1.82_gcc-4.9.3
```

`build-arch-%` splits those on `-`, so it builds `ARCH=88f6281` against `TCVERSION=4.6.4`, a toolchain that does not exist.

`LATEST_ARCHS` comes out worse, because it also splits on `.`: the affected archs lose their real entry entirely, leaving `88f6281-4.6.4`, `qoriq-4.9.3`, a bare `4.6.4` and `88f6281.52_binutils.230_gcc-`. `AVAILABLE_TCVERSIONS` gains `5.2_binutils` and `6.2.4_rust`.

## The fix

A consumer is told apart by the `_` in its name — no base toolchain has one, and it is the same rule `native/binutils-2.30`'s and `native/rustc-1.82`'s consumer generators already use (`case "$base" in *_*) continue ;;`).

## Verified against master

| | change |
|---|---|
| `AVAILABLE_TOOLCHAINS` | loses exactly the ten consumer directories, nothing else |
| `SUPPORTED_ARCHS` | loses exactly the six it had, nothing else |
| `LEGACY_ARCHS` | loses exactly the ten, nothing else |
| `LATEST_ARCHS` | regains `88f6281-6.2.4` and `qoriq-6.2.4`; the mangled entries go |
| `AVAILABLE_TCVERSIONS` | loses `5.2_binutils`, `5.2_rust`, `6.2.4_binutils`, `6.2.4_rust` |
| `ARCHS_WITH_GENERIC_SUPPORT` | unchanged |

## Why now

It is a live bug on `master` — six phantom targets today — but it also scales. #7391 adds **121** more consumer directories, taking the total from 10 to 131.

Verified against that branch's actual tree, applying this PR's expression to its 332 `toolchain/` directories:

```
master's filter (%-rust)   332 entries   <- 131 of them are not architectures
this PR's filter ('_')     201 entries   <- exactly the base toolchains
```

Tight in both directions: no consumer survives the filter, and no real toolchain is rejected. The three naming forms #7391 introduces all carry the separator —

```
syno-<arch>-<dsm>_binutils-2.30
syno-<arch>-<dsm>_gcc-8.5
syno-<arch>-<dsm>_rust-1.82_gcc-4.6.4
```

— and no base toolchain contains an underscore. #7391 does not touch `archs.mk`, so the two do not conflict in either merge order.

Split out of #7391 so it can land on its own; it is effectively a prerequisite for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd