### PR TITLE
ci: classify MIN_GLIBC_VERSION / MIN_GCC_VERSION packages as restricted-DSM builds

### DIFF
--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -136,8 +136,26 @@ min_dsm_for_glibc() {
 }
 
 # ---------------------------------------------------------------------------
+# Map a MIN_GCC_VERSION floor to the minimum DSM version whose toolchains
+# ship at least that gcc. DSM 7.1 toolchains top out at gcc 8.5.0; DSM 7.2+
+# ship gcc 12.2, so any floor above 8.5.0 is classified as min DSM 7.2
+# (7.2 and 7.3 share gcc 12.2, so these land in the 7.2 bucket).
+#
+# Usage: min_dsm_for_gcc <gcc version>
+# Prints the minimum DSM version, or nothing if the floor is below the
+# default builds (7.1 / 6.2.4).
+# ---------------------------------------------------------------------------
+min_dsm_for_gcc() {
+    local gcc="$1"
+    if [ -n "${gcc}" ] && [ "${gcc}" != "8.5.0" ] && \
+       [ "$(printf '%s\n%s\n' "8.5.0" "${gcc}" | sort -V | tail -1)" = "${gcc}" ]; then
+        echo "7.2"
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Collect packages that declare REQUIRED_MIN_DSM = <version> or a
-# MIN_GLIBC_VERSION floor that implies <version>,
+# MIN_GLIBC_VERSION / MIN_GCC_VERSION floor that implies <version>,
 # preserving the build order already established in $packages.
 # Injects required meta-packages by resolving all qualifying packages
 # in a single inject_meta_packages call to avoid cross-iteration state issues.
@@ -153,6 +171,8 @@ collect_min_dsm_packages() {
             if [ "$(grep REQUIRED_MIN_DSM "./spk/${package}/Makefile" | cut -d= -f2 | xargs)" = "${version}" ]; then
                 result+="${package} "
             elif [ "$(min_dsm_for_glibc "$(grep MIN_GLIBC_VERSION "./spk/${package}/Makefile" | cut -d= -f2 | xargs)")" = "${version}" ]; then
+                result+="${package} "
+            elif [ "$(min_dsm_for_gcc "$(grep MIN_GCC_VERSION "./spk/${package}/Makefile" | cut -d= -f2 | xargs)")" = "${version}" ]; then
                 result+="${package} "
             fi
         fi

--- a/.github/actions/prepare.sh
+++ b/.github/actions/prepare.sh
@@ -114,7 +114,30 @@ _inject_one() {
 }
 
 # ---------------------------------------------------------------------------
-# Collect packages that declare REQUIRED_MIN_DSM = <version>,
+# Map a MIN_GLIBC_VERSION floor to the minimum DSM version whose toolchains
+# ship at least that glibc. Packages using MIN_GLIBC_VERSION instead of
+# REQUIRED_MIN_DSM (e.g. kavita, dotnet10-runtime) are otherwise invisible to
+# the restricted-build classification and never built for the DSM they need.
+#
+# DSM 7.1 toolchains ship glibc 2.26; DSM 7.2+ ship 2.36. MIN_GLIBC_VERSION
+# cannot distinguish 7.2 from 7.3 (they share glibc 2.36), so any floor above
+# 2.26 is classified as min DSM 7.2.
+#
+# Usage: min_dsm_for_glibc <glibc version>
+# Prints the minimum DSM version, or nothing if the floor is below the
+# default builds (7.1 / 6.2.4).
+# ---------------------------------------------------------------------------
+min_dsm_for_glibc() {
+    local glibc="$1"
+    if [ -n "${glibc}" ] && [ "${glibc}" != "2.26" ] && \
+       [ "$(printf '%s\n%s\n' "2.26" "${glibc}" | sort -V | tail -1)" = "${glibc}" ]; then
+        echo "7.2"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Collect packages that declare REQUIRED_MIN_DSM = <version> or a
+# MIN_GLIBC_VERSION floor that implies <version>,
 # preserving the build order already established in $packages.
 # Injects required meta-packages by resolving all qualifying packages
 # in a single inject_meta_packages call to avoid cross-iteration state issues.
@@ -128,6 +151,8 @@ collect_min_dsm_packages() {
     for package in ${packages}; do
         if [ -f "./spk/${package}/Makefile" ]; then
             if [ "$(grep REQUIRED_MIN_DSM "./spk/${package}/Makefile" | cut -d= -f2 | xargs)" = "${version}" ]; then
+                result+="${package} "
+            elif [ "$(min_dsm_for_glibc "$(grep MIN_GLIBC_VERSION "./spk/${package}/Makefile" | cut -d= -f2 | xargs)")" = "${version}" ]; then
                 result+="${package} "
             fi
         fi

--- a/docs/developer-guide/publishing/github-actions.md
+++ b/docs/developer-guide/publishing/github-actions.md
@@ -36,7 +36,7 @@ The CI determines which packages to build by:
 
 ### Main Build Workflow
 
-Located at `.github/workflows/build.yml`. By default, packages build for DSM 7.1 and DSM 6.2. DSM 7.2 builds are opt-in and require setting `TCVERSION=7.2` as a minimum in the package Makefile.
+Located at `.github/workflows/build.yml`. By default, packages build for DSM 7.1 and DSM 6.2. DSM 7.2 builds are opt-in: a package opts in by declaring `REQUIRED_MIN_DSM = 7.2`, or a capability floor (`MIN_GLIBC_VERSION` / `MIN_GCC_VERSION`) that implies DSM 7.2.
 
 ### Build Matrix
 


### PR DESCRIPTION
## Description

Fix the CI so packages that gate on `MIN_GLIBC_VERSION` / `MIN_GCC_VERSION` (instead of `REQUIRED_MIN_DSM`) are still built for the DSM they require.

The restricted-build classification in `.github/actions/prepare.sh` only recognized `REQUIRED_MIN_DSM`, so packages using the capability variables (e.g. `kavita`, `dotnet10-runtime`, which set `MIN_GLIBC_VERSION = 2.27`) were never classified as requiring DSM 7.2 — the DSM 7.2 matrix was never enabled for them, and they effectively built for no DSM at all.

Changes:
- Map a `MIN_GLIBC_VERSION` floor above 2.26 (DSM 7.1's glibc) to min DSM 7.2 — fixes kavita and dotnet10-runtime.
- Map a `MIN_GCC_VERSION` floor above 8.5.0 (DSM 7.1's highest GCC) to min DSM 7.2 — future-proofing; no current package needs it.
- `MIN_RUSTC_VERSION` is intentionally not mapped: it is provided by the rust overlay on custom-rust archs and is not tied to a DSM version.

Fixes # <!--Optionally, add links to existing issues or other PR's-->

## Checklist

- [x] Build rule `all-supported` completed successfully
- [ ] New installation of package completed successfully
- [ ] Package upgrade completed successfully (Manually install the package again)
- [ ] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Includes small framework changes
