### PR TITLE
Immich: Update to 3.2.0, fix password handling and sharp runtime

### DIFF
--- a/cross/immich/Makefile
+++ b/cross/immich/Makefile
@@ -147,16 +147,17 @@ immich_install:
 		> $(WORK_DIR)/$(PKG_NAME).plist
 
 .PHONY: immich_post_install
+# sharp >= 0.35 names the binary sharp-linux-<arch>-<version>.node
 immich_post_install:
 	@$(MSG) "Redirect sharp RPATH to target/lib for HEIC-enabled libvips"
-	SHARP_NODE=$$(find $(STAGING_INSTALL_PREFIX)/share/immich/node_modules -name "sharp-linux-$(NODE_ARCH).node" 2>/dev/null | head -1); \
+	SHARP_NODE=$$(find $(STAGING_INSTALL_PREFIX)/share/immich/node_modules -name "sharp-linux-$(NODE_ARCH)*.node" 2>/dev/null | head -1); \
 	if [ -n "$$SHARP_NODE" ]; then \
 	  patchelf --set-rpath /var/packages/immich/target/lib "$$SHARP_NODE"; \
 	else \
 	  $(MSG) "Warning: sharp-linux-$(NODE_ARCH).node not found, skipping RPATH fix" >&2; \
 	fi
 	@$(MSG) "Removing build-time and wrong-arch native binaries"
-	find $(STAGING_INSTALL_PREFIX)/share/immich/node_modules/.pnpm -name "*.node" ! -name "sharp-linux-$(NODE_ARCH).node" ! -path "*bcrypt*" -delete 2>/dev/null || true; \
+	find $(STAGING_INSTALL_PREFIX)/share/immich/node_modules/.pnpm -name "*.node" ! -name "sharp-linux-$(NODE_ARCH)*.node" ! -path "*bcrypt*" -delete 2>/dev/null || true; \
 	find $(STAGING_INSTALL_PREFIX)/share/immich/node_modules/.pnpm -path "*bcrypt*" -name "*.node" ! -path "*linux-$(NODE_ARCH)*" -delete 2>/dev/null || true
 	@$(MSG) "Removing dev-only packages from node_modules"
 	bash -c 'for pkg in typescript eslint @typescript-eslint @swc @esbuild @rolldown vitest jsdom; do \

--- a/cross/immich/Makefile
+++ b/cross/immich/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = immich
-PKG_VERS = 3.1.0
+PKG_VERS = 3.2.0
 PKG_EXT = tar.gz
 PKG_DIST_NAME = v$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/immich-app/immich/archive/refs/tags
@@ -45,7 +45,7 @@ immich_install:
 	# ------------------------------------------------------------
 	$(RUN) pnpm install --frozen-lockfile --ignore-scripts
 	# Ensure target-arch sharp prebuilt is available (frozen lockfile skips non-host platforms)
-	$(RUN) pnpm add @img/sharp-linux-$(NODE_ARCH)@0.34.5 --filter immich --ignore-scripts 2>/dev/null || true
+	$(RUN) pnpm add @img/sharp-linux-$(NODE_ARCH)@0.35.3 --filter immich --ignore-scripts 2>/dev/null || true
 
 	# ------------------------------------------------------------
 	# 3. Build (order: sdk -> plugin-sdk -> plugin-core -> cli -> server -> web)

--- a/cross/immich/digests
+++ b/cross/immich/digests
@@ -1,3 +1,3 @@
-immich-3.1.0.tar.gz SHA1 67678542947da2af40d25a2e993f9dd8230be1d7
-immich-3.1.0.tar.gz SHA256 af0fba69cc5830093392de4f5576eeb7f2ccf28ba55154b7598e10f596fdfb40
-immich-3.1.0.tar.gz MD5 9aab0a3d4e74d24fddd4d5077b084211
+immich-3.2.0.tar.gz SHA1 565eaf6cf4708f68006729d8dd21aac39756a3ee
+immich-3.2.0.tar.gz SHA256 a10ae5e2f185dcf948ffc62bad5251e9bd8275a59b67a10a20fdc3f6de4e67d0
+immich-3.2.0.tar.gz MD5 d169372ad9b3e088ba1a18ea851d55e0

--- a/cross/libvips/Makefile
+++ b/cross/libvips/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = libvips
-PKG_VERS = 8.17.3
+PKG_VERS = 8.18.3
 PKG_EXT = tar.xz
 PKG_DIST_NAME = vips-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://github.com/libvips/libvips/releases/download/v$(PKG_VERS)
@@ -50,5 +50,5 @@ include ../../mk/spksrc.cross-meson.mk
 .PHONY: libvips_post_install
 libvips_post_install:
 	@cd $(STAGING_INSTALL_PREFIX)/lib && \
-	  patchelf --set-soname libvips-cpp.so.8.17.3 libvips-cpp.so.42.19.3 && \
-	  ln -sf libvips-cpp.so.42.19.3 libvips-cpp.so.8.17.3
+	  patchelf --set-soname libvips-cpp.so.8.18.3 libvips-cpp.so.42.20.3 && \
+	  ln -sf libvips-cpp.so.42.20.3 libvips-cpp.so.8.18.3

--- a/cross/libvips/PLIST
+++ b/cross/libvips/PLIST
@@ -1,7 +1,7 @@
 lnk:lib/libvips.so
 lnk:lib/libvips.so.42
-lib:lib/libvips.so.42.19.3
+lib:lib/libvips.so.42.20.3
 lnk:lib/libvips-cpp.so
 lnk:lib/libvips-cpp.so.42
-lib:lib/libvips-cpp.so.42.19.3
-lnk:lib/libvips-cpp.so.8.17.3
+lib:lib/libvips-cpp.so.42.20.3
+lnk:lib/libvips-cpp.so.8.18.3

--- a/cross/libvips/digests
+++ b/cross/libvips/digests
@@ -1,3 +1,3 @@
-libvips-8.17.3.tar.xz SHA1 7b7da222d716bb3a40243aa2d592bef72cc160a1
-libvips-8.17.3.tar.xz SHA256 41e9a1439cd57dcc6d4435a085e2cfe181d9da1962fa84a484f09e8b536e4b77
-libvips-8.17.3.tar.xz MD5 88ce26d55ab77c015cbbb5f8571fcc79
+libvips-8.18.3.tar.xz SHA1 f0ab8cb1b0d904271d1843d0b29ad0272ecb4734
+libvips-8.18.3.tar.xz SHA256 f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146
+libvips-8.18.3.tar.xz MD5 50946f5e177cfcc0ab38bd7e672ac711

--- a/spk/immich/Makefile
+++ b/spk/immich/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = immich
-SPK_VERS = 3.1.0
-SPK_REV = 5
+SPK_VERS = 3.2.0
+SPK_REV = 6
 SPK_ICON = src/immich.png
 
 DEPENDS = cross/immich cross/immich-geodata
@@ -12,7 +12,7 @@ UNSUPPORTED_ARCHS = $(32bit_ARCHS)
 MAINTAINER = SynoCommunity
 DISPLAY_NAME = Immich
 DESCRIPTION = Self-hosted photo and video backup solution.
-CHANGELOG = "1. Update Immich to v3.1.0. <br/>2. Add proxy support for ML dependency downloads. <br/>3. Add custom PyPI mirror option in install wizard."
+CHANGELOG = "Update Immich to v3.2.0 (revamped search UI, Search API v2, workflow tags)."
 HOMEPAGE = https://immich.app
 LICENSE = GPLv3
 

--- a/spk/immich/src/service-setup.sh
+++ b/spk/immich/src/service-setup.sh
@@ -92,8 +92,8 @@ install_ml_packages()
 {
     "${ML_VENV}/bin/pip3" install --upgrade --no-cache-dir \
         onnxruntime \
+        onnx \
         opencv-python-headless \
-        insightface \
         huggingface-hub \
         numpy \
         orjson \
@@ -108,7 +108,7 @@ install_ml_packages()
         rich \
         aiocache \
         rapidocr 2>&1
-    # insightface pulls in opencv-python (GUI); force back to headless
+    # ensure opencv stays headless (GUI variant has no place on DSM)
     "${ML_VENV}/bin/pip3" install \
         --force-reinstall \
         --no-deps \
@@ -288,6 +288,12 @@ service_postupgrade ()
     # Upgrade ML wheels if ML is installed
     if [ -x "${ML_VENV}/bin/python3" ]; then
         setup_proxy
+        # 3.2.0 dropped insightface (replaced by onnx); remove the
+        # leftover wheel on upgrade so it does not linger in the venv
+        if "${ML_VENV}/bin/pip3" show insightface >/dev/null 2>&1; then
+            echo "Removing obsolete insightface wheel."
+            "${ML_VENV}/bin/pip3" uninstall -y insightface 2>&1 || true
+        fi
         install_ml_packages
     fi
 }

--- a/spk/immich/src/service-setup.sh
+++ b/spk/immich/src/service-setup.sh
@@ -42,6 +42,25 @@ install_log ()
     fi
 }
 
+# Wrap a value as a shell single-quoted literal (safe to source)
+shell_quote()
+{
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+# Escape a value for the replacement part of sed 's|...|...|'
+# (backslash, ampersand and the | delimiter)
+sed_escape()
+{
+    printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+# Escape single quotes for use inside a SQL string literal
+sql_escape()
+{
+    printf '%s' "$1" | sed "s/'/''/g"
+}
+
 setup_proxy ()
 {
     [ -f /etc/proxy.conf ] || return 0
@@ -186,15 +205,15 @@ install_immich_config()
 {
     mkdir -p "$(dirname "${IMMICH_CONF}")"
     cp "${SYNOPKG_PKGDEST}/etc/immich.conf" "${IMMICH_CONF}"
-    sed -i -e "s|@immich_build_data@|${IMMICH_BUILD_DATA}|g" \
-           -e "s|@media_path@|${MEDIA_PATH}|g" \
-           -e "s|@ml_url@|${ML_URL}|g" \
-           -e "s|@ml_enabled@|${ML_ENABLED}|g" \
-           -e "s|@db_password@|${DB_PASSWORD}|g" \
-           -e "s|@db_hostname@|${PG_HOST}|g" \
-           -e "s|@db_port@|${PG_PORT}|g" \
-           -e "s|@db_username@|${PG_USER}|g" \
-           -e "s|@redis_hostname@|${REDIS_HOSTNAME}|g" \
+    sed -i -e "s|@immich_build_data@|$(sed_escape "$(shell_quote "${IMMICH_BUILD_DATA}")")|g" \
+           -e "s|@media_path@|$(sed_escape "$(shell_quote "${MEDIA_PATH}")")|g" \
+           -e "s|@ml_url@|$(sed_escape "$(shell_quote "${ML_URL}")")|g" \
+           -e "s|@ml_enabled@|$(sed_escape "$(shell_quote "${ML_ENABLED}")")|g" \
+           -e "s|@db_password@|$(sed_escape "$(shell_quote "${DB_PASSWORD}")")|g" \
+           -e "s|@db_hostname@|$(sed_escape "$(shell_quote "${PG_HOST}")")|g" \
+           -e "s|@db_port@|$(sed_escape "$(shell_quote "${PG_PORT}")")|g" \
+           -e "s|@db_username@|$(sed_escape "$(shell_quote "${PG_USER}")")|g" \
+           -e "s|@redis_hostname@|$(sed_escape "$(shell_quote "${REDIS_HOSTNAME}")")|g" \
            "${IMMICH_CONF}"
     chmod 600 "${IMMICH_CONF}"
 }
@@ -215,7 +234,8 @@ service_postinst ()
         DB_PASSWORD="${wizard_pg_password_immich}"
         install_immich_config
 
-        PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "CREATE USER ${PG_USER} WITH PASSWORD '${wizard_pg_password_immich}' SUPERUSER;" 2>/dev/null || true
+        DB_PASSWORD_SQL="$(sql_escape "${wizard_pg_password_immich}")"
+        PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "CREATE USER ${PG_USER} WITH PASSWORD '${DB_PASSWORD_SQL}' SUPERUSER;" 2>/dev/null || true
         PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d postgres -c "CREATE DATABASE ${PG_DATABASE} OWNER ${PG_USER};" 2>/dev/null || true
         for ext in vector unaccent cube earthdistance pg_trgm uuid-ossp; do
             PGPASSWORD="${PG_ADMIN_PASS}" ${PG_PSQL} -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_ADMIN_USER}" -d "${PG_DATABASE}" -c "CREATE EXTENSION IF NOT EXISTS \"${ext}\";" 2>/dev/null || true


### PR DESCRIPTION
## Description

Update Immich 3.1.0 → 3.2.0 (released 2026-09-10), plus two fixes found while testing the update (password auth #7436, sharp native module).

### Update (`cross/immich`, `spk/immich`)

- `PKG_VERS`/`SPK_VERS` 3.1.0 → 3.2.0, `SPK_REV` 5 → 6, digests regenerated, CHANGELOG updated. No breaking changes upstream; Node 22 / postgres / redis / ffmpeg8 deps unchanged; `immich-geodata` needs no bump (version-independent geonames data).
- Sharp prebuilt pin `0.34.5` → `0.35.3` to match 3.2.0's lockfile.

### Password handling for special characters (fixes #7436)

The wizard mandates a special character, yet three sinks corrupted one: `sed` replacement in `install_immich_config` (`&` expanded, `|` broke syntax), unquoted sourcing of `immich.conf` at every service start (`&`, `#`, `;`, spaces, quotes), and the `CREATE USER ... '...'` SQL literal (`'`). Added POSIX `shell_quote()` / `sed_escape()` / `sql_escape()` helpers, applied uniformly to all substituted config values. Verified with 13 adversarial passwords round-tripping byte-exact through sed→source, SQL quotes doubled. No runtime change needed (Immich consumes discrete `DB_*` env vars, no URL parsing).

### Sharp runtime fix

sharp 0.35.x renamed its binary (`sharp-linux-x64.node` → `sharp-linux-x64-0.35.3.node`), so post-install missed the RPATH fix and the keep-exclusion **deleted the binary** (`Could not load the "sharp" module`). Fixed with a version-tolerant glob. That exposed the second layer: the binary needs `libvips-cpp.so.8.18.3` while `cross/libvips` shipped 8.17.3 (the patchelf redirect replaces the vendored `$ORIGIN` RUNPATH, so only the system lib is searched). Bumped `cross/libvips` 8.17.3 → **8.18.3** (exact match to sharp's expectation, same soname-forgery pattern as before; only immich consumes it — zero blast radius), including PLIST filenames.

### ML packages for 3.2.0

Upstream dropped `insightface` and added `onnx` as a direct dependency. Swapped them in `install_ml_packages` (kept the force-reinstall of headless opencv — still required since `rapidocr-onnxruntime` pulls the GUI variant), and `service_postupgrade` now removes a lingering `insightface` wheel on upgrade (guarded `pip show` check, no-op otherwise).

Fixes #7436

## Checklist

- [x] Build rule `all-supported` completed successfully
- [x] New installation of package completed successfully
- [x] Package upgrade completed successfully (Manually install the package again)
- [x] Package [functionality was tested](https://docs.synocommunity.com/developer-guide/advanced/testing/#checklist-before-pr)
- [x] Any needed [documentation](https://docs.synocommunity.com/contributing/) is updated/created


### Type of change

<!--Please use any relevant tags.-->
- [x] Package update
