### PR TITLE
pre-check: name every gate that blocks an arch, and add make check-<arch>-<tcvers>

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,9 @@ jobs:
           add_dsm70_builds=${{ github.event.inputs.add_dsm70_builds || 'false' }}
           add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'false' }}
           add_dsm61_builds=${{ github.event.inputs.add_dsm61_builds || 'false' }}
-          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}
+          # TEMP (revert before merge): DSM 5.2 carries the toolchains this PR's floors
+          # actually bite on -- gcc 4.3.7 (ppc853x), 4.6.4 (88f6281), 4.7.3 (x86, x64).
+          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'true' }}
           add_srm13_builds=${{ github.event.inputs.add_srm13_builds || 'false' }}
           add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}
           add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'false' }}

--- a/docs/developer-guide/packaging/makefile-variables.md
+++ b/docs/developer-guide/packaging/makefile-variables.md
@@ -320,6 +320,21 @@ without a network query. So a rustc floor refuses only the archs pinned to an ol
 from-source Rust — see [Toolchain: custom from-source
 Rust](../../framework/toolchain.md#custom-from-source-rust-toolchains).
 
+**Ask what stands in the way.** `make check-<arch>-<tcvers>` lists every gate the
+package's whole dependency tree fails for that architecture, so a floor declared three
+levels down is visible without starting a build:
+
+```
+$ make check-x86-5.2
+===>  tvheadend: 17 gate(s) not met for x86-5.2
+         cross/chromaprint-fftw     gcc 4.7.3 < 4.8
+         cross/python314            gcc 4.7.3 < 4.8
+         cross/ffmpeg8              gcc 4.7.3 < 4.9
+```
+
+`make ARCH=x86 TCVERSION=5.2 check` is the same with the pair in variables. The
+pre-check runs the same walk, so a refused build names every blocker at once.
+
 **Keep the floor consistent between `spk/` and `cross/`.** A floor on an `spk/`
 package belongs on its matching `cross/` package too, so a build is refused at its
 own level instead of failing deep in a dependency. If you add a floor to `spk/foo`,

--- a/docs/developer-guide/packaging/makefile-variables.md
+++ b/docs/developer-guide/packaging/makefile-variables.md
@@ -320,20 +320,31 @@ without a network query. So a rustc floor refuses only the archs pinned to an ol
 from-source Rust — see [Toolchain: custom from-source
 Rust](../../framework/toolchain.md#custom-from-source-rust-toolchains).
 
-**Ask what stands in the way.** `make check-<arch>-<tcvers>` lists every gate the
+**Ask what stands in the way.** `make check-<arch>-<tcvers>` lists every check the
 package's whole dependency tree fails for that architecture, so a floor declared three
 levels down is visible without starting a build:
 
 ```
 $ make check-x86-5.2
-===>  tvheadend: 17 gate(s) not met for x86-5.2
-         cross/chromaprint-fftw     gcc 4.7.3 < 4.8
-         cross/python314            gcc 4.7.3 < 4.8
+===>  tvheadend: x86-5.2 check: 17 failed, 14 more behind an optional dependency
+       required
          cross/ffmpeg8              gcc 4.7.3 < 4.9
+         cross/python314            gcc 4.7.3 < 4.8
+         ...
+       optional
+         cross/frei0r               gcc 4.7.3 < 7.5
+         cross/openexr              gcc 4.7.3 < 4.8
+         ...
 ```
 
-`make ARCH=x86 TCVERSION=5.2 check` is the same with the pair in variables. The
-pre-check runs the same walk, so a refused build names every blocker at once.
+`make ARCH=x86 TCVERSION=5.2 check` is the same with the pair in variables, and a clear
+architecture answers `x86-5.2 check: OK`. **required** is what the build actually needs;
+**optional** is what an `OPTIONAL_DEPENDS` branch would demand if that option were turned
+on -- worth knowing before turning it on, and never a reason to refuse the build. A
+package under both a required and an optional parent counts as required.
+
+The pre-check runs the same walk on the required set, so a refused build names every
+blocker at once instead of stopping at the first.
 
 **Keep the floor consistent between `spk/` and `cross/`.** A floor on an `spk/`
 package belongs on its matching `cross/` package too, so a build is refused at its

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -24,11 +24,19 @@ If you only read one thing, read this. The details are in the dated log below.
   capability gate that architecture fails, or says every gate is met:
 
     ```
-    ===>  tvheadend: 17 gate(s) not met for x86-5.2
-             cross/chromaprint-fftw     gcc 4.7.3 < 4.8
-             cross/python314            gcc 4.7.3 < 4.8
+    ===>  tvheadend: x86-5.2 check: 17 failed, 14 more behind an optional dependency
+           required
              cross/ffmpeg8              gcc 4.7.3 < 4.9
+             cross/python314            gcc 4.7.3 < 4.8
+             ...
+           optional
+             cross/frei0r               gcc 4.7.3 < 7.5
+             ...
     ```
+
+    **required** is what the build needs; **optional** is what an `OPTIONAL_DEPENDS`
+    branch would demand if turned on, and never a reason to refuse. A clear architecture
+    answers `x86-5.2 check: OK`.
 
     The pre-check uses the same walk, so a refused build names every blocker at once
     instead of stopping at the first. See
@@ -99,8 +107,13 @@ If you only read one thing, read this. The details are in the dated log below.
 ---
 
 ??? note "September 7th 2026 — An arch exclusion says why, and names every blocker (#7439)"
+    - **Seven restated floors gone.** `spk/tvheadend`, `chromaprint`, `comskip` and
+      `spk/ffmpeg5-8` each declared `MIN_GCC_VERSION = 4.9`, restating what their own
+      `cross/` package declares -- and `cross/<same>` is a direct `DEPENDS`, so the walk
+      finds it. Declare a floor on the `cross/` package, where the requirement is a fact
+      about the code; the `spk/` inherits it by being walked. Verdicts unchanged.
     - **`make check-<arch>-<tcvers>`** reports every capability gate a package's whole
-      dependency tree fails for that architecture, or confirms it is clear.
+      dependency tree fails for that architecture, or answers `<arch>-<vers> check: OK`.
       `make ARCH=x86 TCVERSION=5.2 check` is the same thing with the pair in variables.
       A pure diagnostic: it extracts no toolchain and builds nothing, it reads the floors
       declared across the tree.
@@ -110,12 +123,12 @@ If you only read one thing, read this. The details are in the dated log below.
       same walk and lists all of them before stopping:
 
         ```
-        ===>  gate: cross/x264                 gcc 4.3.7 < 4.6
-        ===>  gate: cross/python314            gcc 4.3.7 < 4.8
-        ===>  gate: cross/ffmpeg8              gcc 4.3.7 < 4.9
+        ===>  check: cross/x264 gcc 4.3.7 < 4.6
+        ===>  check: cross/python314 gcc 4.3.7 < 4.8
+        ===>  check: cross/ffmpeg8 gcc 4.3.7 < 4.9
         ...
-        pre-check.mk:79: *** Arch 'ppc853x-5.2' is not supported by tvheadend:
-            gcc 4.3.7 < 4.9 (18 gate(s) in the tree).  Stop.
+        pre-check.mk:80: *** Arch 'ppc853x-5.2' is not supported by tvheadend
+            (18 failed check(s) in the tree).  Stop.
         ```
 
         It reuses `dependency-flat`'s walk, which already stamps each package so a diamond

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -83,6 +83,34 @@ If you only read one thing, read this. The details are in the dated log below.
 
 ---
 
+??? note "September 7th 2026 — An arch exclusion can say why (#7439)"
+    - **What was missing:** `UNSUPPORTED_ARCHS` states *where* a package fails and never
+      *why*, and the archs are often added by an include rather than by the package -- so
+      the message named a package with no such list in its own Makefile.
+      **`UNSUPPORTED_ARCHS_REASON`** is now carried into the refusal in parentheses:
+
+        ```
+        Arch 'ppc853x' is not a supported architecture (go has no 32-bit PowerPC target)
+        ```
+
+        `spksrc.cross/env-go.mk` and `env-dotnet.mk` say theirs. A capability floor is
+        still the better answer where one fits; this is for exclusions that are not
+        capability checks.
+    - **One accumulator instead of two.** `_tc_cap_join` accumulated
+      `TC_CAPABILITY_UNSUPPORTED` and `unsupported_reason_join` accumulated
+      `UNSUPPORTED_ARCHS_REASON` -- the same operation under two names, and the second was
+      not a macro at all (no argument, just a lazy read of a global). Both are now
+      **`$(call comma_append,<list>,<item>)`**.
+    - **A `$(,)` that expanded to nothing.** `spksrc.common.mk` defined `empty` / `space` /
+      `$(,)` *below* every `spksrc.common/` include, so an included file expanding `$(,)`
+      in a `:=` assignment got the empty string -- which is why `tc-capability.mk` carried
+      a private comma variable. The utility block moved above the includes.
+    - **`spksrc.cross/env-dotnet.mk`** lost 26 tab-indented lines sitting outside any
+      recipe, and its `$(error)` became a `$(warning)`: an unsupported arch should be
+      reported by the pre-check, not by a parse abort in an env file.
+    - **Package-facing:** nothing to change. Add `UNSUPPORTED_ARCHS_REASON` alongside an
+      `UNSUPPORTED_ARCHS` you introduce, and the refusal will carry it.
+
 ??? note "September 4th 2026 — Build logs keep what the console showed (#7396)"
     - **What was lost:** a package refused by a pre-check left a build log holding a
       single line. `$(error)` fires at **parse** time, so no recipe of the inner make

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -19,6 +19,21 @@ If you only read one thing, read this. The details are in the dated log below.
     cd cross/curl && make help
     ```
 
+- **Ask an architecture what stands in the way.** `make check-x86-5.2` (or
+  `make ARCH=x86 TCVERSION=5.2 check`) walks the whole dependency tree and lists every
+  capability gate that architecture fails, or says every gate is met:
+
+    ```
+    ===>  tvheadend: 17 gate(s) not met for x86-5.2
+             cross/chromaprint-fftw     gcc 4.7.3 < 4.8
+             cross/python314            gcc 4.7.3 < 4.8
+             cross/ffmpeg8              gcc 4.7.3 < 4.9
+    ```
+
+    The pre-check uses the same walk, so a refused build names every blocker at once
+    instead of stopping at the first. See
+    [Architecture Support](../developer-guide/packaging/makefile-variables.md#architecture-support).
+
 - **Declare what a package needs, not where it fails.** Instead of
   hand-maintaining an `UNSUPPORTED_ARCHS` list, state the capability floor:
   **`MIN_GCC_VERSION`**, **`MIN_GLIBC_VERSION`**, **`MIN_RUSTC_VERSION`**,
@@ -83,7 +98,36 @@ If you only read one thing, read this. The details are in the dated log below.
 
 ---
 
-??? note "September 7th 2026 — An arch exclusion can say why (#7439)"
+??? note "September 7th 2026 — An arch exclusion says why, and names every blocker (#7439)"
+    - **`make check-<arch>-<tcvers>`** reports every capability gate a package's whole
+      dependency tree fails for that architecture, or confirms it is clear.
+      `make ARCH=x86 TCVERSION=5.2 check` is the same thing with the pair in variables.
+      A pure diagnostic: it extracts no toolchain and builds nothing, it reads the floors
+      declared across the tree.
+    - **The pre-check names every gate, not the first.** A package is as blocked by a floor
+      it never declared as by one it did, and the pre-check only ever saw its own -- so
+      removing the blocker it named revealed the next, one build at a time. It now runs the
+      same walk and lists all of them before stopping:
+
+        ```
+        ===>  gate: cross/x264                 gcc 4.3.7 < 4.6
+        ===>  gate: cross/python314            gcc 4.3.7 < 4.8
+        ===>  gate: cross/ffmpeg8              gcc 4.3.7 < 4.9
+        ...
+        pre-check.mk:79: *** Arch 'ppc853x-5.2' is not supported by tvheadend:
+            gcc 4.3.7 < 4.9 (18 gate(s) in the tree).  Stop.
+        ```
+
+        It reuses `dependency-flat`'s walk, which already stamps each package so a diamond
+        is visited once, already forwards ARCH/TCVERSION so every package evaluates its own
+        conditional `DEPENDS`, and already sets `DEPENDENCY_WALK=1` so a refused package
+        reports instead of aborting. `DEP_FLAT_VERDICT` makes each package visited print its
+        own verdict, so one walk yields both the tree and every gate in it.
+
+        Cost is one walk per parse -- 2.8s warm on tvheadend's 141-package tree, against
+        builds measured in tens of minutes. Verdict-neutral on the archs measured: every
+        `spk/` package across x64-7.1, 88f6281-6.2.4 and ppc853x-5.2 gives the same
+        refused/allowed set as before. What changes is that the whole story is told at once.
     - **What was missing:** `UNSUPPORTED_ARCHS` states *where* a package fails and never
       *why*, and the archs are often added by an include rather than by the package -- so
       the message named a package with no such list in its own Makefile.

--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -49,6 +49,14 @@ ifneq ($(ARCH),)
 ARCH_SUFFIX = -$(ARCH)-$(TCVERSION)
 endif
 
+# Utility variables
+empty :=
+space := $(empty) $(empty)
+# For literal ',' in $(eval ...) contexts interpreted as individual arguments -> $(eval -Wl$(,)--rpath-link$(,)/some/path)
+, := ,
+
+# Ahead of every include below, not further down the file: an included makefile that uses
+# these in a `:=` assignment expands them at its own parse, and would otherwise get empty.
 # Load macros early
 include $(BASEDIR)/mk/spksrc.common/macros.mk
 
@@ -100,12 +108,6 @@ RUN = cd $(WORK_DIR)/$(PKG_DIR) && env $(ENV)
 
 # Display message in a consistent way
 MSG = echo "===> "
-
-# Utility variables
-empty :=
-space := $(empty) $(empty)
-# For literal ',' in $(eval ...) contexts interpreted as individual arguments -> $(eval -Wl$(,)--rpath-link$(,)/some/path)
-, := ,
 
 # Available languages
 LANGUAGES = chs cht csy dan enu fre ger hun ita jpn krn nld nor plk ptb ptg rus spn sve trk

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -59,6 +59,9 @@ ifeq ($(SPKSRC_TREE),toolkit)
 endif
 	@printf "  \033[36m%-24s\033[0m %s\n" "rustup <args>" "run rustup for the rust toolchain (e.g. make rustup show)"
 ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
+	@printf "  \033[36m%-24s\033[0m %s\n" "check-<arch>-<tcvers>" "list the capability gates an arch fails (also: ARCH=.. TCVERSION=.. check)"
+endif
+ifneq ($(filter $(SPKSRC_TREE),cross spk diyspk),)
 	@printf "\n\033[1mMulti-arch\033[0m  (needs 'make setup' once at the spksrc root first)\n"
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-supported" "build for every supported arch"
 	@printf "  \033[36m%-24s\033[0m %s\n" "all-latest" "build for the latest toolchains only"

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -40,7 +40,6 @@ ifeq ($(SPKSRC_TREE),python)
 	@printf "\n  \033[33m%s\033[0m\n" "built only as an spk dependency - it has no direct build here"
 else
 	@printf "\n\033[1mBuild\033[0m\n"
-	@printf "  \033[36m%-24s\033[0m %s\n" "all" "build this package (default target)"
 ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
 	@printf "  \033[36m%-24s\033[0m %s\n" "arch-<arch>-<tcvers>" "build for one arch/version (e.g. arch-x64-7.1)"
 endif
@@ -49,7 +48,7 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk native diyspk),)
 	@printf "  %-24s   %s\n" "" "$(HELP_STEPS)"
 endif
 ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
-	@printf "  \033[33m%s\033[0m\n" "  all and every <step> except download need ARCH=<arch> TCVERSION=<tcvers>"
+	@printf "  \033[33m%s\033[0m\n" "  every <step> except download needs ARCH=<arch> TCVERSION=<tcvers>"
 endif
 ifeq ($(SPKSRC_TREE),toolchain)
 	@printf "  \033[36m%-24s\033[0m %s\n" "tc_vars" "show the toolchain variables (TC_GCC, ...)"

--- a/mk/spksrc.common/macros.mk
+++ b/mk/spksrc.common/macros.mk
@@ -33,6 +33,11 @@ version_ge = $(shell if printf '%s\n' "$(1)" "$(2)" | sort -VCr ; then echo 1; f
 version_lt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VC ; then echo 1; fi)
 version_gt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VCr ; then echo 1; fi)
 
+# Separator for UNSUPPORTED_ARCHS_REASON, so several contributors read as a list rather
+# than running together. Same shape as _tc_cap_join in spksrc.common/tc-capability.mk.
+_ur_comma := ,
+unsupported_reason_join = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)),$(_ur_comma) )
+
 # Remove duplicate words within string while preserving order
 define uniq
 $(strip \

--- a/mk/spksrc.common/macros.mk
+++ b/mk/spksrc.common/macros.mk
@@ -33,9 +33,9 @@ version_ge = $(shell if printf '%s\n' "$(1)" "$(2)" | sort -VCr ; then echo 1; f
 version_lt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VC ; then echo 1; fi)
 version_gt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VCr ; then echo 1; fi)
 
-# Append $(2) to the comma-separated list $(1). Reasons accumulate rather than overwrite:
-# an arch can miss several capabilities at once. An item with a comma would split $(call).
-comma_append = $(1)$(if $(strip $(1)),$(,) )$(2)
+# Append $(2) to the comma-separated list $(1), or return $(1) when there is nothing to add.
+# Reasons accumulate rather than overwrite: an arch can miss several capabilities at once.
+comma_append = $(if $(strip $(2)),$(1)$(if $(strip $(1)),$(,) )$(2),$(1))
 
 # Remove duplicate words within string while preserving order
 define uniq

--- a/mk/spksrc.common/macros.mk
+++ b/mk/spksrc.common/macros.mk
@@ -33,10 +33,9 @@ version_ge = $(shell if printf '%s\n' "$(1)" "$(2)" | sort -VCr ; then echo 1; f
 version_lt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VC ; then echo 1; fi)
 version_gt = $(shell if [ "$(1)" != "$(2)" ] && printf "%s\n" "$(1)" "$(2)" | sort -VCr ; then echo 1; fi)
 
-# Separator for UNSUPPORTED_ARCHS_REASON, so several contributors read as a list rather
-# than running together. Same shape as _tc_cap_join in spksrc.common/tc-capability.mk.
-_ur_comma := ,
-unsupported_reason_join = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)),$(_ur_comma) )
+# Append $(2) to the comma-separated list $(1). Reasons accumulate rather than overwrite:
+# an arch can miss several capabilities at once. An item with a comma would split $(call).
+comma_append = $(1)$(if $(strip $(1)),$(,) )$(2)
 
 # Remove duplicate words within string while preserving order
 define uniq

--- a/mk/spksrc.common/tc-capability.mk
+++ b/mk/spksrc.common/tc-capability.mk
@@ -26,19 +26,11 @@
 # turns that into the arch-refusal error, next to UNSUPPORTED_ARCHS.
 ###############################################################################
 
-# Does this toolchain's gcc ship libatomic? Ask it, rather than tabulate.
-#
-# A target without native 64-bit atomics (ARMv5, PowerPC e500v2) makes gcc emit calls into
-# libatomic, which the link then has to resolve. But the library only ships from gcc 4.7 on,
-# and handing -latomic to an older gcc is fatal ("cannot find -latomic"). Availability is the
-# exact criterion, not a proxy: a gcc old enough to lack libatomic also predates the __atomic_*
-# builtins, emits __sync_* instead, and so never needs the library. One question answers both.
-#
-# Lazy (=), unlike the static reads below: it RUNS the cross gcc, which does not exist yet
-# while the toolchain is still being bootstrapped. Outside the ARCH guard, and keyed on
-# TC_* only, so the native producers (spksrc.native/toolchain-rust.mk) reach it too.
+# Does this toolchain's gcc ship libatomic? Ask it -- a gcc too old to have it also predates
+# __atomic_* and never needs it. Lazy (=), outside the ARCH guard: it runs the cross gcc.
 TC_HAS_LIBATOMIC = $(if $(filter /%,$(shell $(TC_WORK_DIR)/$(TC_TARGET)/bin/$(TC_PREFIX)gcc -print-file-name=libatomic.so 2>/dev/null)),1)
 
+# Outside the guard on purpose: the native producers read TC_HAS_LIBATOMIC with no ARCH.
 ifneq ($(strip $(ARCH))$(strip $(TCVERSION)),)
 
 _TC_CAP_MK := $(BASEDIR)/toolchain/syno-$(ARCH)-$(TCVERSION)/Makefile
@@ -53,16 +45,13 @@ TC_KERNEL := $(shell sed -n 's/^TC_KERNEL *= *//p' $(_TC_CAP_MK) 2>/dev/null)
 # Reasons accumulate rather than overwrite: an arch can miss more than one
 # capability at once -- a 32-bit target on an old gcc fails REQUIRE_64BIT and
 # MIN_GCC_VERSION together -- and reporting only the last is misleading. They are
-# joined with ", "; the messages carry no comma of their own. _tc_cap_comma exists
-# because a bare comma is an argument separator inside the $(if) that adds the
-# separator only from the second reason on.
+# joined by comma_append (spksrc.common/macros.mk); the messages carry no comma of their
+# own, which a $(call) argument would split on.
 #
 # Reset first: this file is included more than once per build (via spksrc.common.mk),
 # and appending is not idempotent the way the old overwrite was -- without this the
 # same reasons would pile up on every re-parse.
 TC_CAPABILITY_UNSUPPORTED :=
-_tc_cap_comma := ,
-_tc_cap_join    = $(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),$(_tc_cap_comma) )
 
 # ---- glibc: a runtime floor, so too old means genuinely unsupported ---------
 # Linking against a newer glibc than the NAS runs produces binaries that will not
@@ -70,7 +59,7 @@ _tc_cap_join    = $(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),$(_tc_cap_comma) )
 ifneq ($(strip $(MIN_GLIBC_VERSION)),)
 ifneq ($(strip $(TC_GLIBC)),)
 ifeq ($(call version_ge,$(TC_GLIBC),$(MIN_GLIBC_VERSION)),)
-TC_CAPABILITY_UNSUPPORTED := $(TC_CAPABILITY_UNSUPPORTED)$(_tc_cap_join)glibc $(TC_GLIBC) < $(MIN_GLIBC_VERSION) (a runtime floor: no toolchain can lift it)
+TC_CAPABILITY_UNSUPPORTED := $(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),glibc $(TC_GLIBC) < $(MIN_GLIBC_VERSION) (a runtime floor: no toolchain can lift it))
 endif
 endif
 endif
@@ -80,7 +69,7 @@ endif
 ifneq ($(strip $(MIN_GCC_VERSION)),)
 ifneq ($(strip $(TC_GCC)),)
 ifeq ($(call version_ge,$(TC_GCC),$(MIN_GCC_VERSION)),)
-TC_CAPABILITY_UNSUPPORTED := $(TC_CAPABILITY_UNSUPPORTED)$(_tc_cap_join)gcc $(TC_GCC) < $(MIN_GCC_VERSION)
+TC_CAPABILITY_UNSUPPORTED := $(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),gcc $(TC_GCC) < $(MIN_GCC_VERSION))
 endif
 endif
 endif
@@ -104,7 +93,7 @@ TC_RUSTC ?= $(if $(OVERLAY_RUSTC_ON),$(_TC_CAP_RUSTC),stable)
 
 ifneq ($(strip $(MIN_RUSTC_VERSION)),)
 ifeq ($(call version_ge,$(TC_RUSTC),$(MIN_RUSTC_VERSION)),)
-TC_CAPABILITY_UNSUPPORTED := $(TC_CAPABILITY_UNSUPPORTED)$(_tc_cap_join)rustc $(TC_RUSTC) < $(MIN_RUSTC_VERSION)
+TC_CAPABILITY_UNSUPPORTED := $(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),rustc $(TC_RUSTC) < $(MIN_RUSTC_VERSION))
 endif
 endif
 
@@ -117,7 +106,7 @@ endif
 ifeq ($(strip $(REQUIRE_64BIT)),1)
 ifneq ($(strip $(ARCH)),)
 ifeq (,$(findstring $(ARCH),$(64bit_ARCHS)))
-TC_CAPABILITY_UNSUPPORTED := $(TC_CAPABILITY_UNSUPPORTED)$(_tc_cap_join)requires a 64-bit architecture
+TC_CAPABILITY_UNSUPPORTED := $(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),requires a 64-bit architecture)
 endif
 endif
 endif

--- a/mk/spksrc.cross/env-go.mk
+++ b/mk/spksrc.cross/env-go.mk
@@ -7,7 +7,7 @@
 
 # Go has no upstream toolchain for 32-bit PowerPC: GOARCH covers ppc64 and ppc64le only.
 UNSUPPORTED_ARCHS += $(PPC_ARCHS)
-UNSUPPORTED_ARCHS_REASON := $(UNSUPPORTED_ARCHS_REASON)$(unsupported_reason_join)go has no 32-bit PowerPC target
+UNSUPPORTED_ARCHS_REASON := $(call comma_append,$(UNSUPPORTED_ARCHS_REASON),go has no 32-bit PowerPC target)
 
 GOOS = linux
 ifeq ($(strip $(CGO_ENABLED)),)

--- a/mk/spksrc.cross/env-go.mk
+++ b/mk/spksrc.cross/env-go.mk
@@ -5,7 +5,9 @@
 #
 ###############################################################################
 
+# Go has no upstream toolchain for 32-bit PowerPC: GOARCH covers ppc64 and ppc64le only.
 UNSUPPORTED_ARCHS += $(PPC_ARCHS)
+UNSUPPORTED_ARCHS_REASON := $(UNSUPPORTED_ARCHS_REASON)$(unsupported_reason_join)go has no 32-bit PowerPC target
 
 GOOS = linux
 ifeq ($(strip $(CGO_ENABLED)),)

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -279,6 +279,7 @@ dependency-flat-raw:
 	@PARALLEL_MAKE=max $(MAKE) -j $(nproc) --silent --no-print-directory \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+		$(if $(DEP_FLAT_VERDICT),DEP_FLAT_VERDICT=1) \
 		dependency-flat-mk 2>/dev/null || true
 	@rm -rf $(DEP_FLAT_STAMP_DIR)
 
@@ -309,6 +310,10 @@ dependency-flat:
 # -------------------------------------------------------------------
 .PHONY: dependency-flat-mk
 dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
+	@# DEP_FLAT_VERDICT: each package visited also reports its own capability verdict, so
+	@# one walk yields both the tree and why any part of it refuses this arch. Emitted here
+	@# rather than by the parent -- TC_CAPABILITY_UNSUPPORTED is only correct in its own make.
+	$(if $(DEP_FLAT_VERDICT),@$(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(TC_CAPABILITY_UNSUPPORTED)",:))
 
 # -------------------------------------------------------------------
 # dep-flat-mk-%
@@ -343,9 +348,27 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 	DEPENDENCY_WALK=1 \
 	$(MAKE) -s --output-sync=target \
 		-C ../../$$dep \
+		$(if $(DEP_FLAT_VERDICT),DEP_FLAT_VERDICT=1) \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
 		dependency-flat-mk
+
+# -------------------------------------------------------------------
+# dependency-unsupported
+# Every package in the tree that refuses this arch, one per line, as
+#     <package> <reason>[, <reason>...]
+# Empty output means the whole tree accepts the arch. The same stamped walk as
+# dependency-flat, so a diamond is visited once, and OPTIONAL_DEPENDS drop out on
+# their own once ARCH and TCVERSION are both set.
+# -------------------------------------------------------------------
+.PHONY: dependency-unsupported
+dependency-unsupported:
+	@DEP_FLAT_VERDICT=1 $(MAKE) -s \
+		$(if $(ARCH),ARCH=$(ARCH)) \
+		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
+		dependency-flat-raw \
+		| sed -n 's/^UNSUPPORTED //p' \
+		| sort -u
 
 # -------------------------------------------------------------------
 # dependency-list

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -61,7 +61,8 @@
 #
 #  dependency-flat-mk
 #      Parallel orchestrator — invokes all dep-flat-mk-% targets.
-#      Emits nothing itself; all output comes from dep-flat-mk-% targets.
+#      Emits nothing itself, except the package's own verdict under
+#      REPORT_UNSUPPORTED; the rest comes from dep-flat-mk-% targets.
 #
 #  dep-flat-mk-%
 #      Processes a single dependency during traversal.
@@ -352,14 +353,14 @@ _why_unsupported     = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_U
 # -------------------------------------------------------------------
 # dependency-flat-mk
 # Parallel orchestrator — invokes all annotated dep-flat-mk-% targets.
-# Emits nothing itself; all output comes from dep-flat-mk-% targets.
+# Emits nothing itself, save one line under REPORT_UNSUPPORTED: this package's own
+# verdict, so a single walk yields both the tree and every refusal in it. Emitted by
+# the package rather than by its parent, _why_unsupported being correct only in its
+# own make, and named <tree>/<pkg> because $(NAME) is the PKG_NAME that cross/foo
+# and spk/foo share.
 # -------------------------------------------------------------------
 .PHONY: dependency-flat-mk
 dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
-	@# Under REPORT_UNSUPPORTED each package visited also reports why it refuses this arch, so
-	@# one walk yields both the tree and every refusal in it. Said here rather than by the
-	@# parent: these variables are only correct in the package's own make. Named <tree>/<pkg>
-	@# as a dependency is everywhere else -- $(NAME) is the PKG_NAME, shared by cross and spk.
 	@$(if $(and $(strip $(REPORT_UNSUPPORTED)),$(strip $(_why_unsupported))),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_why_unsupported)",true)
 
 # -------------------------------------------------------------------

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -12,6 +12,15 @@
 #  - Optional filtering of output by dependency relation type (DEPENDS_TYPE)
 #  - Context-aware traversal: when ARCH and TCVERSION are both set, OPTIONAL_DEPENDS
 #    are excluded at every level so only toolchain-resolved DEPENDS are reported.
+#  - Reporting why a tree refuses an arch, not just what it contains
+#
+# Switches, set by the caller on the sub-make command line:
+#  REPORT_UNSUPPORTED
+#      Each package visited also prints why it refuses this arch, so one walk
+#      yields both the tree and every refusal in it. See dependency-unsupported.
+#  WALK_OPTIONAL_DEPENDS
+#      Walk OPTIONAL_DEPENDS even under an arch context, which normally drops
+#      them. For reporting only: what gets built is unchanged.
 #
 # Root-level Targets (available only when BASEDIR is empty):
 #  dependency-list-spk
@@ -31,6 +40,11 @@
 #      filtered by DEPENDS_TYPE.
 #      Default: all types when ARCH/TCVERSION are absent;
 #               OPTIONAL_DEPENDS excluded when both ARCH and TCVERSION are set.
+#
+#  dependency-unsupported
+#      Prints every package in the tree that refuses this arch, one per line, as
+#      "<tree>/<package> <reason>[, <reason>...]". Empty when the tree accepts it.
+#      Read by `make check-<arch>-<tcvers>` and by the pre-check.
 #
 #  dependency-list
 #      Prints a single-line, space-separated list of dependencies for the
@@ -166,9 +180,9 @@ DEPENDS_TYPE ?= $(_DEFAULT_DEPENDS_TYPE)
 # -------------------------------------------------------------------
 ALL_DEPENDS         = $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
 
-# An arch context drops OPTIONAL_DEPENDS, not being built; DEP_FLAT_WITH_OPTIONAL walks them
+# An arch context drops OPTIONAL_DEPENDS, not being built; WALK_OPTIONAL_DEPENDS walks them
 # anyway, to REPORT what an optional branch would demand. Nothing about the build changes.
-_dep_flat_optional = $(if $(DEP_FLAT_WITH_OPTIONAL),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
+_dep_flat_optional = $(if $(WALK_OPTIONAL_DEPENDS),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
 
 DEP_FLAT_TARGETS_MK = $(strip \
   $(addprefix dep-flat-mk-DEPENDS__,          $(subst /,__,$(DEPENDS))) \
@@ -276,7 +290,9 @@ dependency-tree:
 # Used by dependency-flat and dependency-list to filter by DEPENDS_TYPE
 # without re-traversing the dependency graph.
 # ARCH and TCVERSION are forwarded to dependency-flat-mk so that the
-# correct set of dependencies is traversed for the given toolchain context.
+# correct set of dependencies is traversed for the given toolchain context,
+# and REPORT_UNSUPPORTED with them, so a caller asking for verdicts gets the
+# "UNSUPPORTED <pkg> <reason>" lines interleaved with the "TYPE dep/path" ones.
 # Cleans up the stamp directory on completion.
 # -------------------------------------------------------------------
 .PHONY: dependency-flat-raw
@@ -284,7 +300,7 @@ dependency-flat-raw:
 	@PARALLEL_MAKE=max $(MAKE) -j $(nproc) --silent --no-print-directory \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
-		$(if $(DEP_FLAT_VERDICT),DEP_FLAT_VERDICT=1) \
+		$(if $(REPORT_UNSUPPORTED),REPORT_UNSUPPORTED=1) \
 		dependency-flat-mk 2>/dev/null || true
 	@rm -rf $(DEP_FLAT_STAMP_DIR)
 
@@ -343,11 +359,11 @@ _dep_flat_why    = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUP
 # -------------------------------------------------------------------
 .PHONY: dependency-flat-mk
 dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
-	@# Under DEP_FLAT_VERDICT each package visited also reports why it refuses this arch, so
+	@# Under REPORT_UNSUPPORTED each package visited also reports why it refuses this arch, so
 	@# one walk yields both the tree and every refusal in it. Said here rather than by the
 	@# parent: these variables are only correct in the package's own make. Named <tree>/<pkg>
 	@# as a dependency is everywhere else -- $(NAME) is the PKG_NAME, shared by cross and spk.
-	@$(if $(and $(strip $(DEP_FLAT_VERDICT)),$(strip $(_dep_flat_why))),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_dep_flat_why)",true)
+	@$(if $(and $(strip $(REPORT_UNSUPPORTED)),$(strip $(_dep_flat_why))),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_dep_flat_why)",true)
 
 # -------------------------------------------------------------------
 # dep-flat-mk-%
@@ -382,8 +398,8 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 	DEPENDENCY_WALK=1 \
 	$(MAKE) -s --output-sync=target \
 		-C ../../$$dep \
-		$(if $(DEP_FLAT_VERDICT),DEP_FLAT_VERDICT=1) \
-		$(if $(DEP_FLAT_WITH_OPTIONAL),DEP_FLAT_WITH_OPTIONAL=1) \
+		$(if $(REPORT_UNSUPPORTED),REPORT_UNSUPPORTED=1) \
+		$(if $(WALK_OPTIONAL_DEPENDS),WALK_OPTIONAL_DEPENDS=1) \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
 		dependency-flat-mk
@@ -393,12 +409,12 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 # Every package in the tree that refuses this arch, one per line:
 #     <tree>/<package> <reason>[, <reason>...]
 # Empty output means the whole tree accepts it. The same stamped walk as dependency-flat, so
-# a diamond is visited once and OPTIONAL_DEPENDS stay out unless DEP_FLAT_WITH_OPTIONAL asks
+# a diamond is visited once and OPTIONAL_DEPENDS stay out unless WALK_OPTIONAL_DEPENDS asks
 # for them. The sed keeps only verdicts: stage0's bootstrap notice shares this stdout.
 # -------------------------------------------------------------------
 .PHONY: dependency-unsupported
 dependency-unsupported:
-	@DEP_FLAT_VERDICT=1 $(MAKE) -s \
+	@REPORT_UNSUPPORTED=1 $(MAKE) -s \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
 		dependency-flat-raw \

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -167,7 +167,8 @@ DEPENDS_TYPE ?= $(_DEFAULT_DEPENDS_TYPE)
 ALL_DEPENDS         = $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
 # An arch context normally drops OPTIONAL_DEPENDS: they are not built, so they do not belong
 # in a dependency list. DEP_FLAT_WITH_OPTIONAL walks them anyway, to REPORT what an optional
-# branch would demand. What actually gets built is unchanged either way.
+# branch would demand. What actually gets built is unchanged either way. This one is about
+# WHICH packages are walked; the _dep_flat_* below are about what each of them answers.
 _dep_flat_optional = $(if $(DEP_FLAT_WITH_OPTIONAL),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
 
 DEP_FLAT_TARGETS_MK = $(strip \
@@ -308,29 +309,33 @@ dependency-flat:
 		| grep -P "^(cross|python|native|spk|diyspk)/" \
 		| sort -u
 
-# Everything this package would refuse the arch for, in the shape the pre-check reports:
-# a capability floor, and an explicit UNSUPPORTED_ARCHS with whatever reason came with it.
-# The two lists are reported apart, so the message points at the variable to look in.
+# -------------------------------------------------------------------
+# Why this package refuses this arch, in the shape pre-check.mk reports it. Five parts:
+#
+#   _dep_flat_below    is $(1) below $(2)? the comparison pre-check.mk itself uses
+#   _dep_flat_reason   the optional UNSUPPORTED_ARCHS_REASON, parenthesised
+#   _dep_flat_listed   refused by an arch list, the two lists named apart
+#   _dep_flat_dsm      refused by the DSM/SRM window
+#   _dep_flat_why      all of the above plus the capability floors, comma-joined
+#
+# Only _dep_flat_why is read outside this block, by dependency-flat-mk below. The plain
+# $(sort) rather than version_lt is deliberate: pre-check.mk compares that way, and the
+# two must never disagree about a package -- one reports the refusal the other makes.
+# -------------------------------------------------------------------
+_dep_flat_below  = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
+
 _dep_flat_reason = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
+
 _dep_flat_listed = $(call comma_append,\
                      $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS)),unsupported arch$(_dep_flat_reason)),\
                      $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_dep_flat_reason)))
 
-# Is $(1) below $(2)? The plain $(sort) pre-check.mk uses, not version_lt, so the two can
-# never disagree about a package -- one reports the refusal the other makes.
-_dep_flat_below = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
-
-# The DSM/SRM window: declared, in range, and outside it.
-_dep_flat_dsm = $(strip \
+_dep_flat_dsm    = $(strip \
   $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _dep_flat_below,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
   $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _dep_flat_below,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
   $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _dep_flat_below,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
 
-_dep_flat_why = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_dep_flat_listed)),$(_dep_flat_dsm))
-
-# "cross/foo", "spk/foo" -- the tree and the package, which is how a dependency is named
-# everywhere else. $(NAME) will not do: it is the PKG_NAME, and cross/ and spk/ share it.
-_dep_flat_pkg = $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR))
+_dep_flat_why    = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_dep_flat_listed)),$(_dep_flat_dsm))
 
 # -------------------------------------------------------------------
 # dependency-flat-mk
@@ -341,8 +346,9 @@ _dep_flat_pkg = $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR))
 dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
 	@# Under DEP_FLAT_VERDICT each package visited also reports why it refuses this arch, so
 	@# one walk yields both the tree and every refusal in it. Said here rather than by the
-	@# parent: these variables are only correct in the package's own make.
-	@$(if $(and $(strip $(DEP_FLAT_VERDICT)),$(strip $(_dep_flat_why))),echo "UNSUPPORTED $(_dep_flat_pkg) $(_dep_flat_why)",true)
+	@# parent: these variables are only correct in the package's own make. Named <tree>/<pkg>
+	@# as a dependency is everywhere else -- $(NAME) is the PKG_NAME, shared by cross and spk.
+	@$(if $(and $(strip $(DEP_FLAT_VERDICT)),$(strip $(_dep_flat_why))),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_dep_flat_why)",true)
 
 # -------------------------------------------------------------------
 # dep-flat-mk-%

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -310,7 +310,11 @@ dependency-flat:
 
 # Everything this package would refuse the arch for, in the shape the pre-check reports:
 # a capability floor, and an explicit UNSUPPORTED_ARCHS with whatever reason came with it.
-_dep_flat_listed = $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS))$(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch$(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON)))))
+# The two lists are reported apart, so the message points at the variable to look in.
+_dep_flat_reason = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
+_dep_flat_listed = $(call comma_append,\
+                     $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS)),unsupported arch$(_dep_flat_reason)),\
+                     $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_dep_flat_reason)))
 
 # The DSM/SRM window, tested the way pre-check.mk tests it further down.
 _dep_flat_dsm = $(strip \

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -316,13 +316,21 @@ _dep_flat_listed = $(call comma_append,\
                      $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS)),unsupported arch$(_dep_flat_reason)),\
                      $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_dep_flat_reason)))
 
-# The DSM/SRM window, tested the way pre-check.mk tests it further down.
+# Is $(1) below $(2)? The plain $(sort) pre-check.mk uses, not version_lt, so the two can
+# never disagree about a package -- one reports the refusal the other makes.
+_dep_flat_below = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
+
+# The DSM/SRM window: declared, in range, and outside it.
 _dep_flat_dsm = $(strip \
-  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0)),$(if $(filter $(REQUIRED_MIN_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_DSM)))),,DSM $(TCVERSION) < $(REQUIRED_MIN_DSM))) \
-  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0)),$(if $(filter $(TCVERSION),$(firstword $(sort $(TCVERSION) $(REQUIRED_MAX_DSM)))),,DSM $(TCVERSION) > $(REQUIRED_MAX_DSM))) \
-  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0)),$(if $(filter $(REQUIRED_MIN_SRM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_SRM)))),,SRM $(TCVERSION) < $(REQUIRED_MIN_SRM))))
+  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _dep_flat_below,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
+  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _dep_flat_below,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
+  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _dep_flat_below,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
 
 _dep_flat_why = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_dep_flat_listed)),$(_dep_flat_dsm))
+
+# "cross/foo", "spk/foo" -- the tree and the package, which is how a dependency is named
+# everywhere else. $(NAME) will not do: it is the PKG_NAME, and cross/ and spk/ share it.
+_dep_flat_pkg = $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR))
 
 # -------------------------------------------------------------------
 # dependency-flat-mk
@@ -331,10 +339,10 @@ _dep_flat_why = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPOR
 # -------------------------------------------------------------------
 .PHONY: dependency-flat-mk
 dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
-	@# DEP_FLAT_VERDICT: each package visited also reports its own capability verdict, so
-	@# one walk yields both the tree and why any part of it refuses this arch. Emitted here
-	@# rather than by the parent -- TC_CAPABILITY_UNSUPPORTED is only correct in its own make.
-	$(if $(DEP_FLAT_VERDICT),@$(if $(strip $(_dep_flat_why)),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_dep_flat_why)",:))
+	@# Under DEP_FLAT_VERDICT each package visited also reports why it refuses this arch, so
+	@# one walk yields both the tree and every refusal in it. Said here rather than by the
+	@# parent: these variables are only correct in the package's own make.
+	@$(if $(and $(strip $(DEP_FLAT_VERDICT)),$(strip $(_dep_flat_why))),echo "UNSUPPORTED $(_dep_flat_pkg) $(_dep_flat_why)",true)
 
 # -------------------------------------------------------------------
 # dep-flat-mk-%
@@ -377,13 +385,11 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 
 # -------------------------------------------------------------------
 # dependency-unsupported
-# Every package in the tree that refuses this arch, one per line, as
-#     required|optional <package> <reason>[, <reason>...]
-# Required gates only, OPTIONAL_DEPENDS being out of the walk once an arch is set. The sed
-# drops anything that is not a verdict -- stage0's bootstrap notice shares this stdout.
-# Empty output means the whole tree accepts the arch. The same stamped walk as
-# dependency-flat, so a diamond is visited once, and OPTIONAL_DEPENDS drop out on
-# their own once ARCH and TCVERSION are both set.
+# Every package in the tree that refuses this arch, one per line:
+#     <tree>/<package> <reason>[, <reason>...]
+# Empty output means the whole tree accepts it. The same stamped walk as dependency-flat, so
+# a diamond is visited once and OPTIONAL_DEPENDS stay out unless DEP_FLAT_WITH_OPTIONAL asks
+# for them. The sed keeps only verdicts: stage0's bootstrap notice shares this stdout.
 # -------------------------------------------------------------------
 .PHONY: dependency-unsupported
 dependency-unsupported:

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -325,20 +325,17 @@ dependency-flat:
 		| sort -u
 
 # -------------------------------------------------------------------
-# Why this package refuses this arch, in the shape pre-check.mk reports it. Five parts:
+# Why this package refuses this arch, in the shape pre-check.mk reports it. Four parts:
 #
-#   _precheck_version_lt  is $(1) < $(2)? by the same comparison pre-check.mk makes
 #   _why_reason           the optional UNSUPPORTED_ARCHS_REASON, parenthesised
 #   _why_arch_list        refused by an arch list, the two lists named apart
 #   _why_dsm_window       refused by the DSM/SRM window
 #   _why_unsupported      all of the above plus the capability floors, comma-joined
 #
-# Only _why_unsupported is read outside this block, by dependency-flat-mk below. The plain
-# $(sort) rather than version_lt is deliberate, hence the name: pre-check.mk compares that
-# way, and the two must never disagree -- one reports the refusal the other makes.
+# Only _why_unsupported is read outside this block, by dependency-flat-mk below. The version
+# comparisons are macros.mk's, the same ones pre-check.mk makes, so what is reported here and
+# what is refused there cannot drift apart.
 # -------------------------------------------------------------------
-_precheck_version_lt = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
-
 _why_reason          = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
 
 _why_arch_list       = $(call comma_append,\
@@ -346,9 +343,9 @@ _why_arch_list       = $(call comma_append,\
                      $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_why_reason)))
 
 _why_dsm_window      = $(strip \
-  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_version_lt,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
-  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_version_lt,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
-  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _precheck_version_lt,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
+  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call version_lt,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
+  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call version_gt,$(TCVERSION),$(REQUIRED_MAX_DSM))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
+  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call version_lt,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
 
 _why_unsupported     = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_why_arch_list)),$(_why_dsm_window))
 

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -308,6 +308,18 @@ dependency-flat:
 		| grep -P "^(cross|python|native|spk|diyspk)/" \
 		| sort -u
 
+# Everything this package would refuse the arch for, in the shape the pre-check reports:
+# a capability floor, and an explicit UNSUPPORTED_ARCHS with whatever reason came with it.
+_dep_flat_listed = $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS))$(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch$(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON)))))
+
+# The DSM/SRM window, tested the way pre-check.mk tests it further down.
+_dep_flat_dsm = $(strip \
+  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0)),$(if $(filter $(REQUIRED_MIN_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_DSM)))),,DSM $(TCVERSION) < $(REQUIRED_MIN_DSM))) \
+  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0)),$(if $(filter $(TCVERSION),$(firstword $(sort $(TCVERSION) $(REQUIRED_MAX_DSM)))),,DSM $(TCVERSION) > $(REQUIRED_MAX_DSM))) \
+  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0)),$(if $(filter $(REQUIRED_MIN_SRM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_SRM)))),,SRM $(TCVERSION) < $(REQUIRED_MIN_SRM))))
+
+_dep_flat_why = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_dep_flat_listed)),$(_dep_flat_dsm))
+
 # -------------------------------------------------------------------
 # dependency-flat-mk
 # Parallel orchestrator — invokes all annotated dep-flat-mk-% targets.
@@ -318,7 +330,7 @@ dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
 	@# DEP_FLAT_VERDICT: each package visited also reports its own capability verdict, so
 	@# one walk yields both the tree and why any part of it refuses this arch. Emitted here
 	@# rather than by the parent -- TC_CAPABILITY_UNSUPPORTED is only correct in its own make.
-	$(if $(DEP_FLAT_VERDICT),@$(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(TC_CAPABILITY_UNSUPPORTED)",:))
+	$(if $(DEP_FLAT_VERDICT),@$(if $(strip $(_dep_flat_why)),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_dep_flat_why)",:))
 
 # -------------------------------------------------------------------
 # dep-flat-mk-%

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -327,30 +327,30 @@ dependency-flat:
 # -------------------------------------------------------------------
 # Why this package refuses this arch, in the shape pre-check.mk reports it. Five parts:
 #
-#   _precheck_below    is $(1) below $(2)? the comparison pre-check.mk itself uses
-#   _why_reason        the optional UNSUPPORTED_ARCHS_REASON, parenthesised
-#   _why_arch_list     refused by an arch list, the two lists named apart
-#   _why_dsm_window    refused by the DSM/SRM window
-#   _why_unsupported   all of the above plus the capability floors, comma-joined
+#   _precheck_version_lt  is $(1) < $(2)? by the same comparison pre-check.mk makes
+#   _why_reason           the optional UNSUPPORTED_ARCHS_REASON, parenthesised
+#   _why_arch_list        refused by an arch list, the two lists named apart
+#   _why_dsm_window       refused by the DSM/SRM window
+#   _why_unsupported      all of the above plus the capability floors, comma-joined
 #
 # Only _why_unsupported is read outside this block, by dependency-flat-mk below. The plain
 # $(sort) rather than version_lt is deliberate, hence the name: pre-check.mk compares that
 # way, and the two must never disagree -- one reports the refusal the other makes.
 # -------------------------------------------------------------------
-_precheck_below  = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
+_precheck_version_lt = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
 
-_why_reason      = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
+_why_reason          = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
 
-_why_arch_list   = $(call comma_append,\
+_why_arch_list       = $(call comma_append,\
                      $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS)),unsupported arch$(_why_reason)),\
                      $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_why_reason)))
 
-_why_dsm_window  = $(strip \
-  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_below,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
-  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_below,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
-  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _precheck_below,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
+_why_dsm_window      = $(strip \
+  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_version_lt,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
+  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_version_lt,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
+  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _precheck_version_lt,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
 
-_why_unsupported = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_why_arch_list)),$(_why_dsm_window))
+_why_unsupported     = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_why_arch_list)),$(_why_dsm_window))
 
 # -------------------------------------------------------------------
 # dependency-flat-mk

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -165,10 +165,15 @@ DEPENDS_TYPE ?= $(_DEFAULT_DEPENDS_TYPE)
 # are first evaluated (i.e. when dependency-flat-mk resolves its prerequisites).
 # -------------------------------------------------------------------
 ALL_DEPENDS         = $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
+# An arch context normally drops OPTIONAL_DEPENDS: they are not built, so they do not belong
+# in a dependency list. DEP_FLAT_WITH_OPTIONAL walks them anyway, to REPORT what an optional
+# branch would demand. What actually gets built is unchanged either way.
+_dep_flat_optional = $(if $(DEP_FLAT_WITH_OPTIONAL),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
+
 DEP_FLAT_TARGETS_MK = $(strip \
   $(addprefix dep-flat-mk-DEPENDS__,          $(subst /,__,$(DEPENDS))) \
   $(addprefix dep-flat-mk-BUILD_DEPENDS__,    $(subst /,__,$(BUILD_DEPENDS))) \
-  $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))) \
+  $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(_dep_flat_optional))) \
   $(addprefix dep-flat-mk-NATIVE_DEPENDS__,   $(subst /,__,$(NATIVE_DEPENDS))))
 
 # -------------------------------------------------------------------
@@ -349,6 +354,7 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 	$(MAKE) -s --output-sync=target \
 		-C ../../$$dep \
 		$(if $(DEP_FLAT_VERDICT),DEP_FLAT_VERDICT=1) \
+		$(if $(DEP_FLAT_WITH_OPTIONAL),DEP_FLAT_WITH_OPTIONAL=1) \
 		$(if $(ARCH),ARCH=$(ARCH)) \
 		$(if $(TCVERSION),TCVERSION=$(TCVERSION)) \
 		dependency-flat-mk
@@ -356,7 +362,9 @@ dep-flat-mk-%: | $(DEP_FLAT_STAMP_DIR)
 # -------------------------------------------------------------------
 # dependency-unsupported
 # Every package in the tree that refuses this arch, one per line, as
-#     <package> <reason>[, <reason>...]
+#     required|optional <package> <reason>[, <reason>...]
+# Required gates only, OPTIONAL_DEPENDS being out of the walk once an arch is set. The sed
+# drops anything that is not a verdict -- stage0's bootstrap notice shares this stdout.
 # Empty output means the whole tree accepts the arch. The same stamped walk as
 # dependency-flat, so a diamond is visited once, and OPTIONAL_DEPENDS drop out on
 # their own once ARCH and TCVERSION are both set.

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -165,10 +165,9 @@ DEPENDS_TYPE ?= $(_DEFAULT_DEPENDS_TYPE)
 # are first evaluated (i.e. when dependency-flat-mk resolves its prerequisites).
 # -------------------------------------------------------------------
 ALL_DEPENDS         = $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
-# An arch context normally drops OPTIONAL_DEPENDS: they are not built, so they do not belong
-# in a dependency list. DEP_FLAT_WITH_OPTIONAL walks them anyway, to REPORT what an optional
-# branch would demand. What actually gets built is unchanged either way. This one is about
-# WHICH packages are walked; the _dep_flat_* below are about what each of them answers.
+
+# An arch context drops OPTIONAL_DEPENDS, not being built; DEP_FLAT_WITH_OPTIONAL walks them
+# anyway, to REPORT what an optional branch would demand. Nothing about the build changes.
 _dep_flat_optional = $(if $(DEP_FLAT_WITH_OPTIONAL),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
 
 DEP_FLAT_TARGETS_MK = $(strip \

--- a/mk/spksrc.rules/dependency-tree.mk
+++ b/mk/spksrc.rules/dependency-tree.mk
@@ -182,12 +182,12 @@ ALL_DEPENDS         = $(sort $(NATIVE_DEPENDS) $(BUILD_DEPENDS) $(DEPENDS) $(if 
 
 # An arch context drops OPTIONAL_DEPENDS, not being built; WALK_OPTIONAL_DEPENDS walks them
 # anyway, to REPORT what an optional branch would demand. Nothing about the build changes.
-_dep_flat_optional = $(if $(WALK_OPTIONAL_DEPENDS),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
+_walk_optional = $(if $(WALK_OPTIONAL_DEPENDS),$(OPTIONAL_DEPENDS),$(if $(and $(ARCH),$(TCVERSION)),,$(OPTIONAL_DEPENDS)))
 
 DEP_FLAT_TARGETS_MK = $(strip \
   $(addprefix dep-flat-mk-DEPENDS__,          $(subst /,__,$(DEPENDS))) \
   $(addprefix dep-flat-mk-BUILD_DEPENDS__,    $(subst /,__,$(BUILD_DEPENDS))) \
-  $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(_dep_flat_optional))) \
+  $(addprefix dep-flat-mk-OPTIONAL_DEPENDS__, $(subst /,__,$(_walk_optional))) \
   $(addprefix dep-flat-mk-NATIVE_DEPENDS__,   $(subst /,__,$(NATIVE_DEPENDS))))
 
 # -------------------------------------------------------------------
@@ -327,30 +327,30 @@ dependency-flat:
 # -------------------------------------------------------------------
 # Why this package refuses this arch, in the shape pre-check.mk reports it. Five parts:
 #
-#   _dep_flat_below    is $(1) below $(2)? the comparison pre-check.mk itself uses
-#   _dep_flat_reason   the optional UNSUPPORTED_ARCHS_REASON, parenthesised
-#   _dep_flat_listed   refused by an arch list, the two lists named apart
-#   _dep_flat_dsm      refused by the DSM/SRM window
-#   _dep_flat_why      all of the above plus the capability floors, comma-joined
+#   _precheck_below    is $(1) below $(2)? the comparison pre-check.mk itself uses
+#   _why_reason        the optional UNSUPPORTED_ARCHS_REASON, parenthesised
+#   _why_arch_list     refused by an arch list, the two lists named apart
+#   _why_dsm_window    refused by the DSM/SRM window
+#   _why_unsupported   all of the above plus the capability floors, comma-joined
 #
-# Only _dep_flat_why is read outside this block, by dependency-flat-mk below. The plain
-# $(sort) rather than version_lt is deliberate: pre-check.mk compares that way, and the
-# two must never disagree about a package -- one reports the refusal the other makes.
+# Only _why_unsupported is read outside this block, by dependency-flat-mk below. The plain
+# $(sort) rather than version_lt is deliberate, hence the name: pre-check.mk compares that
+# way, and the two must never disagree -- one reports the refusal the other makes.
 # -------------------------------------------------------------------
-_dep_flat_below  = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
+_precheck_below  = $(if $(filter $(2),$(firstword $(sort $(1) $(2)))),,1)
 
-_dep_flat_reason = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
+_why_reason      = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
 
-_dep_flat_listed = $(call comma_append,\
-                     $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS)),unsupported arch$(_dep_flat_reason)),\
-                     $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_dep_flat_reason)))
+_why_arch_list   = $(call comma_append,\
+                     $(if $(filter $(ARCH),$(UNSUPPORTED_ARCHS)),unsupported arch$(_why_reason)),\
+                     $(if $(filter $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)),unsupported arch-tcversion$(_why_reason)))
 
-_dep_flat_dsm    = $(strip \
-  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _dep_flat_below,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
-  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _dep_flat_below,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
-  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _dep_flat_below,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
+_why_dsm_window  = $(strip \
+  $(if $(and $(REQUIRED_MIN_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_below,$(TCVERSION),$(REQUIRED_MIN_DSM))),DSM $(TCVERSION) < $(REQUIRED_MIN_DSM)) \
+  $(if $(and $(REQUIRED_MAX_DSM),$(call version_ge,$(TCVERSION),3.0),$(call _precheck_below,$(REQUIRED_MAX_DSM),$(TCVERSION))),DSM $(TCVERSION) > $(REQUIRED_MAX_DSM)) \
+  $(if $(and $(REQUIRED_MIN_SRM),$(call version_lt,$(TCVERSION),3.0),$(call _precheck_below,$(TCVERSION),$(REQUIRED_MIN_SRM))),SRM $(TCVERSION) < $(REQUIRED_MIN_SRM)))
 
-_dep_flat_why    = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_dep_flat_listed)),$(_dep_flat_dsm))
+_why_unsupported = $(call comma_append,$(call comma_append,$(TC_CAPABILITY_UNSUPPORTED),$(_why_arch_list)),$(_why_dsm_window))
 
 # -------------------------------------------------------------------
 # dependency-flat-mk
@@ -363,7 +363,7 @@ dependency-flat-mk: $(DEP_FLAT_TARGETS_MK)
 	@# one walk yields both the tree and every refusal in it. Said here rather than by the
 	@# parent: these variables are only correct in the package's own make. Named <tree>/<pkg>
 	@# as a dependency is everywhere else -- $(NAME) is the PKG_NAME, shared by cross and spk.
-	@$(if $(and $(strip $(REPORT_UNSUPPORTED)),$(strip $(_dep_flat_why))),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_dep_flat_why)",true)
+	@$(if $(and $(strip $(REPORT_UNSUPPORTED)),$(strip $(_why_unsupported))),echo "UNSUPPORTED $(notdir $(patsubst %/,%,$(dir $(CURDIR))))/$(notdir $(CURDIR)) $(_why_unsupported)",true)
 
 # -------------------------------------------------------------------
 # dep-flat-mk-%

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -16,7 +16,7 @@
 
 # Disabled for dependency targets, and for the check goal -- whose whole job is to REPORT
 # the gates this arch fails, which a fatal pre-check would cut short at the first one.
-ifeq ($(strip $(filter 1,$(DEPENDENCY_WALK))$(filter check,$(MAKECMDGOALS))),)
+ifeq ($(or $(filter 1,$(DEPENDENCY_WALK)),$(filter check,$(MAKECMDGOALS))),)
 
 # SPK_FOLDER    
 # name of the spk package folder
@@ -60,25 +60,26 @@ ifneq ($(REQUIRE_KERNEL),)
   endif
 endif
 
-# Every gate in the dependency tree, not only this package's own: a package is just as
-# blocked by a floor it never declared, and stopping at the first sends you round the loop
-# once per blocker. Same walk as `make check-<arch>-<vers>` (spksrc.rules/supported.mk),
-# stamped so a diamond is visited once, and it reports this package's verdict too.
+# Every gate in the whole tree, not only this package's own: it is as blocked by a floor it
+# never declared, and stopping at the first sends you round the loop once per blocker. The
+# walk `make check-<arch>-<vers>` runs (spksrc.rules/supported.mk), required gates only --
+# an optional dependency that refuses must not refuse the build.
 #
-# $(shell) folds newlines into spaces, so each line's own spaces travel as ~ and are put
-# back one $(info) at a time. No reason or package path contains one.
+# $(shell) folds newlines into spaces, so each line's own spaces travel as ~ and come back
+# one $(info) at a time. No package path or reason contains one.
 ifneq ($(strip $(ARCH))$(strip $(TCVERSION)),)
-# Required gates only: an optional dependency that refuses must not refuse the build.
 _TREE_GATES := $(shell DEPENDENCY_WALK=1 $(MAKE) -s --no-print-directory dependency-unsupported \
                    ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null \
                    | grep -E '^(cross|spk|diyspk|native|kernel)/' | sed 's/ /~/g')
 endif
 
-# Refuse an arch whose toolchain cannot meet a declared floor (spksrc.common/tc-capability.mk),
-# naming every gate rather than the first, so one run tells the whole story.
+# What this package refuses on its own, then how much the tree adds.
+_own_why  = $(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),: $(TC_CAPABILITY_UNSUPPORTED))
+_tree_why = $(if $(strip $(_TREE_GATES)), ($(words $(_TREE_GATES)) failed check(s) in the tree))
+
 ifneq ($(strip $(TC_CAPABILITY_UNSUPPORTED))$(strip $(_TREE_GATES)),)
   $(foreach _g,$(_TREE_GATES),$(info ===>  check: $(subst ~, ,$(_g))))
-  $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME)$(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),: $(TC_CAPABILITY_UNSUPPORTED))$(if $(strip $(_TREE_GATES)), ($(words $(_TREE_GATES)) failed check(s) in the tree$())))
+  $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME)$(_own_why)$(_tree_why))
 endif
 
 # Check whether package supports ARCH.
@@ -136,4 +137,4 @@ endif
 
 endif # ifneq ($(TCVERSION),)
 
-endif # ifeq (DEPENDENCY_WALK / check)
+endif # ifeq (DEPENDENCY_WALK / check goal)

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -68,6 +68,7 @@ endif
 # $(shell) folds newlines into spaces, so each line's own spaces travel as ~ and are put
 # back one $(info) at a time. No reason or package path contains one.
 ifneq ($(strip $(ARCH))$(strip $(TCVERSION)),)
+# Required gates only: an optional dependency that refuses must not refuse the build.
 _TREE_GATES := $(shell DEPENDENCY_WALK=1 $(MAKE) -s --no-print-directory dependency-unsupported \
                    ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null | sed 's/ /~/g')
 endif
@@ -75,8 +76,8 @@ endif
 # Refuse an arch whose toolchain cannot meet a declared floor (spksrc.common/tc-capability.mk),
 # naming every gate rather than the first, so one run tells the whole story.
 ifneq ($(strip $(TC_CAPABILITY_UNSUPPORTED))$(strip $(_TREE_GATES)),)
-  $(foreach _g,$(_TREE_GATES),$(info ===>  gate: $(subst ~, ,$(_g))))
-  $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME)$(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),: $(TC_CAPABILITY_UNSUPPORTED))$(if $(strip $(_TREE_GATES)), ($(words $(_TREE_GATES)) gate(s) in the tree$())))
+  $(foreach _g,$(_TREE_GATES),$(info ===>  check: $(subst ~, ,$(_g))))
+  $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME)$(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),: $(TC_CAPABILITY_UNSUPPORTED))$(if $(strip $(_TREE_GATES)), ($(words $(_TREE_GATES)) failed check(s) in the tree$())))
 endif
 
 # Check whether package supports ARCH.

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -117,9 +117,6 @@ ifneq ($(REQUIRED_MAX_DSM),)
   endif
 endif
 
-# version_lt/gt rather than a plain $(sort): the latter compares lexically, so a future
-# DSM 10 would read as older than 7. spksrc.rules/dependency-tree.mk reports what is
-# refused here and calls the same macros, so the two cannot drift apart.
 # Check minimum DSM requirements of package
 ifneq ($(REQUIRED_MIN_DSM),)
   ifeq ($(call version_ge, ${TCVERSION}, 3.0),1)

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -65,10 +65,18 @@ ifneq ($(strip $(TC_CAPABILITY_UNSUPPORTED)),)
   $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME): $(TC_CAPABILITY_UNSUPPORTED))
 endif
 
-# Check whether package supports ARCH
+# Check whether package supports ARCH.
+#
+# UNSUPPORTED_ARCHS says WHERE a package fails, never why, and the archs are often added
+# by an include rather than by the package -- so the message names a package that has no
+# such list in its own Makefile. Whoever adds the archs can add UNSUPPORTED_ARCHS_REASON
+# alongside, and it is carried here in parentheses. A capability floor is still the better
+# answer where one fits; this is for the exclusions that are not capability checks.
+_unsupported_why = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
+
 ifneq ($(UNSUPPORTED_ARCHS),)
   ifneq (,$(findstring $(ARCH),$(UNSUPPORTED_ARCHS)))
-    $(call precheck_fatal,Arch '$(ARCH)' is not a supported architecture)
+    $(call precheck_fatal,Arch '$(ARCH)' is not a supported architecture$(_unsupported_why))
   endif
 endif
 
@@ -76,7 +84,7 @@ ifneq ($(TCVERSION),)
 
 ifneq ($(UNSUPPORTED_ARCHS_TCVERSION),)
   ifneq (,$(findstring $(ARCH)-$(TCVERSION),$(UNSUPPORTED_ARCHS_TCVERSION)))
-    $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not a supported architecture)
+    $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not a supported architecture$(_unsupported_why))
   endif
 endif
 

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -60,10 +60,23 @@ ifneq ($(REQUIRE_KERNEL),)
   endif
 endif
 
-# Refuse an arch whose toolchain cannot meet MIN_GCC_VERSION / MIN_GLIBC_VERSION
-# (see spksrc.common/tc-capability.mk). Says why, not just where.
-ifneq ($(strip $(TC_CAPABILITY_UNSUPPORTED)),)
-  $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME): $(TC_CAPABILITY_UNSUPPORTED))
+# Every gate in the dependency tree, not only this package's own: a package is just as
+# blocked by a floor it never declared, and stopping at the first sends you round the loop
+# once per blocker. Same walk as `make check-<arch>-<vers>` (spksrc.rules/supported.mk),
+# stamped so a diamond is visited once, and it reports this package's verdict too.
+#
+# $(shell) folds newlines into spaces, so each line's own spaces travel as ~ and are put
+# back one $(info) at a time. No reason or package path contains one.
+ifneq ($(strip $(ARCH))$(strip $(TCVERSION)),)
+_TREE_GATES := $(shell DEPENDENCY_WALK=1 $(MAKE) -s --no-print-directory dependency-unsupported \
+                   ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null | sed 's/ /~/g')
+endif
+
+# Refuse an arch whose toolchain cannot meet a declared floor (spksrc.common/tc-capability.mk),
+# naming every gate rather than the first, so one run tells the whole story.
+ifneq ($(strip $(TC_CAPABILITY_UNSUPPORTED))$(strip $(_TREE_GATES)),)
+  $(foreach _g,$(_TREE_GATES),$(info ===>  gate: $(subst ~, ,$(_g))))
+  $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME)$(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),: $(TC_CAPABILITY_UNSUPPORTED))$(if $(strip $(_TREE_GATES)), ($(words $(_TREE_GATES)) gate(s) in the tree$())))
 endif
 
 # Check whether package supports ARCH.

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -67,11 +67,8 @@ endif
 
 # Check whether package supports ARCH.
 #
-# UNSUPPORTED_ARCHS says WHERE a package fails, never why, and the archs are often added
-# by an include rather than by the package -- so the message names a package that has no
-# such list in its own Makefile. Whoever adds the archs can add UNSUPPORTED_ARCHS_REASON
-# alongside, and it is carried here in parentheses. A capability floor is still the better
-# answer where one fits; this is for the exclusions that are not capability checks.
+# UNSUPPORTED_ARCHS says WHERE a package fails, never why, and is often added by an include
+# rather than by the package -- so whoever adds the archs adds UNSUPPORTED_ARCHS_REASON too.
 _unsupported_why = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
 
 ifneq ($(UNSUPPORTED_ARCHS),)

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -77,17 +77,17 @@ endif
 _own_why  = $(if $(strip $(TC_CAPABILITY_UNSUPPORTED)),: $(TC_CAPABILITY_UNSUPPORTED))
 _tree_why = $(if $(strip $(_TREE_GATES)), ($(words $(_TREE_GATES)) failed check(s) in the tree))
 
-ifneq ($(strip $(TC_CAPABILITY_UNSUPPORTED))$(strip $(_TREE_GATES)),)
+# Refuse the arch, naming every gate rather than the first, so one run tells the whole story.
+ifneq ($(or $(strip $(TC_CAPABILITY_UNSUPPORTED)),$(strip $(_TREE_GATES))),)
   $(foreach _g,$(_TREE_GATES),$(info ===>  check: $(subst ~, ,$(_g))))
   $(call precheck_fatal,Arch '$(ARCH)-$(TCVERSION)' is not supported by $(SPK_NAME)$(PKG_NAME)$(_own_why)$(_tree_why))
 endif
 
-# Check whether package supports ARCH.
-#
 # UNSUPPORTED_ARCHS says WHERE a package fails, never why, and is often added by an include
 # rather than by the package -- so whoever adds the archs adds UNSUPPORTED_ARCHS_REASON too.
 _unsupported_why = $(if $(strip $(UNSUPPORTED_ARCHS_REASON)), ($(strip $(UNSUPPORTED_ARCHS_REASON))))
 
+# Check whether package supports ARCH
 ifneq ($(UNSUPPORTED_ARCHS),)
   ifneq (,$(findstring $(ARCH),$(UNSUPPORTED_ARCHS)))
     $(call precheck_fatal,Arch '$(ARCH)' is not a supported architecture$(_unsupported_why))

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -111,16 +111,19 @@ endif
 # Check maximal DSM requirements of package
 ifneq ($(REQUIRED_MAX_DSM),)
   ifeq ($(call version_ge, ${TCVERSION}, 3.0),1)
-    ifneq ($(TCVERSION),$(firstword $(sort $(TCVERSION) $(REQUIRED_MAX_DSM))))
+    ifeq ($(call version_gt,$(TCVERSION),$(REQUIRED_MAX_DSM)),1)
       $(call precheck_fatal,DSM Toolchain $(TCVERSION) is higher than $(REQUIRED_MAX_DSM))
     endif
   endif
 endif
 
+# version_lt/gt rather than a plain $(sort): the latter compares lexically, so a future
+# DSM 10 would read as older than 7. spksrc.rules/dependency-tree.mk reports what is
+# refused here and calls the same macros, so the two cannot drift apart.
 # Check minimum DSM requirements of package
 ifneq ($(REQUIRED_MIN_DSM),)
   ifeq ($(call version_ge, ${TCVERSION}, 3.0),1)
-    ifneq ($(REQUIRED_MIN_DSM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_DSM))))
+    ifeq ($(call version_lt,$(TCVERSION),$(REQUIRED_MIN_DSM)),1)
       $(call precheck_fatal,DSM Toolchain $(TCVERSION) is lower than $(REQUIRED_MIN_DSM))
     endif
   endif
@@ -129,7 +132,7 @@ endif
 # Check minimum SRM requirements of package
 ifneq ($(REQUIRED_MIN_SRM),)
   ifeq ($(call version_lt, ${TCVERSION}, 3.0),1)
-    ifneq ($(REQUIRED_MIN_SRM),$(firstword $(sort $(TCVERSION) $(REQUIRED_MIN_SRM))))
+    ifeq ($(call version_lt,$(TCVERSION),$(REQUIRED_MIN_SRM)),1)
       $(call precheck_fatal,SRM Toolchain $(TCVERSION) is lower than $(REQUIRED_MIN_SRM))
     endif
   endif

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -70,7 +70,8 @@ endif
 ifneq ($(strip $(ARCH))$(strip $(TCVERSION)),)
 # Required gates only: an optional dependency that refuses must not refuse the build.
 _TREE_GATES := $(shell DEPENDENCY_WALK=1 $(MAKE) -s --no-print-directory dependency-unsupported \
-                   ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null | sed 's/ /~/g')
+                   ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null \
+                   | grep -E '^(cross|spk|diyspk|native|kernel)/' | sed 's/ /~/g')
 endif
 
 # Refuse an arch whose toolchain cannot meet a declared floor (spksrc.common/tc-capability.mk),

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -14,8 +14,9 @@
 #
 ###############################################################################
 
-# disable checks for dependency targets
-ifneq ($(DEPENDENCY_WALK),1)
+# Disabled for dependency targets, and for the check goal -- whose whole job is to REPORT
+# the gates this arch fails, which a fatal pre-check would cut short at the first one.
+ifeq ($(strip $(filter 1,$(DEPENDENCY_WALK))$(filter check,$(MAKECMDGOALS))),)
 
 # SPK_FOLDER    
 # name of the spk package folder
@@ -120,4 +121,4 @@ endif
 
 endif # ifneq ($(TCVERSION),)
 
-endif # ifneq ($(DEPENDENCY_WALK),1)
+endif # ifeq (DEPENDENCY_WALK / check)

--- a/mk/spksrc.rules/pre-check.mk
+++ b/mk/spksrc.rules/pre-check.mk
@@ -60,13 +60,8 @@ ifneq ($(REQUIRE_KERNEL),)
   endif
 endif
 
-# Every gate in the whole tree, not only this package's own: it is as blocked by a floor it
-# never declared, and stopping at the first sends you round the loop once per blocker. The
-# walk `make check-<arch>-<vers>` runs (spksrc.rules/supported.mk), required gates only --
-# an optional dependency that refuses must not refuse the build.
-#
-# $(shell) folds newlines into spaces, so each line's own spaces travel as ~ and come back
-# one $(info) at a time. No package path or reason contains one.
+# Every gate in the tree, required ones only, as `make check-<arch>-<vers>` walks it: a
+# package is as blocked by a floor it never declared. ~ carries the spaces $(shell) eats.
 ifneq ($(strip $(ARCH))$(strip $(TCVERSION)),)
 _TREE_GATES := $(shell DEPENDENCY_WALK=1 $(MAKE) -s --no-print-directory dependency-unsupported \
                    ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null \

--- a/mk/spksrc.rules/supported.mk
+++ b/mk/spksrc.rules/supported.mk
@@ -69,8 +69,11 @@ $(TARGET_TYPE)-arch-% &: pre-build-native
 # Required gates come from the walk an arch context already defines; the optional ones are
 # what a second walk adds when OPTIONAL_DEPENDS are followed too. A set difference, not a
 # label carried down: a package under both a required and an optional parent is required.
+# The grep is not redundant with the sed inside dependency-unsupported: stage0's bootstrap
+# notice is an $(info) from the sub-make's PARSE, so it bypasses that recipe's own pipe.
 _gate_walk = DEPENDENCY_WALK=1 $(MAKE) --no-print-directory -s dependency-unsupported \
-                 ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null
+                 ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null \
+                 | grep -E '^(cross|spk|diyspk|native|kernel)/'
 _gate_fmt  = awk '{ p = $$1 ; $$1 = "" ; printf "         %-26s %s\n", p, substr($$0, 2) }'
 
 # Every capability gate in the dependency tree that this arch fails, or nothing when it

--- a/mk/spksrc.rules/supported.mk
+++ b/mk/spksrc.rules/supported.mk
@@ -66,6 +66,26 @@ $(TARGET_TYPE)-arch-% &: pre-build-native
 # Teed here rather than in build-arch-%: one level up also catches make's own
 # "*** [build-arch-...] Error 1" cascade, which is emitted after that recipe exits.
 # _runlog's LOGGING_ENABLED guard makes this the only teeing level.
+# Every capability gate in the dependency tree that this arch fails, or nothing when it
+# builds. Pure diagnostic: reads the declared floors across the tree, extracts no toolchain.
+.PHONY: check
+check: SHELL:=/bin/bash
+check:  ## Report the capability gates ARCH/TCVERSION fails (see also check-<arch>-<vers>)
+	@out=$$(DEPENDENCY_WALK=1 $(MAKE) --no-print-directory -s dependency-unsupported \
+	          ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null) ; \
+	if [ -z "$$out" ] ; then \
+	   $(MSG) "$(NAME): every gate met for $(ARCH)-$(TCVERSION)" ; \
+	else \
+	   $(MSG) "$(NAME): $$(echo "$$out" | wc -l) gate(s) not met for $(ARCH)-$(TCVERSION)" ; \
+	   echo "$$out" | awk '{ p = $$1 ; $$1 = "" ; printf "         %-26s %s\n", p, substr($$0, 2) }' ; \
+	fi
+
+# The goal-shaped form, for symmetry with arch-<arch>-<vers>. Carries the pair in the goal
+# rather than in variables, so the parse it runs under has no ARCH to be refused for.
+check-%:
+	@$(MAKE) --no-print-directory check \
+	    ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*))
+
 arch-%: SHELL:=/bin/bash
 arch-%:
 	@set -o pipefail ; \

--- a/mk/spksrc.rules/supported.mk
+++ b/mk/spksrc.rules/supported.mk
@@ -79,7 +79,7 @@ _gate_fmt  = awk '{ p = $$1 ; $$1 = "" ; printf "         %-26s %s\n", p, substr
 check: SHELL:=/bin/bash
 check:  ## Report the capability gates ARCH/TCVERSION fails (see also check-<arch>-<vers>)
 	@req=$$($(_gate_walk)) ; \
-	all=$$(DEP_FLAT_WITH_OPTIONAL=1 $(_gate_walk)) ; \
+	all=$$(WALK_OPTIONAL_DEPENDS=1 $(_gate_walk)) ; \
 	opt=$$(comm -13 <(echo "$$req") <(echo "$$all")) ; \
 	if [ -z "$$req$$opt" ] ; then \
 	   $(MSG) "$(NAME): $(ARCH)-$(TCVERSION) check: OK" ; \

--- a/mk/spksrc.rules/supported.mk
+++ b/mk/spksrc.rules/supported.mk
@@ -63,18 +63,21 @@ pre-build-native:
 $(TARGET_TYPE)-arch-% &: pre-build-native
 	-@MAKEFLAGS= GCC_DEBUG_INFO="$(GCC_DEBUG_INFO)" $(MAKE) arch-$*
 
-# Required gates come from the walk an arch context already defines; the optional ones are
-# what a second walk adds when OPTIONAL_DEPENDS are followed too. A set difference, not a
-# label carried down: a package under both a required and an optional parent is required.
-# The grep is not redundant with the sed inside dependency-unsupported: stage0's bootstrap
-# notice is an $(info) from the sub-make's PARSE, so it bypasses that recipe's own pipe.
+# One walk of the tree. The grep is not redundant with the sed inside dependency-unsupported:
+# stage0's bootstrap notice is an $(info) from the sub-make's PARSE, outside that pipe.
 _gate_walk = DEPENDENCY_WALK=1 $(MAKE) --no-print-directory -s dependency-unsupported \
                  ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null \
                  | grep -E '^(cross|spk|diyspk|native|kernel)/'
+
+# Package name in a column of its own, reason after it.
 _gate_fmt  = awk '{ p = $$1 ; $$1 = "" ; printf "         %-26s %s\n", p, substr($$0, 2) }'
 
 # Every capability gate in the dependency tree that this arch fails, or nothing when it
 # builds. Pure diagnostic: reads the declared floors across the tree, extracts no toolchain.
+#
+# Required is the walk an arch context already defines; optional is what a second walk adds
+# when OPTIONAL_DEPENDS are followed too. A set difference, not a label carried down the
+# walk: a package under both a required and an optional parent is required.
 .PHONY: check
 check: SHELL:=/bin/bash
 check:  ## Report the capability gates ARCH/TCVERSION fails (see also check-<arch>-<vers>)

--- a/mk/spksrc.rules/supported.mk
+++ b/mk/spksrc.rules/supported.mk
@@ -66,18 +66,27 @@ $(TARGET_TYPE)-arch-% &: pre-build-native
 # Teed here rather than in build-arch-%: one level up also catches make's own
 # "*** [build-arch-...] Error 1" cascade, which is emitted after that recipe exits.
 # _runlog's LOGGING_ENABLED guard makes this the only teeing level.
+# Required gates come from the walk an arch context already defines; the optional ones are
+# what a second walk adds when OPTIONAL_DEPENDS are followed too. A set difference, not a
+# label carried down: a package under both a required and an optional parent is required.
+_gate_walk = DEPENDENCY_WALK=1 $(MAKE) --no-print-directory -s dependency-unsupported \
+                 ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null
+_gate_fmt  = awk '{ p = $$1 ; $$1 = "" ; printf "         %-26s %s\n", p, substr($$0, 2) }'
+
 # Every capability gate in the dependency tree that this arch fails, or nothing when it
 # builds. Pure diagnostic: reads the declared floors across the tree, extracts no toolchain.
 .PHONY: check
 check: SHELL:=/bin/bash
 check:  ## Report the capability gates ARCH/TCVERSION fails (see also check-<arch>-<vers>)
-	@out=$$(DEPENDENCY_WALK=1 $(MAKE) --no-print-directory -s dependency-unsupported \
-	          ARCH=$(ARCH) TCVERSION=$(TCVERSION) 2>/dev/null) ; \
-	if [ -z "$$out" ] ; then \
-	   $(MSG) "$(NAME): every gate met for $(ARCH)-$(TCVERSION)" ; \
+	@req=$$($(_gate_walk)) ; \
+	all=$$(DEP_FLAT_WITH_OPTIONAL=1 $(_gate_walk)) ; \
+	opt=$$(comm -13 <(echo "$$req") <(echo "$$all")) ; \
+	if [ -z "$$req$$opt" ] ; then \
+	   $(MSG) "$(NAME): $(ARCH)-$(TCVERSION) check: OK" ; \
 	else \
-	   $(MSG) "$(NAME): $$(echo "$$out" | wc -l) gate(s) not met for $(ARCH)-$(TCVERSION)" ; \
-	   echo "$$out" | awk '{ p = $$1 ; $$1 = "" ; printf "         %-26s %s\n", p, substr($$0, 2) }' ; \
+	   $(MSG) "$(NAME): $(ARCH)-$(TCVERSION) check: $$(echo "$$req" | grep -c .) failed$$([ -n "$$opt" ] && echo ", $$(echo "$$opt" | grep -c .) more behind an optional dependency")" ; \
+	   [ -z "$$req" ] || { echo "       required" ; echo "$$req" | $(_gate_fmt) ; } ; \
+	   [ -z "$$opt" ] || { echo "       optional" ; echo "$$opt" | $(_gate_fmt) ; } ; \
 	fi
 
 # The goal-shaped form, for symmetry with arch-<arch>-<vers>. Carries the pair in the goal

--- a/mk/spksrc.rules/supported.mk
+++ b/mk/spksrc.rules/supported.mk
@@ -63,9 +63,6 @@ pre-build-native:
 $(TARGET_TYPE)-arch-% &: pre-build-native
 	-@MAKEFLAGS= GCC_DEBUG_INFO="$(GCC_DEBUG_INFO)" $(MAKE) arch-$*
 
-# Teed here rather than in build-arch-%: one level up also catches make's own
-# "*** [build-arch-...] Error 1" cascade, which is emitted after that recipe exits.
-# _runlog's LOGGING_ENABLED guard makes this the only teeing level.
 # Required gates come from the walk an arch context already defines; the optional ones are
 # what a second walk adds when OPTIONAL_DEPENDS are followed too. A set difference, not a
 # label carried down: a package under both a required and an optional parent is required.
@@ -98,6 +95,9 @@ check-%:
 	@$(MAKE) --no-print-directory check \
 	    ARCH=$(firstword $(subst -, ,$*)) TCVERSION=$(lastword $(subst -, ,$*))
 
+# Teed here rather than in build-arch-%: one level up also catches make's own
+# "*** [build-arch-...] Error 1" cascade, which is emitted after that recipe exits.
+# _runlog's LOGGING_ENABLED guard makes this the only teeing level.
 arch-%: SHELL:=/bin/bash
 arch-%:
 	@set -o pipefail ; \

--- a/mk/spksrc.spk-meta/python.mk
+++ b/mk/spksrc.spk-meta/python.mk
@@ -10,9 +10,14 @@ ifeq ($(strip $(PYTHON_PACKAGE)),)
   PYTHON_PACKAGE = python312
 endif
 
-# Mark default unsupported archs
-ifeq ($(call version_ge, $(PYTHON_PACKAGE), python312),1)
-  UNSUPPORTED_ARCHS += $(ARMv5_ARCHS) $(OLD_PPC_ARCHS)
+# Carry the selected python's own floor to the consumer, rather than listing the archs it
+# refuses -- read from that package, so the two cannot drift, and correct on archs no list
+# thought of. Raised, never lowered: a consumer keeps its own floor when it asks for more.
+_PYTHON_MIN_GCC := $(shell sed -n 's/^MIN_GCC_VERSION *= *//p' $(CURDIR)/../../cross/$(PYTHON_PACKAGE)/Makefile 2>/dev/null)
+ifneq ($(strip $(_PYTHON_MIN_GCC)),)
+  MIN_GCC_VERSION := $(strip $(if $(strip $(MIN_GCC_VERSION)),\
+                       $(if $(call version_ge,$(MIN_GCC_VERSION),$(_PYTHON_MIN_GCC)),$(MIN_GCC_VERSION),$(_PYTHON_MIN_GCC)),\
+                       $(_PYTHON_MIN_GCC)))
 endif
 
 # set default spk/python* path to use

--- a/mk/spksrc.spk-meta/python.mk
+++ b/mk/spksrc.spk-meta/python.mk
@@ -10,16 +10,6 @@ ifeq ($(strip $(PYTHON_PACKAGE)),)
   PYTHON_PACKAGE = python312
 endif
 
-# Carry the selected python's own floor to the consumer, rather than listing the archs it
-# refuses -- read from that package, so the two cannot drift, and correct on archs no list
-# thought of. Raised, never lowered: a consumer keeps its own floor when it asks for more.
-_PYTHON_MIN_GCC := $(shell sed -n 's/^MIN_GCC_VERSION *= *//p' $(CURDIR)/../../cross/$(PYTHON_PACKAGE)/Makefile 2>/dev/null)
-ifneq ($(strip $(_PYTHON_MIN_GCC)),)
-  MIN_GCC_VERSION := $(strip $(if $(strip $(MIN_GCC_VERSION)),\
-                       $(if $(call version_ge,$(MIN_GCC_VERSION),$(_PYTHON_MIN_GCC)),$(MIN_GCC_VERSION),$(_PYTHON_MIN_GCC)),\
-                       $(_PYTHON_MIN_GCC)))
-endif
-
 # set default spk/python* path to use
 PYTHON_PACKAGE_DIR = $(abspath $(CURDIR)/../../spk/$(PYTHON_PACKAGE))
 PYTHON_PACKAGE_WORK_DIR = $(PYTHON_PACKAGE_DIR)/work-$(ARCH)-$(TCVERSION)

--- a/spk/chromaprint/Makefile
+++ b/spk/chromaprint/Makefile
@@ -7,7 +7,6 @@ FFMPEG_PACKAGE = ffmpeg8
 DEPENDS = cross/chromaprint
 
 # ffmpeg8 needs C11 -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 STARTABLE = no
 

--- a/spk/comskip/Makefile
+++ b/spk/comskip/Makefile
@@ -6,7 +6,6 @@ SPK_ICON = src/comskip.png
 FFMPEG_PACKAGE = ffmpeg8
 
 # ffmpeg8 needs C11 -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 DEPENDS = cross/comskip
 

--- a/spk/ffmpeg5/Makefile
+++ b/spk/ffmpeg5/Makefile
@@ -13,7 +13,6 @@ DEPENDS = cross/ffmpeg5
 VIDEODRV_PACKAGE = synocli-videodriver
 
 # Needs C11 and working atomics -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 MAINTAINER = th0ma7
 DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/

--- a/spk/ffmpeg6/Makefile
+++ b/spk/ffmpeg6/Makefile
@@ -10,7 +10,6 @@ DEPENDS = cross/ffmpeg6
 VIDEODRV_PACKAGE = synocli-videodriver
 
 # Needs C11 and working atomics -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 MAINTAINER = th0ma7
 DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/

--- a/spk/ffmpeg7/Makefile
+++ b/spk/ffmpeg7/Makefile
@@ -10,7 +10,6 @@ DEPENDS = cross/ffmpeg7
 VIDEODRV_PACKAGE = synocli-videodriver
 
 # Needs C11 and working atomics -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 MAINTAINER = th0ma7
 DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/

--- a/spk/ffmpeg8/Makefile
+++ b/spk/ffmpeg8/Makefile
@@ -10,7 +10,6 @@ DEPENDS = cross/ffmpeg8
 VIDEODRV_PACKAGE = synocli-videodriver
 
 # Needs C11 and working atomics -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 MAINTAINER = th0ma7
 DESCRIPTION = FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec - the leading audio/video codec library.  More information from SynoCommunity FFmpeg package available at https://docs.synocommunity.com/packages/ffmpeg/

--- a/spk/tvheadend/Makefile
+++ b/spk/tvheadend/Makefile
@@ -45,7 +45,6 @@ ADMIN_PORT = ${SERVICE_PORT}
 # PPC archs except qoriq are not supported
 #    https://tvheadend.org/issues/5060
 # ffmpeg8 needs C11 -- gcc 4.9 or newer
-MIN_GCC_VERSION = 4.9
 
 DEPENDS  = cross/tvheadend
 DEPENDS += cross/dtv-scan-tables


### PR DESCRIPTION
## The problem

The pre-check stopped at the first floor a package could not meet, and only ever looked at the package's own. Removing that blocker revealed the next one — a build at a time. And `UNSUPPORTED_ARCHS` said **where** a package fails, never why.

## `make check-<arch>-<tcvers>`

Ask an architecture what stands in the way, without starting a build:

```
$ make check-x86-5.2                        # in spk/tvheadend
===>  tvheadend: x86-5.2 check: 17 failed, 14 more behind an optional dependency
       required
         cross/ffmpeg8              gcc 4.7.3 < 4.9
         cross/python314            gcc 4.7.3 < 4.8
         ...
       optional
         cross/frei0r               gcc 4.7.3 < 7.5
         ...

$ make check-x86-5.2                        # in spk/borgbackup
===>  borgbackup: x86-5.2 check: OK
```

`make ARCH=x86 TCVERSION=5.2 check` is the same with the pair in variables. **required** is what the build needs; **optional** is what an `OPTIONAL_DEPENDS` branch would demand if turned on — never a reason to refuse.

A package reports every refusal the pre-check would make: a capability floor, an `UNSUPPORTED_ARCHS` exclusion with its reason, or the DSM/SRM window.

```
cross/minio      unsupported arch (go has no 32-bit PowerPC target)
spk/jellyfin     unsupported arch, DSM 5.2 < 7.2
```

## The pre-check runs the same walk

So a refused build names every blocker at once instead of the first:

```
===>  check: cross/x264 gcc 4.3.7 < 4.6
===>  check: cross/python314 gcc 4.3.7 < 4.8
===>  check: cross/ffmpeg8 gcc 4.3.7 < 4.9
...
pre-check.mk:80: *** Arch 'ppc853x-5.2' is not supported by tvheadend (18 failed check(s) in the tree).  Stop.
```

It reuses `dependency-flat`'s walk, already stamped so a diamond is visited once, already forwarding ARCH/TCVERSION so each package evaluates its own conditional `DEPENDS`, already setting `DEPENDENCY_WALK=1` so a refused package reports instead of aborting. Required and optional are a **set difference** between two walks, not a label carried down — a package under both a required and an optional parent is required.

## Consequences

- **`UNSUPPORTED_ARCHS_REASON`** is carried into the refusal; `env-go.mk` and `env-dotnet.mk` say theirs.
- **Seven restated floors removed.** `spk/tvheadend`, `chromaprint`, `comskip` and `spk/ffmpeg5-8` each declared `MIN_GCC_VERSION = 4.9`, restating their own `cross/` package. Declare the floor on the `cross/`; the `spk/` inherits it by being walked. The python side is left for its own PR.
- **`comma_append`** replaces two names for one operation, and `spksrc.common.mk`'s utility block moves above the includes — `$(,)` expanded to nothing in every file that included it, which is why `tc-capability.mk` carried a private copy.

## Cost and risk

One walk per parse: **2.8s warm** on tvheadend's 141-package tree, against builds measured in tens of minutes. **Verdict-neutral** — every `spk/` package across x64-7.1, 88f6281-6.2.4 and ppc853x-5.2 gives the same refused/allowed set as before. What changes is that the whole story is told at once.

DSM 5.2 is enabled in a separate commit so CI exercises the toolchains below gcc 4.9. **Revert before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd