### PR TITLE
toolchain: give each build its own tc_vars

### DIFF
--- a/docs/developer-guide/packaging/build-rules.md
+++ b/docs/developer-guide/packaging/build-rules.md
@@ -56,6 +56,7 @@ Run from `native/<package>/` directory (host tools built once, then reused via
 | `download` `checksum` `extract` `patch` `configure` `compile` `install` | Individual build lifecycle steps, in order |
 | `build-archive` / `print-archive-name` | Create the reusable archive on demand / print its filename (opt-in via `ARCHIVE_NAME`, see `spksrc.build/archive.mk`) |
 | `nativeclean` | Drop **this** package's build cookies so every step re-runs next `make`, keeping the work dir (source, install, archive). The native counterpart of `spkclean`; leaves dependencies' cookies alone |
+| `toolchainclean` | Drop a toolchain's generated `tc_vars*` and the cookies guarding them, so the next build regenerates them for its own overlay state. Run in `toolchain/syno-<arch>-<vers>/`. Keeps the extracted toolchain and its per-step cookies, so nothing is re-downloaded |
 | `clean` / `smart-clean` | Remove all work directories / this package's source and cookies |
 
 To re-run a single step, remove its one cookie, e.g.

--- a/docs/framework/changes.md
+++ b/docs/framework/changes.md
@@ -83,6 +83,40 @@ If you only read one thing, read this. The details are in the dated log below.
 
 ---
 
+??? note "September 7th 2026 — An overlay switch that did nothing on an installed toolchain (#7440)"
+    - **What was wrong:** the toolchain work dir holds ONE shared `tc_vars*`, and `tcvars`
+      regenerates it only while its cookie is absent. So the first package to build against
+      a toolchain fixed its overlay state, and every package after inherited it. Asking for
+      a different one changed nothing:
+
+        ```bash
+        make -C cross/<pkg> ARCH=qoriq TCVERSION=6.2.4 OVERLAY_RUSTC=1   # ... then
+        make -C cross/<pkg> ARCH=qoriq TCVERSION=6.2.4 OVERLAY_RUSTC=0
+        ```
+
+      `TC_OVERLAY_RUSTC`, `TC_EXTRA_RUSTFLAGS` and `TC_OVERLAY_BINUTILS` kept whatever the
+      first run wrote. The second build did not fail -- it quietly used the first one's
+      toolchain, which is the harder kind of wrong to notice.
+    - **`toolchainclean`** drops the generated `tc_vars*`, their cookie, and
+      `TOOLCHAIN_COOKIE`. The last is both consistent -- without its `tc_vars` a toolchain
+      is not fully installed -- and necessary: those cookies are read with `$(wildcard)` at
+      **parse** time, so one `make` cannot clean and regenerate in a single pass. The
+      rebuild has to come from the next invocation, and the missing cookie is what triggers
+      it. Per-step cookies stay, so nothing is re-downloaded or re-extracted.
+    - **Called from `stage0`,** outside its `ARCH`/`TCVERSION` guards so that one site
+      covers both entry points: `make -C cross/<pkg> ARCH=x TCVERSION=y`, which sets them,
+      and `make arch-<arch>-<vers>`, which does not -- it carries them in the goal, read
+      back from `MAKECMDGOALS`.
+    - **Only a directly invoked package cleans.** Dependencies already agree with whoever
+      pulled them in, and with `PARALLEL_MAKE=max` several parse at once -- one clearing the
+      file while another reads it is a race. `MAKELEVEL` is the discriminator: `0` from a
+      shell, non-zero for every sub-make.
+    - **Package-facing:** `make toolchainclean` in `toolchain/syno-<arch>-<vers>/` is now a
+      documented way to force a toolchain to re-answer. Nothing else changes: with a single
+      overlay state in play, which is the usual case, the regeneration is a few seconds and
+      the result identical.
+    - Pull request: [#7440](https://github.com/SynoCommunity/spksrc/pull/7440)
+
 ??? note "September 4th 2026 — Build logs keep what the console showed (#7396)"
     - **What was lost:** a package refused by a pre-check left a build log holding a
       single line. `$(error)` fires at **parse** time, so no recipe of the inner make
@@ -233,7 +267,9 @@ If you only read one thing, read this. The details are in the dated log below.
         with precedence `command line > environment > local.mk > defaults`. A request
         that cannot be honored degrades to the stock tools and says so in a banner
         rather than failing. `make help` in `cross/`, `spk/` and `diyspk/` prints the
-        switches, the value in effect, and what it resolves to for your arch.
+        switches, the value in effect, and what it resolves to for your arch. **That
+        precedence did not survive an already-installed toolchain until #7440** -- see the
+        September 7th entry: the shared tc_vars kept the first build's answer.
     - **Arch issues fixed along the way:** per-target rustflags, so the PowerPC SPE
       codegen options actually reach the compiler (`-Ctarget-cpu=e500
       -Ctarget-feature=+spe`, not `+efpu2`) — the qoriq `bat`/`lsd` SIGILL of #7304; the

--- a/docs/framework/makefile-system.md
+++ b/docs/framework/makefile-system.md
@@ -54,7 +54,7 @@ The `mk/` directory contains all makefile includes, organized by function:
 
 | File | Purpose |
 |------|--------|
-| `spksrc.toolchain.mk` | Toolchain build and tc_vars generation |
+| `spksrc.toolchain.mk` | Toolchain build and tc_vars generation (also defines `toolchainclean`) |
 | `spksrc.toolkit.mk` | Toolkit management |
 
 ### Build System Adapters

--- a/mk/spksrc.common/help.mk
+++ b/mk/spksrc.common/help.mk
@@ -53,6 +53,7 @@ ifneq ($(filter $(SPKSRC_TREE),cross spk kernel diyspk),)
 endif
 ifeq ($(SPKSRC_TREE),toolchain)
 	@printf "  \033[36m%-24s\033[0m %s\n" "tc_vars" "show the toolchain variables (TC_GCC, ...)"
+	@printf "  \033[36m%-24s\033[0m %s\n" "toolchainclean" "drop tc_vars* so the next build regenerates them"
 endif
 ifeq ($(SPKSRC_TREE),toolkit)
 	@printf "  \033[36m%-24s\033[0m %s\n" "tk_vars" "show the toolkit variables"

--- a/mk/spksrc.common/stage0.mk
+++ b/mk/spksrc.common/stage0.mk
@@ -61,6 +61,17 @@
 #
 ###############################################################################
 
+# The shared tc_vars keeps the overlay state of whoever built first, so a directly invoked
+# package drops it here (MAKELEVEL: not deps) and the bootstrap below rewrites it.
+# Outside the ARCH guards: arch-<arch>-<vers> carries them in the goal, not in variables.
+ifeq ($(MAKELEVEL),0)
+ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)
+  _s0_tc := $(or $(if $(strip $(ARCH)),$(if $(strip $(TCVERSION)),$(ARCH)-$(TCVERSION))),\
+                 $(patsubst arch-%,%,$(filter arch-%,$(MAKECMDGOALS))))
+  $(foreach t,$(_s0_tc),$(shell $(MAKE) --no-print-directory -C $(BASEDIR)/toolchain/syno-$(t) toolchainclean >/dev/null 2>&1))
+endif
+endif
+
 ifneq ($(strip $(filter-out noarch,$(ARCH))),)
 ifneq ($(strip $(TCVERSION)),)
 ifeq ($(filter toolchain,$(subst /, ,$(CURDIR))),)

--- a/mk/spksrc.toolchain.mk
+++ b/mk/spksrc.toolchain.mk
@@ -241,3 +241,14 @@ $(TOOLCHAIN_COOKIE): $(POST_TOOLCHAIN_TARGET)
 else
 toolchain: ;
 endif
+
+#####
+
+# Drop the generated tc_vars* and the cookies guarding them, so the next make rewrites them
+# for its own overlay state. Per-step cookies stay: nothing is re-downloaded or re-extracted.
+.PHONY: toolchainclean
+toolchainclean:
+	@$(MSG) "Removing generated tc_vars* and $(notdir $(TCVARS_COOKIE)) from $(TC_WORK_DIR)"
+	@rm -f $(TC_WORK_DIR)/tc_vars $(TC_WORK_DIR)/tc_vars.* \
+	       $(TC_WORK_DIR)/.$(COOKIE_PREFIX)stage1-tcvars_done \
+	       $(TOOLCHAIN_COOKIE)


### PR DESCRIPTION
The toolchain work dir holds **one** shared `tc_vars*`, and `tcvars` regenerates it only while its cookie is absent:

```make
ifeq ($(wildcard $(TCVARS_COOKIE)),)
tcvars: ... generate_tc_vars_mk generate_tc_vars_other $(TCVARS_COOKIE)
else
tcvars: ;
endif
```

So the first package to build against a toolchain fixes its overlay state, and every package after inherits it. Ask for a different one and nothing happens:

```bash
make -C cross/<pkg> ARCH=qoriq TCVERSION=6.2.4 OVERLAY_RUSTC=1   # ... then
make -C cross/<pkg> ARCH=qoriq TCVERSION=6.2.4 OVERLAY_RUSTC=0
```

`TC_OVERLAY_RUSTC`, `TC_EXTRA_RUSTFLAGS` and `TC_OVERLAY_BINUTILS` keep whatever the first run wrote, because the toolchain is already installed and the cookie short-circuits the regeneration. **The switch is silently ignored** — the second build does not fail, it quietly uses the first one's toolchain.

## The change

`toolchainclean` drops the generated `tc_vars*`, their cookie, and `TOOLCHAIN_COOKIE`.

Removing the last is both consistent — without its `tc_vars` the toolchain is not fully installed — and *necessary*: those cookies are tested with `$(wildcard)` at **parse** time, so a single make cannot clean and regenerate in one pass (`make: 'tcvars' is up to date`). The rebuild has to come from the next invocation, and the missing cookie is what triggers it.

Per-step cookies stay, so nothing is re-downloaded or re-extracted: `toolchain` walks its `DEPENDS` again and rewrites `tc_vars*`. On an installed toolchain this is a few seconds.

## Called from `stage0` alone

Placed **outside** its `ARCH`/`TCVERSION` guards, which is what lets one site cover both entry points:

| entry | |
|---|---|
| `make -C cross/<pkg> ARCH=x TCVERSION=y` | sets both |
| `make arch-<arch>-<vers>` | sets neither — it carries them in the goal, read back from `MAKECMDGOALS` |

The second is how CI builds every package. Splitting the goal on dashes is safe for the same reason `supported.mk` already relies on: no arch name or DSM version contains one. `supported.mk` is untouched.

Only a **directly invoked** package cleans. Dependencies already agree with whoever pulled them in, and with `PARALLEL_MAKE=max` several of them parse at once — one clearing the file while another reads it is a race. `MAKELEVEL` is the discriminator: `0` from a shell, non-zero for every sub-make.

## Testing

Both directions, on an already-installed toolchain:

```
make arch-qoriq-6.2.4                 tc_vars removed, then regenerated
make ARCH=qoriq TCVERSION=6.2.4 ...   same
the same call through a sub-make      untouched
```

`make toolchainclean` is listed by `make help` in a toolchain directory and documented in the build-rules and makefile-system references. `changes.md` records it as a fix to the overlay switches from #7353, whose own entry promises `command line > environment > local.mk > defaults` — a precedence that did not survive an already-installed toolchain.

The defect is behind a non-default switch (`OVERLAY_RUSTC` is 1 in `local.mk`, `OVERLAY_BINUTILS` 0), so there is no failing job to point at — it shows as a switch that does nothing, which is the worse kind.

Extracted from #7391, where a gcc overlay makes the same defect loud: a package built without the overlay inherited `-latomic` from one built with it and died at `ld: cannot find -latomic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd
