### PR TITLE
toolchain: link librt and libatomic instead of discarding them

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -165,14 +165,6 @@ for package in ${GH_DEPENDENCY_FOLDERS}; do
     SPK_TO_BUILD+=" ${found}"
 done
 
-# Fix for packages with different names
-if [ "$(echo "${SPK_TO_BUILD}" | grep -o ' nzbdrone ')" != "" ]; then
-    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "^nzbdrone$" | tr '\n' ' ')" sonarr3"
-fi
-if [ "$(echo "${SPK_TO_BUILD}" | grep -o ' python ')" != "" ]; then
-    SPK_TO_BUILD=$(echo "${SPK_TO_BUILD}" | tr ' ' '\n' | grep -v "^python$" | tr '\n' ' ')" python2"
-fi
-
 # Remove duplicate packages
 packages=$(printf '%s' "${SPK_TO_BUILD}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,9 @@ jobs:
           add_dsm70_builds=${{ github.event.inputs.add_dsm70_builds || 'false' }}
           add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'false' }}
           add_dsm61_builds=${{ github.event.inputs.add_dsm61_builds || 'false' }}
-          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}
+          # TEMP (revert before merge): DSM 5.2 carries ppc853x-5.2 and 88f6281-5.2,
+          # the toolchains below glibc 2.17 that this PR's -lrt correction is tested on.
+          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'true' }}
           add_srm13_builds=${{ github.event.inputs.add_srm13_builds || 'false' }}
           add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}
           add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'false' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,9 +281,7 @@ jobs:
           add_dsm70_builds=${{ github.event.inputs.add_dsm70_builds || 'false' }}
           add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'false' }}
           add_dsm61_builds=${{ github.event.inputs.add_dsm61_builds || 'false' }}
-          # TEMP (revert before merge): DSM 5.2 carries ppc853x-5.2 and 88f6281-5.2,
-          # the toolchains below glibc 2.17 that this PR's -lrt correction is tested on.
-          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'true' }}
+          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}
           add_srm13_builds=${{ github.event.inputs.add_srm13_builds || 'false' }}
           add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}
           add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'false' }}

--- a/cross/ffmpeg4/Makefile
+++ b/cross/ffmpeg4/Makefile
@@ -180,11 +180,6 @@ CONFIGURE_ARGS += --enable-libspeex
 
 DEPENDS += cross/libsrt
 CONFIGURE_ARGS += --enable-libsrt
-# clock_gettime is in librt until glibc 2.17 and libsrt.so does not declare it; the -lrt
-# from TC_EXTRA_LDFLAGS sits inside --as-needed, too early for ld to keep it.
-ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
-CONFIGURE_ARGS += --extra-ldflags="-lrt"
-endif
 
 DEPENDS += cross/flac
 DEPENDS += cross/libtheora

--- a/cross/ffmpeg5/Makefile
+++ b/cross/ffmpeg5/Makefile
@@ -144,11 +144,6 @@ CONFIGURE_ARGS += --enable-libspeex
 
 DEPENDS += cross/libsrt
 CONFIGURE_ARGS += --enable-libsrt
-# clock_gettime is in librt until glibc 2.17 and libsrt.so does not declare it; the -lrt
-# from TC_EXTRA_LDFLAGS sits inside --as-needed, too early for ld to keep it.
-ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
-CONFIGURE_ARGS += --extra-ldflags="-lrt"
-endif
 
 DEPENDS += cross/flac
 DEPENDS += cross/libtheora

--- a/cross/ffmpeg6/Makefile
+++ b/cross/ffmpeg6/Makefile
@@ -150,11 +150,6 @@ CONFIGURE_ARGS += --enable-libspeex
 
 DEPENDS += cross/libsrt
 CONFIGURE_ARGS += --enable-libsrt
-# clock_gettime is in librt until glibc 2.17 and libsrt.so does not declare it; the -lrt
-# from TC_EXTRA_LDFLAGS sits inside --as-needed, too early for ld to keep it.
-ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
-CONFIGURE_ARGS += --extra-ldflags="-lrt"
-endif
 
 DEPENDS += cross/flac
 DEPENDS += cross/libtheora

--- a/cross/ffmpeg7/Makefile
+++ b/cross/ffmpeg7/Makefile
@@ -163,11 +163,6 @@ CONFIGURE_ARGS += --enable-libspeex
 
 DEPENDS += cross/libsrt
 CONFIGURE_ARGS += --enable-libsrt
-# clock_gettime is in librt until glibc 2.17 and libsrt.so does not declare it; the -lrt
-# from TC_EXTRA_LDFLAGS sits inside --as-needed, too early for ld to keep it.
-ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
-CONFIGURE_ARGS += --extra-ldflags="-lrt"
-endif
 
 DEPENDS += cross/flac
 DEPENDS += cross/libtheora

--- a/cross/ffmpeg8/Makefile
+++ b/cross/ffmpeg8/Makefile
@@ -163,11 +163,6 @@ CONFIGURE_ARGS += --enable-libspeex
 
 DEPENDS += cross/libsrt
 CONFIGURE_ARGS += --enable-libsrt
-# clock_gettime is in librt until glibc 2.17 and libsrt.so does not declare it; the -lrt
-# from TC_EXTRA_LDFLAGS sits inside --as-needed, too early for ld to keep it.
-ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
-CONFIGURE_ARGS += --extra-ldflags="-lrt"
-endif
 
 DEPENDS += cross/flac
 DEPENDS += cross/libtheora

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -59,8 +59,10 @@ If you only read one thing, read this. The details are in the dated log below.
   once in **`TC_EXTRA_BUILD_FLAGS`**; the framework folds it into every
   `TC_EXTRA_<LANG>FLAGS` and the link, so C, C++, Fortran and the linker all
   agree on the ABI. Link-time libraries (`-lrt`, `-latomic`) live in
-  **`TC_EXTRA_LDFLAGS`**, `-latomic` auto-dropped where the gcc lacks it and both
-  linked `--as-needed` so a binary depends on them only when it truly uses them.
+  **`TC_EXTRA_LDFLAGS`** and are passed plainly, with `-latomic` auto-dropped
+  where the gcc lacks it. They are *not* wrapped in `--as-needed`: `LDFLAGS`
+  precedes the objects, so a front-placed library there resolves nothing yet and
+  the wrap discarded it outright.
   See [Extra flags a toolchain can declare](../framework/toolchain.md#extra-flags-a-toolchain-can-declare).
 
 - **Build a host tool once, host it, reuse it.** A native package hosts its build
@@ -80,6 +82,62 @@ If you only read one thing, read this. The details are in the dated log below.
   shows which are active for your arch.
 
 ---
+
+??? note "September 4th 2026 — Link librt and libatomic instead of discarding them (#7433)"
+    - **What:** `TC_EXTRA_LDFLAGS` no longer wraps `-lrt` / `-latomic` in
+      `-Wl,--as-needed ... -Wl,--no-as-needed`:
+
+        ```makefile
+        TC_EXTRA_LDFLAGS = $(TC_EXTRA_BUILD_FLAGS) $(_tc_ld_syslibs)
+        ```
+
+    - **Why:** `--as-needed` keeps a library only if it resolves a symbol that is
+      *already* undefined when the linker reaches it. `LDFLAGS` is placed **before**
+      the objects and libraries being linked, so nothing is undefined yet and the
+      bracketed `-lrt` was dropped every time. The declaration introduced by #7314
+      was therefore inert — measurably identical to declaring nothing:
+
+        ```
+        -Wl,--as-needed -lrt -Wl,--no-as-needed ... -lsrt
+            -> undefined reference to `clock_gettime'
+        (nothing declared at all)              ... -lsrt
+            -> undefined reference to `clock_gettime'
+        -lrt                                   ... -lsrt
+            -> links, DT_NEEDED librt
+        ```
+
+    - **How it surfaced:** on glibc &lt; 2.17 toolchains (`ppc853x-5.2`,
+      `88f6281-5.2`, `88f6281-6.1`), `libsrt.so` calls `clock_gettime` without
+      declaring it. ffmpeg reported the resulting link failure as
+      `ERROR: srt >= 1.3.0 not found using pkg-config`, which reads as a missing
+      dependency rather than a missing library.
+    - **Package-facing:** the five per-package workarounds it forced are gone —
+      `cross/ffmpeg4` through `cross/ffmpeg8` each carried
+
+        ```makefile
+        ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
+        CONFIGURE_ARGS += --extra-ldflags="-lrt"
+        endif
+        ```
+
+      to put back what the toolchain had already declared. A package should not have
+      to re-declare a toolchain library; if you have such a workaround, drop it.
+    - **Cost:** one `DT_NEEDED` entry on binaries that never call into `librt` or
+      `libatomic`. Both are part of the toolchain's own runtime and present on every
+      target that ships them.
+    - **Also in this PR:** `dependency-list` now keys its output on the package
+      **folder** instead of `$(NAME)`. Three packages set `SPK_NAME` to something
+      else — `spk/ffmpeg4` (`ffmpeg`), `spk/mkvtoolnix_22` (`mkvtoolnix`),
+      `spk/mono_58` (`mono`) — while every consumer of the list already looked the
+      key up as a directory (`.github/actions/prepare.sh`, `spk-meta/base.mk`). The
+      three silently fell out of the CI build matrix, and the latter two collided
+      with the `mkvtoolnix` / `mono` folders that still exist beside them. This is
+      the rule `SPK_FOLDER` already states in `spksrc.rules/pre-check.mk`. The
+      hand-maintained fixup list in `prepare.sh` (`nzbdrone -> sonarr3`,
+      `python -> python2`, both stale) is removed with it.
+    - Documented in
+      [Extra flags a toolchain can declare](../framework/toolchain.md#extra-flags-a-toolchain-can-declare).
+    - Pull request: [#7433](https://github.com/SynoCommunity/spksrc/pull/7433)
 
 ??? note "August 17th 2026 — Custom from-source Rust toolchains, and the overlay family (#7353)"
     - **What:** the archs `rustup` ships no usable prebuilt `rust-std` for now build
@@ -213,7 +271,9 @@ If you only read one thing, read this. The details are in the dated log below.
       `gcc -print-file-name=libatomic.so`. Both are wrapped in
       `-Wl,--as-needed ... -Wl,--no-as-needed` so, now that they are declared
       toolchain-wide, a binary records a `librt` / `libatomic` dependency only when
-      it truly references one.
+      it truly references one. **The wrap was removed in #7433** — see the
+      September 4th 2026 entry: it discarded both libraries instead of pruning
+      them.
     - **Why:** passing the ABI only through `CFLAGS` silently built C++ / Fortran
       objects with a different ABI than the C they link against, and the rt/atomic
       arch lists had to be rechecked by hand each time a toolchain moved.

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -135,6 +135,15 @@ If you only read one thing, read this. The details are in the dated log below.
       the rule `SPK_FOLDER` already states in `spksrc.rules/pre-check.mk`. The
       hand-maintained fixup list in `prepare.sh` (`nzbdrone -> sonarr3`,
       `python -> python2`, both stale) is removed with it.
+    - **Confirmed:** with DSM 5.2 switched on for the run, `cross/ffmpeg4` -- the only
+      package in the tree with no `MIN_GCC_VERSION`, and so the only one that reaches
+      a pre-2.17 toolchain -- built on both, with its workaround removed:
+
+        ```
+        ffmpeg4: (ppc853x-5.2) DONE      glibc 2.8, gcc 4.3.7
+        ffmpeg4: (88f6281-5.2) DONE      glibc 2.15, gcc 4.6.4
+        ```
+
     - Documented in
       [Extra flags a toolchain can declare](../framework/toolchain.md#extra-flags-a-toolchain-can-declare).
     - Pull request: [#7433](https://github.com/SynoCommunity/spksrc/pull/7433)

--- a/docs/framework/toolchain.md
+++ b/docs/framework/toolchain.md
@@ -95,13 +95,21 @@ instead, and so never needs the library — and handing `-latomic` to such a gcc
 fatal *"cannot find -latomic"*. A toolchain lists `-latomic` in its
 `TC_EXTRA_LDFLAGS`; the framework drops it where it would not resolve.
 
-Because these libraries are declared toolchain-wide, they reach every link even
-though most binaries call neither `clock_gettime` nor an atomic builtin. The
-framework therefore wraps them in `-Wl,--as-needed ... -Wl,--no-as-needed`, so the
-linker records a `librt` / `libatomic` dependency only where the objects actually
-reference a symbol it provides. The wrap is scoped to just these two libraries —
-it restores the default immediately after — so it never drops a package library
-that is present only for its side effects.
+These libraries are declared toolchain-wide, so they reach every link even though
+most binaries call neither `clock_gettime` nor an atomic builtin. They are
+nonetheless passed **plainly**, not wrapped in `-Wl,--as-needed`.
+
+`--as-needed` keeps a library only if, *at the point the linker sees it*, it
+resolves an already-undefined symbol. `LDFLAGS` is placed **before** the objects
+and libraries being linked, so at that point nothing is undefined yet: a
+front-placed `-lrt` inside an `--as-needed` bracket is always discarded, and a
+later `-lsrt` that needs `clock_gettime` then fails with *undefined reference*.
+The wrap was therefore not a refinement of the declaration but a silent deletion
+of it — exactly equivalent to declaring nothing at all.
+
+Linking them plainly costs one `DT_NEEDED` entry on binaries that do not call
+into them. That is the correct trade: `librt` and `libatomic` are part of the
+toolchain's own runtime and are present on every target that has them.
 
 ## tc_vars Files
 

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -353,11 +353,14 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 # by DEPENDS_TYPE. Delegates to dependency-flat for traversal and filtering.
 # ARCH and TCVERSION are forwarded so the correct dependency graph is used.
 # Output format:
-#     $(NAME): cross/foo cross/bar native/baz ...
+#     <folder>: cross/foo cross/bar native/baz ...
+# The key is the directory name, not $(NAME): CI keys its build matrix on
+# folders (see SPK_FOLDER in spksrc.rules/pre-check.mk), and a handful of
+# packages set SPK_NAME to something else -- spk/ffmpeg4 is SPK_NAME=ffmpeg.
 # -------------------------------------------------------------------
 .PHONY: dependency-list
 dependency-list:
-	@echo -n "$(NAME): "
+	@echo -n "$(notdir $(CURDIR)): "
 	@$(MAKE) -s \
 	    $(if $(ARCH),ARCH=$(ARCH)) \
 	    $(if $(TCVERSION),TCVERSION=$(TCVERSION)) \

--- a/mk/spksrc.toolchain/tc-flags.mk
+++ b/mk/spksrc.toolchain/tc-flags.mk
@@ -76,16 +76,29 @@ endif
 # copy: TC_HAS_LIBATOMIC runs the compiler, not extracted yet while the
 # toolchain is being parsed.
 #
-# These libs are declared toolchain-wide now, not per package, so they would land on
-# every link -- yet most binaries call neither clock_gettime nor an atomic builtin.
-# Wrap them in -Wl,--as-needed so the linker records a librt/libatomic dependency
-# only where the objects actually reference a symbol it provides, and -Wl,--no-as-needed
-# restores the default right after: the policy change is scoped to these two libs and
-# never drops a package library kept only for its side effects.
-_tc_comma := ,
+# These libs are declared toolchain-wide, not per package, so they land on every link --
+# yet most binaries call neither clock_gettime nor an atomic builtin. They used to be
+# wrapped in -Wl,--as-needed ... -Wl,--no-as-needed to record a librt/libatomic
+# dependency only where the objects reference one.
+#
+# That cannot work from here. LDFLAGS precedes the objects on every link line, and
+# --as-needed keeps a library only if it resolves a symbol that is ALREADY undefined
+# where the linker sees it. At the front of the line no object has been read yet, so
+# nothing is undefined and the libraries are always discarded -- measured identical to
+# passing nothing at all:
+#
+#   -Wl,--as-needed -lrt -Wl,--no-as-needed  ... -lsrt   undefined reference to clock_gettime
+#   (nothing)                                ... -lsrt   undefined reference to clock_gettime
+#   -lrt                                     ... -lsrt   links, DT_NEEDED librt
+#
+# So the bracket is dropped and the libraries are linked outright. The cost is a
+# DT_NEEDED that may go unused on the archs whose toolchain declares one; both librt and
+# libatomic ship with the glibc already on the device, so an unused entry costs a mapping
+# and nothing else -- against a link that fails outright, or a package carrying its own
+# workaround to put the library back.
 _TC_EXTRA_LDFLAGS := $(TC_EXTRA_LDFLAGS)
 _tc_ld_syslibs = $(if $(TC_HAS_LIBATOMIC),$(_TC_EXTRA_LDFLAGS),$(filter-out -latomic,$(_TC_EXTRA_LDFLAGS)))
-TC_EXTRA_LDFLAGS = $(TC_EXTRA_BUILD_FLAGS) $(if $(strip $(_tc_ld_syslibs)),-Wl$(_tc_comma)--as-needed $(_tc_ld_syslibs) -Wl$(_tc_comma)--no-as-needed)
+TC_EXTRA_LDFLAGS = $(TC_EXTRA_BUILD_FLAGS) $(_tc_ld_syslibs)
 
 # TC_EXTRA_BUILD_FLAGS holds the target's ABI/arch flags (-march, -mcpu, -mfpu,
 # -mfloat-abi, -mthumb, ...). They select the ABI, so they must reach every language


### PR DESCRIPTION
`TC_EXTRA_LDFLAGS` carries the system libraries a toolchain declares — `librt` on the archs whose glibc predates 2.17, `libatomic` where the compiler emits atomic builtins it cannot inline. They are toolchain-wide rather than per package, so they would land on every link even though most binaries call neither. To scope that, they were wrapped in `-Wl,--as-needed … -Wl,--no-as-needed`, so the linker would record a dependency only where the objects reference one.

## That cannot work from where it sits

`LDFLAGS` precedes the objects on every link line, and `--as-needed` keeps a library only if it resolves a symbol that is **already undefined where the linker sees it**. At the front of the line no object has been read yet, nothing is undefined, and the libraries are discarded every time.

The bracket does not scope the policy — it voids it. Measured on the `88f6281-5.2` toolchain, linking ffmpeg's own libsrt test source:

```
-Wl,--as-needed -lrt -Wl,--no-as-needed ... -lsrt   undefined reference to clock_gettime
(nothing at all)                        ... -lsrt   undefined reference to clock_gettime
-lrt                                    ... -lsrt   links, DT_NEEDED librt
```

The first two lines are the point: today's form is indistinguishable from declaring nothing at all.

## What packages have been doing instead

Every package that actually needs one of these has had to put it back by hand:

- `cross/ffmpeg4` carried `--extra-ldflags="-lrt"` inside its ARMv5 block, commented only *"Needed for libsrt"* — which is why 88f6281 built and `ppc853x-5.2` did not, in #7397
- the same file passes `--extra-libs=-latomic` on the e500v2 archs, for the same reason
- #7391 works around it in `tc-flags.mk` itself, but only under `OVERLAY_GCC_ON`

## The change

```make
-TC_EXTRA_LDFLAGS = $(TC_EXTRA_BUILD_FLAGS) $(if $(strip $(_tc_ld_syslibs)),-Wl$(_tc_comma)--as-needed $(_tc_ld_syslibs) -Wl$(_tc_comma)--no-as-needed)
+TC_EXTRA_LDFLAGS = $(TC_EXTRA_BUILD_FLAGS) $(_tc_ld_syslibs)
```

`TC_EXTRA_BUILD_FLAGS` and the `TC_HAS_LIBATOMIC` filter are untouched: an arch whose compiler ships no libatomic still drops `-latomic` before this point.

| | master | this PR |
|---|---|---|
| ppc853x-5.2 | `-mcpu=8548 … -Wl,--as-needed -lrt -Wl,--no-as-needed` | `-mcpu=8548 … -lrt` |
| qoriq-6.2.4 | `-mcpu=8548 … -Wl,--as-needed -latomic -Wl,--no-as-needed` | `-mcpu=8548 … -latomic` |
| 88f6281-6.2.4 | `-Wl,--as-needed -lrt -Wl,--no-as-needed` | `-lrt` |
| armv7-6.2.4 | `-D__ARM_PCS_VFP=1` | unchanged |
| x64-7.1 | *(empty)* | unchanged |

## Blast radius

Six (arch, DSM) pairs declare a system library and therefore change: **88f6281** at 5.2, 6.1 and 6.2.4, **ppc853x-5.2**, **qoriq** at 6.1 and 6.2.4. Every other arch declares none and is bit-for-bit unaffected.

The cost on those six is a `DT_NEEDED` that may go unused. Both `librt` and `libatomic` belong to the glibc already on the device, so an unused entry costs a mapping and nothing else — against a link that fails outright, or a package carrying its own workaround to put the library back.

## The proof is in this PR

A second commit removes the `-lrt` workaround from all five ffmpeg packages — the `version_lt(TC_GLIBC, 2.17)` gate that #7397 and #7430 added to put back a library the `--as-needed` bracket was discarding:

```make
-ifeq ($(call version_lt,$(TC_GLIBC),2.17),1)
-CONFIGURE_ARGS += --extra-ldflags="-lrt"
-endif
```

With the bracket gone the toolchain supplies it, so the packages need say nothing:

```
ppc853x-5.2     -mcpu=8548 -lrt
88f6281-6.2.4   -lrt
qoriq-6.2.4     -mcpu=8548 -latomic     (no librt: glibc 2.20)
x64-7.1         (empty)
```

**ffmpeg4 is what proves it,** and it now has. It is the only package in the tree with no `MIN_GCC_VERSION`, so the only one that reaches a toolchain below glibc 2.17 — and it is where the missing `-lrt` first surfaced, reported as `ERROR: srt >= 1.3.0 not found using pkg-config`, which was ffmpeg dressing a link failure in a pkg-config message. With DSM 5.2 switched on for the run and its gate removed:

```
ffmpeg4: (ppc853x-5.2) DONE      glibc 2.8,  gcc 4.3.7
ffmpeg4: (88f6281-5.2) DONE      glibc 2.15, gcc 4.6.4
ffmpeg4: (x86-5.2)     DONE
```

No `undefined reference to clock_gettime` anywhere in the run. librt is coming from `TC_EXTRA_LDFLAGS` as declared.

## The first green run proved nothing — and why

The initial CI run on this branch came back fully green without building `ffmpeg4` at all. Two things had to be true for the proof to be hollow, and both were:

1. **`prepare.sh` never selected it.** `dependency-list` printed `$(NAME):`, which for an spk is `SPK_NAME`. `spk/ffmpeg4` sets `SPK_NAME = ffmpeg`, so the list said `ffmpeg:` while every consumer looks the key up as a **directory** — and `spk/ffmpeg` does not exist. The entry vanished. `spk/mkvtoolnix_22` (`mkvtoolnix`) and `spk/mono_58` (`mono`) hit the same wall, and worse: those two folders still exist beside the `_22` / `_58` ones, so two directories collapsed onto one key.
2. **No other package could have covered for it.** `cross/libsrt` is pulled only by ffmpeg4..8, and ffmpeg5..8 all declare `MIN_GCC_VERSION = 4.9`. The three toolchains below glibc 2.17 ship gcc 4.3.7 / 4.6.4, so pre-check stopped every one of them before a single object was compiled.

| toolchain | gcc | glibc | can build ffmpeg5..8? |
|---|---|---|---|
| `ppc853x-5.2` | 4.3.7 | 2.8 | no |
| `88f6281-5.2` | 4.6.4 | 2.15 | no |
| `88f6281-6.1` | 4.6.4 | 2.15 | no |

`cross/ffmpeg4` is the only package in the tree with no gcc floor. It is therefore the *only* thing that can reach this code path — and it was precisely the one being dropped.

## The fix

```make
-	@echo -n "$(NAME): "
+	@echo -n "$(notdir $(CURDIR)): "
```

This is the rule `spksrc.rules/pre-check.mk` already states, and already defines `SPK_FOLDER` for: *"github status check does not rely on the (SPK) NAME but uses the folder name"*. The hand-maintained fixup list in `.github/actions/prepare.sh` goes with it — it patched `nzbdrone → sonarr3` and `python → python2`, neither folder exists any more, and neither covered a single one of the three real cases. A derived key cannot drift the way a list does.

Simulated on this branch, `prepare.sh` now selects:

```
chromaprint comskip ffmpeg4 ffmpeg5 ffmpeg6 ffmpeg7 ffmpeg8 shairport-sync tvheadend
```

against `synocli-videodriver ffmpeg8 chromaprint comskip ffmpeg5 ffmpeg6 ffmpeg7 shairport-sync python314 tvheadend` before.

## DSM 5.2 in CI

DSM 5.2 was switched on for the run, since `ppc853x-5.2` and `88f6281-5.2` are not in `DEFAULT_TC`. It is **reverted as a commit** rather than by rewriting history, so the green run stays attached to the PR.

## Also

Documentation: `docs/framework/toolchain.md` described the `--as-needed` wrap as the behaviour in force; it now says what actually happens. `docs/framework/changes.md` gets the dated entry, and the #7314 entry that introduced the wrap keeps its original text with a forward reference, so the log stays a record of what each PR did.

`--extra-libs=-latomic` on ffmpeg's e500v2 block is deliberately left in place: same class of workaround, but a different symbol and a separate proof.

Groundwork for #7391, which currently carries this correction scoped to `OVERLAY_GCC_ON`; once this lands, that scoping comes out too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd

