### PR TITLE
dotnet: keep the arch exclusions with dotnet, not in the common arch groups

### DIFF
--- a/mk/spksrc.common.mk
+++ b/mk/spksrc.common.mk
@@ -61,6 +61,9 @@ include $(BASEDIR)/mk/spksrc.common/stage0.mk
 # Load common definitions
 include $(BASEDIR)/mk/spksrc.common/archs.mk
 
+# Which archs a dotnet package refuses (needs the arch groups above)
+include $(BASEDIR)/mk/spksrc.common/dotnet.mk
+
 include $(BASEDIR)/mk/spksrc.common/logs.mk
 
 # Load local configuration

--- a/mk/spksrc.common/archs.mk
+++ b/mk/spksrc.common/archs.mk
@@ -91,31 +91,6 @@ OLD_PPC_ARCHS = powerpc ppc824x ppc853x ppc854x
 # outdated unsupported archs
 DEPRECATED_ARCHS = powerpc ppc824x ppc854x ppc853x
 
-# Notes for .NET 6 compatibility:
-# 1. dotnet for x86 (32-bit) is unsupported on linux and must be built from source
-# 2. ARMv7_ARCHS without full vfpv3 support (having only vfpv3-d16) are not supported
-# 3. SRM ARMv7 archs are not supported
-# 4. Certain combinations of ARMv7 and DSM are incompatible (issues #4790, #5089, #5302, #5315)
-# 5. Comprehensive ARMv7 testing conducted under issue #5574 resulted in the following exclusions
-
-# Exclusions for dotnet core apps
-ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370 alpine comcerto2k
-    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
-endif
-
-# Exclusions for dotnet 6.0 servarr apps (except x86)
-ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine comcerto2k
-    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
-endif
-
-# Exclusions for dotnet 6.0 servarr apps (except x86)
-# ARMv7 incompatibility — see: https://github.com/dotnet/runtime/issues/109739
-ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),2)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(ARMv7_ARCHS)
-endif
-
 # Filter to exclude TC versions greater than DEFAULT_TC (from local configuration)
 TCVERSION_DUPES = $(addprefix %,$(filter-out $(DEFAULT_TC),$(AVAILABLE_TCVERSIONS)))
 

--- a/mk/spksrc.common/dotnet.mk
+++ b/mk/spksrc.common/dotnet.mk
@@ -7,7 +7,11 @@
 #
 # Selected by the package:
 #   DOTNET_CORE_ARCHS   = 1   a dotnet core app
-#   DOTNET_SERVARR_ARCHS= 1   a dotnet 6.0 servarr app
+# Selected by spksrc.cross-dotnet.mk itself, for anything built with the dotnet SDK:
+#   DOTNET_BUILD_ARCHS  = 1   the archs dotnet has no runtime port for
+#
+# A package matching neither declares its own list and reuses _dotnet_why for the reason;
+# spk/readarr does, its ARMv7 ground being its alone.
 #
 # Notes for .NET 6 compatibility:
 # 1. dotnet for x86 (32-bit) is unsupported on linux and must be built from source
@@ -15,9 +19,6 @@
 # 3. SRM ARMv7 archs are not supported
 # 4. Certain combinations of ARMv7 and DSM are incompatible (issues #4790, #5089, #5302, #5315)
 # 5. Comprehensive ARMv7 testing conducted under issue #5574 resulted in the following exclusions
-#
-# Selected for a package built with the dotnet SDK by spksrc.cross-dotnet.mk itself:
-#   DOTNET_BUILD_ARCHS  = 1   the archs dotnet has no runtime port for
 ###############################################################################
 
 # dotnet is absent here for four different reasons, so the reason is picked by the arch at
@@ -30,12 +31,7 @@ _dotnet_why = $(strip $(or \
   $(if $(filter $(ARCH),comcerto2k),dotnet is incompatible with this arch (issue #5574)),\
   $(if $(filter $(ARCH),$(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS)),dotnet has no runtime port for this arch)))
 
-# The .NET 6.0 ARMv7 segfault: a ground of its own, not a missing port, and it takes
-# precedence over the map above. No flavour here -- one package hits it and says so itself.
-_dotnet_why_armv7_net60 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739)),$(_dotnet_why))
-
-# Anything built with the dotnet SDK; spksrc.cross-dotnet.mk sets this before it includes
-# spksrc.common.mk. Narrower than the app lists below: only the archs with no runtime port.
+# Narrower than the app list below: only the archs with no runtime port.
 ifeq ($(strip $(DOTNET_BUILD_ARCHS)),1)
     UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
     UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
@@ -44,13 +40,6 @@ endif
 # Exclusions for dotnet core apps
 ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370 alpine comcerto2k
-    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
-    UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
-endif
-
-# Exclusions for dotnet 6.0 servarr apps (except x86)
-ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine comcerto2k
     UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
     UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
 endif

--- a/mk/spksrc.common/dotnet.mk
+++ b/mk/spksrc.common/dotnet.mk
@@ -1,0 +1,43 @@
+###############################################################################
+# spksrc.common/dotnet.mk
+#
+# Which architectures a dotnet package refuses, and why. Included for every
+# package (spksrc.common.mk), because the consumers are spk/ packages that
+# include spksrc.spk.mk and never see spksrc.cross/env-dotnet.mk.
+#
+# Selected by the package:
+#   DOTNET_CORE_ARCHS   = 1   a dotnet core app
+#   DOTNET_SERVARR_ARCHS= 1   a dotnet 6.0 servarr app
+#   DOTNET_SERVARR_ARCHS= 2   ... one hitting the ARMv7 runtime bug
+#
+# Notes for .NET 6 compatibility:
+# 1. dotnet for x86 (32-bit) is unsupported on linux and must be built from source
+# 2. ARMv7_ARCHS without full vfpv3 support (having only vfpv3-d16) are not supported
+# 3. SRM ARMv7 archs are not supported
+# 4. Certain combinations of ARMv7 and DSM are incompatible (issues #4790, #5089, #5302, #5315)
+# 5. Comprehensive ARMv7 testing conducted under issue #5574 resulted in the following exclusions
+#
+# The cross/ side of the same story is in spksrc.cross/env-dotnet.mk, which the
+# dotnet build environment pulls in; it excludes on the same grounds.
+###############################################################################
+
+# Exclusions for dotnet core apps
+ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370 alpine comcerto2k
+    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
+    UNSUPPORTED_ARCHS_REASON := dotnet core ships no runtime for this arch
+endif
+
+# Exclusions for dotnet 6.0 servarr apps (except x86)
+ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine comcerto2k
+    UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
+    UNSUPPORTED_ARCHS_REASON := dotnet 6.0 servarr ships no runtime for this arch
+endif
+
+# Exclusions for dotnet 6.0 servarr apps (except x86)
+# ARMv7 incompatibility -- see: https://github.com/dotnet/runtime/issues/109739
+ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),2)
+    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(ARMv7_ARCHS)
+    UNSUPPORTED_ARCHS_REASON := dotnet 6.0 servarr on ARMv7: dotnet/runtime#109739
+endif

--- a/mk/spksrc.common/dotnet.mk
+++ b/mk/spksrc.common/dotnet.mk
@@ -17,27 +17,41 @@
 # 4. Certain combinations of ARMv7 and DSM are incompatible (issues #4790, #5089, #5302, #5315)
 # 5. Comprehensive ARMv7 testing conducted under issue #5574 resulted in the following exclusions
 #
-# The cross/ side of the same story is in spksrc.cross/env-dotnet.mk, which the
-# dotnet build environment pulls in; it excludes on the same grounds.
+# The cross/ side is in spksrc.cross/env-dotnet.mk, which the dotnet build environment
+# pulls in; it carries its own list and its own reason.
 ###############################################################################
+
+# dotnet is absent here for four different reasons, so the reason is picked by the arch at
+# hand: one umbrella line would misdescribe most of a list that is not homogeneous.
+# First match wins, most specific first.
+_dotnet_why = $(strip $(or \
+  $(if $(filter $(ARCH)-$(TCVERSION),armv7-6.2.4 armv7-1.2 armv7-1.3),dotnet is incompatible with this arch/DSM pair (issues #4790 #5089 #5302 #5315)),\
+  $(if $(filter $(ARCH),armada370),dotnet needs full vfpv3 and this toolchain is vfpv3-d16),\
+  $(if $(filter $(ARCH),alpine),dotnet segfaults on this arch despite capable silicon (issue #5302)),\
+  $(if $(filter $(ARCH),comcerto2k),dotnet is incompatible with this arch (issue #5574)),\
+  $(if $(filter $(ARCH),$(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS)),dotnet has no runtime port for this arch)))
+
+# Servarr 2 refuses every ARMv7, capable silicon included, on a runtime bug rather than a
+# missing port -- so that ground is its own, and takes precedence over the map above.
+_dotnet_why_servarr2 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 servarr on ARMv7: dotnet/runtime#109739),$(_dotnet_why))
 
 # Exclusions for dotnet core apps
 ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS) armada370 alpine comcerto2k
     UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
-    UNSUPPORTED_ARCHS_REASON := dotnet core ships no runtime for this arch
+    UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
 endif
 
 # Exclusions for dotnet 6.0 servarr apps (except x86)
 ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine comcerto2k
     UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
-    UNSUPPORTED_ARCHS_REASON := dotnet 6.0 servarr ships no runtime for this arch
+    UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
 endif
 
 # Exclusions for dotnet 6.0 servarr apps (except x86)
 # ARMv7 incompatibility -- see: https://github.com/dotnet/runtime/issues/109739
 ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),2)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(ARMv7_ARCHS)
-    UNSUPPORTED_ARCHS_REASON := dotnet 6.0 servarr on ARMv7: dotnet/runtime#109739
+    UNSUPPORTED_ARCHS_REASON := $(_dotnet_why_servarr2)
 endif

--- a/mk/spksrc.common/dotnet.mk
+++ b/mk/spksrc.common/dotnet.mk
@@ -8,7 +8,6 @@
 # Selected by the package:
 #   DOTNET_CORE_ARCHS   = 1   a dotnet core app
 #   DOTNET_SERVARR_ARCHS= 1   a dotnet 6.0 servarr app
-#   DOTNET_SERVARR_ARCHS= 2   ... one hitting the ARMv7 runtime bug
 #
 # Notes for .NET 6 compatibility:
 # 1. dotnet for x86 (32-bit) is unsupported on linux and must be built from source
@@ -31,9 +30,9 @@ _dotnet_why = $(strip $(or \
   $(if $(filter $(ARCH),comcerto2k),dotnet is incompatible with this arch (issue #5574)),\
   $(if $(filter $(ARCH),$(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS)),dotnet has no runtime port for this arch)))
 
-# Servarr 2 refuses every ARMv7, capable silicon included, on a .NET 6.0 runtime segfault
-# rather than a missing port -- its own ground, and it takes precedence over the map above.
-_dotnet_why_servarr2 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739)),$(_dotnet_why))
+# The .NET 6.0 ARMv7 segfault: a ground of its own, not a missing port, and it takes
+# precedence over the map above. No flavour here -- one package hits it and says so itself.
+_dotnet_why_armv7_net60 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739)),$(_dotnet_why))
 
 # Anything built with the dotnet SDK; spksrc.cross-dotnet.mk sets this before it includes
 # spksrc.common.mk. Narrower than the app lists below: only the archs with no runtime port.
@@ -54,11 +53,4 @@ ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),1)
     UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) armada370 alpine comcerto2k
     UNSUPPORTED_ARCHS_TCVERSION = armv7-6.2.4 armv7-1.2 armv7-1.3
     UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
-endif
-
-# Exclusions for dotnet 6.0 servarr apps (except x86)
-# ARMv7 incompatibility -- see: https://github.com/dotnet/runtime/issues/109739
-ifeq ($(strip $(DOTNET_SERVARR_ARCHS)),2)
-    UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(ARMv7_ARCHS)
-    UNSUPPORTED_ARCHS_REASON := $(_dotnet_why_servarr2)
 endif

--- a/mk/spksrc.common/dotnet.mk
+++ b/mk/spksrc.common/dotnet.mk
@@ -31,9 +31,9 @@ _dotnet_why = $(strip $(or \
   $(if $(filter $(ARCH),comcerto2k),dotnet is incompatible with this arch (issue #5574)),\
   $(if $(filter $(ARCH),$(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(i686_ARCHS)),dotnet has no runtime port for this arch)))
 
-# Servarr 2 refuses every ARMv7, capable silicon included, on a runtime bug rather than a
-# missing port -- so that ground is its own, and takes precedence over the map above.
-_dotnet_why_servarr2 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 servarr on ARMv7: dotnet/runtime#109739),$(_dotnet_why))
+# Servarr 2 refuses every ARMv7, capable silicon included, on a .NET 6.0 runtime segfault
+# rather than a missing port -- its own ground, and it takes precedence over the map above.
+_dotnet_why_servarr2 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739)),$(_dotnet_why))
 
 # Anything built with the dotnet SDK; spksrc.cross-dotnet.mk sets this before it includes
 # spksrc.common.mk. Narrower than the app lists below: only the archs with no runtime port.

--- a/mk/spksrc.common/dotnet.mk
+++ b/mk/spksrc.common/dotnet.mk
@@ -17,8 +17,8 @@
 # 4. Certain combinations of ARMv7 and DSM are incompatible (issues #4790, #5089, #5302, #5315)
 # 5. Comprehensive ARMv7 testing conducted under issue #5574 resulted in the following exclusions
 #
-# The cross/ side is in spksrc.cross/env-dotnet.mk, which the dotnet build environment
-# pulls in; it carries its own list and its own reason.
+# Selected for a package built with the dotnet SDK by spksrc.cross-dotnet.mk itself:
+#   DOTNET_BUILD_ARCHS  = 1   the archs dotnet has no runtime port for
 ###############################################################################
 
 # dotnet is absent here for four different reasons, so the reason is picked by the arch at
@@ -34,6 +34,13 @@ _dotnet_why = $(strip $(or \
 # Servarr 2 refuses every ARMv7, capable silicon included, on a runtime bug rather than a
 # missing port -- so that ground is its own, and takes precedence over the map above.
 _dotnet_why_servarr2 = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 servarr on ARMv7: dotnet/runtime#109739),$(_dotnet_why))
+
+# Anything built with the dotnet SDK; spksrc.cross-dotnet.mk sets this before it includes
+# spksrc.common.mk. Narrower than the app lists below: only the archs with no runtime port.
+ifeq ($(strip $(DOTNET_BUILD_ARCHS)),1)
+    UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
+    UNSUPPORTED_ARCHS_REASON := $(_dotnet_why)
+endif
 
 # Exclusions for dotnet core apps
 ifeq ($(strip $(DOTNET_CORE_ARCHS)),1)

--- a/mk/spksrc.cross-dotnet.mk
+++ b/mk/spksrc.cross-dotnet.mk
@@ -39,11 +39,11 @@ endif
 endif
 
 
-# Common makefiles
 # Every dotnet build refuses the archs dotnet has no runtime port for. Raised here, before
 # common.mk, because spksrc.common/dotnet.mk holds the list and the reason for all of them.
 DOTNET_BUILD_ARCHS = 1
 
+# Common makefiles
 include ../../mk/spksrc.common.mk
 
 ##### dotnet specific configurations

--- a/mk/spksrc.cross-dotnet.mk
+++ b/mk/spksrc.cross-dotnet.mk
@@ -40,6 +40,10 @@ endif
 
 
 # Common makefiles
+# Every dotnet build refuses the archs dotnet has no runtime port for. Raised here, before
+# common.mk, because spksrc.common/dotnet.mk holds the list and the reason for all of them.
+DOTNET_BUILD_ARCHS = 1
+
 include ../../mk/spksrc.common.mk
 
 ##### dotnet specific configurations

--- a/mk/spksrc.cross/env-dotnet.mk
+++ b/mk/spksrc.cross/env-dotnet.mk
@@ -5,11 +5,6 @@
 #
 ###############################################################################
 
-# NOTE: 32bit (x86) is not supported:
-# https://github.com/dotnet/core/issues/5403
-# https://github.com/dotnet/core/issues/4595
-UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
-
 DOTNET_OS = linux
 DOTNET_DEFAULT_VERSION = 3.1
 

--- a/mk/spksrc.cross/env-dotnet.mk
+++ b/mk/spksrc.cross/env-dotnet.mk
@@ -8,9 +8,7 @@
 # NOTE: 32bit (x86) is not supported:
 # https://github.com/dotnet/core/issues/5403
 # https://github.com/dotnet/core/issues/4595
-# The spk/ side of the same story is in spksrc.common/dotnet.mk.
 UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
-UNSUPPORTED_ARCHS_REASON := dotnet ships no runtime for this arch
 
 DOTNET_OS = linux
 DOTNET_DEFAULT_VERSION = 3.1

--- a/mk/spksrc.cross/env-dotnet.mk
+++ b/mk/spksrc.cross/env-dotnet.mk
@@ -9,66 +9,66 @@ DOTNET_OS = linux
 DOTNET_DEFAULT_VERSION = 3.1
 
 ifeq ($(strip $(DOTNET_VERSION)),)
-	DOTNET_VERSION = $(DOTNET_DEFAULT_VERSION)
+  DOTNET_VERSION = $(DOTNET_DEFAULT_VERSION)
 endif
 
 ifeq ($(strip $(DOTNET_FRAMEWORK)),)
-	DOTNET_FRAMEWORK = net$(DOTNET_VERSION)
-	ifeq ($(call version_lt, $(DOTNET_VERSION), 5.0),1)
-		DOTNET_FRAMEWORK = netcoreapp$(DOTNET_VERSION)
-	endif
+  DOTNET_FRAMEWORK = net$(DOTNET_VERSION)
+  ifeq ($(call version_lt, $(DOTNET_VERSION), 5.0),1)
+    DOTNET_FRAMEWORK = netcoreapp$(DOTNET_VERSION)
+  endif
 endif
 DOTNET_BUILD_ARGS += -f $(DOTNET_FRAMEWORK)
 
 # Define DOTNET_ARCH for compiler
 ifeq ($(findstring $(ARCH),$(ARMv7_ARCHS)),$(ARCH))
-	DOTNET_ARCH = arm
+  DOTNET_ARCH = arm
 endif
 ifeq ($(findstring $(ARCH),$(ARMv8_ARCHS)),$(ARCH))
-	DOTNET_ARCH = arm64
+  DOTNET_ARCH = arm64
 endif
 ifeq ($(findstring $(ARCH),$(i686_ARCHS)),$(ARCH))
-	DOTNET_ARCH = x86
+  DOTNET_ARCH = x86
 endif
 ifeq ($(findstring $(ARCH),$(x64_ARCHS)),$(ARCH))
-	DOTNET_ARCH = x64
+  DOTNET_ARCH = x64
 endif
 ifeq ($(DOTNET_ARCH),)
-	# don't report error to use regular UNSUPPORTED_ARCHS logging
-	$(error Unsupported ARCH $(ARCH))
+  # don't report error to use regular UNSUPPORTED_ARCHS logging
+  $(warning Unsupported ARCH $(ARCH))
 endif
 
 ifeq ($(strip $(DOTNET_ROOT)),)
-	# dotnet sdk path
-	DOTNET_ROOT = $(WORK_DIR)/../../../native/dotnet-sdk-$(DOTNET_VERSION)/work-native
+  # dotnet sdk path
+  DOTNET_ROOT = $(WORK_DIR)/../../../native/dotnet-sdk-$(DOTNET_VERSION)/work-native
 endif
 
 ifeq ($(strip $(DOTNET_ROOT_X86)),)
-	# dotnet sdk-32bit path
-	DOTNET_ROOT_X86 = ""
-	# DOTNET_ROOT_X86 = $(WORK_DIR)/../../../native/dotnet-x86-sdk-$(DOTNET_VERSION)/work-native
+  # dotnet sdk-32bit path
+  DOTNET_ROOT_X86 = ""
+  # DOTNET_ROOT_X86 = $(WORK_DIR)/../../../native/dotnet-x86-sdk-$(DOTNET_VERSION)/work-native
 endif
 
 
 ifeq ($(strip $(NUGET_PACKAGES)),)
-	# cache nuget packages
-	# https://github.com/dotnet/sdk/commit/e5a9249418f8387602ee8a26fef0f1604acf5911
-	NUGET_PACKAGES = $(DISTRIB_DIR)/nuget/packages
+  # cache nuget packages
+  # https://github.com/dotnet/sdk/commit/e5a9249418f8387602ee8a26fef0f1604acf5911
+  NUGET_PACKAGES = $(DISTRIB_DIR)/nuget/packages
 endif
 
 ifneq ($(strip $(DOTNET_NOT_RELEASE)),1)
-	DOTNET_BUILD_ARGS += --configuration Release
+  DOTNET_BUILD_ARGS += --configuration Release
 endif
 ifneq ($(strip $(DOTNET_SHARED_FRAMEWORK)),1)
-	# Include .NET Core into package unless DOTNET_SHARED_FRAMEWORK is set to 1
-	# https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained
-	DOTNET_BUILD_ARGS += --self-contained
-	DOTNET_BUILD_PROPERTIES += -p:UseAppHost=true
+  # Include .NET Core into package unless DOTNET_SHARED_FRAMEWORK is set to 1
+  # https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained
+  DOTNET_BUILD_ARGS += --self-contained
+  DOTNET_BUILD_PROPERTIES += -p:UseAppHost=true
 endif
 
 ifeq ($(strip $(DOTNET_SINGLE_FILE)),1)
-	# package all dlls into a single binary
-	DOTNET_BUILD_PROPERTIES += -p:PublishSingleFile=true
+  # package all dlls into a single binary
+  DOTNET_BUILD_PROPERTIES += -p:PublishSingleFile=true
 endif
 
 DOTNET_BUILD_ARGS += --runtime $(DOTNET_OS)-$(DOTNET_ARCH)

--- a/mk/spksrc.cross/env-dotnet.mk
+++ b/mk/spksrc.cross/env-dotnet.mk
@@ -8,7 +8,9 @@
 # NOTE: 32bit (x86) is not supported:
 # https://github.com/dotnet/core/issues/5403
 # https://github.com/dotnet/core/issues/4595
+# The spk/ side of the same story is in spksrc.common/dotnet.mk.
 UNSUPPORTED_ARCHS += $(PPC_ARCHS) $(ARMv5_ARCHS) $(i686_ARCHS) $(ARMv7L_ARCHS)
+UNSUPPORTED_ARCHS_REASON := dotnet ships no runtime for this arch
 
 DOTNET_OS = linux
 DOTNET_DEFAULT_VERSION = 3.1

--- a/spk/readarr/Makefile
+++ b/spk/readarr/Makefile
@@ -6,11 +6,12 @@ SPK_ICON = src/readarr.png
 OPTIONAL_DEPENDS = cross/libstdc++
 DEPENDS = cross/readarr
 
-# dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739), and readarr is the only package
-# left on it: 0.4.18, its last release, still ships net6.0. Reasons: spksrc.common/dotnet.mk
-# -- lazy (=), this file assigns before it includes common.mk, where the reason is defined.
+# No dotnet flavour fits: every one of them excludes i686, and upstream does ship a
+# linux-core-x86 build that evansport uses. So the list is readarr's own, ARMv7 included --
+# dotnet 6.0 segfaults there (dotnet/runtime#109739) and 0.4.18, the last release, is still
+# net6.0. Lazy (=): this assigns before common.mk defines _dotnet_why, which names the rest.
 UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(ARMv7_ARCHS)
-UNSUPPORTED_ARCHS_REASON = $(_dotnet_why_armv7_net60)
+UNSUPPORTED_ARCHS_REASON = $(or $(if $(filter $(ARCH),$(ARMv7_ARCHS)),dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739)),$(_dotnet_why))
 
 MAINTAINER = SynoCommunity
 MAINTAINER_URL = https://synocommunity.com/

--- a/spk/readarr/Makefile
+++ b/spk/readarr/Makefile
@@ -6,8 +6,11 @@ SPK_ICON = src/readarr.png
 OPTIONAL_DEPENDS = cross/libstdc++
 DEPENDS = cross/readarr
 
-# Arch exclusions for dotnet 6.0
-DOTNET_SERVARR_ARCHS = 2
+# dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739), and readarr is the only package
+# left on it: 0.4.18, its last release, still ships net6.0. Reasons: spksrc.common/dotnet.mk
+# -- lazy (=), this file assigns before it includes common.mk, where the reason is defined.
+UNSUPPORTED_ARCHS = $(PPC_ARCHS) $(ARMv5_ARCHS) $(ARMv7L_ARCHS) $(ARMv7_ARCHS)
+UNSUPPORTED_ARCHS_REASON = $(_dotnet_why_armv7_net60)
 
 MAINTAINER = SynoCommunity
 MAINTAINER_URL = https://synocommunity.com/


### PR DESCRIPTION
## The problem

Answering "why is this arch refused for sonarr" meant looking in two unrelated files, neither named after dotnet:

- `spksrc.common/archs.mk` — which otherwise just classifies architectures (`ARMv7_ARCHS`, `PPC_ARCHS`, `64bit_ARCHS`) — carried three blocks listing the archs a **dotnet** package refuses.
- `spksrc.cross/env-dotnet.mk` carried a fourth, overlapping list of its own.

## One file

They move to a new **`mk/spksrc.common/dotnet.mk`**, included right after `archs.mk` since they need its arch groups.

**It has to stay under `spksrc.common/`.** The consumers are `spk/` packages — sonarr, radarr, lidarr, prowlarr, ombi, kavita, dotnet\*-runtime — which include `spksrc.spk.mk` and never see `env-dotnet.mk`, pulled in only by `spksrc.cross-dotnet.mk`. `cross/libe_sqlite3` uses the same flags from the cross tree, which confirms it.

`env-dotnet.mk` gives up its copy: `spksrc.cross-dotnet.mk` raises `DOTNET_BUILD_ARCHS` before it includes `common.mk` and opts in like any other consumer. A separate flavour on purpose — the build list is narrower than the app list, and reusing the app flag would have excluded archs `cross/jellyfin` builds on today.

Two flavours remain, both with real users. **`DOTNET_SERVARR_ARCHS` is gone**: nothing in the tree declares it. `= 1` was already dead on master, and `= 2` had exactly one user, `spk/readarr`, which now declares its own list — no flavour fits it, since every one of them excludes i686 while upstream does ship a `linux-core-x86` build that evansport uses.

## A parse error along the way

26 lines in `env-dotnet.mk` were indented with a tab outside any recipe. Anything reaching them before a rule is defined dies, so `cross/jellyfin` could not be parsed **at all** on an arch dotnet does not support — the exclusion was never even reached:

```
before: env-dotnet.mk:43: *** recipe commences before first target.  Stop.
after:  env-dotnet.mk:38: Unsupported ARCH ppc853x
        pre-check.mk:71: *** Arch 'ppc853x' is not a supported architecture.  Stop.
```

The `$(error)` for an unresolved `DOTNET_ARCH` becomes a `$(warning)`, as its own comment always asked.

## Reasons

`UNSUPPORTED_ARCHS_REASON` is picked by the arch at hand rather than one umbrella line — dotnet is absent here for four different grounds:

```
armada370            dotnet needs full vfpv3 and this toolchain is vfpv3-d16
alpine               dotnet segfaults on this arch despite capable silicon (issue #5302)
comcerto2k           dotnet is incompatible with this arch (issue #5574)
armv7-6.2.4 ...      dotnet is incompatible with this arch/DSM pair (issues #4790 #5089 #5302 #5315)
PPC, ARMv5, ARMv7L   dotnet has no runtime port for this arch
readarr on ARMv7     dotnet 6.0 segfaults on ARMv7 (dotnet/runtime#109739)
```

`armada370` is structurally incompatible (`-mfpu=vfpv3-d16`); `alpine` is empirically broken on capable silicon (`-mfpu=neon-vfpv4`). A package declaring its own list still reuses that map for the grounds it shares — readarr's `$(or ...)` falls through to it for PPC, ARMv5 and ARMv7L.

Verified against the binaries spksrc downloads: Readarr **0.4.16.2793** ships `"tfm": "net6.0"` with `Microsoft.NETCore.App 6.0.35`, and so does **0.4.18.2805**, the latest release — upstream has published nothing since June 2025. The ARMv7 exclusion is not going away on its own.

The variable is unused until #7439 lands, so **the two PRs merge in either order** — this one no longer shares a file with it.

## Testing

Behaviour-neutral: 7 dotnet packages across `armv7-6.2.4`, `ppc853x-5.2`, `evansport-7.1` and `x64-7.1` give an identical excluded/allowed set against master. Rebased on `3cb895bb0` (Jellyfin 12.0 / dotnet 10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd
