### PR TITLE
ci: turn DSM 5.2 back off

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,9 +281,7 @@ jobs:
           add_dsm70_builds=${{ github.event.inputs.add_dsm70_builds || 'false' }}
           add_dsm62_builds=${{ github.event.inputs.add_dsm62_builds || 'false' }}
           add_dsm61_builds=${{ github.event.inputs.add_dsm61_builds || 'false' }}
-          # TEMP (revert before merge): DSM 5.2 carries the toolchains this PR's floors
-          # actually bite on -- gcc 4.3.7 (ppc853x), 4.6.4 (88f6281), 4.7.3 (x86, x64).
-          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'true' }}
+          add_dsm52_builds=${{ github.event.inputs.add_dsm52_builds || 'false' }}
           add_srm13_builds=${{ github.event.inputs.add_srm13_builds || 'false' }}
           add_srm12_builds=${{ github.event.inputs.add_srm12_builds || 'false' }}
           add_noarch_builds=${{ github.event.inputs.add_noarch_builds || 'false' }}


### PR DESCRIPTION
#7439 turned DSM 5.2 on to exercise the four toolchains below gcc 4.9 — ppc853x (4.3.7), 88f6281 (4.6.4), x86 and x64 (4.7.3) — which is where the capability floors it reports actually bite. That commit was marked *revert before merge* and slipped through.

This puts `add_dsm52_builds` back to `false`, its value before #7439 and the same default every other `add_*_builds` carries. One line, `.github/workflows/build.yml`.

DSM 5.2 remains available on demand through the workflow's `add_dsm52_builds` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkzQnRy1W48Vg2QGRbwLSd
